### PR TITLE
Represent reflection runtime state with enums

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/reflect/reflect.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/reflect/reflect.baml
@@ -187,6 +187,11 @@ class InvalidArgumentError {
   got reflect.Type
 }
 
+/// One-shot compiler output consumed by Package._finish or Session._finish.
+class CompileArtifact {
+  _inner unknown
+}
+
 /// An isolated runtime-compiled package.
 class Package {
   _inner unknown
@@ -201,13 +206,13 @@ class Package {
     Package._finish(artifact, packages)
   }
 
-  function _compile(files: map<string, string>, packages: map<string, Package>) -> Package throws reflect.errors.CompilationError {
+  function _compile(files: map<string, string>, packages: map<string, Package>) -> CompileArtifact throws reflect.errors.CompilationError {
     $rust_io_function
   }
 
   //baml:mut_vm
   //baml:may_yield
-  function _finish(artifact: Package, packages: map<string, Package>) -> Package throws unknown {
+  function _finish(artifact: CompileArtifact, packages: map<string, Package>) -> Package throws unknown {
     $rust_function
   }
 
@@ -297,13 +302,13 @@ class Session {
     }
   }
 
-  function _compile<T>(self, source: string) -> Package throws reflect.errors.CompilationError | reflect.errors.SessionBusy {
+  function _compile<T>(self, source: string) -> CompileArtifact throws reflect.errors.CompilationError | reflect.errors.SessionBusy {
     $rust_io_function
   }
 
   //baml:mut_vm
   //baml:may_yield
-  function _finish<T>(self, artifact: Package) -> T throws unknown {
+  function _finish<T>(self, artifact: CompileArtifact) -> T throws unknown {
     $rust_function
   }
 

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_reflect_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_reflect_package_listing.snap
@@ -13,10 +13,11 @@ interface        reflect.AnyFunction              <builtin>/reflect/reflect.baml
 interface        reflect.AnyClass                 <builtin>/reflect/reflect.baml:73
 class            reflect.Signature                <builtin>/reflect/reflect.baml:162
 class            reflect.InvalidArgumentError     <builtin>/reflect/reflect.baml:184
-class            reflect.Package                  <builtin>/reflect/reflect.baml:191
-class            reflect.Session                  <builtin>/reflect/reflect.baml:281
-function         reflect.signature                <builtin>/reflect/reflect.baml:323
-function         reflect.call_any                 <builtin>/reflect/reflect.baml:339
+class            reflect.CompileArtifact          <builtin>/reflect/reflect.baml:191
+class            reflect.Package                  <builtin>/reflect/reflect.baml:196
+class            reflect.Session                  <builtin>/reflect/reflect.baml:286
+function         reflect.signature                <builtin>/reflect/reflect.baml:328
+function         reflect.call_any                 <builtin>/reflect/reflect.baml:344
 class            reflect.Type                     <builtin>/reflect/type.baml:8
 class            reflect.array.Type               <builtin>/reflect/ns_array/array.baml:2
 class            reflect.class.Field              <builtin>/reflect/ns_class/class.baml:1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
@@ -249,10 +249,10 @@ function reflect.AnyClass.type(self: reflect.AnyClass) -> reflect.Type {
     return
 }
 
-function reflect.Package._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.Package {
+function reflect.Package._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.CompileArtifact {
 }
 
-function reflect.Package._finish(artifact: reflect.Package, packages: map<string, reflect.Package>) -> reflect.Package {
+function reflect.Package._finish(artifact: reflect.CompileArtifact, packages: map<string, reflect.Package>) -> reflect.Package {
 }
 
 function reflect.Package.classes(self: reflect.Package) -> map<string, reflect.class.Type> {
@@ -306,10 +306,10 @@ function reflect.Package.tests(self: reflect.Package) -> map<string, () -> null 
 function reflect.Package.with_types(self: reflect.Package, types: map<string, reflect.Type | reflect.TypeView>) -> reflect.Package {
 }
 
-function reflect.Session._compile(self: reflect.Session, source: string) -> reflect.Package {
+function reflect.Session._compile(self: reflect.Session, source: string) -> reflect.CompileArtifact {
 }
 
-function reflect.Session._finish(self: reflect.Session, artifact: reflect.Package) -> #0 {
+function reflect.Session._finish(self: reflect.Session, artifact: reflect.CompileArtifact) -> #0 {
 }
 
 function reflect.Session._new(packages: map<string, reflect.Package>) -> reflect.Session {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
@@ -590,8 +590,8 @@ fn reflect.Package.compile(files: map<string, string>, packages: map<string, ref
     let _1: map<string, string> // files // param
     let _2: map<string, reflect.Package> // packages // param
     let _3: bool
-    let _4: reflect.Package // artifact
-    let _5: reflect.Package
+    let _4: reflect.CompileArtifact // artifact
+    let _5: reflect.CompileArtifact
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -675,10 +675,10 @@ fn reflect.Session.eval(self: reflect.Session, source: string) -> T {
     let _0: T // _0 // return
     let _1: reflect.Session // self // param
     let _2: string // source // param
-    let _3: reflect.Package // artifact
+    let _3: reflect.CompileArtifact // artifact
     let _4: reflect.Type
     let _5: unknown // _
-    let _6: reflect.Package
+    let _6: reflect.CompileArtifact
     let _7: reflect.Type
     let _8: reflect.errors.EvaluationError
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/ppir.snap
@@ -221,6 +221,12 @@ class reflect.Arg$stream {
   name: string | null
   type: unknown
 }
+class reflect.CompileArtifact {
+  _inner: unknown
+}
+class reflect.CompileArtifact$stream {
+  _inner: unknown
+}
 class reflect.Diagnostic {
   code: string
   span: reflect.Span?
@@ -307,10 +313,10 @@ class reflect.WithMeta$stream {
 }
 type reflect.TypeKind = reflect.class.Type | reflect.enum.Type | reflect.union.Type | reflect.literal.Type | reflect.array.Type | reflect.map.Type | reflect.interface.Type | reflect.primitive.Type | reflect.function.Type
 type reflect.TypeKind$stream = reflect.class.Type$stream | reflect.enum.Type$stream | reflect.union.Type$stream | reflect.literal.Type$stream | reflect.array.Type$stream | reflect.map.Type$stream | reflect.interface.Type$stream | reflect.primitive.Type$stream | reflect.function.Type$stream
-function reflect._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
-function reflect._compile(self: ?, source: string) -> reflect.Package  [builtin]
-function reflect._finish(artifact: reflect.Package, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
-function reflect._finish(self: ?, artifact: reflect.Package) -> T  [builtin]
+function reflect._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.CompileArtifact  [builtin]
+function reflect._compile(self: ?, source: string) -> reflect.CompileArtifact  [builtin]
+function reflect._finish(artifact: reflect.CompileArtifact, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
+function reflect._finish(self: ?, artifact: reflect.CompileArtifact) -> T  [builtin]
 function reflect._new(packages: map<string, reflect.Package>) -> reflect.Session  [builtin]
 function reflect.as_type(self: ?) -> reflect.Type  [missing]
 function reflect.attributes(self: ?) -> reflect.Meta  [expr] {

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -132,6 +132,24 @@ class Broken { value MissingType }
 }
 "####;
 
+#[tokio::test]
+async fn package_finish_refuses_session_compile_artifact() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = session._compile<int>(#"1"#)
+  let rejected = false
+  let _ = reflect.Package._finish(artifact, {}) catch (_) {
+    _ => { rejected = true },
+  }
+  rejected && session.eval<int>(#"2"#) == 2
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
 const SCENARIO_6_SOURCE: &str = r####"
 class AgentState {
   goal string

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -138,12 +138,12 @@ async fn package_finish_refuses_session_compile_artifact() {
         r####"
 function main() -> bool throws unknown {
   let session = reflect.Session.new()
-  let artifact = session._compile<int>(#"1"#)
+  let artifact = session._compile<int>(`1`)
   let rejected = false
   let _ = reflect.Package._finish(artifact, {}) catch (_) {
     _ => { rejected = true },
   }
-  rejected && session.eval<int>(#"2"#) == 2
+  rejected && session.eval<int>(`2`) == 2
 }
 "####
     );

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -56,6 +56,22 @@ function main() -> bool throws unknown {
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
 
+#[tokio::test]
+async fn session_synthetic_step_names_do_not_collide_with_user_bindings() {
+    let output = baml_test!(
+        r####"
+function main() -> int throws unknown {
+  let session = reflect.Session.new()
+  session.eval(`let result = 5`)
+  session.eval(`let stmt_1 = 7
+log.info("keep the second generated step")`)
+  session.eval<int>(`result + stmt_1`)
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Int(12)));
+}
+
 const S11_LIVENESS_PROBE: &str = r#####"
 function escape_one_session_value() -> reflect.Type throws unknown {
   let dependency = reflect.Package.compile({

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -16,6 +16,46 @@ function main() -> int throws unknown {
 }
 "####;
 
+#[tokio::test]
+async fn session_compile_artifact_is_consumed_once() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = session._compile<int>(`1`)
+  let first = session._finish<int>(artifact)
+  let rejected = false
+  let _ = session._finish<int>(artifact) catch (_) {
+    _ => { rejected = true },
+  }
+  first == 1 && rejected
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn session_finish_refuses_package_compile_artifact() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = reflect.Package._compile(
+    { "main.baml": "function ready() -> bool { true }" },
+    {},
+  )
+  let rejected = false
+  let _ = session._finish<unknown>(artifact) catch (_) {
+    _ => { rejected = true },
+  }
+  rejected
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
 const S11_LIVENESS_PROBE: &str = r#####"
 function escape_one_session_value() -> reflect.Type throws unknown {
   let dependency = reflect.Package.compile({
@@ -511,12 +551,9 @@ async fn escaped_session_type_retains_provenance_only_while_handle_is_live() {
         let Object::Package(owner) = (unsafe { owner_ptr.get() }) else {
             panic!("escaped definition owner should be a Package")
         };
-        owner_is_session = owner.session.is_some();
-        session_history = owner
-            .session
-            .as_ref()
-            .map_or(0, |state| state.history.len());
-        let runtime = owner.runtime.as_ref().expect("runtime owner image");
+        owner_is_session = owner.session().is_some();
+        session_history = owner.session().map_or(0, |state| state.history.len());
+        let runtime = owner.runtime().expect("runtime owner image");
         retained_globals = runtime.globals.len();
         retained_objects = runtime.objects.len();
         retained_dependencies = runtime.dependencies.len();
@@ -524,10 +561,9 @@ async fn escaped_session_type_retains_provenance_only_while_handle_is_live() {
             .dependencies
             .iter()
             .map(|dependency| match unsafe { dependency.get() } {
-                Object::Package(package) => package
-                    .runtime
-                    .as_ref()
-                    .map_or(0, |runtime| runtime.objects.len()),
+                Object::Package(package) => {
+                    package.runtime().map_or(0, |runtime| runtime.objects.len())
+                }
                 _ => 0,
             })
             .sum::<usize>();

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -2876,7 +2876,7 @@ impl BexEngine {
             let Object::Package(package) = vm.get_object(owner) else {
                 continue;
             };
-            let Some(runtime) = package.runtime.as_ref() else {
+            let Some(runtime) = package.runtime() else {
                 continue;
             };
             pending.extend(runtime.dependencies.iter().copied());
@@ -7194,8 +7194,7 @@ impl BexEngine {
                 ));
             };
             package
-                .session
-                .as_ref()
+                .session()
                 .map(|state| state.busy.clone())
                 .ok_or_else(|| invalid("Session has an invalid runtime payload".to_string()))?
         };
@@ -7219,17 +7218,15 @@ impl BexEngine {
                     "Session has an invalid runtime payload".to_string(),
                 ));
             };
-            let state = package
-                .session
-                .as_mut()
-                .ok_or_else(|| invalid("Session has an invalid runtime payload".to_string()))?;
+            let bex_vm_types::types::PackageKind::Session { runtime, state } = &mut package.kind
+            else {
+                return Err(invalid(
+                    "Session has an invalid runtime payload".to_string(),
+                ));
+            };
             let sequence = state.submission_counter;
             state.submission_counter = state.submission_counter.saturating_add(1);
-            let dependencies = package
-                .runtime
-                .as_ref()
-                .map(|runtime| runtime.dependency_names.clone())
-                .unwrap_or_default();
+            let dependencies = runtime.dependency_names.clone();
             (
                 state.history.clone(),
                 state.visible.clone(),
@@ -7312,10 +7309,10 @@ impl BexEngine {
             };
             match compiler.compile(request) {
                 Ok(artifact) => Ok(BexExternalValue::Instance {
-                    class_name: "reflect.Package".to_string(),
+                    class_name: "reflect.CompileArtifact".to_string(),
                     type_args: Vec::new(),
                     fields: indexmap::indexmap! {
-                        "_inner".to_string() => BexExternalValue::RustData(Arc::new(artifact)),
+                        "_inner".to_string() => BexExternalValue::RustData(Arc::new(Mutex::new(Some(artifact)))),
                     },
                 }),
                 Err(diagnostics) => {

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -27,7 +27,10 @@
 
 use std::{cell::UnsafeCell, collections::HashMap};
 
-use bex_vm_types::{FutureRead, HeapPtr, Object, Value, types::Future};
+use bex_vm_types::{
+    FutureRead, HeapPtr, Object, Value,
+    types::{Future, PackageKind},
+};
 
 use crate::{
     BexHeap,
@@ -679,19 +682,22 @@ impl BexHeap {
                     worklist.push(*interface);
                     worklist.extend(rules.iter().copied());
                 }
-                if let Some(runtime) = &package.runtime {
-                    worklist.extend(runtime.objects.iter().copied());
-                    worklist.extend(runtime.object_names.values().copied());
-                    worklist.extend(runtime.type_values.values().copied());
-                    worklist.extend(runtime.dependencies.iter().copied());
-                    worklist.extend(runtime.dependency_names.values().copied());
-                    worklist.extend(runtime.init);
-                    worklist.extend(
-                        runtime
-                            .globals
-                            .iter()
-                            .filter_map(|slot| slot.load().as_object_ptr()),
-                    );
+                match &package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        worklist.extend(runtime.objects.iter().copied());
+                        worklist.extend(runtime.object_names.values().copied());
+                        worklist.extend(runtime.type_values.values().copied());
+                        worklist.extend(runtime.dependencies.iter().copied());
+                        worklist.extend(runtime.dependency_names.values().copied());
+                        worklist.extend(runtime.init);
+                        worklist.extend(
+                            runtime
+                                .globals
+                                .iter()
+                                .filter_map(|slot| slot.load().as_object_ptr()),
+                        );
+                    }
                 }
             }
             Object::Function(function) => {
@@ -939,49 +945,52 @@ impl BexHeap {
                         (interface, rules)
                     })
                     .collect();
-                if let Some(runtime) = &mut package.runtime {
-                    for ptr in runtime.objects.iter_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
+                match &mut package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        for ptr in runtime.objects.iter_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        for ptr in runtime.object_names.values_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        // Keyed by the declaration each value names, so the keys
+                        // move too — rebuilt through the forwarding map rather than
+                        // mutated in place, as `impl_rules` above is.
+                        let old_type_values = std::mem::take(&mut runtime.type_values);
+                        runtime.type_values = old_type_values
+                            .into_iter()
+                            .map(|(declaration, value)| {
+                                (
+                                    forwarding.get(&declaration).copied().unwrap_or(declaration),
+                                    forwarding.get(&value).copied().unwrap_or(value),
+                                )
+                            })
+                            .collect();
+                        for ptr in runtime.dependencies.iter_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        for ptr in runtime.dependency_names.values_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        if let Some(ptr) = &mut runtime.init
+                            && let Some(&new_ptr) = forwarding.get(ptr)
+                        {
                             *ptr = new_ptr;
                         }
-                    }
-                    for ptr in runtime.object_names.values_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
+                        for slot in &runtime.globals {
+                            let mut value = slot.load();
+                            self.fixup_value(&mut value, forwarding);
+                            slot.store(value);
                         }
-                    }
-                    // Keyed by the declaration each value names, so the keys
-                    // move too — rebuilt through the forwarding map rather than
-                    // mutated in place, as `impl_rules` above is.
-                    let old_type_values = std::mem::take(&mut runtime.type_values);
-                    runtime.type_values = old_type_values
-                        .into_iter()
-                        .map(|(declaration, value)| {
-                            (
-                                forwarding.get(&declaration).copied().unwrap_or(declaration),
-                                forwarding.get(&value).copied().unwrap_or(value),
-                            )
-                        })
-                        .collect();
-                    for ptr in runtime.dependencies.iter_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
-                        }
-                    }
-                    for ptr in runtime.dependency_names.values_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
-                        }
-                    }
-                    if let Some(ptr) = &mut runtime.init
-                        && let Some(&new_ptr) = forwarding.get(ptr)
-                    {
-                        *ptr = new_ptr;
-                    }
-                    for slot in &runtime.globals {
-                        let mut value = slot.load();
-                        self.fixup_value(&mut value, forwarding);
-                        slot.store(value);
                     }
                 }
             }
@@ -1337,30 +1346,33 @@ impl BexHeap {
                 {
                     worklist.push(ptr);
                 }
-                if let Some(runtime) = &package.runtime {
-                    worklist.extend(
-                        runtime
-                            .objects
-                            .iter()
-                            .chain(runtime.object_names.values())
-                            .chain(runtime.type_values.values())
-                            .chain(runtime.dependencies.iter())
-                            .chain(runtime.dependency_names.values())
-                            .copied()
-                            .filter(|ptr| self.generation_of(*ptr).is_young()),
-                    );
-                    if let Some(ptr) = runtime.init
-                        && self.generation_of(ptr).is_young()
-                    {
-                        worklist.push(ptr);
+                match &package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        worklist.extend(
+                            runtime
+                                .objects
+                                .iter()
+                                .chain(runtime.object_names.values())
+                                .chain(runtime.type_values.values())
+                                .chain(runtime.dependencies.iter())
+                                .chain(runtime.dependency_names.values())
+                                .copied()
+                                .filter(|ptr| self.generation_of(*ptr).is_young()),
+                        );
+                        if let Some(ptr) = runtime.init
+                            && self.generation_of(ptr).is_young()
+                        {
+                            worklist.push(ptr);
+                        }
+                        worklist.extend(
+                            runtime
+                                .globals
+                                .iter()
+                                .filter_map(|slot| slot.load().as_object_ptr())
+                                .filter(|ptr| self.generation_of(*ptr).is_young()),
+                        );
                     }
-                    worklist.extend(
-                        runtime
-                            .globals
-                            .iter()
-                            .filter_map(|slot| slot.load().as_object_ptr())
-                            .filter(|ptr| self.generation_of(*ptr).is_young()),
-                    );
                 }
             }
             Object::Function(function) => {

--- a/baml_language/crates/bex_heap/tests/generational.rs
+++ b/baml_language/crates/bex_heap/tests/generational.rs
@@ -13,7 +13,7 @@ use bex_heap::{BexHeap, CollectionLevel, Generation, Tlab};
 use bex_vm_types::{
     Class, ClassField, GenericFunction, GlobalIndex, Object, RealizedTy,
     types::{
-        InterfaceDef, LocalName, MethodImpl, Package, RuntimeImplRule, RuntimePackage,
+        InterfaceDef, LocalName, MethodImpl, Package, PackageKind, RuntimeImplRule, RuntimePackage,
         TypeAliasDef, TypeValue,
     },
 };
@@ -118,7 +118,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
             interface_blob: Vec::new(),
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
+            kind: PackageKind::Runtime(Box::new(RuntimePackage {
                 objects: Box::new([]),
                 object_names: IndexMap::new(),
                 globals: Box::new([]),
@@ -130,7 +130,6 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
                 init: None,
                 initialized: true,
             })),
-            session: None,
         };
         let package_ptr = tlab.alloc(Object::Package(Box::new(package)));
         let class_name = QualifiedTypeName::local(Name::new("RuntimeClass"));
@@ -171,7 +170,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
             },
             class_ptr,
         );
-        let runtime = package.runtime.as_mut().expect("runtime image");
+        let runtime = package.runtime_mut().expect("runtime image");
         runtime.objects = vec![type_ptr, function_ptr, class_ptr].into_boxed_slice();
         runtime.type_values.insert(class_ptr, type_ptr);
         (tlab, package_ptr, function_ptr)
@@ -193,7 +192,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
         panic!("root ceased to be a package")
     };
     let moved_class = package.classes.values().next().copied().unwrap();
-    let moved_type = package.runtime.as_ref().unwrap().type_values[&moved_class];
+    let moved_type = package.runtime().unwrap().type_values[&moved_class];
     let Object::Type(type_value) = (unsafe { moved_type.get() }) else {
         panic!("package type value ceased to be a type")
     };
@@ -1048,8 +1047,7 @@ fn empty_package() -> Package {
         interface_blob: Vec::new(),
         test_init: None,
         mounted_types: IndexMap::new(),
-        runtime: None,
-        session: None,
+        kind: PackageKind::Static,
     }
 }
 

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -25,7 +25,8 @@ use bex_vm_types::{
     InitTail, RuntimeCompileArtifact, RuntimeCompileDiagnostic, RuntimeCompileMode,
     RuntimeCompileRequest, RuntimeDiagnosticSeverity, RuntimePackageMount,
     RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest, RuntimeSessionInitializer,
-    RuntimeSessionStep, RuntimeSourceSpan, SessionVisibleKind, SessionVisibleSymbol,
+    RuntimeSessionStep, RuntimeSessionStepKind, RuntimeSourceSpan, SessionVisibleKind,
+    SessionVisibleSymbol,
     bytecode::Instruction,
     relink::{IndexOperand, visit_object_operands},
 };
@@ -869,9 +870,7 @@ fn runtime_type_binding_parts(source: &str) -> Option<(String, &str)> {
 fn runtime_type_binding_prelude(bindings: &IndexMap<String, SessionVisibleSymbol>) -> String {
     let mut prelude = String::new();
     for symbol in bindings.values() {
-        if symbol.kind == SessionVisibleKind::TypeBinding
-            && let Some(type_value) = &symbol.type_value
-        {
+        if let SessionVisibleKind::TypeBinding { type_value } = &symbol.kind {
             let _ = writeln!(
                 prelude,
                 "type {} = unreflect({type_value});",
@@ -1145,7 +1144,6 @@ fn lower_session_submission(
             let symbol = SessionVisibleSymbol {
                 internal: internal(&name),
                 kind: SessionVisibleKind::Declaration,
-                type_value: None,
             };
             declaration_name_ranges.insert(range, symbol.internal.clone());
             declarations.insert(name, symbol);
@@ -1155,7 +1153,7 @@ fn lower_session_submission(
     let mut declaration_mapping = request
         .visible
         .iter()
-        .filter(|(_, symbol)| symbol.kind != SessionVisibleKind::Let)
+        .filter(|(_, symbol)| !matches!(symbol.kind, SessionVisibleKind::Let))
         .map(|(name, symbol)| (name.clone(), symbol.internal.clone()))
         .collect::<IndexMap<_, _>>();
     declaration_mapping.extend(
@@ -1259,11 +1257,12 @@ fn lower_session_submission(
     let mut active_type_bindings = request
         .visible
         .iter()
-        .filter(|(_, symbol)| symbol.kind == SessionVisibleKind::TypeBinding)
+        .filter(|(_, symbol)| matches!(symbol.kind, SessionVisibleKind::TypeBinding { .. }))
         .map(|(name, symbol)| (name.clone(), symbol.clone()))
         .collect::<IndexMap<_, _>>();
     let mut generated = declaration_source.clone();
     let mut steps = Vec::new();
+    let mut result_step = None;
 
     for (index, element) in elements.iter().enumerate() {
         let (node, wrapped_range, has_semicolon, is_statement) = match element {
@@ -1334,8 +1333,9 @@ fn lower_session_submission(
             let source = format!("let {backing_name} = {{\n{prelude}({operand})\n}}\n");
             let symbol = SessionVisibleSymbol {
                 internal: type_name,
-                kind: SessionVisibleKind::TypeBinding,
-                type_value: Some(backing_name.clone()),
+                kind: SessionVisibleKind::TypeBinding {
+                    type_value: backing_name.clone(),
+                },
             };
             (backing_name, source, None, Some((name, symbol)))
         } else {
@@ -1350,7 +1350,6 @@ fn lower_session_submission(
                 let symbol = SessionVisibleSymbol {
                     internal: internal_name.clone(),
                     kind: SessionVisibleKind::Let,
-                    type_value: None,
                 };
                 binding = Some((name, symbol));
                 internal_name
@@ -1362,7 +1361,8 @@ fn lower_session_submission(
                 .flatten()
                 .and_then(|(target, operator, rhs)| {
                     let symbol = request.visible.get(target)?;
-                    (symbol.kind == SessionVisibleKind::Let).then_some((symbol, operator, rhs))
+                    matches!(symbol.kind, SessionVisibleKind::Let)
+                        .then_some((symbol, operator, rhs))
                 });
             let (source, commit_global) = if let Some((target, operator, rhs)) = assignment {
                 let rhs = rewrite_identifiers(
@@ -1435,39 +1435,44 @@ fn lower_session_submission(
         generated.push_str(&step_source);
         let returns_value =
             index + 1 == elements.len() && !is_outer_let && !is_statement && !has_semicolon;
+        if returns_value {
+            result_step = Some(steps.len());
+        }
+        let kind = binding
+            .clone()
+            .map_or(RuntimeSessionStepKind::Expression, |(name, symbol)| {
+                RuntimeSessionStepKind::Binding {
+                    name,
+                    symbol,
+                    replay_source: step_source.clone(),
+                }
+            });
         steps.push(RuntimeSessionStep {
             global: format!("user.{generated_name}"),
             commit_global,
-            binding: binding.clone(),
-            replay_source: binding.as_ref().map(|_| step_source),
-            returns_value,
+            kind,
         });
         if let Some((name, symbol)) = binding {
             visible_mapping.insert(name.clone(), symbol.internal.clone());
-            if symbol.kind == SessionVisibleKind::TypeBinding {
+            if matches!(symbol.kind, SessionVisibleKind::TypeBinding { .. }) {
                 active_type_bindings.insert(name, symbol);
             }
         }
     }
 
-    if !steps.iter().any(|step| step.returns_value) {
+    if result_step.is_none() {
         let generated_name = format!("__baml_session_{sequence}_result");
         let step_source = format!("let {generated_name} = null\n");
         generated.push_str(&step_source);
+        result_step = Some(steps.len());
         steps.push(RuntimeSessionStep {
             global: format!("user.{generated_name}"),
             commit_global: None,
-            binding: None,
-            replay_source: None,
-            returns_value: true,
+            kind: RuntimeSessionStepKind::Expression,
         });
     }
-    let result_global = steps
-        .iter()
-        .find(|step| step.returns_value)
-        .expect("session lowering always has a result")
-        .global
-        .clone();
+    let result_step = result_step.expect("session lowering always has a result");
+    let result_global = steps[result_step].global.clone();
     Ok(LoweredSession {
         source: generated,
         artifact: RuntimeSessionCompileArtifact {
@@ -1475,6 +1480,7 @@ fn lower_session_submission(
             declaration_source,
             declarations,
             steps,
+            result_step: Some(result_step),
             initializers: Vec::new(),
         },
         result_global,
@@ -1942,17 +1948,17 @@ impl RuntimeCompiler for ProjectRuntimeCompiler {
             }
             session.artifact.initializers = initializers;
         }
-        // The public artifact still carries these as two independent `Option`s,
-        // so the pair splits here — once, at the boundary that demands it —
-        // rather than being threaded through the function as separate values.
-        let (session_artifact, session_lease) =
-            session.map_or((None, None), |s| (Some(s.artifact), Some(s.lease)));
+        let kind = session.map_or(bex_vm_types::ArtifactKind::Package, |session| {
+            bex_vm_types::ArtifactKind::Session {
+                meta: session.artifact,
+                lease: session.lease,
+            }
+        });
         Ok(RuntimeCompileArtifact {
             units,
             interface_blob,
             diagnostics,
-            session: session_artifact,
-            session_lease,
+            kind,
         })
     }
 }

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -1354,7 +1354,10 @@ fn lower_session_submission(
                 binding = Some((name, symbol));
                 internal_name
             } else {
-                format!("__baml_session_{sequence}_stmt_{index}")
+                // Synthetic step globals must live outside `internal()`'s
+                // namespace so a user binding such as `stmt_1` cannot mint
+                // the same name.
+                format!("__baml_stmt_{sequence}_{index}")
             };
             let assignment = is_statement
                 .then(|| assignment_parts(raw))
@@ -1461,7 +1464,9 @@ fn lower_session_submission(
     }
 
     if result_step.is_none() {
-        let generated_name = format!("__baml_session_{sequence}_result");
+        // This fallback must likewise be outside `internal()`'s namespace:
+        // otherwise a user binding called `result` collides with it.
+        let generated_name = format!("__baml_result_{sequence}");
         let step_source = format!("let {generated_name} = null\n");
         generated.push_str(&step_source);
         result_step = Some(steps.len());

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -123,7 +123,7 @@ impl<'vm> ImplResolver<'vm> {
             if let Some(rules) = package.impl_rules.get(&iface_ptr) {
                 pointers.extend(rules);
             }
-            if let Some(runtime) = &package.runtime {
+            if let Some(runtime) = package.runtime() {
                 packages.extend(runtime.dependencies.iter().copied());
             }
         }

--- a/baml_language/crates/bex_vm/src/package_load.rs
+++ b/baml_language/crates/bex_vm/src/package_load.rs
@@ -23,7 +23,10 @@ use baml_type::Name;
 use bex_heap::{BexHeap, Generation};
 use bex_vm_types::{
     GlobalIndex, HeapPtr, Object, ObjectIndex,
-    types::{LocalName, MethodImpl, Package, ProgramImplRule, ProgramPackage, RuntimeImplRule},
+    types::{
+        LocalName, MethodImpl, Package, PackageKind, ProgramImplRule, ProgramPackage,
+        RuntimeImplRule,
+    },
 };
 use indexmap::IndexMap;
 
@@ -427,8 +430,7 @@ fn fill_package_slots(
                 .test_init
                 .map(|index| heap.compile_time_ptr(index.into_raw())),
             mounted_types: IndexMap::new(),
-            runtime: None,
-            session: None,
+            kind: PackageKind::Static,
         };
         heap.set_compile_time_object(slots.package_slot, Object::Package(Box::new(package)));
         index

--- a/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
@@ -20,13 +20,14 @@ use baml_compiler_diagnostics::{
 use baml_type::{TyAttr, normalize, normalize::TypeContext};
 use bex_heap::TlabHolder;
 use bex_vm_types::{
-    AtomicValueSlot, HeapPtr, Interface, Object, RealizedTy, RuntimeCompileArtifact,
-    RuntimeSessionCompileArtifact, SessionEvalLease, Ty,
+    ArtifactKind, AtomicValueSlot, HeapPtr, Interface, Object, RealizedTy, RuntimeCompileArtifact,
+    RuntimeCompileArtifactSlot, RuntimeSessionCompileArtifact, RuntimeSessionStepKind,
+    SessionEvalLease, Ty,
     link::link_dynamic,
     relink::{IndexOperand, visit_object_operands},
     types::{
-        LocalName, MethodImpl, Package, RuntimeImplRule, RuntimePackage, SessionState, TypeValue,
-        Value,
+        LocalName, MethodImpl, Package, PackageKind, RuntimeImplRule, RuntimePackage, SessionState,
+        TypeValue, Value,
     },
 };
 use indexmap::IndexMap;
@@ -92,9 +93,6 @@ fn package_ptr(vm: &BexVm, value: Value) -> Result<HeapPtr, VmRustFnError> {
         }
         .into());
     };
-    if matches!(vm.get_object(wrapper_ptr), Object::Package(_)) {
-        return Ok(wrapper_ptr);
-    }
     let Object::Instance(wrapper) = vm.get_object(wrapper_ptr) else {
         return Err(VmBamlError::InvalidArgument {
             message: "reflect.Package receiver is not an instance".to_string(),
@@ -114,6 +112,39 @@ fn package_ptr(vm: &BexVm, value: Value) -> Result<HeapPtr, VmRustFnError> {
         .into());
     }
     Ok(ptr)
+}
+
+fn take_compile_artifact(
+    vm: &BexVm,
+    value: Value,
+    invalid_message: &str,
+    consumed_message: &str,
+) -> Result<RuntimeCompileArtifact, VmRustFnError> {
+    let Some(inner) = value
+        .as_object_ptr()
+        .and_then(|pointer| match vm.get_object(pointer) {
+            Object::Instance(instance) => Some(instance.load_field(0)),
+            _ => None,
+        })
+    else {
+        return Err(VmBamlError::InvalidArgument {
+            message: invalid_message.to_string(),
+        }
+        .into());
+    };
+    let slot = vm
+        .as_rust_data::<RuntimeCompileArtifactSlot>(&inner)
+        .map_err(|_| VmBamlError::InvalidArgument {
+            message: invalid_message.to_string(),
+        })?;
+    let mut slot = slot.lock().map_err(|_| VmBamlError::InvalidArgument {
+        message: format!("{invalid_message}: artifact state is unavailable"),
+    })?;
+    slot.take().ok_or_else(|| {
+        VmRustFnError::from(VmBamlError::InvalidArgument {
+            message: consumed_message.to_string(),
+        })
+    })
 }
 
 fn local_name(path: &str) -> Option<LocalName> {
@@ -152,12 +183,7 @@ fn stored_package_type(package: &Package, name: &LocalName) -> Option<HeapPtr> {
                 .get(name)
                 .or_else(|| package.enums.get(name))
                 .or_else(|| package.interfaces.get(name))?;
-            package
-                .runtime
-                .as_ref()?
-                .type_values
-                .get(declaration)
-                .copied()
+            package.runtime()?.type_values.get(declaration).copied()
         })
 }
 
@@ -394,7 +420,7 @@ fn package_function_value(vm: &mut BexVm, package_ptr: HeapPtr, name: &LocalName
         .collect::<Vec<_>>()
         .join(".");
     let (slot, runtime_package) = match vm.get_object(package_ptr) {
-        Object::Package(package) => match package.runtime.as_ref() {
+        Object::Package(package) => match package.runtime() {
             Some(runtime) => {
                 let slot = runtime
                     .global_names
@@ -563,8 +589,7 @@ impl Continuation for FinishPackage {
             unreachable!("finish continuation retained a Package")
         };
         package
-            .runtime
-            .as_mut()
+            .runtime_mut()
             .expect("runtime package has an image")
             .initialized = true;
         NativeCallResult::Done(Value::object(self.wrapper))
@@ -690,23 +715,21 @@ impl BamlClassPackage for PackageReflectImpl {
         artifact: &Value,
         packages: &IndexMap<bex_str::BexStr, Value>,
     ) -> NativeCallResult {
-        let Some(artifact_inner) =
-            artifact
-                .as_object_ptr()
-                .and_then(|ptr| match vm.get_object(ptr) {
-                    Object::Instance(instance) => Some(instance.load_field(0)),
-                    _ => None,
-                })
-        else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "reflect.Package._finish received an invalid artifact".to_string(),
-            })
-            .into();
-        };
-        let artifact = match vm.as_rust_data::<RuntimeCompileArtifact>(&artifact_inner) {
-            Ok(artifact) => artifact.clone(),
+        let artifact = match take_compile_artifact(
+            vm,
+            *artifact,
+            "reflect.Package._finish received an invalid artifact",
+            "Package compile artifact has already been consumed",
+        ) {
+            Ok(artifact) => artifact,
             Err(error) => return error.into(),
         };
+        if !matches!(&artifact.kind, ArtifactKind::Package) {
+            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                message: "reflect.Package._finish received a Session.eval artifact".to_string(),
+            })
+            .into();
+        }
         let plan = match link_dynamic(&artifact.units) {
             Ok(plan) => plan,
             Err(error) => {
@@ -755,7 +778,7 @@ impl BamlClassPackage for PackageReflectImpl {
             interface_blob: artifact.interface_blob,
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
+            kind: PackageKind::Runtime(Box::new(RuntimePackage {
                 objects: Box::new([]),
                 object_names: IndexMap::new(),
                 globals: Box::new([]),
@@ -767,7 +790,6 @@ impl BamlClassPackage for PackageReflectImpl {
                 init: None,
                 initialized: false,
             })),
-            session: None,
         };
         let package_ptr = vm.alloc(Object::Package(Box::new(package)));
 
@@ -886,7 +908,7 @@ impl BamlClassPackage for PackageReflectImpl {
                         else {
                             return None;
                         };
-                        if let Some(runtime) = package.runtime.as_ref() {
+                        if let Some(runtime) = package.runtime() {
                             let index = runtime
                                 .global_names
                                 .get(&format!("user.{local}"))
@@ -1010,7 +1032,7 @@ impl BamlClassPackage for PackageReflectImpl {
         package.impl_rules = impl_rules;
         package.functions = functions;
         package.test_init = test_init;
-        let runtime = package.runtime.as_mut().expect("runtime package image");
+        let runtime = package.runtime_mut().expect("runtime package image");
         runtime.objects = objects.into_boxed_slice();
         runtime.globals = globals.into_boxed_slice();
         runtime.global_names = global_names;
@@ -1038,7 +1060,7 @@ impl BamlClassPackage for PackageReflectImpl {
             let Object::Package(package) = vm.get_object_mut(package_ptr) else {
                 unreachable!()
             };
-            package.runtime.as_mut().expect("runtime image").initialized = true;
+            package.runtime_mut().expect("runtime image").initialized = true;
             NativeCallResult::Done(wrapper)
         }
     }
@@ -1330,8 +1352,7 @@ impl BamlClassPackage for PackageReflectImpl {
         };
         let diagnostics = match vm.get_object(ptr) {
             Object::Package(package) => package
-                .runtime
-                .as_ref()
+                .runtime()
                 .map(|runtime| runtime.diagnostics.clone())
                 .unwrap_or_default(),
             _ => Vec::new(),
@@ -1574,8 +1595,7 @@ fn session_external_object(
 ) -> Option<HeapPtr> {
     if let Object::Package(package) = vm.get_object(session)
         && let Some(pointer) = package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.object_names.get(name))
     {
         return Some(*pointer);
@@ -1593,7 +1613,7 @@ fn session_external_global(
     name: &str,
 ) -> Option<Value> {
     if let Object::Package(package) = vm.get_object(session)
-        && let Some(runtime) = package.runtime.as_ref()
+        && let Some(runtime) = package.runtime()
         && let Some(index) = runtime.global_names.get(name)
     {
         return runtime.load_global(*index);
@@ -1607,7 +1627,7 @@ fn session_external_global(
             let Object::Package(package) = vm.get_object(dependency) else {
                 return None;
             };
-            if let Some(runtime) = package.runtime.as_ref() {
+            if let Some(runtime) = package.runtime() {
                 let index = runtime
                     .global_names
                     .get(&format!("user.{local}"))
@@ -1667,23 +1687,27 @@ impl Continuation for SessionExecution {
             let Object::Package(package) = vm.get_object_mut(self.package) else {
                 unreachable!("Session continuation retained its package")
             };
-            let runtime = package.runtime.as_mut().expect("Session runtime image");
+            let PackageKind::Session { runtime, state } = &mut package.kind else {
+                unreachable!("Session continuation retained a Session package")
+            };
             runtime.globals[action.target].store(value);
 
             if let Some(step_index) = action.step {
                 let step = &self.metadata.steps[step_index];
-                let state = package.session.as_mut().expect("Session state");
-                if let Some(source) = &step.replay_source {
+                if let RuntimeSessionStepKind::Binding {
+                    name,
+                    symbol,
+                    replay_source,
+                } = &step.kind
+                {
                     state
                         .history
                         .entry(self.metadata.submission_name.clone())
                         .or_default()
-                        .push_str(source);
-                }
-                if let Some((name, symbol)) = &step.binding {
+                        .push_str(replay_source);
                     state.visible.insert(name.clone(), symbol.clone());
                 }
-                if step.returns_value {
+                if self.metadata.result_step == Some(step_index) {
                     self.result = value;
                 }
             }
@@ -1735,7 +1759,7 @@ fn graft_session_submission(
         let Object::Package(package) = vm.get_object(package_ptr) else {
             unreachable!("Session payload is a Package")
         };
-        let runtime = package.runtime.as_ref().expect("Session runtime image");
+        let runtime = package.runtime().expect("Session runtime image");
         (
             runtime.dependency_names.clone(),
             runtime.global_names.clone(),
@@ -1988,7 +2012,7 @@ fn graft_session_submission(
     // A session's earlier evals published their declarations under fully
     // qualified names; a later eval's type positions name them the same way.
     if let Object::Package(package) = vm.get_object(package_ptr)
-        && let Some(runtime) = package.runtime.as_ref()
+        && let Some(runtime) = package.runtime()
     {
         named_surfaces.extend(
             runtime
@@ -2103,7 +2127,9 @@ fn graft_session_submission(
             .extend(rules);
     }
     package.interface_blob.clone_from(&artifact.interface_blob);
-    let state = package.session.as_mut().expect("Session state");
+    let PackageKind::Session { runtime, state } = &mut package.kind else {
+        unreachable!("Session graft target changed package kind")
+    };
     if !metadata.declaration_source.trim().is_empty() {
         state.history.insert(
             metadata.submission_name.clone(),
@@ -2111,7 +2137,6 @@ fn graft_session_submission(
         );
     }
     state.visible.extend(metadata.declarations.clone());
-    let runtime = package.runtime.as_mut().expect("Session runtime image");
     let mut globals = runtime.globals.to_vec();
     globals.extend(appended.into_iter().map(AtomicValueSlot::new));
     runtime.globals = globals.into_boxed_slice();
@@ -2166,25 +2191,27 @@ impl BamlClassSession for PackageReflectImpl {
             interface_blob: Vec::new(),
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
-                objects: Box::new([]),
-                object_names: IndexMap::new(),
-                globals: Box::new([]),
-                global_names: IndexMap::new(),
-                type_values: IndexMap::new(),
-                diagnostics: Vec::new(),
-                dependencies: dependencies.values().copied().collect(),
-                dependency_names: dependencies,
-                init: None,
-                // Session cells intentionally stay mutable between evals.
-                initialized: false,
-            })),
-            session: Some(Box::new(SessionState {
-                history: IndexMap::new(),
-                visible: IndexMap::new(),
-                busy: Arc::new(AtomicBool::new(false)),
-                submission_counter: 0,
-            })),
+            kind: PackageKind::Session {
+                runtime: Box::new(RuntimePackage {
+                    objects: Box::new([]),
+                    object_names: IndexMap::new(),
+                    globals: Box::new([]),
+                    global_names: IndexMap::new(),
+                    type_values: IndexMap::new(),
+                    diagnostics: Vec::new(),
+                    dependencies: dependencies.values().copied().collect(),
+                    dependency_names: dependencies,
+                    init: None,
+                    // Session cells intentionally stay mutable between evals.
+                    initialized: false,
+                }),
+                state: Box::new(SessionState {
+                    history: IndexMap::new(),
+                    visible: IndexMap::new(),
+                    busy: Arc::new(AtomicBool::new(false)),
+                    submission_counter: 0,
+                }),
+            },
         };
         let package = vm.alloc(Object::Package(Box::new(package)));
         Ok(copy::Session {
@@ -2198,34 +2225,24 @@ impl BamlClassSession for PackageReflectImpl {
             Ok(package) => package,
             Err(error) => return error.into(),
         };
-        let Some(artifact_inner) =
-            artifact
-                .as_object_ptr()
-                .and_then(|pointer| match vm.get_object(pointer) {
-                    Object::Instance(instance) => Some(instance.load_field(0)),
-                    _ => None,
-                })
-        else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session._finish received an invalid artifact".to_string(),
-            })
-            .into();
-        };
-        let mut artifact = match vm.as_rust_data::<RuntimeCompileArtifact>(&artifact_inner) {
-            Ok(artifact) => artifact.clone(),
+        let mut artifact = match take_compile_artifact(
+            vm,
+            *artifact,
+            "Session._finish received an invalid artifact",
+            "Session artifact has already been consumed",
+        ) {
+            Ok(artifact) => artifact,
             Err(error) => return error.into(),
         };
-        let Some(metadata) = artifact.session.clone() else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session._finish received a Package.compile artifact".to_string(),
-            })
-            .into();
-        };
-        let Some(lease) = artifact.session_lease.take() else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session artifact has already been consumed".to_string(),
-            })
-            .into();
+        let kind = std::mem::replace(&mut artifact.kind, ArtifactKind::Package);
+        let (metadata, lease) = match kind {
+            ArtifactKind::Session { meta, lease } => (meta, lease),
+            ArtifactKind::Package => {
+                return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                    message: "Session._finish received a Package.compile artifact".to_string(),
+                })
+                .into();
+            }
         };
         let actions = match graft_session_submission(vm, package, &artifact, &metadata) {
             Ok(actions) => actions,
@@ -2255,8 +2272,7 @@ impl BamlClassSession for PackageReflectImpl {
         };
         let diagnostics = match vm.get_object(package) {
             Object::Package(package) => package
-                .runtime
-                .as_ref()
+                .runtime()
                 .map(|runtime| runtime.diagnostics.clone())
                 .unwrap_or_default(),
             _ => Vec::new(),

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2309,7 +2309,7 @@ impl BexVm {
             if baml_builtins2::stdlib_package_names().contains(&qtn.package().as_str()) {
                 return self.package(qtn.package());
             }
-            let runtime = current.runtime.as_ref()?;
+            let runtime = current.runtime()?;
             if let Some(dependency) = runtime.dependency_names.get(qtn.package().as_str()) {
                 return self.get_object(*dependency).as_package();
             }
@@ -2526,12 +2526,7 @@ impl BexVm {
         // The head *is* the key: a declaration this package created has an
         // entry, and one it merely imported or composed does not — which is
         // exactly the set that must reuse the created-once value.
-        let ptr = package
-            .runtime
-            .as_ref()?
-            .type_values
-            .get(&head.ptr())
-            .copied()?;
+        let ptr = package.runtime()?.type_values.get(&head.ptr()).copied()?;
         match self.get_object(ptr) {
             Object::Type(value) if &value.ty == ty => Some(ptr),
             _ => None,
@@ -2546,8 +2541,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.load_global(index.raw()))
             .expect("runtime global index was validated by dynamic link")
     }
@@ -2567,8 +2561,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         let runtime = package
-            .runtime
-            .as_ref()
+            .runtime()
             .expect("runtime function owner has a runtime image");
         if runtime.initialized {
             return Err(VmInternalError::StoreGlobalAfterInit);
@@ -2595,8 +2588,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.objects.get(idx.raw()))
             .copied()
             .expect("runtime object index was validated by dynamic link")

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -35,10 +35,11 @@ pub use indexable::{
 pub use link::LinkError;
 pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use runtime_compile::{
-    RuntimeCompileArtifact, RuntimeCompileDiagnostic, RuntimeCompileMode, RuntimeCompileRequest,
-    RuntimeDiagnosticSeverity, RuntimeMountedClass, RuntimeMountedEnum, RuntimeMountedFieldAttrs,
-    RuntimePackageMount, RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest,
-    RuntimeSessionInitializer, RuntimeSessionStep, RuntimeSourceSpan, RuntimeTypeMount,
+    ArtifactKind, RuntimeCompileArtifact, RuntimeCompileArtifactSlot, RuntimeCompileDiagnostic,
+    RuntimeCompileMode, RuntimeCompileRequest, RuntimeDiagnosticSeverity, RuntimeMountedClass,
+    RuntimeMountedEnum, RuntimeMountedFieldAttrs, RuntimePackageMount,
+    RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest, RuntimeSessionInitializer,
+    RuntimeSessionStep, RuntimeSessionStepKind, RuntimeSourceSpan, RuntimeTypeMount,
     SessionContract, SessionEvalLease, SessionVisibleKind, SessionVisibleSymbol,
 };
 pub use task_group::{TaskGroupInner, TaskGroupPermit, TaskGroupTicket};

--- a/baml_language/crates/bex_vm_types/src/runtime_compile.rs
+++ b/baml_language/crates/bex_vm_types/src/runtime_compile.rs
@@ -5,7 +5,7 @@
 //! compiler implementation is assembled in `bex_project`.
 
 use std::sync::{
-    Arc, Weak,
+    Arc, Mutex, Weak,
     atomic::{AtomicBool, Ordering},
 };
 
@@ -63,11 +63,11 @@ pub struct RuntimePackageMount {
 }
 
 /// The kind of a name retained in a Session's compile-time scope.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionVisibleKind {
     Declaration,
     Let,
-    TypeBinding,
+    TypeBinding { type_value: String },
 }
 
 /// One source-visible name and the hygienic name used in replayed source.
@@ -75,8 +75,6 @@ pub enum SessionVisibleKind {
 pub struct SessionVisibleSymbol {
     pub internal: String,
     pub kind: SessionVisibleKind,
-    /// Backing top-level value for a scoped runtime type binding.
-    pub type_value: Option<String>,
 }
 
 /// The `eval<T>` contract, spelled for the compiler's name-headed world.
@@ -122,12 +120,20 @@ pub struct RuntimeSessionStep {
     /// Existing Session cell to update after this initializer succeeds. `None`
     /// means the generated global itself receives the value.
     pub commit_global: Option<String>,
-    /// Source-visible binding committed by this step, if it is a `let`.
-    pub binding: Option<(String, SessionVisibleSymbol)>,
-    /// Replayed source fragment to append only after this step succeeds.
-    pub replay_source: Option<String>,
-    /// Whether this step is the submission's observable final expression.
-    pub returns_value: bool,
+    pub kind: RuntimeSessionStepKind,
+}
+
+/// The two legal commit shapes of a Session initializer step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeSessionStepKind {
+    Expression,
+    Binding {
+        /// Source-visible binding committed by this step.
+        name: String,
+        symbol: SessionVisibleSymbol,
+        /// Replayed source fragment appended only after this step succeeds.
+        replay_source: String,
+    },
 }
 
 /// Compiler-owned Session metadata retained after the fresh database drops.
@@ -138,6 +144,8 @@ pub struct RuntimeSessionCompileArtifact {
     pub declaration_source: String,
     pub declarations: IndexMap<String, SessionVisibleSymbol>,
     pub steps: Vec<RuntimeSessionStep>,
+    /// The step whose value is the submission's observable result.
+    pub result_step: Option<usize>,
     /// Current-submission initializer helpers in execution order. `helper_slot`
     /// addresses the anonymous helper-slot list retained in the pruned tail.
     pub initializers: Vec<RuntimeSessionInitializer>,
@@ -243,7 +251,7 @@ pub struct RuntimeCompileDiagnostic {
 }
 
 /// Successful compiler output retained by the runtime.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct RuntimeCompileArtifact {
     /// Relocatable user units. Builtin/dependency definitions remain imports.
     pub units: Vec<CompilationUnit>,
@@ -252,8 +260,19 @@ pub struct RuntimeCompileArtifact {
     pub interface_blob: Vec<u8>,
     /// Non-error diagnostics produced by the successful compilation.
     pub diagnostics: Vec<RuntimeCompileDiagnostic>,
-    /// Present only for `reflect.Session.eval`.
-    pub session: Option<RuntimeSessionCompileArtifact>,
-    /// S-9 permit transferred from the request to the successful artifact.
-    pub session_lease: Option<SessionEvalLease>,
+    pub kind: ArtifactKind,
 }
+
+/// Which runtime compilation door produced an artifact.
+#[derive(Debug)]
+pub enum ArtifactKind {
+    Package,
+    Session {
+        meta: RuntimeSessionCompileArtifact,
+        /// S-9 permit transferred from the request to the successful artifact.
+        lease: SessionEvalLease,
+    },
+}
+
+/// One-shot storage used by the BAML `CompileArtifact` wrapper.
+pub type RuntimeCompileArtifactSlot = Mutex<Option<RuntimeCompileArtifact>>;

--- a/baml_language/crates/bex_vm_types/src/types/package.rs
+++ b/baml_language/crates/bex_vm_types/src/types/package.rs
@@ -49,12 +49,55 @@ pub struct Package {
     /// Exact runtime type values attached by `Package.with_types`.
     #[borsh(skip)]
     pub mounted_types: IndexMap<String, HeapPtr>,
-    /// Present only for a package produced by `reflect.Package.compile`.
+    /// Runtime-only state, discriminated so a package cannot be both an
+    /// ordinary runtime package and a Session (or a Session without an image).
     #[borsh(skip)]
-    pub runtime: Option<Box<RuntimePackage>>,
-    /// Present only for the package-shaped payload owned by a Session.
-    #[borsh(skip)]
-    pub session: Option<Box<SessionState>>,
+    pub kind: PackageKind,
+}
+
+/// The three legal runtime shapes of a [`Package`].
+#[derive(Clone, Debug, Default)]
+pub enum PackageKind {
+    /// A package loaded from the serialized program image.
+    #[default]
+    Static,
+    /// A package produced by `reflect.Package.compile`.
+    Runtime(Box<RuntimePackage>),
+    /// The package-shaped runtime image and persistent state owned by a Session.
+    Session {
+        runtime: Box<RuntimePackage>,
+        state: Box<SessionState>,
+    },
+}
+
+impl Package {
+    pub fn runtime(&self) -> Option<&RuntimePackage> {
+        match &self.kind {
+            PackageKind::Static => None,
+            PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => Some(runtime),
+        }
+    }
+
+    pub fn runtime_mut(&mut self) -> Option<&mut RuntimePackage> {
+        match &mut self.kind {
+            PackageKind::Static => None,
+            PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => Some(runtime),
+        }
+    }
+
+    pub fn session(&self) -> Option<&SessionState> {
+        match &self.kind {
+            PackageKind::Session { state, .. } => Some(state),
+            PackageKind::Static | PackageKind::Runtime(_) => None,
+        }
+    }
+
+    pub fn session_mut(&mut self) -> Option<&mut SessionState> {
+        match &mut self.kind {
+            PackageKind::Session { state, .. } => Some(state),
+            PackageKind::Static | PackageKind::Runtime(_) => None,
+        }
+    }
 }
 
 /// Compiler-free persistent state of one `reflect.Session`.
@@ -103,7 +146,8 @@ pub struct RuntimePackage {
     pub dependency_names: IndexMap<String, HeapPtr>,
     /// The candidate `$init`, if one exists.
     pub init: Option<HeapPtr>,
-    /// False while `$init` may write package globals; true after commit.
+    /// False while `$init` may write package globals; true after commit. A
+    /// Session keeps this false because its globals remain mutable across evals.
     pub initialized: bool,
 }
 

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -34,7 +34,7 @@ impl io::IoClassReflectPackage for NativeSysOps {
         _files: indexmap::IndexMap<String, String>,
         _packages: indexmap::IndexMap<String, io::owned::reflect::Package>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         SysOpOutput::err(VmBamlError::Unsupported {
             message: "runtime compiler is not installed".to_string(),
         })
@@ -50,7 +50,7 @@ impl io::IoClassReflectSession for NativeSysOps {
         _source: String,
         _type_arg_0: ::sys_types::SapTy,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         SysOpOutput::err(VmBamlError::Unsupported {
             message: "runtime compiler is not installed".to_string(),
         })

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -985,7 +985,7 @@ impl io::IoClassReflectPackage for DefaultIoOps {
         _files: indexmap::IndexMap<String, String>,
         _packages: indexmap::IndexMap<String, io::owned::reflect::Package>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         // BexEngine intercepts this operation and delegates to its injected
         // RuntimeCompiler before the provider table is consulted.
         SysOpOutput::err(VmBamlError::Unsupported {
@@ -1003,7 +1003,7 @@ impl io::IoClassReflectSession for DefaultIoOps {
         _source: String,
         _type_arg_0: ::sys_types::SapTy,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         // BexEngine intercepts Session compilation for the same reason as
         // Package.compile: the concrete compiler is injected above sys_ops.
         SysOpOutput::err(VmBamlError::Unsupported {


### PR DESCRIPTION
B-1605 PR2 makes reflection runtime states explicit instead of representing them with unrelated option and boolean combinations.

It introduces a one-shot `CompileArtifact` boundary with package/session artifact kinds, discriminates static/runtime/session packages, and encodes session-visible symbols and evaluation steps with enums. Cross-kind and repeated artifact consumption now fail clearly.

`RuntimePackage::initialized` remains on shared runtime images and is documented as permanently false for Sessions, whose globals stay mutable across evals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-shot compile artifacts for package and session compilation.
  * Added validation to prevent artifact reuse or finishing artifacts with the wrong package or session.
  * Improved handling of static, runtime, and session package states.
  * Prevented generated session step names from colliding with user bindings.

* **Bug Fixes**
  * Sessions remain usable after rejected or completed compilation artifacts.

* **Tests**
  * Added coverage for artifact consumption, type mismatches, session recovery, and generated-name collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->