### PR TITLE
fix(compiler2): diagnose untyped empty containers

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
@@ -270,6 +270,8 @@ pub enum TirTypeError {
     /// Lowered to `Ty::Error` so it never reaches the canonical normalizer, which treats
     /// `Ty::Infer` as `unreachable!`.
     CannotInferType,
+    /// An ordinary inference variable remained unresolved at writeback.
+    TypeMustBeKnown { full_type: Ty },
     /// An associated-type projection references `member`, but the subject it
     /// projects through does not declare (or cannot declare) it as an
     /// associated type.
@@ -1167,6 +1169,13 @@ impl fmt::Display for TirTypeError {
             }
             TirTypeError::CannotInferType => {
                 write!(f, "type inference failed; write the type explicitly")
+            }
+            TirTypeError::TypeMustBeKnown { full_type } => {
+                write!(
+                    f,
+                    "type annotations needed\nfull type: `{}`",
+                    full_type.render_user_facing()
+                )
             }
             TirTypeError::UnknownAssociatedType { member, container } => {
                 write!(f, "unknown associated type `{member}` for {container}")

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -617,6 +617,15 @@ enum HoleAnchor {
     TypeRef(BodyTypeRefId),
 }
 
+/// Where an inference variable came from and the user-facing type that
+/// contains it. Writeback uses this to report unsolved variables before
+/// replacing them with the error sentinel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InferVarOrigin {
+    location: crate::diagnostics::DiagnosticLocation,
+    containing_type: Ty,
+}
+
 /// S17 pending diagnostic (engine-internal): arena-anchored, payload
 /// types interned (still var-carrying until finish); finalized into the
 /// shared vocabulary with PLAIN types at writeback. Short-lived and
@@ -1607,6 +1616,12 @@ struct InferenceContext<'db> {
     /// finalize reports E0147 `CannotInferType` there (rustc's E0282
     /// discipline) instead of leaking a bare `Infer` into lowering.
     hole_vars: Vec<(baml_type::interned::InferVar, HoleAnchor)>,
+    /// User-source origins for ordinary inference variables that require a
+    /// concrete solution. The order vector makes diagnostic selection stable
+    /// when several source variables unify into one unresolved class.
+    infer_var_origins: FxHashMap<baml_type::interned::InferVar, InferVarOrigin>,
+    infer_var_origin_order: Vec<baml_type::interned::InferVar>,
+    diagnosed_infer_vars: rustc_hash::FxHashSet<baml_type::interned::InferVar>,
     /// One lowering per written body annotation (rust-analyzer's
     /// discipline): the let rule, the pattern walk, and the backfill all
     /// read the SAME lowered type - and so the same instantiated hole
@@ -1748,6 +1763,9 @@ impl<'db> InferenceContext<'db> {
             throws_channels: vec![Vec::new()],
             pending_diags: Vec::new(),
             hole_vars: Vec::new(),
+            infer_var_origins: FxHashMap::default(),
+            infer_var_origin_order: Vec::new(),
+            diagnosed_infer_vars: rustc_hash::FxHashSet::default(),
             annotation_cache: FxHashMap::default(),
             canonical_cache: baml_type::normalize::InternedCanonicalCache::default(),
             member_probe_depth: 0,
@@ -2381,7 +2399,7 @@ impl<'db> InferenceContext<'db> {
                     None if elements.is_empty() => {
                         // `[]`: a list over a fresh element variable - the
                         // honest replacement for the EvolvingList sentinel.
-                        Ty::list(self.table.new_establishment_var_ty())
+                        self.untyped_empty_container_ty(expr, Ty::list)
                     }
                     None => {
                         let joined: Vec<Ty> = elements
@@ -2437,10 +2455,12 @@ impl<'db> InferenceContext<'db> {
                     // `checked_map_key`), so a key var has exactly one
                     // legal solution and leaving it open lets `m[0] = 1`
                     // silently solve `?K := int`.
-                    Ty::intern(TyKind::Map {
-                        key: Ty::string(),
-                        value: self.table.new_establishment_var_ty(),
-                        attr: TyAttr::default(),
+                    self.untyped_empty_container_ty(expr, |value| {
+                        Ty::intern(TyKind::Map {
+                            key: Ty::string(),
+                            value,
+                            attr: TyAttr::default(),
+                        })
                     })
                 } else {
                     let (keys, values): (Vec<Ty>, Vec<Ty>) = entries
@@ -2511,10 +2531,12 @@ impl<'db> InferenceContext<'db> {
                             attr: TyAttr::default(),
                         })
                     } else if fields.is_empty() {
-                        Ty::intern(TyKind::Map {
-                            key: Ty::string(),
-                            value: self.table.new_establishment_var_ty(),
-                            attr: TyAttr::default(),
+                        self.untyped_empty_container_ty(expr, |value| {
+                            Ty::intern(TyKind::Map {
+                                key: Ty::string(),
+                                value,
+                                attr: TyAttr::default(),
+                            })
                         })
                     } else {
                         let values: Vec<Ty> = fields
@@ -9825,6 +9847,54 @@ impl<'db> InferenceContext<'db> {
             .insert(expr, ResolvedPath { segments: steps });
     }
 
+    fn untyped_empty_container_ty(
+        &mut self,
+        expr: ExprId,
+        make_container: impl FnOnce(Ty) -> Ty,
+    ) -> Ty {
+        let slot = self.table.new_establishment_var_ty();
+        let TyKind::Infer { var: Some(var), .. } = slot.kind() else {
+            unreachable!("a fresh establishment variable must be an inference type");
+        };
+        let var = *var;
+        let containing_type = make_container(slot);
+        self.infer_var_origin_order.push(var);
+        self.infer_var_origins.insert(
+            var,
+            InferVarOrigin {
+                location: crate::diagnostics::DiagnosticLocation::Expr(expr),
+                containing_type: containing_type.clone(),
+            },
+        );
+        containing_type
+    }
+
+    fn take_unresolved_infer_diagnostics(
+        &mut self,
+    ) -> Vec<(crate::diagnostics::DiagnosticLocation, baml_type::Ty)> {
+        let mut diagnostics = Vec::new();
+        for var in std::mem::take(&mut self.infer_var_origin_order) {
+            let Some(origin) = self.infer_var_origins.remove(&var) else {
+                continue;
+            };
+            let Some(root) = self.table.unsolved_root_var(var) else {
+                continue;
+            };
+            let full_type = self.table.resolve_completely(&origin.containing_type);
+            if full_type.has_error() {
+                continue;
+            }
+            if !self.diagnosed_infer_vars.insert(root) {
+                continue;
+            }
+            diagnostics.push((
+                origin.location,
+                infer_to_diagnostic_unknown(&full_type).to_plain(),
+            ));
+        }
+        diagnostics
+    }
+
     fn finish(mut self) -> InferenceResult<'db> {
         // The fulfillment fixpoint: solve what FULL bounds determine,
         // attempt obligations, re-drive the deferred residue, repeat
@@ -9879,6 +9949,7 @@ impl<'db> InferenceContext<'db> {
         // BAML's only defaulting rule: an unconstrained EFFECT is `never`
         // (a value variable erases to Error instead - ruling 2).
         self.table.default_unsolved_effects_to_never();
+        let unresolved_infer_diagnostics = self.take_unresolved_infer_diagnostics();
         let throws = match self.declared_throws.clone() {
             // A closed clause IS the surface (declared wins, rule 1),
             // VERBATIM - the written member order is render fidelity
@@ -9995,6 +10066,14 @@ impl<'db> InferenceContext<'db> {
                 DiagnosticLocation, DiagnosticSeverity, TirDiagnostic, TirTypeError,
             };
             let mut diags: Vec<TirDiagnostic<'db>> = Vec::new();
+            for (location, full_type) in unresolved_infer_diagnostics {
+                diags.push(TirDiagnostic {
+                    error: TirTypeError::TypeMustBeKnown { full_type },
+                    severity: DiagnosticSeverity::Error,
+                    primary: location,
+                    related: Vec::new(),
+                });
+            }
             for (&expr, (expected, actual)) in &result.type_mismatches {
                 // rustc's tainted_by_errors discipline: a mismatch whose
                 // operand IS the error sentinel is a CASCADE of a reported
@@ -12086,6 +12165,20 @@ fn erase_infer(ty: &Ty) -> Ty {
         return Ty::error();
     }
     Ty::intern(ty.kind().map_children(erase_infer))
+}
+
+/// Replaces every unresolved inference node with the user-denotable top type
+/// while preserving the surrounding shape for diagnostics.
+fn infer_to_diagnostic_unknown(ty: &Ty) -> Ty {
+    if !ty.has_infer() {
+        return ty.clone();
+    }
+    if matches!(ty.kind(), TyKind::Infer { .. }) {
+        return Ty::intern(TyKind::Unknown {
+            attr: TyAttr::default(),
+        });
+    }
+    Ty::intern(ty.kind().map_children(infer_to_diagnostic_unknown))
 }
 
 /// A fresh literal widens to its base primitive at binding sites (the spec's

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/unify.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/unify.rs
@@ -134,6 +134,13 @@ impl InferenceTable {
         Ty::infer_var(var)
     }
 
+    /// Returns the canonical representative when `var`'s equivalence class
+    /// still lacks a solution.
+    pub fn unsolved_root_var(&mut self, var: InferVar) -> Option<InferVar> {
+        let root = self.vars.find(VarKey(var));
+        matches!(self.vars.probe_value(root), VarValue::Unknown).then_some(root.0)
+    }
+
     /// Whether `var`'s equivalence class contains an establishment var.
     pub fn is_establishment_var(&mut self, var: InferVar) -> bool {
         let root = self.vars.find(VarKey(var));
@@ -524,6 +531,21 @@ mod tests {
         let b = table.new_var_ty();
         assert_ne!(a, b);
         assert_eq!(table.shallow_resolve(&a), a);
+    }
+
+    #[test]
+    fn unsolved_root_var_tracks_equivalence_classes() {
+        let mut table = InferenceTable::new();
+        let a = table.new_var();
+        let b = table.new_var();
+        assert_ne!(table.unsolved_root_var(a), table.unsolved_root_var(b));
+
+        table.unify(&Ty::infer_var(a), &Ty::infer_var(b)).unwrap();
+        assert_eq!(table.unsolved_root_var(a), table.unsolved_root_var(b));
+
+        table.unify(&Ty::infer_var(a), &Ty::int()).unwrap();
+        assert_eq!(table.unsolved_root_var(a), None);
+        assert_eq!(table.unsolved_root_var(b), None);
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -392,6 +392,8 @@ pub enum DiagnosticId {
     /// declared interface bound, or any at all for a callable with nothing
     /// left to bind.
     ReflectSpecializationFailed,
+    /// An ordinary inference variable remained unresolved at writeback (E0155).
+    TypeMustBeKnown,
 }
 
 impl DiagnosticId {
@@ -601,6 +603,7 @@ impl DiagnosticId {
             // E0167 is owned by the always-constant-condition lint in #4498.
             DiagnosticId::RuntimeTypeMustBeNamed => "E0168",
             DiagnosticId::ReflectSpecializationFailed => "E0169",
+            DiagnosticId::TypeMustBeKnown => "E0155",
         }
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1603,6 +1603,7 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::BuiltinInterfaceNotABound { .. } => DiagnosticId::BuiltinInterfaceNotABound,
         // A `_` placeholder in a non-inferable position.
         TirTypeError::CannotInferType => DiagnosticId::WildcardTypeNotAllowed,
+        TirTypeError::TypeMustBeKnown { .. } => DiagnosticId::TypeMustBeKnown,
         // Generic-parameter / associated-type declaration hygiene.
         TirTypeError::TypeParamShadowedImplParam { .. } => DiagnosticId::TypeMismatch,
         TirTypeError::DuplicateGenericParam { .. }

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/constructors_invalid.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/constructors_invalid.baml
@@ -86,6 +86,14 @@ function Foo() -> Bar {
 //  7 │   let x = Bar { a: "hello", c: 12 };
 //    ·                             ─
 //    ╰────
+// E0155
+//
+//   × type annotations needed
+//   │ full type: `map<string, unknown>`
+//     ╭─[expr_constructors_invalid.baml:10:14]
+//  10 │     headers: {},
+//     ·              ──
+//     ╰────
 // E0003
 //
 //   × unresolved name: `a`

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/unresolved_builtin_namespace.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/expr/unresolved_builtin_namespace.baml
@@ -25,6 +25,14 @@ function TestBamlEventsTypo() -> void {
 //  4 │     baml.ev.send("test", {})
 //    ·     ────────────
 //    ╰────
+// E0155
+//
+//   × type annotations needed
+//   │ full type: `map<string, unknown>`
+//    ╭─[expr_unresolved_builtin_namespace.baml:4:26]
+//  4 │     baml.ev.send("test", {})
+//    ·                          ──
+//    ╰────
 // E0003
 //
 //   × unresolved name: `baml.lo.info`
@@ -45,4 +53,12 @@ function TestBamlEventsTypo() -> void {
 //     ╭─[expr_unresolved_builtin_namespace.baml:16:5]
 //  16 │     baml.event.send("test", {})
 //     ·     ───────────────
+//     ╰────
+// E0155
+//
+//   × type annotations needed
+//   │ full type: `map<string, unknown>`
+//     ╭─[expr_unresolved_builtin_namespace.baml:16:29]
+//  16 │     baml.event.send("test", {})
+//     ·                             ──
 //     ╰────

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/untyped_empty_containers/main.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/untyped_empty_containers/main.baml
@@ -1,0 +1,35 @@
+function fail() -> never throws string {
+    throw "boom"
+}
+
+function catch_array() -> null {
+    let values = fail() catch (e) {
+        string => []
+    };
+    for (let value in values) {
+        log.info(value)
+    }
+    null
+}
+
+function bare_array() -> null {
+    let values = [];
+    null
+}
+
+function bare_map() -> null {
+    let values = {};
+    null
+}
+
+function bare_map_constructor() -> null {
+    let values = map {  };
+    null
+}
+
+function contextual_types_are_enough() -> null {
+    let array: int[] = [];
+    let object_map: map<string, int> = {};
+    let constructor_map: map<string, int> = map {  };
+    null
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__05_diagnostics.snap
@@ -1328,6 +1328,15 @@ source: crates/baml_tests/src/generated_tests.rs
      ·                                                                    ╰── expected `string`, found `0`
      ╰────
 
+  [type] E0155
+
+  × type annotations needed
+  │ full type: `unknown[]`
+     ╭─[other_exprs.baml:101:5]
+ 101 │     [];
+     ·     ──
+     ╰────
+
   [validation] E0011
 
   × duplicate function `ManyParams`

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/untyped_empty_containers/baml_tests__diagnostic_errors__untyped_empty_containers__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/untyped_empty_containers/baml_tests__diagnostic_errors__untyped_empty_containers__03_ppir.snap
@@ -1,0 +1,22 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+function user.bare_array() -> null  [expr] {
+  { let values = [] } null
+}
+function user.bare_map() -> null  [expr] {
+  { let values = map {  } } null
+}
+function user.bare_map_constructor() -> null  [expr] {
+  { let values = map {  } } null
+}
+function user.catch_array() -> null  [expr] {
+  { let values = fail() catch (e) { string => [] }; for value in values {  } log.info(value) } null
+}
+function user.contextual_types_are_enough() -> null  [expr] {
+  { let array: int[] = []; let object_map: map<string, int> = map {  }; let constructor_map: map<string, int> = map {  } } null
+}
+function user.fail() -> never  [expr] {
+  { throw "boom" }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/untyped_empty_containers/baml_tests__diagnostic_errors__untyped_empty_containers__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/untyped_empty_containers/baml_tests__diagnostic_errors__untyped_empty_containers__05_diagnostics.snap
@@ -1,0 +1,39 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+  [type] E0155
+
+  × type annotations needed
+  │ full type: `unknown[]`
+   ╭─[main.baml:7:19]
+ 7 │         string => []
+   ·                   ──
+   ╰────
+
+  [type] E0155
+
+  × type annotations needed
+  │ full type: `unknown[]`
+    ╭─[main.baml:16:18]
+ 16 │     let values = [];
+    ·                  ──
+    ╰────
+
+  [type] E0155
+
+  × type annotations needed
+  │ full type: `map<string, unknown>`
+    ╭─[main.baml:21:18]
+ 21 │     let values = {};
+    ·                  ──
+    ╰────
+
+  [type] E0155
+
+  × type annotations needed
+  │ full type: `map<string, unknown>`
+    ╭─[main.baml:26:18]
+ 26 │     let values = map {  };
+    ·                  ────────
+    ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/untyped_empty_containers/baml_tests__diagnostic_errors__untyped_empty_containers__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/untyped_empty_containers/baml_tests__diagnostic_errors__untyped_empty_containers__10_formatter__main.snap
@@ -1,0 +1,38 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+function fail() -> never throws string {
+    throw "boom"
+}
+
+function catch_array() -> null {
+    let values = fail() catch (e) {
+        string => []
+    };
+    for (let value in values) {
+        log.info(value)
+    }
+    null
+}
+
+function bare_array() -> null {
+    let values = [];
+    null
+}
+
+function bare_map() -> null {
+    let values = {};
+    null
+}
+
+function bare_map_constructor() -> null {
+    let values = map {  };
+    null
+}
+
+function contextual_types_are_enough() -> null {
+    let array: int[] = [];
+    let object_map: map<string, int> = {};
+    let constructor_map: map<string, int> = map {  };
+    null
+}


### PR DESCRIPTION
Fixes B-1612. Tracks user-source origins for empty-container inference slots, reports E0155 with the unresolved container shape during writeback, and keeps MIR conversion strict. Adds native BAML diagnostics and contextual-typing coverage for catch arms, arrays, and maps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for unresolved types, including empty arrays and maps.
  * Added a clear “type annotations needed” error with diagnostic code E0155.
  * Prevented unresolved type information from being silently discarded.
  * Empty containers now provide actionable feedback when their types cannot be inferred.
* **Tests**
  * Added coverage for untyped empty containers, contextual type annotations, error handling, and unresolved container types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->