### PR TITLE
Allow unreflect in any type position

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/reflect/reflect.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/reflect/reflect.baml
@@ -187,6 +187,11 @@ class InvalidArgumentError {
   got reflect.Type
 }
 
+/// One-shot compiler output consumed by Package._finish or Session._finish.
+class CompileArtifact {
+  _inner unknown
+}
+
 /// An isolated runtime-compiled package.
 class Package {
   _inner unknown
@@ -201,13 +206,13 @@ class Package {
     Package._finish(artifact, packages)
   }
 
-  function _compile(files: map<string, string>, packages: map<string, Package>) -> Package throws reflect.errors.CompilationError {
+  function _compile(files: map<string, string>, packages: map<string, Package>) -> CompileArtifact throws reflect.errors.CompilationError {
     $rust_io_function
   }
 
   //baml:mut_vm
   //baml:may_yield
-  function _finish(artifact: Package, packages: map<string, Package>) -> Package throws unknown {
+  function _finish(artifact: CompileArtifact, packages: map<string, Package>) -> Package throws unknown {
     $rust_function
   }
 
@@ -297,13 +302,13 @@ class Session {
     }
   }
 
-  function _compile<T>(self, source: string) -> Package throws reflect.errors.CompilationError | reflect.errors.SessionBusy {
+  function _compile<T>(self, source: string) -> CompileArtifact throws reflect.errors.CompilationError | reflect.errors.SessionBusy {
     $rust_io_function
   }
 
   //baml:mut_vm
   //baml:may_yield
-  function _finish<T>(self, artifact: Package) -> T throws unknown {
+  function _finish<T>(self, artifact: CompileArtifact) -> T throws unknown {
     $rust_function
   }
 

--- a/baml_language/crates/baml_builtins2/baml_std/reflect/type.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/reflect/type.baml
@@ -31,8 +31,9 @@ class Type {
     function optional(self) -> reflect.union.Type throws never { $rust_function }
 
     /// Render deterministic canonical BAML source for this definition.
-    //baml:vm
-    function to_baml(self) -> string throws never { $rust_function }
+    /// Non-equivalent declarations with the same display name are rejected.
+    //baml:mut_vm
+    function to_baml(self) -> string throws reflect.errors.CompilationError { $rust_function }
 
     /// Returns the precise kind view of this type value: a freshly
     /// allocated view instance wrapping the receiver in its `_ty` field.

--- a/baml_language/crates/baml_builtins2_codegen/src/extract.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/extract.rs
@@ -923,6 +923,7 @@ fn type_expr_to_baml_type(ty: &TypeExpr, generics: &[String]) -> BamlType {
         TypeExprKind::Literal { .. } => BamlType::Named("literal".to_string()),
         TypeExprKind::Function { .. } => BamlType::Named("function".to_string()),
         TypeExprKind::AssociatedTypeProjection { .. }
+        | TypeExprKind::Unreflect { .. }
         | TypeExprKind::BuiltinUnknown { .. }
         | TypeExprKind::Unknown { .. }
         | TypeExprKind::Error { .. }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_reflect_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_reflect_package_listing.snap
@@ -13,10 +13,11 @@ interface        reflect.AnyFunction              <builtin>/reflect/reflect.baml
 interface        reflect.AnyClass                 <builtin>/reflect/reflect.baml:73
 class            reflect.Signature                <builtin>/reflect/reflect.baml:162
 class            reflect.InvalidArgumentError     <builtin>/reflect/reflect.baml:184
-class            reflect.Package                  <builtin>/reflect/reflect.baml:191
-class            reflect.Session                  <builtin>/reflect/reflect.baml:281
-function         reflect.signature                <builtin>/reflect/reflect.baml:323
-function         reflect.call_any                 <builtin>/reflect/reflect.baml:339
+class            reflect.CompileArtifact          <builtin>/reflect/reflect.baml:191
+class            reflect.Package                  <builtin>/reflect/reflect.baml:196
+class            reflect.Session                  <builtin>/reflect/reflect.baml:286
+function         reflect.signature                <builtin>/reflect/reflect.baml:328
+function         reflect.call_any                 <builtin>/reflect/reflect.baml:344
 class            reflect.Type                     <builtin>/reflect/type.baml:8
 class            reflect.array.Type               <builtin>/reflect/ns_array/array.baml:2
 class            reflect.class.Field              <builtin>/reflect/ns_class/class.baml:1

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -38,6 +38,13 @@ pub struct RawAttributeArg {
 /// happens once during `lower_file` and is never repeated.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeExprKind {
+    /// A runtime type atom. Body-owned occurrences carry the carrier expression
+    /// in the enclosing body's arena. Declaration-owned occurrences have no
+    /// body arena and keep `None`; the declaration checker diagnoses them.
+    Unreflect {
+        operand: Option<ExprId>,
+        attrs: Vec<RawAttribute>,
+    },
     /// Named type path: `User`, `baml.http.Request`, `Stream<T>`
     Path {
         segments: Vec<Name>,
@@ -189,23 +196,6 @@ impl std::ops::Deref for TypeExpr {
     }
 }
 
-/// One explicit generic argument at an expression call site.
-///
-/// Static arguments retain the existing type grammar. `Unreflect` is a
-/// contextual whole-argument marker whose operand is an ordinary expression
-/// in the enclosing body arena; it is never a type-expression atom.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TypeArg {
-    Static(TypeExpr),
-    Unreflect(ExprId),
-}
-
-impl From<TypeExpr> for TypeArg {
-    fn from(value: TypeExpr) -> Self {
-        Self::Static(value)
-    }
-}
-
 impl std::ops::DerefMut for TypeExpr {
     fn deref_mut(&mut self) -> &mut TypeExprKind {
         &mut self.kind
@@ -227,13 +217,72 @@ impl TypeExpr {
         self.span = span;
         self
     }
+
+    /// Append every runtime carrier nested in this type, in source order.
+    pub fn unreflect_operands(&self, out: &mut Vec<ExprId>) {
+        match &self.kind {
+            TypeExprKind::Unreflect {
+                operand: Some(operand),
+                ..
+            } => out.push(*operand),
+            TypeExprKind::Unreflect { operand: None, .. } => {}
+            TypeExprKind::Path {
+                generic_args,
+                associated_type_bindings,
+                ..
+            } => {
+                for arg in generic_args {
+                    arg.unreflect_operands(out);
+                }
+                for binding in associated_type_bindings {
+                    binding.ty.unreflect_operands(out);
+                }
+            }
+            TypeExprKind::AssociatedTypeProjection {
+                base, interface, ..
+            } => {
+                base.unreflect_operands(out);
+                if let Some(interface) = interface {
+                    interface.unreflect_operands(out);
+                }
+            }
+            TypeExprKind::Optional { inner, .. } | TypeExprKind::List { inner, .. } => {
+                inner.unreflect_operands(out);
+            }
+            TypeExprKind::Map { key, value, .. } => {
+                key.unreflect_operands(out);
+                value.unreflect_operands(out);
+            }
+            TypeExprKind::Union { variants, .. } => {
+                for variant in variants {
+                    variant.unreflect_operands(out);
+                }
+            }
+            TypeExprKind::Function {
+                params,
+                ret,
+                throws,
+                ..
+            } => {
+                for param in params {
+                    param.ty.unreflect_operands(out);
+                }
+                ret.unreflect_operands(out);
+                if let Some(throws) = throws {
+                    throws.unreflect_operands(out);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 impl TypeExprKind {
     /// Access the type-level attributes on this type expression.
     pub fn attrs(&self) -> &[RawAttribute] {
         match self {
-            Self::Path { attrs, .. }
+            Self::Unreflect { attrs, .. }
+            | Self::Path { attrs, .. }
             | Self::AssociatedTypeProjection { attrs, .. }
             | Self::Int { attrs }
             | Self::Bigint { attrs }
@@ -263,7 +312,8 @@ impl TypeExprKind {
     /// Mutable access to the type-level attributes on this type expression.
     pub fn attrs_mut(&mut self) -> &mut Vec<RawAttribute> {
         match self {
-            Self::Path { attrs, .. }
+            Self::Unreflect { attrs, .. }
+            | Self::Path { attrs, .. }
             | Self::AssociatedTypeProjection { attrs, .. }
             | Self::Int { attrs }
             | Self::Bigint { attrs }
@@ -315,6 +365,7 @@ impl std::fmt::Display for TypeExprKind {
         }
 
         match self {
+            TypeExprKind::Unreflect { .. } => write!(f, "unreflect(…)"),
             TypeExprKind::Path {
                 segments,
                 generic_args,
@@ -567,15 +618,7 @@ impl ExprBody {
                 let ty_args_str = if type_args.is_empty() {
                     String::new()
                 } else {
-                    let tys: Vec<_> = type_args
-                        .iter()
-                        .map(|arg| match arg {
-                            TypeArg::Static(ty) => ty.to_string(),
-                            TypeArg::Unreflect(expr) => {
-                                format!("unreflect({})", self.display_expr_inner(*expr, depth + 1))
-                            }
-                        })
-                        .collect();
+                    let tys: Vec<_> = type_args.iter().map(ToString::to_string).collect();
                     format!("<{}>", tys.join(", "))
                 };
                 let args_str: Vec<_> = args
@@ -965,7 +1008,7 @@ pub enum Expr {
         callee: ExprId,
         /// Explicit type arguments at the call site, e.g. `foo<int, string>(x)`.
         /// Empty vec when no `<...>` was written.
-        type_args: Vec<TypeArg>,
+        type_args: Vec<TypeExpr>,
         args: Vec<CallArg>,
     },
     Object {
@@ -1174,7 +1217,7 @@ pub enum Stmt {
     /// lexical type parameter for the remainder of the enclosing block.
     TypeBinding {
         name: Name,
-        value: ExprId,
+        value: TypeExpr,
     },
     Let {
         /// The binding pattern. A `: T` annotation lives inside the pattern

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -281,6 +281,10 @@ mod tests {
         }
 
         let __stripped = match &expr.kind {
+            TypeExprKind::Unreflect { operand, attrs } => TypeExprKind::Unreflect {
+                operand: *operand,
+                attrs: strip_attrs(attrs),
+            },
             TypeExprKind::Int { attrs } => TypeExprKind::Int {
                 attrs: strip_attrs(attrs),
             },
@@ -470,9 +474,16 @@ mod tests {
             .exprs
             .iter()
             .find_map(|(_, expr)| match expr {
-                Expr::Call { type_args, .. } => type_args.iter().find_map(|arg| match arg {
-                    crate::ast::TypeArg::Unreflect(operand) => Some(*operand),
-                    crate::ast::TypeArg::Static(_) => None,
+                Expr::Call { type_args, .. } => type_args.iter().find_map(|arg| {
+                    if let TypeExprKind::Unreflect {
+                        operand: Some(operand),
+                        ..
+                    } = &arg.kind
+                    {
+                        Some(*operand)
+                    } else {
+                        None
+                    }
                 }),
                 _ => None,
             })
@@ -481,6 +492,21 @@ mod tests {
             matches!(&body.exprs[operand], Expr::Path(path) if path.len() == 1 && path[0].as_str() == "t"),
             "unreflect operand lowered as {:?}",
             body.exprs[operand]
+        );
+    }
+
+    #[test]
+    fn nested_unreflect_type_arguments_allocate_each_carrier_once() {
+        let function = first_function(parse_and_lower(
+            "function main(t: reflect.Type) -> reflect.Type { return reflect.Type.of<unreflect(make<unreflect(t)>())>() }",
+        ));
+        let Some(crate::ast::FunctionBodyDef::Expr(_, source_map)) = function.body else {
+            panic!("expected expression body")
+        };
+        assert_eq!(
+            source_map.unreflect_arg_spans.len(),
+            2,
+            "the outer call operand and nested type operand must each be lowered exactly once"
         );
     }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -1186,12 +1186,13 @@ impl LoweringContext {
         }
     }
 
-    /// Lower a type written inside this body, allocating each runtime carrier
-    /// into the body's expression arena before attaching it to the type atom.
-    fn lower_body_type_expr(
+    /// Allocate each runtime carrier in `type_expr` into this body's expression
+    /// arena, then attach those expression ids to the already-lowered type.
+    fn attach_body_type_operands(
         &mut self,
         type_expr: &baml_compiler_syntax::ast::TypeExpr,
-    ) -> TypeExpr {
+        ty: &mut TypeExpr,
+    ) {
         let mut operands = std::collections::HashMap::new();
         let mut preorder = type_expr.syntax().preorder();
         while let Some(event) = preorder.next() {
@@ -1210,8 +1211,17 @@ impl LoweringContext {
             // arguments inside it. Do not allocate those nested carriers again.
             preorder.skip_subtree();
         }
+        Self::attach_unreflect_operands(ty, &operands);
+    }
+
+    /// Lower a type written inside this body, allocating each runtime carrier
+    /// into the body's expression arena before attaching it to the type atom.
+    fn lower_body_type_expr(
+        &mut self,
+        type_expr: &baml_compiler_syntax::ast::TypeExpr,
+    ) -> TypeExpr {
         let mut ty = crate::lower_type_expr::lower_type_expr_node(type_expr, &mut self.diags);
-        Self::attach_unreflect_operands(&mut ty, &operands);
+        self.attach_body_type_operands(type_expr, &mut ty);
         ty
     }
 
@@ -2803,7 +2813,14 @@ impl LoweringContext {
             .flat_map(|args_node| args_node.children())
             .filter_map(baml_compiler_syntax::ast::AssociatedTypeDecl::cast)
             .filter_map(|binding| {
-                crate::lower_type_expr::lower_associated_type_binding(&binding, &mut self.diags)
+                let mut lowered = crate::lower_type_expr::lower_associated_type_binding(
+                    &binding,
+                    &mut self.diags,
+                )?;
+                if let Some(ty) = binding.default_or_binding() {
+                    self.attach_body_type_operands(&ty, &mut lowered.ty);
+                }
+                Some(lowered)
             })
             .collect();
 
@@ -5170,7 +5187,7 @@ impl LoweringContext {
         // recovery and ignored here — `LambdaDef` has nowhere to put them.
 
         // Lower parameter list — gives us Vec<Param>
-        let (params, defaults) = node
+        let (mut params, defaults) = node
             .children()
             .find(|n| n.kind() == SyntaxKind::PARAMETER_LIST)
             .and_then(ast::ParameterList::cast)
@@ -5185,6 +5202,24 @@ impl LoweringContext {
                 )
             })
             .unwrap_or_else(|| (Vec::new(), FunctionDefaults::empty()));
+
+        if let Some(parameter_list) = node
+            .children()
+            .find(|n| n.kind() == SyntaxKind::PARAMETER_LIST)
+            .and_then(ast::ParameterList::cast)
+        {
+            for parameter in parameter_list.params() {
+                let Some(type_expr) = parameter.ty() else {
+                    continue;
+                };
+                let span = parameter.syntax().span_range();
+                if let Some(lowered) = params.iter_mut().find(|param| param.span == span)
+                    && let Some(lowered_ty) = &mut lowered.type_expr
+                {
+                    self.attach_body_type_operands(&type_expr, lowered_ty);
+                }
+            }
+        }
 
         // Lower optional return type: the TYPE_EXPR that is a direct child of the
         // lambda node, appearing after PARAMETER_LIST but before THROWS_CLAUSE/BLOCK_EXPR.

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -17,8 +17,8 @@ use crate::{
         CatchClauseKind, DefaultExprId, Expr, ExprBody, ExprId, FieldPat, FunctionDefaults,
         LambdaDef, LambdaKind, LetDef, LetOrigin, Literal, LoopOrigin, MapExprEntry, MatchArm,
         MatchArmId, ObjectExprField, Param, PatId, Pattern, SpreadField, Stmt, StmtId,
-        TemplateIfBranch, TemplateSegment, TemplateTag, TypeAnnotId, TypeArg, TypeExpr,
-        TypeExprKind, UnaryOp,
+        TemplateIfBranch, TemplateSegment, TemplateTag, TypeAnnotId, TypeExpr, TypeExprKind,
+        UnaryOp,
     },
 };
 
@@ -100,33 +100,6 @@ fn find_callee_generic_args(callee_node: &SyntaxNode) -> Option<SyntaxNode> {
         }
         _ => None,
     }
-}
-
-/// Read back what the author wrote around an `unreflect(...)` type-argument
-/// slot, so an E0167 report can spell the fix in their own source rather than
-/// a reconstruction. `expr` must contain `slot`; anything else degrades to the
-/// generic suggestion.
-fn unreflect_rewrite(
-    expr: &SyntaxNode,
-    slot: &SyntaxNode,
-) -> baml_compiler_diagnostics::runtime_type::RuntimeTypeNameRewrite {
-    use baml_compiler_diagnostics::runtime_type::RuntimeTypeNameRewrite;
-
-    let expr_range = expr.span_range();
-    let slot_range = slot.span_range();
-    if !expr_range.contains_range(slot_range) {
-        return RuntimeTypeNameRewrite::default();
-    }
-    let node_text = expr.text().to_string();
-    let base = usize::from(expr.text_range().start());
-    let Some(written) =
-        node_text.get(usize::from(expr_range.start()) - base..usize::from(expr_range.end()) - base)
-    else {
-        return RuntimeTypeNameRewrite::default();
-    };
-    let start = usize::from(slot_range.start() - expr_range.start());
-    let end = usize::from(slot_range.end() - expr_range.start());
-    RuntimeTypeNameRewrite::from_source(written, start..end)
 }
 
 /// Lower a CST `ExprFunctionBody` to an owned `ExprBody` + parallel `AstSourceMap`.
@@ -863,7 +836,7 @@ pub(crate) fn synthesize_spec_parse_body(
     let call = ctx.alloc_expr(
         Expr::Call {
             callee,
-            type_args: out_type.map(|t| vec![t.into()]).unwrap_or_default(),
+            type_args: out_type.map(|t| vec![t]).unwrap_or_default(),
             args: vec![CallArg::positional(json_ref)],
         },
         span,
@@ -1009,7 +982,7 @@ pub fn synthesize_spec_stream_body(
     let call = ctx.alloc_expr(
         Expr::Call {
             callee: stream_spec_callee,
-            type_args: type_args.into_iter().map(Into::into).collect(),
+            type_args,
             args: vec![
                 CallArg::positional(spec_call),
                 CallArg::named("client", client_ref),
@@ -1026,7 +999,7 @@ pub fn synthesize_spec_stream_body(
 /// Re-apply a companion's enclosing generic parameters when it calls another
 /// companion. Some LLM type parameters occur only in the return type, so
 /// ordinary argument inference has no value-position evidence for them.
-fn static_type_args(names: &[Name], span: TextRange) -> Vec<TypeArg> {
+fn static_type_args(names: &[Name], span: TextRange) -> Vec<TypeExpr> {
     names
         .iter()
         .map(|name| {
@@ -1037,7 +1010,6 @@ fn static_type_args(names: &[Name], span: TextRange) -> Vec<TypeArg> {
                 attrs: vec![],
             }
             .at(span)
-            .into()
         })
         .collect()
 }
@@ -1126,6 +1098,121 @@ impl LoweringContext {
             consumed_generic_args: std::collections::HashSet::new(),
             synthesizing: false,
         }
+    }
+
+    fn lower_unreflect_operand(&mut self, node: &SyntaxNode) -> ExprId {
+        node.children()
+            .next()
+            .map(|expr| self.lower_expr(&expr))
+            .or_else(|| {
+                let mut skipped_marker = false;
+                node.children_with_tokens()
+                    .filter_map(rowan::NodeOrToken::into_token)
+                    .find(|token| {
+                        if token.kind().is_trivia()
+                            || matches!(token.kind(), SyntaxKind::L_PAREN | SyntaxKind::R_PAREN)
+                        {
+                            return false;
+                        }
+                        if !skipped_marker && token.text() == "unreflect" {
+                            skipped_marker = true;
+                            return false;
+                        }
+                        true
+                    })
+                    .map(|token| {
+                        let expr = lower_bare_token_expr(self, &token);
+                        self.alloc_expr(expr, token.text_range())
+                    })
+            })
+            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.span_range()))
+    }
+
+    fn attach_unreflect_operands(
+        ty: &mut TypeExpr,
+        operands: &std::collections::HashMap<TextRange, ExprId>,
+    ) {
+        match &mut ty.kind {
+            TypeExprKind::Unreflect { operand, .. } => {
+                *operand = operands.get(&ty.span).copied();
+            }
+            TypeExprKind::Path {
+                generic_args,
+                associated_type_bindings,
+                ..
+            } => {
+                for arg in generic_args {
+                    Self::attach_unreflect_operands(arg, operands);
+                }
+                for binding in associated_type_bindings {
+                    Self::attach_unreflect_operands(&mut binding.ty, operands);
+                }
+            }
+            TypeExprKind::AssociatedTypeProjection {
+                base, interface, ..
+            } => {
+                Self::attach_unreflect_operands(base, operands);
+                if let Some(interface) = interface {
+                    Self::attach_unreflect_operands(interface, operands);
+                }
+            }
+            TypeExprKind::Optional { inner, .. } | TypeExprKind::List { inner, .. } => {
+                Self::attach_unreflect_operands(inner, operands);
+            }
+            TypeExprKind::Map { key, value, .. } => {
+                Self::attach_unreflect_operands(key, operands);
+                Self::attach_unreflect_operands(value, operands);
+            }
+            TypeExprKind::Union { variants, .. } => {
+                for variant in variants {
+                    Self::attach_unreflect_operands(variant, operands);
+                }
+            }
+            TypeExprKind::Function {
+                params,
+                ret,
+                throws,
+                ..
+            } => {
+                for param in params {
+                    Self::attach_unreflect_operands(&mut param.ty, operands);
+                }
+                Self::attach_unreflect_operands(ret, operands);
+                if let Some(throws) = throws {
+                    Self::attach_unreflect_operands(throws, operands);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Lower a type written inside this body, allocating each runtime carrier
+    /// into the body's expression arena before attaching it to the type atom.
+    fn lower_body_type_expr(
+        &mut self,
+        type_expr: &baml_compiler_syntax::ast::TypeExpr,
+    ) -> TypeExpr {
+        let mut operands = std::collections::HashMap::new();
+        let mut preorder = type_expr.syntax().preorder();
+        while let Some(event) = preorder.next() {
+            let rowan::WalkEvent::Enter(node) = event else {
+                continue;
+            };
+            if node.kind() != SyntaxKind::UNREFLECT_TYPE {
+                continue;
+            }
+            let operand = self.lower_unreflect_operand(&node);
+            self.source_map
+                .unreflect_arg_spans
+                .insert(operand, node.span_range());
+            operands.insert(node.span_range(), operand);
+            // Lowering this outer operand recursively lowers any unreflect type
+            // arguments inside it. Do not allocate those nested carriers again.
+            preorder.skip_subtree();
+        }
+        let mut ty = crate::lower_type_expr::lower_type_expr_node(type_expr, &mut self.diags);
+        Self::attach_unreflect_operands(&mut ty, &operands);
+        ty
     }
 
     fn warn_const_introducer(&mut self, span: TextRange) {
@@ -2302,10 +2389,7 @@ impl LoweringContext {
                             baml_compiler_syntax::ast::TypeExpr::cast(child.clone())
                         {
                             let span = child.span_range();
-                            let ty = crate::lower_type_expr::lower_type_expr_node(
-                                &type_expr,
-                                &mut self.diags,
-                            );
+                            let ty = self.lower_body_type_expr(&type_expr);
                             scrutinee_type = Some(self.alloc_type_annot(ty, span));
                         }
                     }
@@ -2522,7 +2606,6 @@ impl LoweringContext {
             SyntaxKind::DESTRUCTURE_PATTERN => self.lower_destructure_pattern(node),
             SyntaxKind::ARRAY_PATTERN => self.lower_array_pattern(node),
             SyntaxKind::TYPE_PATTERN => self.lower_type_pattern(node),
-            SyntaxKind::UNREFLECT_PATTERN => self.lower_unreflect_pattern(node),
             SyntaxKind::PAREN_PATTERN => {
                 match node.children().find(|n| n.kind() == SyntaxKind::PATTERN) {
                     Some(inner) => self.lower_pattern(&inner),
@@ -2664,27 +2747,16 @@ impl LoweringContext {
         else {
             return self.alloc_pattern(Pattern::Wildcard, node.span_range());
         };
-        let ty = crate::lower_type_expr::lower_type_expr_node(&type_expr, &mut self.diags);
-        self.alloc_pattern(Pattern::Type(ty), node.span_range())
-    }
-
-    fn lower_unreflect_pattern(&mut self, node: &SyntaxNode) -> PatId {
-        let operand = node
-            .children()
-            .next()
-            .map(|expr| self.lower_expr(&expr))
-            .or_else(|| {
-                node.children_with_tokens()
-                    .filter_map(rowan::NodeOrToken::into_token)
-                    .find(|token| {
-                        !token.kind().is_trivia()
-                            && !matches!(token.kind(), SyntaxKind::L_PAREN | SyntaxKind::R_PAREN)
-                            && token.text() != "unreflect"
-                    })
-                    .and_then(|token| self.try_lower_bare_token(&token))
-            })
-            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.span_range()));
-        self.alloc_pattern(Pattern::Unreflect(operand), node.span_range())
+        let ty = self.lower_body_type_expr(&type_expr);
+        if let TypeExprKind::Unreflect {
+            operand: Some(operand),
+            ..
+        } = ty.kind
+        {
+            self.alloc_pattern(Pattern::Unreflect(operand), node.span_range())
+        } else {
+            self.alloc_pattern(Pattern::Type(ty), node.span_range())
+        }
     }
 
     /// Lower a `DESTRUCTURE_PATTERN` (`(let|const)? PATH ('<' types '>')? '{' field_list '}'`).
@@ -2722,7 +2794,7 @@ impl LoweringContext {
             .flat_map(rowan::SyntaxNode::children)
             .filter(|n| n.kind() == SyntaxKind::TYPE_EXPR)
             .filter_map(baml_compiler_syntax::ast::TypeExpr::cast)
-            .map(|te| crate::lower_type_expr::lower_type_expr_node(&te, &mut self.diags))
+            .map(|te| self.lower_body_type_expr(&te))
             .collect();
 
         let associated_type_bindings = args_node
@@ -2842,9 +2914,7 @@ impl LoweringContext {
         let ascription = node
             .children()
             .find_map(baml_compiler_syntax::ast::TypeExpr::cast)
-            .map(|type_expr| {
-                crate::lower_type_expr::lower_type_expr_node(&type_expr, &mut self.diags)
-            });
+            .map(|type_expr| self.lower_body_type_expr(&type_expr));
 
         self.alloc_pattern(
             Pattern::Array {
@@ -3158,7 +3228,7 @@ impl LoweringContext {
         //      method's frame correctly (e.g. `Box.from_json` sees
         //      `T = Secret`).
         let callee_generic_args = callee_node.as_ref().and_then(find_callee_generic_args);
-        let type_args: Vec<TypeArg> = callee_generic_args
+        let type_args: Vec<TypeExpr> = callee_generic_args
             .as_ref()
             .map(|ga| self.lower_call_generic_args_node(ga))
             .unwrap_or_default();
@@ -3295,70 +3365,19 @@ impl LoweringContext {
     }
 
     /// Lower the `TYPE_EXPR` children of a `GENERIC_ARGS` node to `TypeExpr`s.
-    fn lower_generic_args_node(
-        ga: &SyntaxNode,
-        diags: &mut Vec<LoweringDiagnostic>,
-    ) -> Vec<TypeExpr> {
+    fn lower_generic_args_node(&mut self, ga: &SyntaxNode) -> Vec<TypeExpr> {
         ga.children()
             .filter(|n| n.kind() == SyntaxKind::TYPE_EXPR)
             .filter_map(baml_compiler_syntax::ast::TypeExpr::cast)
-            .map(|te| crate::lower_type_expr::lower_type_expr_node(&te, diags))
+            .map(|te| self.lower_body_type_expr(&te))
             .collect()
     }
 
     /// Lower a call's generic arguments. Unlike type constructors and
     /// value-position generic application, calls may contain the contextual
     /// whole-slot `unreflect(expr)` form.
-    fn lower_call_generic_args_node(&mut self, ga: &SyntaxNode) -> Vec<TypeArg> {
-        let mut args = Vec::new();
-        for node in ga.children() {
-            match node.kind() {
-                SyntaxKind::TYPE_EXPR => {
-                    if let Some(te) = baml_compiler_syntax::ast::TypeExpr::cast(node) {
-                        args.push(TypeArg::Static(
-                            crate::lower_type_expr::lower_type_expr_node(&te, &mut self.diags),
-                        ));
-                    }
-                }
-                SyntaxKind::UNREFLECT_ARG => {
-                    let operand = node
-                        .children()
-                        .next()
-                        .map(|expr| self.lower_expr(&expr))
-                        .or_else(|| {
-                            let mut skipped_marker = false;
-                            node.children_with_tokens()
-                                .filter_map(rowan::NodeOrToken::into_token)
-                                .find(|token| {
-                                    if token.kind().is_trivia()
-                                        || matches!(
-                                            token.kind(),
-                                            SyntaxKind::L_PAREN | SyntaxKind::R_PAREN
-                                        )
-                                    {
-                                        return false;
-                                    }
-                                    if !skipped_marker && token.text() == "unreflect" {
-                                        skipped_marker = true;
-                                        return false;
-                                    }
-                                    true
-                                })
-                                .map(|token| {
-                                    let expr = lower_bare_token_expr(self, &token);
-                                    self.alloc_expr(expr, token.text_range())
-                                })
-                        })
-                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.span_range()));
-                    self.source_map
-                        .unreflect_arg_spans
-                        .insert(operand, node.span_range());
-                    args.push(TypeArg::Unreflect(operand));
-                }
-                _ => {}
-            }
-        }
-        args
+    fn lower_call_generic_args_node(&mut self, ga: &SyntaxNode) -> Vec<TypeExpr> {
+        self.lower_generic_args_node(ga)
     }
 
     /// If `node` has a direct, unconsumed `GENERIC_ARGS` child, wrap `base` in an
@@ -3374,7 +3393,7 @@ impl LoweringContext {
         if self.consumed_generic_args.contains(&ga.text_range()) {
             return base;
         }
-        let type_args = Self::lower_generic_args_node(&ga, &mut self.diags);
+        let type_args = self.lower_generic_args_node(&ga);
         if type_args.is_empty() {
             return base;
         }
@@ -3581,7 +3600,7 @@ impl LoweringContext {
                     .find(|child| child.kind() == SyntaxKind::TYPE_EXPR)
             })
             .and_then(baml_compiler_syntax::ast::TypeExpr::cast)
-            .map(|te| crate::lower_type_expr::lower_type_expr_node(&te, &mut self.diags))
+            .map(|te| self.lower_body_type_expr(&te))
             .unwrap_or_else(|| TypeExprKind::Unknown { attrs: Vec::new() }.at(node.span_range()));
 
         let id = self.alloc_expr(Expr::Upcast { base, target }, node.span_range());
@@ -3605,7 +3624,7 @@ impl LoweringContext {
         let mut types = node
             .children()
             .filter_map(baml_compiler_syntax::ast::TypeExpr::cast)
-            .map(|te| crate::lower_type_expr::lower_type_expr_node(&te, &mut self.diags));
+            .map(|te| self.lower_body_type_expr(&te));
         let unknown = || TypeExprKind::Unknown { attrs: Vec::new() }.at(span);
         let qself = types.next().unwrap_or_else(unknown);
         let interface = types.next().unwrap_or_else(unknown);
@@ -4906,9 +4925,7 @@ impl LoweringContext {
         fn collect_constructor_path(
             node: &SyntaxNode,
             path_segments: &mut Vec<Name>,
-            type_args: &mut Vec<TypeExpr>,
-            unreflect_slots: &mut Vec<SyntaxNode>,
-            diags: &mut Vec<LoweringDiagnostic>,
+            generic_args: &mut Option<SyntaxNode>,
         ) {
             for elem in node.children_with_tokens() {
                 match elem {
@@ -4918,36 +4935,10 @@ impl LoweringContext {
                     rowan::NodeOrToken::Node(args_node)
                         if args_node.kind() == SyntaxKind::GENERIC_ARGS =>
                     {
-                        // A class literal cannot carry a runtime type
-                        // argument (see the E0167 report below), but the slot
-                        // still holds its place: dropping it would leave the
-                        // turbofish short and inference would report a
-                        // missing type parameter on top of the real finding.
-                        *type_args = args_node
-                            .children()
-                            .filter_map(|arg| match arg.kind() {
-                                SyntaxKind::TYPE_EXPR => {
-                                    baml_compiler_syntax::ast::TypeExpr::cast(arg).map(|te| {
-                                        crate::lower_type_expr::lower_type_expr_node(&te, diags)
-                                    })
-                                }
-                                SyntaxKind::UNREFLECT_ARG => {
-                                    let span = arg.span_range();
-                                    unreflect_slots.push(arg);
-                                    Some(TypeExprKind::Error { attrs: Vec::new() }.at(span))
-                                }
-                                _ => None,
-                            })
-                            .collect();
+                        *generic_args = Some(args_node);
                     }
                     rowan::NodeOrToken::Node(child_node) => {
-                        collect_constructor_path(
-                            &child_node,
-                            path_segments,
-                            type_args,
-                            unreflect_slots,
-                            diags,
-                        );
+                        collect_constructor_path(&child_node, path_segments, generic_args);
                     }
                     rowan::NodeOrToken::Token(_) => {}
                 }
@@ -4958,9 +4949,8 @@ impl LoweringContext {
         let mut field_name_spans = Vec::new();
         let mut spreads = Vec::new();
         let mut position = 0;
-        let mut type_args: Vec<TypeExpr> = vec![];
+        let mut generic_args = None;
         let mut type_path_segments: Vec<Name> = vec![];
-        let mut unreflect_slots: Vec<SyntaxNode> = vec![];
 
         // Look for the optional type name (first WORD or path before the brace):
         //   - A simple WORD token: `MyClass { ... }` → `TypePath::bare`.
@@ -4982,21 +4972,15 @@ impl LoweringContext {
                     collect_constructor_path(
                         &child_node,
                         &mut type_path_segments,
-                        &mut type_args,
-                        &mut unreflect_slots,
-                        &mut self.diags,
+                        &mut generic_args,
                     );
                 }
             }
         }
-        for slot in &unreflect_slots {
-            let rewrite = unreflect_rewrite(node, slot);
-            self.diags.push(LoweringDiagnostic::RuntimeTypeMustBeNamed {
-                carrier: rewrite.carrier,
-                named: rewrite.named,
-                span: slot.span_range(),
-            });
-        }
+        let type_args = generic_args
+            .as_ref()
+            .map(|args| self.lower_generic_args_node(args))
+            .unwrap_or_default();
         // Malformed parser-recovery shapes can still manufacture a PATH_EXPR
         // with no constructor identifier (for example `(1)<int> { x: 2 }`).
         // Invalid source must remain diagnostic-only: do not construct an
@@ -5218,10 +5202,8 @@ impl LoweringContext {
                     }
                     SyntaxKind::TYPE_EXPR if after_params && found.is_none() => {
                         if let Some(te) = ast::TypeExpr::cast(child.clone()) {
-                            found = Some(
-                                crate::lower_type_expr::lower_type_expr_node(&te, &mut self.diags)
-                                    .with_span(child.span_range()),
-                            );
+                            found =
+                                Some(self.lower_body_type_expr(&te).with_span(child.span_range()));
                         }
                     }
                     _ => {}
@@ -5237,7 +5219,7 @@ impl LoweringContext {
             .and_then(ast::ThrowsClause::cast)
             .and_then(|tc| tc.type_expr())
             .map(|te| {
-                crate::lower_type_expr::lower_type_expr_node(&te, &mut self.diags)
+                self.lower_body_type_expr(&te)
                     .with_span(te.syntax().span_range())
             });
 
@@ -5410,69 +5392,11 @@ impl LoweringContext {
             .find(|token| token.kind() == SyntaxKind::WORD)
             .map(|token| Name::new(token.text()))
             .unwrap_or_else(|| Name::new("<missing>"));
-        // The operand may have direct-token path heads and structural postfix
-        // children (`reflect.Type.of<T>()` has a GENERIC_ARGS sibling before its call),
-        // so selecting the first arbitrary child is not expression-safe.
         let value = node
             .children()
-            .find(|child| {
-                matches!(
-                    child.kind(),
-                    SyntaxKind::BINARY_EXPR
-                        | SyntaxKind::IS_EXPR
-                        | SyntaxKind::UNARY_EXPR
-                        | SyntaxKind::CALL_EXPR
-                        | SyntaxKind::IF_EXPR
-                        | SyntaxKind::IF_LET_EXPR
-                        | SyntaxKind::MATCH_EXPR
-                        | SyntaxKind::CATCH_EXPR
-                        | SyntaxKind::THROW_EXPR
-                        | SyntaxKind::RETURN_EXPR
-                        | SyntaxKind::BLOCK_EXPR
-                        | SyntaxKind::PATH_EXPR
-                        | SyntaxKind::FIELD_ACCESS_EXPR
-                        | SyntaxKind::UPCAST_EXPR
-                        | SyntaxKind::QUALIFIED_PATH_EXPR
-                        | SyntaxKind::OPTIONAL_FIELD_ACCESS_EXPR
-                        | SyntaxKind::ENV_ACCESS_EXPR
-                        | SyntaxKind::INDEX_EXPR
-                        | SyntaxKind::OPTIONAL_INDEX_EXPR
-                        | SyntaxKind::OPTIONAL_CALL_EXPR
-                        | SyntaxKind::TAGGED_TEMPLATE_EXPR
-                        | SyntaxKind::PAREN_EXPR
-                        | SyntaxKind::STRING_LITERAL
-                        | SyntaxKind::BACKTICK_STRING_LITERAL
-                        | SyntaxKind::BYTE_STRING_LITERAL
-                        | SyntaxKind::ARRAY_LITERAL
-                        | SyntaxKind::OBJECT_LITERAL
-                        | SyntaxKind::MAP_LITERAL
-                        | SyntaxKind::LAMBDA_EXPR
-                        | SyntaxKind::SPAWN_EXPR
-                        | SyntaxKind::AWAIT_EXPR
-                )
-            })
-            .map(|child| self.lower_expr(&child))
-            .or_else(|| {
-                let mut inside_operand = false;
-                node.children_with_tokens()
-                    .filter_map(rowan::NodeOrToken::into_token)
-                    .find_map(|token| {
-                        if !inside_operand {
-                            inside_operand = token.text() == "unreflect";
-                            return None;
-                        }
-                        if token.kind().is_trivia()
-                            || matches!(
-                                token.kind(),
-                                SyntaxKind::L_PAREN | SyntaxKind::R_PAREN | SyntaxKind::SEMICOLON
-                            )
-                        {
-                            return None;
-                        }
-                        self.try_lower_bare_token(&token)
-                    })
-            })
-            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.span_range()));
+            .find_map(baml_compiler_syntax::ast::TypeExpr::cast)
+            .map(|ty| self.lower_body_type_expr(&ty))
+            .unwrap_or_else(|| TypeExprKind::Error { attrs: Vec::new() }.at(node.span_range()));
         self.alloc_stmt(Stmt::TypeBinding { name, value }, node.span_range())
     }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -13,12 +13,12 @@ use text_size::TextRange;
 use crate::{
     LoweringDiagnostic,
     ast::{
-        ArrayRestPat, AssignOp, AstSourceMap, BinaryOp, CallArg, CatchArm, CatchArmId, CatchClause,
-        CatchClauseKind, DefaultExprId, Expr, ExprBody, ExprId, FieldPat, FunctionDefaults,
-        LambdaDef, LambdaKind, LetDef, LetOrigin, Literal, LoopOrigin, MapExprEntry, MatchArm,
-        MatchArmId, ObjectExprField, Param, PatId, Pattern, SpreadField, Stmt, StmtId,
-        TemplateIfBranch, TemplateSegment, TemplateTag, TypeAnnotId, TypeExpr, TypeExprKind,
-        UnaryOp,
+        ArrayRestPat, AssignOp, AssociatedTypeBinding, AstSourceMap, BinaryOp, CallArg, CatchArm,
+        CatchArmId, CatchClause, CatchClauseKind, DefaultExprId, Expr, ExprBody, ExprId, FieldPat,
+        FunctionDefaults, LambdaDef, LambdaKind, LetDef, LetOrigin, Literal, LoopOrigin,
+        MapExprEntry, MatchArm, MatchArmId, ObjectExprField, Param, PatId, Pattern, SpreadField,
+        Stmt, StmtId, TemplateIfBranch, TemplateSegment, TemplateTag, TypeAnnotId, TypeExpr,
+        TypeExprKind, UnaryOp,
     },
 };
 
@@ -1223,6 +1223,24 @@ impl LoweringContext {
         let mut ty = crate::lower_type_expr::lower_type_expr_node(type_expr, &mut self.diags);
         self.attach_body_type_operands(type_expr, &mut ty);
         ty
+    }
+
+    /// Lower an associated binding written in this body through the same
+    /// body-aware road as every other type expression. The item-level helper
+    /// cannot allocate `unreflect(...)` carriers into this expression arena.
+    fn lower_body_associated_type_binding(
+        &mut self,
+        binding: &baml_compiler_syntax::ast::AssociatedTypeDecl,
+    ) -> Option<AssociatedTypeBinding> {
+        let name = binding.name()?;
+        let ty = binding
+            .default_or_binding()
+            .map(|ty| self.lower_body_type_expr(&ty))
+            .unwrap_or_else(|| TypeExprKind::Unknown { attrs: vec![] }.at(TextRange::default()));
+        Some(AssociatedTypeBinding {
+            name: Name::new(name.text()),
+            ty: Box::new(ty),
+        })
     }
 
     fn warn_const_introducer(&mut self, span: TextRange) {
@@ -2812,16 +2830,7 @@ impl LoweringContext {
             .filter(|args_node| args_node.kind() == SyntaxKind::TYPE_ARGS)
             .flat_map(|args_node| args_node.children())
             .filter_map(baml_compiler_syntax::ast::AssociatedTypeDecl::cast)
-            .filter_map(|binding| {
-                let mut lowered = crate::lower_type_expr::lower_associated_type_binding(
-                    &binding,
-                    &mut self.diags,
-                )?;
-                if let Some(ty) = binding.default_or_binding() {
-                    self.attach_body_type_operands(&ty, &mut lowered.ty);
-                }
-                Some(lowered)
-            })
+            .filter_map(|binding| self.lower_body_associated_type_binding(&binding))
             .collect();
 
         let fields: Vec<FieldPat> = node

--- a/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
@@ -172,6 +172,17 @@ fn lower_base(type_expr: &CstTypeExpr, diags: &mut Vec<LoweringDiagnostic>) -> T
 /// Parse the base type (no modifiers, not a union).
 fn lower_base_terminal(type_expr: &CstTypeExpr, diags: &mut Vec<LoweringDiagnostic>) -> TypeExpr {
     let span = type_expr.syntax().span_range();
+    if let Some(unreflect) = type_expr
+        .syntax()
+        .children()
+        .find(|node| node.kind() == SyntaxKind::UNREFLECT_TYPE)
+    {
+        return TypeExprKind::Unreflect {
+            operand: None,
+            attrs: vec![],
+        }
+        .at(unreflect.span_range());
+    }
     // BUG: a qualified projection captures only a single member — `(base as I).A.B`
     // drops the trailing `.B` (`associated_type_projection` returns one member). A chained
     // explicit qualifier (`(T as Outer).Asdf.Assoc`) therefore silently loses `.Assoc`,
@@ -353,6 +364,17 @@ fn lower_union_member_base(
     diags: &mut Vec<LoweringDiagnostic>,
 ) -> TypeExpr {
     let span = parts.span().unwrap_or_default();
+    if let Some(unreflect) = parts
+        .child_nodes
+        .iter()
+        .find(|node| node.kind() == SyntaxKind::UNREFLECT_TYPE)
+    {
+        return TypeExprKind::Unreflect {
+            operand: None,
+            attrs: vec![],
+        }
+        .at(unreflect.span_range());
+    }
     if let Some((base, interface, member)) = parts.associated_type_projection() {
         return TypeExprKind::AssociatedTypeProjection {
             base: Box::new(lower_type_expr_inner(&base, false, diags)),

--- a/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
@@ -28,24 +28,6 @@ pub enum LoweringDiagnostic {
         span: TextRange,
     },
 
-    /// A class-literal turbofish supplied an inline `unreflect(value)` type
-    /// argument (`Holder<unreflect(t)> { .. }`). The constructed value's type
-    /// is `Holder<T>` — it mentions the call-scoped runtime parameter, which
-    /// stops existing the moment the literal finishes — so the runtime type
-    /// has to be named with a `type` binding first. The literal is the one
-    /// shape whose answer never depends on a callee signature, so it is
-    /// decided here, where the written source is still at hand.
-    RuntimeTypeMustBeNamed {
-        /// The carrier expression inside `unreflect(...)`, when it prints
-        /// cleanly on one line.
-        carrier: Option<String>,
-        /// The written literal with the inline slot replaced by the suggested
-        /// name, when it prints cleanly on one line.
-        named: Option<String>,
-        /// The `unreflect(...)` slot itself.
-        span: TextRange,
-    },
-
     /// A function parameter has no name token.
     MissingParamName {
         function_name: String,
@@ -331,32 +313,6 @@ impl LoweringDiagnostic {
                 *span,
                 "unparseable type",
             ),
-            LoweringDiagnostic::RuntimeTypeMustBeNamed {
-                carrier,
-                named,
-                span,
-            } => {
-                let span = Span {
-                    file_id,
-                    range: *span,
-                };
-                let rewrite = baml_compiler_diagnostics::runtime_type::RuntimeTypeNameRewrite {
-                    carrier: carrier.clone(),
-                    named: named.clone(),
-                };
-                return baml_compiler_diagnostics::runtime_type::runtime_type_must_be_named()
-                    .with_primary(
-                        span,
-                        baml_compiler_diagnostics::runtime_type::RUNTIME_TYPE_MUST_BE_NAMED_NOTE,
-                    )
-                    .with_related(
-                        span,
-                        baml_compiler_diagnostics::runtime_type::runtime_type_must_be_named_help(
-                            &rewrite,
-                        ),
-                    )
-                    .with_phase(DiagnosticPhase::Hir);
-            }
             LoweringDiagnostic::MissingParamName {
                 function_name,
                 span,

--- a/baml_language/crates/baml_compiler2_ast/src/traverse.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/traverse.rs
@@ -109,9 +109,14 @@ impl ExprBody {
                 out.extend(else_branch.map(BodyNode::Expr));
             }
             Expr::Match {
-                scrutinee, arms, ..
+                scrutinee,
+                scrutinee_type,
+                arms,
             } => {
                 out.push(BodyNode::Expr(*scrutinee));
+                if let Some(type_id) = scrutinee_type {
+                    append_type_operands(&self.type_annotations[*type_id], out);
+                }
                 for arm in arms {
                     let arm = &self.match_arms[*arm];
                     self.pattern_expr_children(arm.pattern, out);

--- a/baml_language/crates/baml_compiler2_ast/src/traverse.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/traverse.rs
@@ -20,7 +20,7 @@
 use std::collections::HashSet;
 
 use crate::ast::{
-    Expr, ExprBody, ExprId, PatId, Pattern, Stmt, StmtId, TemplateSegment, TemplateTag, TypeArg,
+    Expr, ExprBody, ExprId, PatId, Pattern, Stmt, StmtId, TemplateSegment, TemplateTag,
 };
 
 /// A direct child of an expression or statement.
@@ -28,6 +28,12 @@ use crate::ast::{
 pub enum BodyNode {
     Expr(ExprId),
     Stmt(StmtId),
+}
+
+fn append_type_operands(ty: &crate::ast::TypeExpr, out: &mut Vec<BodyNode>) {
+    let mut operands = Vec::new();
+    ty.unreflect_operands(&mut operands);
+    out.extend(operands.into_iter().map(BodyNode::Expr));
 }
 
 impl ExprBody {
@@ -43,15 +49,39 @@ impl ExprBody {
             | Expr::ByteStringLiteral(_)
             | Expr::Null
             | Expr::Path(_)
-            // Both halves of a qualified item reference are TYPES, so the
-            // node has no expression children to walk.
-            | Expr::QualifiedPath { .. }
-            | Expr::Lambda(_)
             | Expr::Missing => {}
-            Expr::GenericApply { base, .. }
-            | Expr::MemberAccess { base, .. }
-            | Expr::OptionalMemberAccess { base, .. }
-            | Expr::Upcast { base, .. } => out.push(BodyNode::Expr(*base)),
+            Expr::QualifiedPath {
+                qself, interface, ..
+            } => {
+                append_type_operands(qself, out);
+                append_type_operands(interface, out);
+            }
+            Expr::Lambda(def) => {
+                for param in &def.params {
+                    if let Some(ty) = &param.type_expr {
+                        append_type_operands(ty, out);
+                    }
+                }
+                if let Some(ty) = &def.return_type {
+                    append_type_operands(ty, out);
+                }
+                if let Some(ty) = &def.throws {
+                    append_type_operands(ty, out);
+                }
+            }
+            Expr::GenericApply { base, type_args } => {
+                out.push(BodyNode::Expr(*base));
+                for ty in type_args {
+                    append_type_operands(ty, out);
+                }
+            }
+            Expr::MemberAccess { base, .. } | Expr::OptionalMemberAccess { base, .. } => {
+                out.push(BodyNode::Expr(*base));
+            }
+            Expr::Upcast { base, target } => {
+                out.push(BodyNode::Expr(*base));
+                append_type_operands(target, out);
+            }
             Expr::Unary { expr, .. } | Expr::OptionalChain { expr } => {
                 out.push(BodyNode::Expr(*expr));
             }
@@ -130,10 +160,9 @@ impl ExprBody {
                 args,
             } => {
                 out.push(BodyNode::Expr(*callee));
-                out.extend(type_args.iter().filter_map(|arg| match arg {
-                    TypeArg::Static(_) => None,
-                    TypeArg::Unreflect(expr) => Some(BodyNode::Expr(*expr)),
-                }));
+                for ty in type_args {
+                    append_type_operands(ty, out);
+                }
                 out.extend(args.iter().map(|arg| BodyNode::Expr(arg.expr)));
             }
             Expr::OptionalCall { callee, args } => {
@@ -141,8 +170,14 @@ impl ExprBody {
                 out.extend(args.iter().map(|arg| BodyNode::Expr(arg.expr)));
             }
             Expr::Object {
-                fields, spreads, ..
+                type_args,
+                fields,
+                spreads,
+                ..
             } => {
+                for ty in type_args {
+                    append_type_operands(ty, out);
+                }
                 out.extend(fields.iter().map(|field| BodyNode::Expr(field.value)));
                 out.extend(spreads.iter().map(|s| BodyNode::Expr(s.expr)));
             }
@@ -187,14 +222,26 @@ impl ExprBody {
     /// `unreflect(expr)` atoms contribute expression children.
     pub fn pattern_expr_children(&self, id: PatId, out: &mut Vec<BodyNode>) {
         match &self.patterns[id] {
-            Pattern::Wildcard | Pattern::Type(_) => {}
+            Pattern::Wildcard => {}
+            Pattern::Type(ty) => append_type_operands(ty, out),
             Pattern::Unreflect(operand) => out.push(BodyNode::Expr(*operand)),
             Pattern::Bind { subpat, .. } => {
                 if let Some(subpat) = subpat {
                     self.pattern_expr_children(*subpat, out);
                 }
             }
-            Pattern::Class { fields, .. } => {
+            Pattern::Class {
+                generic_args,
+                associated_type_bindings,
+                fields,
+                ..
+            } => {
+                for ty in generic_args {
+                    append_type_operands(ty, out);
+                }
+                for binding in associated_type_bindings {
+                    append_type_operands(&binding.ty, out);
+                }
                 for field in fields {
                     self.pattern_expr_children(field.pat, out);
                 }
@@ -203,8 +250,11 @@ impl ExprBody {
                 prefix,
                 rest,
                 suffix,
-                ..
+                ascription,
             } => {
+                if let Some(ty) = ascription {
+                    append_type_operands(ty, out);
+                }
                 for pattern in prefix {
                     self.pattern_expr_children(*pattern, out);
                 }
@@ -227,12 +277,10 @@ impl ExprBody {
     pub fn stmt_children(&self, id: StmtId, out: &mut Vec<BodyNode>) {
         match &self.stmts[id] {
             Stmt::Break | Stmt::Continue | Stmt::Missing | Stmt::HeaderComment { .. } => {}
-            Stmt::Expr(expr)
-            | Stmt::TypeBinding { value: expr, .. }
-            | Stmt::Throw { value: expr }
-            | Stmt::Defer { body: expr } => {
+            Stmt::Expr(expr) | Stmt::Throw { value: expr } | Stmt::Defer { body: expr } => {
                 out.push(BodyNode::Expr(*expr));
             }
+            Stmt::TypeBinding { value, .. } => append_type_operands(value, out),
             Stmt::Return(expr) => out.extend(expr.map(BodyNode::Expr)),
             Stmt::Let {
                 pattern,

--- a/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
@@ -15,7 +15,7 @@
 //! generic args join when pattern inference needs them.
 
 use baml_base::Name;
-use baml_compiler2_ast::{Expr, ExprBody, ExprId, PatId, Pattern, TypeArg};
+use baml_compiler2_ast::{Expr, ExprBody, ExprId, PatId, Pattern, Stmt, StmtId, TypeExprKind};
 use rustc_hash::FxHashMap;
 
 use crate::type_ref::{TypeRefBuilder, TypeRefId, TypeRefSourceMap, TypeRefStore};
@@ -58,6 +58,8 @@ pub struct BodyTypeRefs {
     /// and `Object` constructors), in written order. Never empty when
     /// present.
     pub expr_type_args: FxHashMap<ExprId, Box<[BodyTypeArgRef]>>,
+    /// RHS types of lexical `type T = ...` bindings.
+    pub stmt_type_bindings: FxHashMap<StmtId, BodyTypeRefId>,
     /// `.as<T>` upcast targets.
     pub upcast_targets: FxHashMap<ExprId, BodyTypeRefId>,
     /// The two written halves of a `(Base as Interface).item` reference.
@@ -170,13 +172,12 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSour
                     expr_id,
                     type_args
                         .iter()
-                        .map(|arg| match arg {
-                            TypeArg::Static(ty) => {
-                                BodyTypeArgRef::Static(BodyTypeRefId(builder.lower(ty)))
-                            }
-                            TypeArg::Unreflect(operand) => {
-                                BodyTypeArgRef::Runtime { operand: *operand }
-                            }
+                        .map(|arg| match &arg.kind {
+                            TypeExprKind::Unreflect {
+                                operand: Some(operand),
+                                ..
+                            } => BodyTypeArgRef::Runtime { operand: *operand },
+                            _ => BodyTypeArgRef::Static(BodyTypeRefId(builder.lower(arg))),
                         })
                         .collect(),
                 );
@@ -236,6 +237,13 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSour
         }
     }
 
+    for (stmt_id, stmt) in body.stmts.iter() {
+        if let Stmt::TypeBinding { value, .. } = stmt {
+            refs.stmt_type_bindings
+                .insert(stmt_id, BodyTypeRefId(builder.lower(value)));
+        }
+    }
+
     let (store, source_map) = builder.finish();
     refs.store = store;
     (refs, BodyTypeRefSourceMap(source_map))
@@ -243,7 +251,7 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSour
 
 #[cfg(test)]
 mod tests {
-    use baml_compiler2_ast::{Expr, ExprBody, TypeArg, TypeExprKind};
+    use baml_compiler2_ast::{Expr, ExprBody, TypeExprKind};
     use text_size::{TextRange, TextSize};
 
     use super::*;
@@ -257,9 +265,14 @@ mod tests {
             .alloc(Expr::Path(vec![Name::new("runtime_type")]));
         let static_span = TextRange::new(TextSize::from(10), TextSize::from(13));
         let static_ty = TypeExprKind::Int { attrs: Vec::new() }.at(static_span);
+        let runtime_ty = TypeExprKind::Unreflect {
+            operand: Some(operand),
+            attrs: Vec::new(),
+        }
+        .at(TextRange::new(TextSize::from(15), TextSize::from(38)));
         let call = body.exprs.alloc(Expr::Call {
             callee,
-            type_args: vec![TypeArg::Static(static_ty), TypeArg::Unreflect(operand)],
+            type_args: vec![static_ty, runtime_ty],
             args: Vec::new(),
         });
 

--- a/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
@@ -245,11 +245,10 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSour
                 scrutinee_type: Some(type_id),
                 ..
             } => {
-                refs.match_scrutinee_types
-                    .insert(
-                        expr_id,
-                        BodyTypeRefId(builder.lower(&body.type_annotations[*type_id])),
-                    );
+                refs.match_scrutinee_types.insert(
+                    expr_id,
+                    BodyTypeRefId(builder.lower(&body.type_annotations[*type_id])),
+                );
             }
             _ => {}
         }

--- a/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
@@ -11,8 +11,8 @@
 //! Collected today: pattern type ascriptions (`let x: T`, type patterns in
 //! match arms), array-pattern ascriptions, explicit expression-position type
 //! args (`f<int>(..)`, `f<unreflect(t)>(..)`, `Box<int> { .. }` turbofish),
-//! `.as<T>` upcast targets, and lambda signature slots. Class-destructure
-//! generic args join when pattern inference needs them.
+//! `.as<T>` upcast targets, match scrutinee annotations, and lambda signature
+//! slots. Class-destructure generic args join when pattern inference needs them.
 
 use baml_base::Name;
 use baml_compiler2_ast::{Expr, ExprBody, ExprId, PatId, Pattern, Stmt, StmtId, TypeExprKind};
@@ -60,6 +60,8 @@ pub struct BodyTypeRefs {
     pub expr_type_args: FxHashMap<ExprId, Box<[BodyTypeArgRef]>>,
     /// RHS types of lexical `type T = ...` bindings.
     pub stmt_type_bindings: FxHashMap<StmtId, BodyTypeRefId>,
+    /// Written annotations on match scrutinees (`match (value: T)`).
+    pub match_scrutinee_types: FxHashMap<ExprId, BodyTypeRefId>,
     /// `.as<T>` upcast targets.
     pub upcast_targets: FxHashMap<ExprId, BodyTypeRefId>,
     /// The two written halves of a `(Base as Interface).item` reference.
@@ -239,6 +241,16 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSour
                     },
                 );
             }
+            Expr::Match {
+                scrutinee_type: Some(type_id),
+                ..
+            } => {
+                refs.match_scrutinee_types
+                    .insert(
+                        expr_id,
+                        BodyTypeRefId(builder.lower(&body.type_annotations[*type_id])),
+                    );
+            }
             _ => {}
         }
     }
@@ -261,6 +273,7 @@ mod tests {
     use text_size::{TextRange, TextSize};
 
     use super::*;
+    use crate::type_ref::TypeRefKind;
 
     #[test]
     fn expression_type_arguments_preserve_static_runtime_order_and_identity() {
@@ -294,5 +307,41 @@ mod tests {
         assert_eq!(*runtime, operand);
         assert_eq!(source_map.span(*static_ref), static_span);
         assert_eq!(refs.store.iter().count(), 1, "runtime slots are not types");
+    }
+
+    #[test]
+    fn match_scrutinee_annotations_preserve_runtime_operands() {
+        let mut body = ExprBody::default();
+        let scrutinee = body.exprs.alloc(Expr::Path(vec![Name::new("value")]));
+        let operand = body
+            .exprs
+            .alloc(Expr::Path(vec![Name::new("runtime_type")]));
+        let annotation_span = TextRange::new(TextSize::from(10), TextSize::from(33));
+        let annotation = body.type_annotations.alloc(
+            TypeExprKind::Unreflect {
+                operand: Some(operand),
+                attrs: Vec::new(),
+            }
+            .at(annotation_span),
+        );
+        let match_expr = body.exprs.alloc(Expr::Match {
+            scrutinee,
+            scrutinee_type: Some(annotation),
+            arms: Vec::new(),
+        });
+
+        let (refs, source_map) = collect_body_type_refs(&body);
+        let type_ref = refs
+            .match_scrutinee_types
+            .get(&match_expr)
+            .copied()
+            .expect("match scrutinee type reference");
+        assert!(matches!(
+            refs.store.get(refs.raw_id(type_ref)).kind,
+            TypeRefKind::Unreflect {
+                operand: Some(found)
+            } if found == operand
+        ));
+        assert_eq!(source_map.span(type_ref), annotation_span);
     }
 }

--- a/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
@@ -189,7 +189,13 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSour
                     expr_id,
                     type_args
                         .iter()
-                        .map(|arg| BodyTypeArgRef::Static(BodyTypeRefId(builder.lower(arg))))
+                        .map(|arg| match &arg.kind {
+                            TypeExprKind::Unreflect {
+                                operand: Some(operand),
+                                ..
+                            } => BodyTypeArgRef::Runtime { operand: *operand },
+                            _ => BodyTypeArgRef::Static(BodyTypeRefId(builder.lower(arg))),
+                        })
                         .collect(),
                 );
             }

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -623,9 +623,14 @@ impl<'db> SemanticIndexBuilder<'db> {
                 }
             }
             ast::Expr::Match {
-                scrutinee, arms, ..
+                scrutinee,
+                scrutinee_type,
+                arms,
             } => {
                 self.walk_expr(*scrutinee, body, source_map, true);
+                if let Some(type_id) = scrutinee_type {
+                    self.walk_type_operands(&body.type_annotations[*type_id], body, source_map);
+                }
                 for &arm_id in arms {
                     self.walk_match_arm(arm_id, body, source_map);
                 }
@@ -1261,6 +1266,20 @@ impl<'db> SemanticIndexBuilder<'db> {
         self.emit_duplicate_param_diagnostics(&lambda.params);
         self.lambda_stack.push(scope_id);
         self.walk_parameter_defaults(&lambda.params, &lambda.defaults);
+
+        let metadata_scope = ExprMetadataScope::Body(scope_id);
+        self.expr_metadata_scope_stack.push(metadata_scope);
+        for param in &lambda.params {
+            if let Some(ty) = &param.type_expr {
+                self.walk_type_operands(ty, body, source_map);
+            }
+        }
+        if let Some(ty) = &lambda.return_type {
+            self.walk_type_operands(ty, body, source_map);
+        }
+        if let Some(ty) = &lambda.throws {
+            self.walk_type_operands(ty, body, source_map);
+        }
         if let Some(lambda_body) = lambda.body {
             // The body shares this arena, but it still gets its own metadata
             // namespace keyed by the lambda's scope. That keeps HIR agreeing
@@ -1269,13 +1288,11 @@ impl<'db> SemanticIndexBuilder<'db> {
             // mismatch here does not fail loudly: `path_resolution` simply
             // misses, flow narrowing silently stops inside every lambda, and
             // reconstructed closure signatures silently degrade to `unknown`.
-            let metadata_scope = ExprMetadataScope::Body(scope_id);
-            self.expr_metadata_scope_stack.push(metadata_scope);
             self.walk_expr(lambda_body, body, source_map, false);
-            let popped = self.expr_metadata_scope_stack.pop();
-            debug_assert_eq!(popped, Some(metadata_scope));
             self.analyze_lambda_captures(scope_id, body, source_map);
         }
+        let popped = self.expr_metadata_scope_stack.pop();
+        debug_assert_eq!(popped, Some(metadata_scope));
         self.lambda_stack.pop();
         self.pop_scope();
     }

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -348,6 +348,19 @@ impl<'db> SemanticIndexBuilder<'db> {
         }
     }
 
+    fn walk_type_operands(
+        &mut self,
+        ty: &ast::TypeExpr,
+        body: &ast::ExprBody,
+        source_map: &ast::AstSourceMap,
+    ) {
+        let mut operands = Vec::new();
+        ty.unreflect_operands(&mut operands);
+        for operand in operands {
+            self.walk_expr(operand, body, source_map, true);
+        }
+    }
+
     /// Walk an `ExprBody` arena in source order, recording expression ownership
     /// and local bindings in the lexical scope that owns each expression.
     fn walk_expr_body(&mut self, body: &ast::ExprBody, source_map: &ast::AstSourceMap) {
@@ -434,7 +447,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         match &body.stmts[stmt_id] {
             ast::Stmt::Expr(expr) => self.walk_expr(*expr, body, source_map, true),
             ast::Stmt::TypeBinding { value, .. } => {
-                self.walk_expr(*value, body, source_map, true);
+                self.walk_type_operands(value, body, source_map);
             }
             ast::Stmt::Let {
                 pattern,
@@ -697,9 +710,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             } => {
                 self.walk_expr(*callee, body, source_map, true);
                 for type_arg in type_args {
-                    if let ast::TypeArg::Unreflect(operand) = type_arg {
-                        self.walk_expr(*operand, body, source_map, true);
-                    }
+                    self.walk_type_operands(type_arg, body, source_map);
                 }
                 for arg in args {
                     self.walk_expr(arg.expr, body, source_map, true);
@@ -712,8 +723,14 @@ impl<'db> SemanticIndexBuilder<'db> {
                 }
             }
             ast::Expr::Object {
-                fields, spreads, ..
+                type_args,
+                fields,
+                spreads,
+                ..
             } => {
+                for type_arg in type_args {
+                    self.walk_type_operands(type_arg, body, source_map);
+                }
                 for field in fields {
                     self.walk_expr(field.value, body, source_map, true);
                 }
@@ -732,10 +749,12 @@ impl<'db> SemanticIndexBuilder<'db> {
                     self.walk_expr(entry.value, body, source_map, true);
                 }
             }
-            ast::Expr::MemberAccess { base, .. }
-            | ast::Expr::Upcast { base, .. }
-            | ast::Expr::OptionalMemberAccess { base, .. } => {
+            ast::Expr::MemberAccess { base, .. } | ast::Expr::OptionalMemberAccess { base, .. } => {
                 self.walk_expr(*base, body, source_map, true);
+            }
+            ast::Expr::Upcast { base, target } => {
+                self.walk_expr(*base, body, source_map, true);
+                self.walk_type_operands(target, body, source_map);
             }
             ast::Expr::Index { base, index } | ast::Expr::OptionalIndex { base, index } => {
                 self.walk_expr(*base, body, source_map, true);
@@ -749,21 +768,27 @@ impl<'db> SemanticIndexBuilder<'db> {
                     self.resolve_path_expr(expr_id, root, use_scope, use_offset);
                 }
             }
-            ast::Expr::GenericApply { base, .. } => {
+            ast::Expr::GenericApply { base, type_args } => {
                 // `foo<int>` references the base callable; walk it so the path
                 // root is recorded for name resolution. Type args are types,
                 // not value references, so they need no walking here.
                 self.walk_expr(*base, body, source_map, true);
+                for type_arg in type_args {
+                    self.walk_type_operands(type_arg, body, source_map);
+                }
             }
             ast::Expr::Literal(_)
             | ast::Expr::ByteStringLiteral(_)
             | ast::Expr::Null
             | ast::Expr::Block { .. }
-            // Both halves are TYPES, so a qualified item reference opens no
-            // scope and names no local: nothing here to walk or resolve.
-            | ast::Expr::QualifiedPath { .. }
             | ast::Expr::Lambda(_)
             | ast::Expr::Missing => {}
+            ast::Expr::QualifiedPath {
+                qself, interface, ..
+            } => {
+                self.walk_type_operands(qself, body, source_map);
+                self.walk_type_operands(interface, body, source_map);
+            }
         }
     }
 
@@ -898,6 +923,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         source_map: &ast::AstSourceMap,
     ) {
         match &body.patterns[pat_id] {
+            ast::Pattern::Type(ty) => self.walk_type_operands(ty, body, source_map),
             ast::Pattern::Unreflect(operand) => {
                 self.walk_expr(*operand, body, source_map, true);
             }
@@ -906,7 +932,18 @@ impl<'db> SemanticIndexBuilder<'db> {
                     self.walk_pattern_expressions(*subpat, body, source_map);
                 }
             }
-            ast::Pattern::Class { fields, .. } => {
+            ast::Pattern::Class {
+                generic_args,
+                associated_type_bindings,
+                fields,
+                ..
+            } => {
+                for ty in generic_args {
+                    self.walk_type_operands(ty, body, source_map);
+                }
+                for binding in associated_type_bindings {
+                    self.walk_type_operands(&binding.ty, body, source_map);
+                }
                 for field in fields {
                     self.walk_pattern_expressions(field.pat, body, source_map);
                 }
@@ -915,8 +952,11 @@ impl<'db> SemanticIndexBuilder<'db> {
                 prefix,
                 rest,
                 suffix,
-                ..
+                ascription,
             } => {
+                if let Some(ty) = ascription {
+                    self.walk_type_operands(ty, body, source_map);
+                }
                 for pattern in prefix {
                     self.walk_pattern_expressions(*pattern, body, source_map);
                 }
@@ -932,7 +972,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                     self.walk_pattern_expressions(*pattern, body, source_map);
                 }
             }
-            ast::Pattern::Wildcard | ast::Pattern::Type(_) => {}
+            ast::Pattern::Wildcard => {}
         }
     }
 
@@ -2415,6 +2455,7 @@ impl<'db> SemanticIndexBuilder<'db> {
 
     fn render_type_expr(type_expr: &ast::TypeExpr) -> String {
         match &type_expr.kind {
+            ast::TypeExprKind::Unreflect { .. } => "unreflect(…)".to_string(),
             ast::TypeExprKind::Path { segments, .. } => segments
                 .iter()
                 .map(Name::as_str)

--- a/baml_language/crates/baml_compiler2_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/type_ref.rs
@@ -43,6 +43,11 @@ pub struct TypeRef {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeRefKind {
+    /// Runtime type atom. Body-owned stores carry the carrier expression;
+    /// declaration-owned stores leave it absent for the checker diagnostic.
+    Unreflect {
+        operand: Option<baml_compiler2_ast::ExprId>,
+    },
     /// Named type path: `User`, `baml.http.Request`, `Stream<T>`.
     Path {
         segments: Vec<Name>,
@@ -194,6 +199,7 @@ impl std::fmt::Display for TypeRefDisplay<'_> {
 
         let store = self.store;
         match &store[self.id].kind {
+            TypeRefKind::Unreflect { .. } => write!(f, "unreflect(…)"),
             TypeRefKind::Path {
                 segments,
                 generic_args,
@@ -385,6 +391,7 @@ impl TypeRefBuilder {
         let attrs: Box<[Attribute]> = te.kind.attrs().iter().map(Attribute::from).collect();
 
         let kind = match &te.kind {
+            K::Unreflect { operand, .. } => TypeRefKind::Unreflect { operand: *operand },
             K::Path {
                 segments,
                 generic_args,

--- a/baml_language/crates/baml_compiler2_hir_ty/src/defaults.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/defaults.rs
@@ -250,9 +250,11 @@ fn collect_default_expr_forward_references(
         } => {
             collect_default_expr_forward_references(*callee, body, later_params, shadowed, refs);
             for type_arg in type_args {
-                if let ast::TypeArg::Unreflect(operand) = type_arg {
+                let mut operands = Vec::new();
+                type_arg.unreflect_operands(&mut operands);
+                for operand in operands {
                     collect_default_expr_forward_references(
-                        *operand,
+                        operand,
                         body,
                         later_params,
                         shadowed,
@@ -590,11 +592,21 @@ fn collect_default_stmt_forward_references(
     refs: &mut Vec<Name>,
 ) {
     match &body.stmts[stmt_id] {
-        Stmt::Expr(expr)
-        | Stmt::TypeBinding { value: expr, .. }
-        | Stmt::Return(Some(expr))
-        | Stmt::Throw { value: expr } => {
+        Stmt::Expr(expr) | Stmt::Return(Some(expr)) | Stmt::Throw { value: expr } => {
             collect_default_expr_forward_references(*expr, body, later_params, shadowed, refs);
+        }
+        Stmt::TypeBinding { value, .. } => {
+            let mut operands = Vec::new();
+            value.unreflect_operands(&mut operands);
+            for operand in operands {
+                collect_default_expr_forward_references(
+                    operand,
+                    body,
+                    later_params,
+                    shadowed,
+                    refs,
+                );
+            }
         }
         Stmt::Let {
             pattern,
@@ -712,7 +724,8 @@ fn collect_default_stmt_forward_references(
 #[cfg(test)]
 mod tests {
     use baml_base::Literal;
-    use baml_compiler2_ast::{CallArg, Pattern, TypeArg};
+    use baml_compiler2_ast::{CallArg, Pattern, TypeExprKind};
+    use text_size::TextRange;
 
     use super::*;
 
@@ -729,7 +742,13 @@ mod tests {
         let operand = call_body.exprs.alloc(Expr::Path(vec![Name::new("later")]));
         let call = call_body.exprs.alloc(Expr::Call {
             callee,
-            type_args: vec![TypeArg::Unreflect(operand)],
+            type_args: vec![
+                TypeExprKind::Unreflect {
+                    operand: Some(operand),
+                    attrs: Vec::new(),
+                }
+                .at(TextRange::default()),
+            ],
             args: Vec::<CallArg>::new(),
         });
         assert_eq!(
@@ -743,7 +762,11 @@ mod tests {
             .alloc(Expr::Path(vec![Name::new("later")]));
         let stmt = binding_body.stmts.alloc(Stmt::TypeBinding {
             name: Name::new("T"),
-            value,
+            value: TypeExprKind::Unreflect {
+                operand: Some(value),
+                attrs: Vec::new(),
+            }
+            .at(TextRange::default()),
         });
         let block = binding_body.exprs.alloc(Expr::Block {
             stmts: vec![stmt],

--- a/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
@@ -144,6 +144,9 @@ pub enum TirTypeError {
     /// `escape` picks the note; the headline and the fix are the same either
     /// way.
     RuntimeTypeMustBeNamed { escape: RuntimeTypeEscape },
+    /// `unreflect(...)` in a declaration signature has no executable scope
+    /// in which to allocate its runtime type slot.
+    RuntimeTypeHasNoScope,
     /// A mounted callable whose implementation is compiler-owned and has no
     /// location-free link ABI was invoked from a source-less consumer.
     MountedPackageCallUnsupported { path: Name },
@@ -944,6 +947,11 @@ impl fmt::Display for TirTypeError {
             TirTypeError::RuntimeTypeMustBeNamed { .. } => {
                 let diagnostic =
                     baml_compiler_diagnostics::runtime_type::runtime_type_must_be_named();
+                f.write_str(diagnostic.message.as_str())
+            }
+            TirTypeError::RuntimeTypeHasNoScope => {
+                let diagnostic =
+                    baml_compiler_diagnostics::runtime_type::runtime_type_has_no_scope();
                 f.write_str(diagnostic.message.as_str())
             }
             TirTypeError::UnresolvedPropertyShorthand { name, suggestions } => {
@@ -2204,10 +2212,9 @@ pub fn removed_reflect_spelling(name: &Name) -> Option<TirTypeError> {
         (format!("reflect.Type.{rest}"), true)
     } else if written == "baml.reflect" {
         ("reflect".to_string(), false)
-    } else if let Some(rest) = written.strip_prefix("baml.reflect.") {
-        (format!("reflect.{rest}"), false)
     } else {
-        return None;
+        let rest = written.strip_prefix("baml.reflect.")?;
+        (format!("reflect.{rest}"), false)
     };
     Some(TirTypeError::RemovedReflectSpelling {
         written: name.clone(),

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -1762,6 +1762,10 @@ struct InferenceContext<'db> {
     /// Carriers already reported as escaping their call (E0168), so a callee
     /// road walked twice reports once.
     reported_runtime_escapes: rustc_hash::FxHashSet<ExprId>,
+    /// Runtime carriers can be reached by more than one inference road (for
+    /// example the claim and body passes over a catch pattern). Their
+    /// expression effects and diagnostics must still be inferred once.
+    validated_runtime_operands: rustc_hash::FxHashSet<ExprId>,
     /// Inline `unreflect(...)` carriers whose call publishes the parameter in
     /// its RESULT — the bare `-> T` included. The `?.` check consults this at
     /// the chain boundary, where the callee's signature is no longer reachable.
@@ -1831,6 +1835,7 @@ impl<'db> InferenceContext<'db> {
             wf_scope_env: std::cell::OnceCell::new(),
             runtime_dependent_call_params: FxHashMap::default(),
             reported_runtime_escapes: rustc_hash::FxHashSet::default(),
+            validated_runtime_operands: rustc_hash::FxHashSet::default(),
             runtime_slots_named_by_result: rustc_hash::FxHashSet::default(),
             result: InferenceResult::default(),
         }
@@ -1948,7 +1953,7 @@ impl<'db> InferenceContext<'db> {
             .iter()
             .any(|param| ty_mentions_param(&expected, param))
         {
-            return self.sub(&actual, &expected);
+            return self.probe_sub(&actual, &expected);
         }
 
         match (actual.kind(), expected.kind()) {
@@ -2082,6 +2087,19 @@ impl<'db> InferenceContext<'db> {
             (_, TyKind::AssociatedTypeProjection { .. }) => true,
             _ => false,
         }
+    }
+
+    /// Ask the ordinary relation for a verdict without retaining any bounds,
+    /// obligations, or deferred pairs deposited by that speculative check.
+    fn probe_sub(&mut self, actual: &Ty, expected: &Ty) -> bool {
+        let snapshot = self.table.snapshot();
+        let obligations_len = self.obligations.len();
+        let deferred_subs_len = self.deferred_subs.len();
+        let result = self.sub(actual, expected);
+        self.table.rollback_to(snapshot);
+        self.obligations.truncate(obligations_len);
+        self.deferred_subs.truncate(deferred_subs_len);
+        result
     }
 
     /// Checking mode: infer with the expectation, then constrain -
@@ -2420,18 +2438,17 @@ impl<'db> InferenceContext<'db> {
                 // instantiations). Interface views only (TIR's rule);
                 // the non-interface diagnostic is S17's.
                 let base_ty = self.infer_expr(body, *base, &Expectation::None);
-                let target = if let Some(target_ref) =
-                    self.type_refs.upcast_targets.get(&expr).copied()
-                {
-                    let (lowered, diagnostics) = self.lower_body_type_ref_at(
-                        target_ref,
-                        crate::lower::TypePosition::Existential,
-                    );
-                    self.queue_body_lowering_diagnostics(diagnostics);
-                    self.reject_expr_position_holes(&lowered, expr)
-                } else {
-                    Ty::error()
-                };
+                let target =
+                    if let Some(target_ref) = self.type_refs.upcast_targets.get(&expr).copied() {
+                        let (lowered, diagnostics) = self.lower_body_type_ref_at(
+                            target_ref,
+                            crate::lower::TypePosition::Existential,
+                        );
+                        self.queue_body_lowering_diagnostics(diagnostics);
+                        self.reject_expr_position_holes(&lowered, expr)
+                    } else {
+                        Ty::error()
+                    };
                 // The interface-view gate is a STRUCTURE demand: an
                 // alias naming an interface answers as the interface.
                 let target = self.expand_alias_ty(&target);
@@ -4972,6 +4989,9 @@ impl<'db> InferenceContext<'db> {
     }
 
     fn validate_runtime_type_operand(&mut self, body: &ExprBody, operand: ExprId) {
+        if !self.validated_runtime_operands.insert(operand) {
+            return;
+        }
         let got = self.infer_expr(body, operand, &Expectation::None);
         let pending_type = matches!(got.kind(), TyKind::Class(name, _, _)
             if name.package().as_str() == "reflect"

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -557,6 +557,8 @@ pub enum CallTypeArgPlan {
         /// Written type shape used only when MIR emits `LoadType`. It is
         /// resolved without union set-algebra so coercion try-order survives.
         emission_ty: Ty,
+        /// Scoped carriers nested inside the written static shape.
+        runtime_bindings: Box<[ScopedTypeBinding]>,
     },
     Runtime {
         operand: ExprId,
@@ -581,7 +583,11 @@ pub enum RuntimeCheck {
 pub struct ScopedTypeBinding {
     pub name: baml_type::Name,
     pub parameter: baml_type::ParamTy,
-    pub operand: ExprId,
+    /// Direct runtime carrier, or `None` when this binding is materialized
+    /// from a composite type template.
+    pub operand: Option<ExprId>,
+    /// Composite template loaded before `BindType` for a lexical alias.
+    pub template_ty: Option<Ty>,
     pub occurrence_ty: Ty,
 }
 
@@ -1058,6 +1064,10 @@ pub struct InferenceResult<'db> {
     /// evaluates and installs them. MIR consumes this identity instead of
     /// rebuilding a synthetic parameter from syntax.
     pub type_bindings: FxHashMap<StmtId, ScopedTypeBinding>,
+    /// Synthesized runtime slots keyed by the body-owned type reference that
+    /// contains them.
+    pub type_ref_bindings:
+        FxHashMap<baml_compiler2_hir::type_ref::TypeRefId, Box<[ScopedTypeBinding]>>,
     /// Checks whose expected shape depends on a lexical runtime-type binding.
     /// Static inference records the actual expression type but cannot decide
     /// the relation until the binding's operand has produced a runtime type;
@@ -1088,6 +1098,7 @@ impl Default for InferenceResult<'_> {
             path_resolutions: FxHashMap::default(),
             call_plans: FxHashMap::default(),
             type_bindings: FxHashMap::default(),
+            type_ref_bindings: FxHashMap::default(),
             runtime_checks: Vec::new(),
             expr_adjustments: FxHashMap::default(),
             desugared_callees: rustc_hash::FxHashSet::default(),
@@ -1604,6 +1615,9 @@ struct InferenceContext<'db> {
     /// lowering context remains immutable; body-owned type lowering forks it
     /// with these rigid parameters.
     scoped_type_bindings: Vec<ScopedTypeBinding>,
+    /// One durable synthesized binding per `Unreflect` type-ref node.
+    synthesized_type_bindings:
+        FxHashMap<baml_compiler2_hir::type_ref::TypeRefId, ScopedTypeBinding>,
     /// Stable hash of the body owner, combined with `StmtId` for scoped rigid
     /// parameter identity.
     body_owner_identity: u32,
@@ -1778,6 +1792,7 @@ impl<'db> InferenceContext<'db> {
             flow: FxHashMap::default(),
             lower,
             scoped_type_bindings: Vec::new(),
+            synthesized_type_bindings: FxHashMap::default(),
             body_owner_identity,
             body_owner_id: None,
             param_tys,
@@ -1911,6 +1926,164 @@ impl<'db> InferenceContext<'db> {
         }
     }
 
+    /// Reject an impossible outer shape before replacing runtime-rigid leaves
+    /// with inference variables. `Sub` intentionally treats some
+    /// variable-carrying pairs as deferred, so by itself it cannot distinguish
+    /// `int` from `list<?runtime>` at this stage.
+    fn runtime_static_skeleton_matches(
+        &mut self,
+        actual: &Ty,
+        expected: &Ty,
+        runtime_params: &[baml_type::ParamTy],
+    ) -> bool {
+        let actual = self.table.shallow_resolve(actual);
+        let expected = self.table.shallow_resolve(expected);
+        if actual.has_error() || expected.has_error() {
+            return true;
+        }
+        if matches!(expected.kind(), TyKind::TypeVar(param, _) if runtime_params.contains(param)) {
+            return true;
+        }
+        if !runtime_params
+            .iter()
+            .any(|param| ty_mentions_param(&expected, param))
+        {
+            return self.sub(&actual, &expected);
+        }
+
+        match (actual.kind(), expected.kind()) {
+            (TyKind::Union(actual_members, _), _) => {
+                for member in actual_members {
+                    if !self.runtime_static_skeleton_matches(member, &expected, runtime_params) {
+                        return false;
+                    }
+                }
+                true
+            }
+            (_, TyKind::Union(expected_members, _)) => {
+                for member in expected_members {
+                    if self.runtime_static_skeleton_matches(&actual, member, runtime_params) {
+                        return true;
+                    }
+                }
+                false
+            }
+            (TyKind::List(actual_item, _), TyKind::List(expected_item, _)) => {
+                self.runtime_static_skeleton_matches(actual_item, expected_item, runtime_params)
+            }
+            (
+                TyKind::Map {
+                    key: actual_key,
+                    value: actual_value,
+                    ..
+                },
+                TyKind::Map {
+                    key: expected_key,
+                    value: expected_value,
+                    ..
+                },
+            ) => {
+                self.runtime_static_skeleton_matches(actual_key, expected_key, runtime_params)
+                    && self.runtime_static_skeleton_matches(
+                        actual_value,
+                        expected_value,
+                        runtime_params,
+                    )
+            }
+            (
+                TyKind::Class(actual_name, actual_args, _),
+                TyKind::Class(expected_name, expected_args, _),
+            ) if actual_name == expected_name && actual_args.len() == expected_args.len() => {
+                for (actual_arg, expected_arg) in actual_args.iter().zip(expected_args) {
+                    if !self.runtime_static_skeleton_matches(
+                        actual_arg,
+                        expected_arg,
+                        runtime_params,
+                    ) {
+                        return false;
+                    }
+                }
+                true
+            }
+            (
+                TyKind::Interface(actual_name, actual_args, actual_pins, _),
+                TyKind::Interface(expected_name, expected_args, expected_pins, _),
+            ) if actual_name == expected_name && actual_args.len() == expected_args.len() => {
+                for (actual_arg, expected_arg) in actual_args.iter().zip(expected_args) {
+                    if !self.runtime_static_skeleton_matches(
+                        actual_arg,
+                        expected_arg,
+                        runtime_params,
+                    ) {
+                        return false;
+                    }
+                }
+                for (name, expected_pin) in expected_pins {
+                    if let Some((_, actual_pin)) = actual_pins
+                        .iter()
+                        .find(|(actual_name, _)| actual_name == name)
+                        && !self.runtime_static_skeleton_matches(
+                            actual_pin,
+                            expected_pin,
+                            runtime_params,
+                        )
+                    {
+                        return false;
+                    }
+                }
+                true
+            }
+            // A class may satisfy a runtime-parameterized interface. The
+            // subsequent `Sub` call owns that implementation lookup.
+            (TyKind::Class(..), TyKind::Interface(..)) => true,
+            (
+                TyKind::Function {
+                    params: actual_params,
+                    ret: actual_ret,
+                    throws: actual_throws,
+                    ..
+                },
+                TyKind::Function {
+                    params: expected_params,
+                    ret: expected_ret,
+                    throws: expected_throws,
+                    ..
+                },
+            ) if actual_params.len() == expected_params.len() => {
+                for (actual_param, expected_param) in actual_params.iter().zip(expected_params) {
+                    if !self.runtime_static_skeleton_matches(
+                        &actual_param.ty,
+                        &expected_param.ty,
+                        runtime_params,
+                    ) {
+                        return false;
+                    }
+                }
+                self.runtime_static_skeleton_matches(actual_ret, expected_ret, runtime_params)
+                    && self.runtime_static_skeleton_matches(
+                        actual_throws,
+                        expected_throws,
+                        runtime_params,
+                    )
+            }
+            (
+                TyKind::Future(actual_value, actual_error, _),
+                TyKind::Future(expected_value, expected_error, _),
+            ) => {
+                self.runtime_static_skeleton_matches(actual_value, expected_value, runtime_params)
+                    && self.runtime_static_skeleton_matches(
+                        actual_error,
+                        expected_error,
+                        runtime_params,
+                    )
+            }
+            // Projections are resolved by `Sub`; their head may legitimately
+            // differ from the concrete type they reduce to.
+            (_, TyKind::AssociatedTypeProjection { .. }) => true,
+            _ => false,
+        }
+    }
+
     /// Checking mode: infer with the expectation, then constrain -
     /// `Sub(actual, expected)`, discharged eagerly. Definite failures are
     /// recorded against the checked expression, never dropped.
@@ -1932,14 +2105,30 @@ impl<'db> InferenceContext<'db> {
             // still rejects an `int`, while a `list<int>` advances to the
             // runtime gate for its element relation. This is the same
             // dependent-only discipline used by call-site runtime slots.
-            let static_expected =
-                self.scoped_type_bindings
-                    .iter()
-                    .fold(expected.clone(), |expected, binding| {
-                        replace_rigid_param(&expected, &binding.parameter, &binding.occurrence_ty)
-                    });
+            // Replace each runtime-rigid leaf with one fresh inference variable
+            // for this static shape check. `unknown` is still an ordinary,
+            // invariant generic argument (`Wrapper<string>` is not a subtype
+            // of `Wrapper<unknown>`), whereas this check needs a true hole:
+            // prove the surrounding constructors line up, then leave the leaf
+            // relation to MIR's runtime gate.
+            let runtime_params: Vec<_> = self
+                .scoped_type_bindings
+                .iter()
+                .map(|binding| binding.parameter.clone())
+                .collect();
+            let skeleton_matches =
+                self.runtime_static_skeleton_matches(&ty, expected, &runtime_params);
+            let dynamic_holes: Vec<_> = runtime_params
+                .into_iter()
+                .map(|parameter| (parameter, self.table.new_establishment_var_ty()))
+                .collect();
+            let static_expected = dynamic_holes
+                .iter()
+                .fold(expected.clone(), |expected, (parameter, hole)| {
+                    replace_rigid_param(&expected, parameter, hole)
+                });
             let saved_anchor = self.obligation_anchor.replace(expr);
-            let fits_static_shape = self.sub(&ty, &static_expected);
+            let fits_static_shape = skeleton_matches && self.sub(&ty, &static_expected);
             self.obligation_anchor = saved_anchor;
             if fits_static_shape {
                 self.result.runtime_checks.push(RuntimeCheck::Argument {
@@ -2231,20 +2420,18 @@ impl<'db> InferenceContext<'db> {
                 // instantiations). Interface views only (TIR's rule);
                 // the non-interface diagnostic is S17's.
                 let base_ty = self.infer_expr(body, *base, &Expectation::None);
-                let target = self
-                    .type_refs
-                    .upcast_targets
-                    .get(&expr)
-                    .copied()
-                    .map(|target_ref| {
-                        let (lowered, diagnostics) = self.lower_scoped_body_type_ref_at(
-                            target_ref,
-                            crate::lower::TypePosition::Existential,
-                        );
-                        self.queue_body_lowering_diagnostics(diagnostics);
-                        self.reject_expr_position_holes(&lowered, expr)
-                    })
-                    .unwrap_or_else(Ty::error);
+                let target = if let Some(target_ref) =
+                    self.type_refs.upcast_targets.get(&expr).copied()
+                {
+                    let (lowered, diagnostics) = self.lower_body_type_ref_at(
+                        target_ref,
+                        crate::lower::TypePosition::Existential,
+                    );
+                    self.queue_body_lowering_diagnostics(diagnostics);
+                    self.reject_expr_position_holes(&lowered, expr)
+                } else {
+                    Ty::error()
+                };
                 // The interface-view gate is a STRUCTURE demand: an
                 // alias naming an interface answers as the interface.
                 let target = self.expand_alias_ty(&target);
@@ -2275,6 +2462,7 @@ impl<'db> InferenceContext<'db> {
                 }
             }
             Expr::GenericApply { base, .. } => {
+                self.validate_runtime_type_arg_operands(body, expr);
                 // Value-position turbofish (rustc's `let f =
                 // identity::<i32>`; r-a's `substs_from_path`): the SAME
                 // resolution ladder a call's callee takes, reading the
@@ -2539,6 +2727,7 @@ impl<'db> InferenceContext<'db> {
                 fields,
                 spreads,
             } => {
+                self.validate_runtime_type_arg_operands(body, expr);
                 // `map { .. }` is a map literal in constructor clothing
                 // (identifier keys are string keys), never a class named
                 // `map` - same routing guard as the parser's object form.
@@ -2659,7 +2848,10 @@ impl<'db> InferenceContext<'db> {
                 self.infer_expr(body, *expr, &Expectation::None);
             }
             Stmt::TypeBinding { name, value } => {
-                self.bind_scoped_runtime_type(body, stmt, name.clone(), *value);
+                let Some(type_ref) = self.type_refs.stmt_type_bindings.get(&stmt).copied() else {
+                    return;
+                };
+                self.bind_scoped_runtime_type(body, stmt, name.clone(), value, type_ref);
             }
             Stmt::Let {
                 pattern,
@@ -2890,10 +3082,28 @@ impl<'db> InferenceContext<'db> {
         body: &ExprBody,
         stmt: StmtId,
         name: baml_type::Name,
-        operand: ExprId,
+        value: &baml_compiler2_ast::TypeExpr,
+        type_ref: BodyTypeRefId,
     ) {
-        // The RHS is evaluated before the new name enters scope.
-        self.validate_runtime_type_operand(body, operand);
+        let direct_operand = match &value.kind {
+            baml_compiler2_ast::TypeExprKind::Unreflect {
+                operand: Some(operand),
+                ..
+            } => Some(*operand),
+            _ => None,
+        };
+        // The RHS is evaluated before the new name enters scope. A composite
+        // first synthesizes its nested slots, then materializes the template
+        // into the named slot.
+        let template_ty = if let Some(operand) = direct_operand {
+            self.validate_runtime_type_operand(body, operand);
+            None
+        } else {
+            let (ty, diagnostics) =
+                self.lower_body_type_ref_at(type_ref, crate::lower::TypePosition::Existential);
+            self.queue_body_lowering_diagnostics(diagnostics);
+            Some(ty)
+        };
         let mut identity = self.body_owner_identity;
         for byte in stmt.into_raw().into_u32().to_le_bytes() {
             identity ^= u32::from(byte);
@@ -2902,7 +3112,8 @@ impl<'db> InferenceContext<'db> {
         let binding = ScopedTypeBinding {
             name: name.clone(),
             parameter: baml_type::ParamTy::new(0x8000_0000 | (identity & 0x7fff_ffff), name),
-            operand,
+            operand: direct_operand,
+            template_ty,
             occurrence_ty: Ty::intern(TyKind::Unknown {
                 attr: TyAttr::default(),
             }),
@@ -2972,17 +3183,59 @@ impl<'db> InferenceContext<'db> {
             .map(|binding| &binding.parameter)
     }
 
-    fn lower_scoped_body_type_ref_at(
-        &self,
-        type_ref: BodyTypeRefId,
+    fn lower_scoped_type_ref_at(
+        &mut self,
+        store: &baml_compiler2_hir::type_ref::TypeRefStore,
+        type_ref: baml_compiler2_hir::type_ref::TypeRefId,
         position: crate::lower::TypePosition,
     ) -> (Ty, Vec<crate::lower::LoweringDiag>) {
-        self.lower.lower_type_ref_with_overlay_and_diagnostics(
-            &self.type_refs.store,
-            self.type_refs.raw_id(type_ref),
-            position,
-            &self.scoped_type_params(),
-        )
+        let mut runtime_params = FxHashMap::default();
+        let mut occurrences = Vec::new();
+        collect_unreflect_type_refs(store, type_ref, &mut occurrences);
+        let mut bindings = Vec::new();
+        for (runtime_ref, operand) in occurrences {
+            let binding = if let Some(binding) = self.synthesized_type_bindings.get(&runtime_ref) {
+                binding.clone()
+            } else {
+                let mut identity = self.body_owner_identity;
+                for byte in runtime_ref.into_raw().into_u32().to_le_bytes() {
+                    identity ^= u32::from(byte);
+                    identity = identity.wrapping_mul(0x0100_0193);
+                }
+                let name = baml_type::Name::new(format!("$unreflect${identity:08x}"));
+                let binding = ScopedTypeBinding {
+                    name: name.clone(),
+                    parameter: baml_type::ParamTy::new(
+                        0xa000_0000 | (identity & 0x1fff_ffff),
+                        name,
+                    ),
+                    operand: Some(operand),
+                    template_ty: None,
+                    occurrence_ty: Ty::intern(TyKind::Unknown {
+                        attr: TyAttr::default(),
+                    }),
+                };
+                self.synthesized_type_bindings
+                    .insert(runtime_ref, binding.clone());
+                self.scoped_type_bindings.push(binding.clone());
+                binding
+            };
+            runtime_params.insert(runtime_ref, binding.parameter.clone());
+            bindings.push(binding);
+        }
+        if !bindings.is_empty() {
+            self.result
+                .type_ref_bindings
+                .insert(type_ref, bindings.into_boxed_slice());
+        }
+        self.lower
+            .lower_type_ref_with_runtime_bindings_and_diagnostics(
+                store,
+                type_ref,
+                position,
+                &self.scoped_type_params(),
+                &runtime_params,
+            )
     }
 
     fn queue_body_lowering_diagnostics(&mut self, diagnostics: Vec<crate::lower::LoweringDiag>) {
@@ -2997,6 +3250,18 @@ impl<'db> InferenceContext<'db> {
             );
     }
 
+    fn lower_body_type_ref_at(
+        &mut self,
+        type_ref: BodyTypeRefId,
+        position: crate::lower::TypePosition,
+    ) -> (Ty, Vec<crate::lower::LoweringDiag>) {
+        let type_refs = Arc::clone(&self.type_refs);
+        self.lower_scoped_type_ref_at(
+            &type_refs.store,
+            type_refs.raw_id(type_ref),
+            position,
+        )
+    }
     fn lower_scoped_type_path(&self, segments: &[baml_type::Name]) -> Ty {
         self.lower
             .lower_type_path_with_overlay(segments, &self.scoped_type_params())
@@ -4610,7 +4875,12 @@ impl<'db> InferenceContext<'db> {
         let requires_runtime_check = plan
             .slots
             .iter()
-            .any(|slot| matches!(slot, CallTypeArgPlan::Runtime { .. }))
+            .any(|slot| match slot {
+                CallTypeArgPlan::Runtime { .. } => true,
+                CallTypeArgPlan::Static {
+                    runtime_bindings, ..
+                } => !runtime_bindings.is_empty(),
+            })
             || !plan.deferred_checks.is_empty()
             || self.result.runtime_checks.iter().any(|check| match check {
                 RuntimeCheck::Argument { arg, .. } => plan.bindings.iter().any(|binding| {
@@ -4683,9 +4953,17 @@ impl<'db> InferenceContext<'db> {
             .get(&call)
             .into_iter()
             .flat_map(|slots| slots.iter())
-            .filter_map(|slot| match slot {
-                BodyTypeArgRef::Runtime { operand } => Some(*operand),
-                BodyTypeArgRef::Static(_) => None,
+            .flat_map(|slot| match slot {
+                BodyTypeArgRef::Runtime { operand } => vec![*operand],
+                BodyTypeArgRef::Static(type_ref) => {
+                    let mut nested = Vec::new();
+                    collect_unreflect_type_refs(
+                        &self.type_refs.store,
+                        self.type_refs.raw_id(*type_ref),
+                        &mut nested,
+                    );
+                    nested.into_iter().map(|(_, operand)| operand).collect()
+                }
             })
             .collect();
         for operand in operands {
@@ -6606,7 +6884,7 @@ impl<'db> InferenceContext<'db> {
         let member = member.clone();
 
         let lower = |this: &mut Self, type_ref, position| {
-            let (ty, diagnostics) = this.lower_scoped_body_type_ref_at(type_ref, position);
+            let (ty, diagnostics) = this.lower_body_type_ref_at(type_ref, position);
             this.queue_body_lowering_diagnostics(diagnostics);
             this.reject_expr_position_holes(&ty, expr)
         };
@@ -7795,8 +8073,13 @@ impl<'db> InferenceContext<'db> {
             match slot {
                 BodyTypeArgRef::Static(type_ref) => {
                     let computed = self.computed_generic_argument_name(*type_ref, site);
-                    let (lowered, diagnostics) =
-                        self.lower_scoped_body_type_ref_at(*type_ref, position);
+                    let (lowered, diagnostics) = self.lower_body_type_ref_at(*type_ref, position);
+                    let runtime_bindings = self
+                        .result
+                        .type_ref_bindings
+                        .get(&self.type_refs.raw_id(*type_ref))
+                        .cloned()
+                        .unwrap_or_default();
                     if let Some(name) = computed {
                         self.specialize_computed_generic_diagnostic(
                             diagnostics,
@@ -7811,6 +8094,7 @@ impl<'db> InferenceContext<'db> {
                     slots.push(CallTypeArgPlan::Static {
                         ty: ty.clone(),
                         emission_ty: ty.clone(),
+                        runtime_bindings,
                     });
                     instantiation.push(ty);
                 }
@@ -7908,11 +8192,20 @@ impl<'db> InferenceContext<'db> {
             .get(&call)
             .into_iter()
             .flat_map(|plan| &plan.slots)
-            .filter_map(|slot| match slot {
+            .flat_map(|slot| match slot {
                 CallTypeArgPlan::Runtime {
                     operand, parameter, ..
-                } => escapes(parameter).then_some(*operand),
-                CallTypeArgPlan::Static { .. } => None,
+                } => escapes(parameter)
+                    .then_some(*operand)
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+                CallTypeArgPlan::Static {
+                    runtime_bindings, ..
+                } => runtime_bindings
+                    .iter()
+                    .filter(|binding| escapes(&binding.parameter))
+                    .filter_map(|binding| binding.operand)
+                    .collect(),
             })
             .collect()
     }
@@ -7979,9 +8272,12 @@ impl<'db> InferenceContext<'db> {
         bound_receiver: bool,
     ) {
         if !self.result.call_plans.get(&call).is_some_and(|plan| {
-            plan.slots
-                .iter()
-                .any(|slot| matches!(slot, CallTypeArgPlan::Runtime { .. }))
+            plan.slots.iter().any(|slot| match slot {
+                CallTypeArgPlan::Runtime { .. } => true,
+                CallTypeArgPlan::Static {
+                    runtime_bindings, ..
+                } => !runtime_bindings.is_empty(),
+            })
         }) {
             return;
         }
@@ -7991,6 +8287,17 @@ impl<'db> InferenceContext<'db> {
         // caller, so both are checked — the note is worded for a clause the
         // author may never have spelled.
         self.report_runtime_type_escape(call, &signature.throws, RuntimeTypeEscape::Error);
+        if let Some(instantiation) = self
+            .result
+            .call_plans
+            .get(&call)
+            .map(|plan| plan.type_args.clone())
+        {
+            let instantiated_ret = substitute_params(&signature.ret, &instantiation);
+            let instantiated_throws = substitute_params(&signature.throws, &instantiation);
+            self.report_runtime_type_escape(call, &instantiated_ret, RuntimeTypeEscape::Value);
+            self.report_runtime_type_escape(call, &instantiated_throws, RuntimeTypeEscape::Error);
+        }
         let runtime_params = self.runtime_call_params(call);
         if runtime_params.is_empty() {
             return;
@@ -8322,6 +8629,7 @@ impl<'db> InferenceContext<'db> {
         for spread in spreads {
             self.check_expr(body, spread.expr, &object_ty);
         }
+        self.report_runtime_type_escape(object, &object_ty, RuntimeTypeEscape::Value);
         object_ty
     }
 
@@ -8449,6 +8757,7 @@ impl<'db> InferenceContext<'db> {
         for spread in spreads {
             self.check_expr(body, spread.expr, &object_ty);
         }
+        self.report_runtime_type_escape(object, &object_ty, RuntimeTypeEscape::Value);
         object_ty
     }
 
@@ -9327,7 +9636,7 @@ impl<'db> InferenceContext<'db> {
             return cached.clone();
         }
         let (lowered, diagnostics) =
-            self.lower_scoped_body_type_ref_at(type_ref, crate::lower::TypePosition::Existential);
+            self.lower_body_type_ref_at(type_ref, crate::lower::TypePosition::Existential);
         self.queue_body_lowering_diagnostics(diagnostics);
         // Written-type well-formedness (rustc's wfcheck at body
         // annotations): generic arguments must satisfy their heads'
@@ -11100,7 +11409,9 @@ impl<'db> InferenceContext<'db> {
             }
             for slot in &mut plan.slots {
                 match slot {
-                    CallTypeArgPlan::Static { ty, emission_ty } => {
+                    CallTypeArgPlan::Static {
+                        ty, emission_ty, ..
+                    } => {
                         *ty = self.finalize_ty(ty);
                         *emission_ty = self.finalize_emission_ty(emission_ty);
                     }
@@ -12074,6 +12385,66 @@ fn runtime_param_escapes(published: &Ty, param: &baml_type::ParamTy) -> bool {
         return false;
     }
     ty_mentions_param(published, param)
+}
+
+fn collect_unreflect_type_refs(
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    id: baml_compiler2_hir::type_ref::TypeRefId,
+    out: &mut Vec<(baml_compiler2_hir::type_ref::TypeRefId, ExprId)>,
+) {
+    use baml_compiler2_hir::type_ref::TypeRefKind;
+    match &store[id].kind {
+        TypeRefKind::Unreflect {
+            operand: Some(operand),
+        } => out.push((id, *operand)),
+        TypeRefKind::Unreflect { operand: None } => {}
+        TypeRefKind::Path {
+            generic_args,
+            associated_type_bindings,
+            ..
+        } => {
+            for child in generic_args {
+                collect_unreflect_type_refs(store, *child, out);
+            }
+            for binding in associated_type_bindings {
+                collect_unreflect_type_refs(store, binding.ty, out);
+            }
+        }
+        TypeRefKind::AssociatedTypeProjection {
+            base, interface, ..
+        } => {
+            collect_unreflect_type_refs(store, *base, out);
+            if let Some(interface) = interface {
+                collect_unreflect_type_refs(store, *interface, out);
+            }
+        }
+        TypeRefKind::Optional { inner } | TypeRefKind::List { inner } => {
+            collect_unreflect_type_refs(store, *inner, out);
+        }
+        TypeRefKind::Map { key, value } => {
+            collect_unreflect_type_refs(store, *key, out);
+            collect_unreflect_type_refs(store, *value, out);
+        }
+        TypeRefKind::Union { variants } => {
+            for child in variants {
+                collect_unreflect_type_refs(store, *child, out);
+            }
+        }
+        TypeRefKind::Function {
+            params,
+            ret,
+            throws,
+        } => {
+            for param in params {
+                collect_unreflect_type_refs(store, param.ty, out);
+            }
+            collect_unreflect_type_refs(store, *ret, out);
+            if let Some(throws) = throws {
+                collect_unreflect_type_refs(store, *throws, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn interface_occurrence_ty(interface: &InterfaceRef) -> Ty {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -3267,11 +3267,7 @@ impl<'db> InferenceContext<'db> {
         position: crate::lower::TypePosition,
     ) -> (Ty, Vec<crate::lower::LoweringDiag>) {
         let type_refs = Arc::clone(&self.type_refs);
-        self.lower_scoped_type_ref_at(
-            &type_refs.store,
-            type_refs.raw_id(type_ref),
-            position,
-        )
+        self.lower_scoped_type_ref_at(&type_refs.store, type_refs.raw_id(type_ref), position)
     }
     fn lower_scoped_type_path(&self, segments: &[baml_type::Name]) -> Ty {
         self.lower

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -1949,11 +1949,13 @@ impl<'db> InferenceContext<'db> {
         if matches!(expected.kind(), TyKind::TypeVar(param, _) if runtime_params.contains(param)) {
             return true;
         }
-        if !runtime_params
-            .iter()
-            .any(|param| ty_mentions_param(&expected, param))
+        if !actual.has_infer()
+            && !expected.has_infer()
+            && !runtime_params
+                .iter()
+                .any(|param| ty_mentions_param(&expected, param))
         {
-            return self.probe_sub(&actual, &expected);
+            return self.cached_subtype(&actual, &expected);
         }
 
         match (actual.kind(), expected.kind()) {
@@ -2085,21 +2087,13 @@ impl<'db> InferenceContext<'db> {
             // Projections are resolved by `Sub`; their head may legitimately
             // differ from the concrete type they reduce to.
             (_, TyKind::AssociatedTypeProjection { .. }) => true,
+            // Open inference and rigid generic leaves carry no statically
+            // inspectable shape. The committed `Sub` relation immediately
+            // after this guard owns their bounds and obligations.
+            (TyKind::Infer { .. } | TyKind::TypeVar(..), _)
+            | (_, TyKind::Infer { .. } | TyKind::TypeVar(..)) => true,
             _ => false,
         }
-    }
-
-    /// Ask the ordinary relation for a verdict without retaining any bounds,
-    /// obligations, or deferred pairs deposited by that speculative check.
-    fn probe_sub(&mut self, actual: &Ty, expected: &Ty) -> bool {
-        let snapshot = self.table.snapshot();
-        let obligations_len = self.obligations.len();
-        let deferred_subs_len = self.deferred_subs.len();
-        let result = self.sub(actual, expected);
-        self.table.rollback_to(snapshot);
-        self.obligations.truncate(obligations_len);
-        self.deferred_subs.truncate(deferred_subs_len);
-        result
     }
 
     /// Checking mode: infer with the expectation, then constrain -
@@ -8200,6 +8194,14 @@ impl<'db> InferenceContext<'db> {
         self.report_escaping_carriers(call, escaping, escape);
     }
 
+    /// A class literal publishes its instantiated class type directly. Every
+    /// inline runtime slot is therefore embedded in that result, including
+    /// carriers nested inside a nominal argument.
+    fn report_object_runtime_type_escape(&mut self, object: ExprId) {
+        let escaping = self.escaping_carriers(object, |_| true);
+        self.report_escaping_carriers(object, escaping, RuntimeTypeEscape::Value);
+    }
+
     /// The carrier expressions of `call`'s inline `unreflect(...)` slots whose
     /// parameter `escapes`.
     fn escaping_carriers(
@@ -8649,7 +8651,7 @@ impl<'db> InferenceContext<'db> {
         for spread in spreads {
             self.check_expr(body, spread.expr, &object_ty);
         }
-        self.report_runtime_type_escape(object, &object_ty, RuntimeTypeEscape::Value);
+        self.report_object_runtime_type_escape(object);
         object_ty
     }
 
@@ -8777,7 +8779,7 @@ impl<'db> InferenceContext<'db> {
         for spread in spreads {
             self.check_expr(body, spread.expr, &object_ty);
         }
-        self.report_runtime_type_escape(object, &object_ty, RuntimeTypeEscape::Value);
+        self.report_object_runtime_type_escape(object);
         object_ty
     }
 

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -393,6 +393,39 @@ impl<'db> InferenceContext<'db> {
     }
 
     fn lower_pattern_inner(&mut self, body: &ExprBody, pat: PatId, scrut: &Ty) -> PatternOutcome {
+        let mut written_refs = Vec::new();
+        written_refs.extend(self.type_refs.pattern_types.get(&pat).copied());
+        written_refs.extend(self.type_refs.array_ascriptions.get(&pat).copied());
+        written_refs.extend(
+            self.type_refs
+                .pattern_class_args
+                .get(&pat)
+                .into_iter()
+                .flatten()
+                .copied(),
+        );
+        written_refs.extend(
+            self.type_refs
+                .pattern_assoc_bindings
+                .get(&pat)
+                .into_iter()
+                .flatten()
+                .map(|(_, type_ref)| *type_ref),
+        );
+        let mut operands = Vec::new();
+        for type_ref in written_refs {
+            let mut nested = Vec::new();
+            super::collect_unreflect_type_refs(
+                &self.type_refs.store,
+                self.type_refs.raw_id(type_ref),
+                &mut nested,
+            );
+            operands.extend(nested.into_iter().map(|(_, operand)| operand));
+        }
+        for operand in operands {
+            self.validate_runtime_type_operand(body, operand);
+        }
+
         match &body.patterns[pat] {
             Pattern::Wildcard => PatternOutcome {
                 dpat: DPat::wildcard(scrut.to_plain()),

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -68,7 +68,27 @@ impl<'db> InferenceContext<'db> {
         arms: &[MatchArmId],
         expected: &Expectation,
     ) -> Ty {
-        let scrut_ty = self.infer_expr(body, scrutinee, &Expectation::None);
+        let written_scrutinee = self
+            .type_refs
+            .match_scrutinee_types
+            .get(&match_expr)
+            .copied();
+        let scrut_ty = match written_scrutinee {
+            Some(type_ref) => {
+                let mut nested = Vec::new();
+                super::collect_unreflect_type_refs(&self.type_refs.store, type_ref, &mut nested);
+                for (_, operand) in nested {
+                    self.validate_runtime_type_operand(body, operand);
+                }
+                let annotation = self.lower_body_annotation(type_ref);
+                self.check_expr(body, scrutinee, &annotation);
+                // A match annotation declares the matrix's full input type.
+                // Keep it instead of narrowing back to the scrutinee's current
+                // concrete value so later arms remain reachable.
+                annotation
+            }
+            None => self.infer_expr(body, scrutinee, &Expectation::None),
+        };
         let scrut_resolved = self.scrutinee_demand(&scrut_ty);
         let scrut_binding = self.narrowable_binding(body, scrutinee);
         let branch_expectation = expected.adjust_for_branches(&mut self.table);

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -76,7 +76,11 @@ impl<'db> InferenceContext<'db> {
         let scrut_ty = match written_scrutinee {
             Some(type_ref) => {
                 let mut nested = Vec::new();
-                super::collect_unreflect_type_refs(&self.type_refs.store, type_ref, &mut nested);
+                super::collect_unreflect_type_refs(
+                    &self.type_refs.store,
+                    self.type_refs.raw_id(type_ref),
+                    &mut nested,
+                );
                 for (_, operand) in nested {
                     self.validate_runtime_type_operand(body, operand);
                 }
@@ -435,7 +439,11 @@ impl<'db> InferenceContext<'db> {
         let mut operands = Vec::new();
         for type_ref in written_refs {
             let mut nested = Vec::new();
-            super::collect_unreflect_type_refs(&self.type_refs.store, type_ref, &mut nested);
+            super::collect_unreflect_type_refs(
+                &self.type_refs.store,
+                self.type_refs.raw_id(type_ref),
+                &mut nested,
+            );
             operands.extend(nested.into_iter().map(|(_, operand)| operand));
         }
         for operand in operands {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -415,11 +415,7 @@ impl<'db> InferenceContext<'db> {
         let mut operands = Vec::new();
         for type_ref in written_refs {
             let mut nested = Vec::new();
-            super::collect_unreflect_type_refs(
-                &self.type_refs.store,
-                self.type_refs.raw_id(type_ref),
-                &mut nested,
-            );
+            super::collect_unreflect_type_refs(&self.type_refs.store, type_ref, &mut nested);
             operands.extend(nested.into_iter().map(|(_, operand)| operand));
         }
         for operand in operands {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
@@ -56,6 +56,8 @@ pub struct LoweringDiag {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LoweringDiagKind {
+    /// `unreflect(...)` appeared where no body scope can own its runtime slot.
+    RuntimeTypeHasNoScope,
     /// The written path resolved nowhere (E0002).
     Unresolved {
         name: Name,
@@ -128,6 +130,9 @@ pub struct LowerCtx<'db> {
     /// param's CONJUNCTION. Projections (`T.Output`) determine their
     /// interface through these.
     bounds: FxHashMap<ParamTy, Vec<baml_type::interned::InterfaceRef>>,
+    /// Body-local runtime type atoms replaced by their synthesized rigid
+    /// parameters. Empty for declaration signatures.
+    runtime_type_params: FxHashMap<TypeRefId, ParamTy>,
 }
 
 /// A lowering context for type syntax written in `file`, with an empty
@@ -149,6 +154,7 @@ pub fn lower_ctx_for_file(
         self_ty: None,
         self_impl_target: None,
         bounds: FxHashMap::default(),
+        runtime_type_params: FxHashMap::default(),
     }
 }
 
@@ -171,6 +177,7 @@ pub fn lower_ctx_for_package<'db>(
         self_ty: None,
         self_impl_target: None,
         bounds: FxHashMap::default(),
+        runtime_type_params: FxHashMap::default(),
     }
 }
 
@@ -316,6 +323,22 @@ impl<'db> LowerCtx<'db> {
         (ty, fork.take_diagnostics())
     }
 
+    /// Lower a body-owned type through both its lexical name overlay and the
+    /// synthesized bindings for nested `unreflect(...)` atoms. Diagnostics
+    /// are scoped to this store and lowering operation.
+    pub fn lower_type_ref_with_runtime_bindings_and_diagnostics(
+        &self,
+        store: &TypeRefStore,
+        id: TypeRefId,
+        position: TypePosition,
+        overlay: &[ParamTy],
+        runtime_type_params: &FxHashMap<TypeRefId, ParamTy>,
+    ) -> (Ty, Vec<LoweringDiag>) {
+        let mut fork = self.fork_with_overlay_and_diagnostics(overlay);
+        fork.runtime_type_params.clone_from(runtime_type_params);
+        let ty = fork.lower_type_ref_at(store, id, position);
+        (ty, fork.take_diagnostics())
+    }
     /// [`Self::lower_type_path`] through the same body-local overlay.
     pub fn lower_type_path_with_overlay(&self, segments: &[Name], overlay: &[ParamTy]) -> Ty {
         if overlay.is_empty() {
@@ -343,6 +366,7 @@ impl<'db> LowerCtx<'db> {
             self_ty: self.self_ty.clone(),
             self_impl_target: self.self_impl_target.clone(),
             bounds: self.bounds.clone(),
+            runtime_type_params: self.runtime_type_params.clone(),
         }
     }
 
@@ -372,6 +396,19 @@ impl<'db> LowerCtx<'db> {
             position
         };
         match &store[id].kind {
+            TypeRefKind::Unreflect { .. } => {
+                if let Some(param) = self.runtime_type_params.get(&id) {
+                    Ty::intern(TyKind::TypeVar(param.clone(), attr()))
+                } else {
+                    if let Some(diags) = &self.diags {
+                        diags.borrow_mut().push(LoweringDiag {
+                            type_ref: id,
+                            kind: LoweringDiagKind::RuntimeTypeHasNoScope,
+                        });
+                    }
+                    Ty::error()
+                }
+            }
             TypeRefKind::Int => Ty::int(),
             TypeRefKind::Bigint => Ty::intern(TyKind::Bigint { attr: attr() }),
             TypeRefKind::Float => Ty::float(),
@@ -2151,6 +2188,7 @@ pub fn lowering_diag_error(kind: &LoweringDiagKind) -> crate::diagnostics::TirTy
         }
         LoweringDiagKind::Projection(error) => (**error).clone(),
         LoweringDiagKind::FnTypeMissingThrows => TirTypeError::FunctionTypeMissingThrows,
+        LoweringDiagKind::RuntimeTypeHasNoScope => TirTypeError::RuntimeTypeHasNoScope,
     }
 }
 

--- a/baml_language/crates/baml_compiler2_hir_ty/src/throw_facts.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/throw_facts.rs
@@ -606,7 +606,8 @@ fn collect_widened_leaf_types(ty: &Ty, out: &mut BTreeSet<Ty>) {
 
 #[cfg(test)]
 mod tests {
-    use baml_compiler2_ast::{Pattern, Stmt, TypeArg};
+    use baml_compiler2_ast::{Pattern, Stmt, TypeExprKind};
+    use text_size::TextRange;
 
     use super::*;
 
@@ -624,7 +625,13 @@ mod tests {
         let call_throw = throwing_expr(&mut body, "call");
         let call = body.exprs.alloc(Expr::Call {
             callee,
-            type_args: vec![TypeArg::Unreflect(call_throw)],
+            type_args: vec![
+                TypeExprKind::Unreflect {
+                    operand: Some(call_throw),
+                    attrs: Vec::new(),
+                }
+                .at(TextRange::default()),
+            ],
             args: Vec::new(),
         });
         let call_stmt = body.stmts.alloc(Stmt::Expr(call));
@@ -632,7 +639,11 @@ mod tests {
         let binding_throw = throwing_expr(&mut body, "binding");
         let binding = body.stmts.alloc(Stmt::TypeBinding {
             name: Name::new("T"),
-            value: binding_throw,
+            value: TypeExprKind::Unreflect {
+                operand: Some(binding_throw),
+                attrs: Vec::new(),
+            }
+            .at(TextRange::default()),
         });
 
         let scrutinee = body.exprs.alloc(Expr::Literal(Literal::Int(1)));

--- a/baml_language/crates/baml_compiler2_mir/src/inference_provider.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/inference_provider.rs
@@ -119,6 +119,7 @@ pub(crate) enum CallTypeArgPlan {
     Static {
         ty: Tir2Ty,
         emission_ty: Tir2Ty,
+        runtime_bindings: Box<[ScopedTypeBinding]>,
     },
     Runtime {
         operand: AstExprId,
@@ -143,7 +144,8 @@ pub(crate) enum RuntimeCheck {
 pub(crate) struct ScopedTypeBinding {
     pub(crate) name: Name,
     pub(crate) parameter: baml_type::ParamTy,
-    pub(crate) operand: AstExprId,
+    pub(crate) operand: Option<AstExprId>,
+    pub(crate) template_ty: Option<Tir2Ty>,
     pub(crate) occurrence_ty: Tir2Ty,
 }
 
@@ -236,6 +238,8 @@ pub(crate) struct ConvertedTables<'db> {
     path_member_resolutions: FxHashMap<AstExprId, Vec<MemberResolution<'db>>>,
     call_plans: FxHashMap<AstExprId, CallPlan>,
     type_bindings: FxHashMap<AstStmtId, ScopedTypeBinding>,
+    runtime_type_bindings: FxHashMap<AstExprId, ScopedTypeBinding>,
+    runtime_type_params: Vec<baml_type::ParamTy>,
     runtime_checks: Vec<RuntimeCheck>,
     function_coercions: FxHashMap<AstExprId, FunctionCoercion>,
     /// Condition expressions the checker marked for truthiness coercion
@@ -297,6 +301,12 @@ impl<'db> ConvertedTables<'db> {
     }
     pub(crate) fn type_binding(&self, stmt: AstStmtId) -> Option<&ScopedTypeBinding> {
         self.type_bindings.get(&stmt)
+    }
+    pub(crate) fn runtime_type_binding(&self, operand: AstExprId) -> Option<&ScopedTypeBinding> {
+        self.runtime_type_bindings.get(&operand)
+    }
+    pub(crate) fn runtime_type_params(&self) -> &[baml_type::ParamTy] {
+        &self.runtime_type_params
     }
     #[allow(dead_code)]
     pub(crate) fn runtime_checks(&self) -> &[RuntimeCheck] {
@@ -391,12 +401,18 @@ fn convert<'db>(result: &hir_infer::InferenceResult<'db>) -> ConvertedTables<'db
                     .slots
                     .iter()
                     .map(|slot| match slot {
-                        hir_infer::CallTypeArgPlan::Static { ty, emission_ty } => {
-                            CallTypeArgPlan::Static {
-                                ty: ty.to_plain(),
-                                emission_ty: emission_ty.to_plain(),
-                            }
-                        }
+                        hir_infer::CallTypeArgPlan::Static {
+                            ty,
+                            emission_ty,
+                            runtime_bindings,
+                        } => CallTypeArgPlan::Static {
+                            ty: ty.to_plain(),
+                            emission_ty: emission_ty.to_plain(),
+                            runtime_bindings: runtime_bindings
+                                .iter()
+                                .map(convert_scoped_type_binding)
+                                .collect(),
+                        },
                         hir_infer::CallTypeArgPlan::Runtime {
                             operand,
                             occurrence_ty,
@@ -423,18 +439,28 @@ fn convert<'db>(result: &hir_infer::InferenceResult<'db>) -> ConvertedTables<'db
     out.type_bindings = result
         .type_bindings
         .iter()
-        .map(|(&stmt, binding)| {
-            (
-                stmt,
-                ScopedTypeBinding {
-                    name: binding.name.clone(),
-                    parameter: binding.parameter.clone(),
-                    operand: binding.operand,
-                    occurrence_ty: binding.occurrence_ty.to_plain(),
-                },
-            )
-        })
+        .map(|(&stmt, binding)| (stmt, convert_scoped_type_binding(binding)))
         .collect();
+    for bindings in result.type_ref_bindings.values() {
+        for binding in bindings {
+            let Some(operand) = binding.operand else {
+                continue;
+            };
+            out.runtime_type_bindings
+                .entry(operand)
+                .or_insert_with(|| convert_scoped_type_binding(binding));
+        }
+    }
+    out.runtime_type_params = out
+        .runtime_type_bindings
+        .values()
+        .map(|binding| binding.parameter.clone())
+        .collect();
+    out.runtime_type_params.sort_by(|left, right| {
+        left.index()
+            .cmp(&right.index())
+            .then_with(|| left.name().cmp(right.name()))
+    });
     out.runtime_checks = result
         .runtime_checks
         .iter()
@@ -483,6 +509,19 @@ fn convert<'db>(result: &hir_infer::InferenceResult<'db>) -> ConvertedTables<'db
         result.non_exhaustive_matches.iter().copied().collect(),
     );
     out
+}
+
+fn convert_scoped_type_binding(binding: &hir_infer::ScopedTypeBinding) -> ScopedTypeBinding {
+    ScopedTypeBinding {
+        name: binding.name.clone(),
+        parameter: binding.parameter.clone(),
+        operand: binding.operand,
+        template_ty: binding
+            .template_ty
+            .as_ref()
+            .map(baml_type::interned::Ty::to_plain),
+        occurrence_ty: binding.occurrence_ty.to_plain(),
+    }
 }
 
 fn convert_runtime_check(check: &hir_infer::RuntimeCheck) -> RuntimeCheck {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1754,6 +1754,11 @@ struct LoweringContext<'db> {
     /// captured cells or object fields after a successful test.
     tested_pattern_values: HashMap<PatMetadataKey, Local>,
     atomic_pattern_test: bool,
+    /// Runtime type operands already lowered in this lexical frame. Pattern
+    /// lowering can visit the same scoped binding during both structural-let
+    /// pre-emission and an or-alternative's runtime test; its expression must
+    /// still execute only once.
+    emitted_runtime_type_binding_operands: HashSet<ExprMetadataKey>,
 
     // The FileScopeId of the expression body currently being lowered.
     // Updated when descending into lambda bodies (Phase 3+).
@@ -2380,6 +2385,7 @@ impl<'db> LoweringContext<'db> {
             match_scrutinee: None,
             tested_pattern_values: HashMap::new(),
             atomic_pattern_test: false,
+            emitted_runtime_type_binding_operands: HashSet::new(),
             current_scope: func_scope_id,
             current_metadata_scope: MetadataScope::Body(func_scope_id),
             body: expr_body,
@@ -2462,6 +2468,7 @@ impl<'db> LoweringContext<'db> {
             match_scrutinee: None,
             tested_pattern_values: HashMap::new(),
             atomic_pattern_test: false,
+            emitted_runtime_type_binding_operands: HashSet::new(),
             current_scope: let_scope_id,
             current_metadata_scope: MetadataScope::Body(let_scope_id),
             body: expr_body,
@@ -10352,6 +10359,10 @@ impl LoweringContext<'_> {
 
     fn emit_scoped_type_binding(&mut self, binding: &crate::inference_provider::ScopedTypeBinding) {
         let value = if let Some(operand) = binding.operand {
+            let key = self.expr_metadata_key(operand);
+            if !self.emitted_runtime_type_binding_operands.insert(key) {
+                return;
+            }
             self.lower_to_operand(operand)
         } else if let Some(template_ty) = &binding.template_ty {
             let generic_params = self.enclosing_generic_params();

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6817,7 +6817,7 @@ impl<'db> LoweringContext<'db> {
                 self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
             {
                 debug_assert!(
-                    self.class_fields.contains_key(&tn),
+                    self.is_interface_type_name(&tn) || self.class_fields.contains_key(&tn),
                     "MIR field-access lowering has no class_fields row for `{tn}`"
                 );
                 if let Some(fields) = self.class_fields.get(&tn) {
@@ -11100,7 +11100,7 @@ impl<'db> LoweringContext<'db> {
         // Look up field index from class_fields
         let field_idx = if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
             debug_assert!(
-                self.class_fields.contains_key(tn),
+                self.is_interface_type_name(tn) || self.class_fields.contains_key(tn),
                 "MIR field-access lowering has no class_fields row for `{tn}`"
             );
             self.class_fields
@@ -13109,7 +13109,7 @@ impl LoweringContext<'_> {
                         self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
                     {
                         debug_assert!(
-                            self.class_fields.contains_key(&tn),
+                            self.is_interface_type_name(&tn) || self.class_fields.contains_key(&tn),
                             "MIR field-access lowering has no class_fields row for `{tn}`"
                         );
                         if let Some(fields) = self.class_fields.get(&tn) {
@@ -13248,7 +13248,7 @@ impl LoweringContext<'_> {
                 let unwrapped_ty = base_ty.strip_null();
                 if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
                     debug_assert!(
-                        self.class_fields.contains_key(tn),
+                        self.is_interface_type_name(tn) || self.class_fields.contains_key(tn),
                         "MIR field-access lowering has no class_fields row for `{tn}`"
                     );
                     if let Some(fields) = self.class_fields.get(tn) {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2116,6 +2116,7 @@ impl<'db> LoweringContext<'db> {
             Place::local(elem_local),
             Rvalue::Use(Operand::Copy(Place::Local(next_local))),
         );
+        self.emit_pattern_runtime_bindings_recursive(binding);
         self.bind_pattern_with_fresh_cells(elem_local, binding);
         let names: Vec<Name> = self.body.patterns[binding]
             .bound_names(&self.body.patterns)
@@ -10028,7 +10029,7 @@ impl LoweringContext<'_> {
     /// `TyTemplate::TypeArgRef` leaves; attempting it here would emit a broken
     /// `LoadType` instruction.
     fn check_type_of_intrinsic(
-        &self,
+        &mut self,
         callee: AstExprId,
         call_expr_id: AstExprId,
     ) -> Option<TyTemplate> {
@@ -10121,6 +10122,7 @@ impl LoweringContext<'_> {
         if matches!(type_arg.kind, AstTypeExprKind::Unreflect { .. }) {
             return None;
         }
+        self.emit_type_expr_runtime_bindings(&type_arg);
 
         // Include the enclosing class + function generic params so that `T`
         // in `reflect.Type.of<T>()` resolves to `Tir2Ty::TypeVar("T")` rather
@@ -10129,6 +10131,22 @@ impl LoweringContext<'_> {
         // then function params) mirrors TIR's `enclosing_class_generic_params
         // ++ user_generic_params` convention used in `callable.rs`.
         let generic_params = self.enclosing_generic_params();
+
+        // Nested runtime atoms have already been replaced by synthesized
+        // rigid parameters in TIR. Use that authoritative emission type so
+        // the template loads the slots bound just above instead of trying to
+        // lower the raw `unreflect(...)` syntax as a static type.
+        if let Some(crate::inference_provider::CallTypeArgPlan::Static {
+            emission_ty,
+            runtime_bindings,
+            ..
+        }) = self
+            .tir_call_plan(self.expr_metadata_key(call_expr_id))
+            .and_then(|plan| plan.slots.first())
+            && !runtime_bindings.is_empty()
+        {
+            return Some(self.ty_to_template(emission_ty, &generic_params));
+        }
 
         // ── 4. Build TyTemplate — TypeVar → TypeArgRef(N) ─────────────────────
         let template = self.type_expr_to_template(&type_arg, &generic_params);

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6816,6 +6816,10 @@ impl<'db> LoweringContext<'db> {
             if let Some((tn, class_type_args)) =
                 self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
             {
+                debug_assert!(
+                    self.class_fields.contains_key(&tn),
+                    "MIR field-access lowering has no class_fields row for `{tn}`"
+                );
                 if let Some(fields) = self.class_fields.get(&tn) {
                     if let Some(&idx) = fields.get(seg.as_str()) {
                         // Substitute the receiver's class type-args into the
@@ -11095,6 +11099,10 @@ impl<'db> LoweringContext<'db> {
 
         // Look up field index from class_fields
         let field_idx = if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
+            debug_assert!(
+                self.class_fields.contains_key(tn),
+                "MIR field-access lowering has no class_fields row for `{tn}`"
+            );
             self.class_fields
                 .get(tn)
                 .and_then(|fields| fields.get(&field_str))
@@ -13100,6 +13108,10 @@ impl LoweringContext<'_> {
                     if let Some((tn, class_type_args)) =
                         self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
                     {
+                        debug_assert!(
+                            self.class_fields.contains_key(&tn),
+                            "MIR field-access lowering has no class_fields row for `{tn}`"
+                        );
                         if let Some(fields) = self.class_fields.get(&tn) {
                             if let Some(&idx) = fields.get(seg.as_str()) {
                                 let next_ty = self.class_field_ty(&tn, seg, &class_type_args);
@@ -13235,6 +13247,10 @@ impl LoweringContext<'_> {
                 // Unwrap Optional — we've already null-checked, so use the inner type.
                 let unwrapped_ty = base_ty.strip_null();
                 if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
+                    debug_assert!(
+                        self.class_fields.contains_key(tn),
+                        "MIR field-access lowering has no class_fields row for `{tn}`"
+                    );
                     if let Some(fields) = self.class_fields.get(tn) {
                         if let Some(&idx) = fields.get(member_name.as_str()) {
                             return Place::Field {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1313,8 +1313,8 @@ fn resolution_external_callable<'a>(
 use baml_compiler2_ast::{
     AssignOp as AstAssignOp, AstSourceMap, BinaryOp as AstBinaryOp, CallArg, Expr as AstExpr,
     ExprBody as AstExprBody, ExprId as AstExprId, Literal as AstLiteral, PatId as AstPatId,
-    Pattern as AstPattern, Stmt as AstStmt, StmtId as AstStmtId, TypeArg as AstTypeArg,
-    TypeExpr as AstTypeExpr, TypeExprKind as AstTypeExprKind, UnaryOp as AstUnaryOp,
+    Pattern as AstPattern, Stmt as AstStmt, StmtId as AstStmtId, TypeExpr as AstTypeExpr,
+    TypeExprKind as AstTypeExprKind, UnaryOp as AstUnaryOp,
 };
 use baml_compiler2_hir::{
     body::{FunctionBody, LetBody, let_body, let_body_source_map},
@@ -2830,6 +2830,21 @@ impl<'db> LoweringContext<'db> {
             .type_binding(stmt)
     }
 
+    fn tir_runtime_type_binding(
+        &self,
+        operand: AstExprId,
+    ) -> Option<&crate::inference_provider::ScopedTypeBinding> {
+        self.tables
+            .for_scope(self.current_metadata_scope)
+            .runtime_type_binding(operand)
+    }
+
+    fn tir_runtime_type_params(&self) -> &[ParamTy] {
+        self.tables
+            .for_scope(self.current_metadata_scope)
+            .runtime_type_params()
+    }
+
     fn tir_function_coercion(
         &self,
         key: ExprMetadataKey,
@@ -3963,10 +3978,32 @@ impl<'db> LoweringContext<'db> {
     }
 
     fn object_class_type_arg_templates(
-        &self,
+        &mut self,
         expr_id: AstExprId,
         explicit_type_args: &[AstTypeExpr],
     ) -> Vec<TyTemplate> {
+        if let Some(plan) = self.tir_call_plan(self.expr_metadata_key(expr_id)).cloned()
+            && !plan.slots.is_empty()
+        {
+            let generic_params = self.enclosing_generic_params();
+            return plan
+                .slots
+                .iter()
+                .filter_map(|slot| match slot {
+                    crate::inference_provider::CallTypeArgPlan::Static {
+                        emission_ty,
+                        runtime_bindings,
+                        ..
+                    } => {
+                        for binding in runtime_bindings {
+                            self.emit_scoped_type_binding(binding);
+                        }
+                        Some(self.ty_to_template(emission_ty, &generic_params))
+                    }
+                    crate::inference_provider::CallTypeArgPlan::Runtime { .. } => None,
+                })
+                .collect();
+        }
         // Empty (`Box { … }`) or unlowerable (`Box<_> { … }` — a compile error
         // whose arg lowers to an error sentinel) type args: use the class type
         // TIR inferred/solved for this expression rather than re-lowering the
@@ -5919,19 +5956,25 @@ impl LoweringContext<'_> {
                 self.lower_member_access(expr_id, base, &member, dest);
             }
 
-            AstExpr::Upcast { base, .. } => {
+            AstExpr::Upcast { base, target } => {
                 // `.as<I>` is a static type projection. Runtime representation
                 // is the original value.
                 self.lower_expr(base, dest);
+                self.emit_type_expr_runtime_bindings(&target);
             }
 
-            AstExpr::QualifiedPath { .. } => {
+            AstExpr::QualifiedPath {
+                qself, interface, ..
+            } => {
+                use crate::inference_provider::MemberResolution;
+
+                self.emit_type_expr_runtime_bindings(&qself);
+                self.emit_type_expr_runtime_bindings(&interface);
                 // `(Base as I).m` as a VALUE: an unbound callable resolved
                 // from the recorded frame — the same type-keyed road every
                 // other spelling takes (the frame realizes associated types
                 // the written qualifier omits). `self`, if the method takes
                 // one, stays an ordinary first parameter.
-                use crate::inference_provider::MemberResolution;
                 if let Some(MemberResolution::InterfaceVirtualMethod { iface_loc, method }) = self
                     .tir_resolution(self.expr_metadata_key(expr_id))
                     .cloned()
@@ -5951,7 +5994,7 @@ impl LoweringContext<'_> {
             }
 
             AstExpr::GenericApply { base, type_args } => {
-                self.lower_generic_apply(base, &type_args, dest);
+                self.lower_generic_apply(expr_id, base, &type_args, dest);
             }
 
             AstExpr::OptionalMemberAccess { base, member } => {
@@ -10075,9 +10118,9 @@ impl LoweringContext<'_> {
             return None;
         };
         let type_arg = type_args.into_iter().next()?;
-        let AstTypeArg::Static(type_arg) = type_arg else {
+        if matches!(type_arg.kind, AstTypeExprKind::Unreflect { .. }) {
             return None;
-        };
+        }
 
         // Include the enclosing class + function generic params so that `T`
         // in `reflect.Type.of<T>()` resolves to `Tir2Ty::TypeVar("T")` rather
@@ -10231,6 +10274,7 @@ impl LoweringContext<'_> {
             .map(|fl| baml_compiler2_hir_ty::lower::function_generic_frame(self.db, fl))
             .unwrap_or_default();
         params.extend(self.lambda_generic_params.iter().cloned());
+        params.extend(self.tir_runtime_type_params().iter().cloned());
         params.extend(self.runtime_type_binding_params.iter().cloned());
         params
     }
@@ -10282,6 +10326,99 @@ impl LoweringContext<'_> {
             .collect()
     }
 
+    fn emit_scoped_type_binding(&mut self, binding: &crate::inference_provider::ScopedTypeBinding) {
+        let value = if let Some(operand) = binding.operand {
+            self.lower_to_operand(operand)
+        } else if let Some(template_ty) = &binding.template_ty {
+            let generic_params = self.enclosing_generic_params();
+            let template = self.ty_to_template(template_ty, &generic_params);
+            let temp = self.builder.temp(RuntimeTy::type_type());
+            self.builder
+                .assign(Place::local(temp), Rvalue::LoadType(template));
+            Operand::Copy(Place::local(temp))
+        } else {
+            return;
+        };
+        let slot = RuntimeGenericLayout::new(&self.enclosing_generic_params())
+            .slot(&binding.parameter)
+            .expect("a synthesized runtime type parameter has a frame slot");
+        self.builder.push_statement(
+            StatementKind::Intrinsic {
+                op: IntrinsicOp::BindType(slot as usize),
+                args: vec![value],
+            },
+            self.builder.current_source_span,
+        );
+    }
+
+    fn emit_type_expr_runtime_bindings(&mut self, ty: &AstTypeExpr) {
+        let mut operands = Vec::new();
+        ty.unreflect_operands(&mut operands);
+        for operand in operands {
+            if let Some(binding) = self.tir_runtime_type_binding(operand).cloned() {
+                self.emit_scoped_type_binding(&binding);
+            }
+        }
+    }
+
+    fn emit_pattern_runtime_bindings_direct(&mut self, pattern: &AstPattern) {
+        match pattern {
+            AstPattern::Type(ty) => self.emit_type_expr_runtime_bindings(ty),
+            AstPattern::Array {
+                ascription: Some(ty),
+                ..
+            } => self.emit_type_expr_runtime_bindings(ty),
+            AstPattern::Class {
+                generic_args,
+                associated_type_bindings,
+                ..
+            } => {
+                for ty in generic_args {
+                    self.emit_type_expr_runtime_bindings(ty);
+                }
+                for binding in associated_type_bindings {
+                    self.emit_type_expr_runtime_bindings(&binding.ty);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn emit_pattern_runtime_bindings_recursive(&mut self, pat_id: AstPatId) {
+        let pattern = self.body.patterns[pat_id].clone();
+        self.emit_pattern_runtime_bindings_direct(&pattern);
+        match pattern {
+            AstPattern::Bind {
+                subpat: Some(subpat),
+                ..
+            } => self.emit_pattern_runtime_bindings_recursive(subpat),
+            AstPattern::Or(parts) => {
+                for part in parts {
+                    self.emit_pattern_runtime_bindings_recursive(part);
+                }
+            }
+            AstPattern::Class { fields, .. } => {
+                for field in fields {
+                    self.emit_pattern_runtime_bindings_recursive(field.pat);
+                }
+            }
+            AstPattern::Array {
+                prefix,
+                rest,
+                suffix,
+                ..
+            } => {
+                for part in prefix.into_iter().chain(suffix) {
+                    self.emit_pattern_runtime_bindings_recursive(part);
+                }
+                if let Some(rest) = rest.and_then(|rest| rest.pat) {
+                    self.emit_pattern_runtime_bindings_recursive(rest);
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn lower_call_type_args(
         &mut self,
         call_expr_id: AstExprId,
@@ -10308,7 +10445,14 @@ impl LoweringContext<'_> {
             let mut operands = Vec::with_capacity(plan.slots.len().min(limit));
             for slot in plan.slots.iter().take(limit) {
                 match slot {
-                    crate::inference_provider::CallTypeArgPlan::Static { emission_ty, .. } => {
+                    crate::inference_provider::CallTypeArgPlan::Static {
+                        emission_ty,
+                        runtime_bindings,
+                        ..
+                    } => {
+                        for binding in runtime_bindings {
+                            self.emit_scoped_type_binding(binding);
+                        }
                         let template = self.ty_to_template(emission_ty, &generic_params);
                         let temp = self.builder.temp(RuntimeTy::type_type());
                         self.builder
@@ -10371,11 +10515,12 @@ impl LoweringContext<'_> {
         let Some(plan) = scope.call_plan(call_expr_id) else {
             return false;
         };
-        if plan
-            .slots
-            .iter()
-            .any(|slot| matches!(slot, CallTypeArgPlan::Runtime { .. }))
-            || !plan.deferred_checks.is_empty()
+        if plan.slots.iter().any(|slot| match slot {
+            CallTypeArgPlan::Runtime { .. } => true,
+            CallTypeArgPlan::Static {
+                runtime_bindings, ..
+            } => !runtime_bindings.is_empty(),
+        }) || !plan.deferred_checks.is_empty()
         {
             return true;
         }
@@ -10396,14 +10541,21 @@ impl LoweringContext<'_> {
     /// `frame.type_args` when called). Otherwise fall back to lowering the base
     /// value with type args erased — for exotic bases (bound methods, lambdas)
     /// or param-dependent args (`foo<T>` inside a generic function).
-    fn lower_generic_apply(&mut self, base: AstExprId, type_args: &[AstTypeExpr], dest: Place) {
+    fn lower_generic_apply(
+        &mut self,
+        expr_id: AstExprId,
+        base: AstExprId,
+        type_args: &[AstTypeExpr],
+        dest: Place,
+    ) {
         let Some(item) = self.try_resolve_generic_apply_base(base) else {
             // Non-`ItemRef` base (a local/captured generic function value):
             // there is no function global to pool, so specialize the *runtime
             // value* — evaluate it and wrap it in a closure carrying the
             // (frame-resolved) type args — instead of silently erasing them.
             let value = self.lower_to_operand(base);
-            let type_arg_templates = self.generic_apply_type_arg_templates(type_args);
+            let type_arg_templates =
+                self.planned_generic_apply_type_arg_templates(expr_id, type_args);
             self.builder.assign(
                 dest,
                 Rvalue::MakeGenericFunctionFromValue {
@@ -10413,7 +10565,7 @@ impl LoweringContext<'_> {
             );
             return;
         };
-        let templates = self.generic_apply_type_arg_templates(type_args);
+        let templates = self.planned_generic_apply_type_arg_templates(expr_id, type_args);
         if templates.iter().all(TyTemplate::is_fully_concrete) {
             // Concrete args → pooled, interned compile-time constant
             // (pointer-stable identity). Each template is fully concrete, so it
@@ -10513,6 +10665,36 @@ impl LoweringContext<'_> {
             .iter()
             .map(|type_arg| self.type_expr_to_template(type_arg, &generic_params))
             .collect()
+    }
+
+    fn planned_generic_apply_type_arg_templates(
+        &mut self,
+        expr_id: AstExprId,
+        type_args: &[AstTypeExpr],
+    ) -> Vec<TyTemplate> {
+        if let Some(plan) = self.tir_call_plan(self.expr_metadata_key(expr_id)).cloned()
+            && !plan.slots.is_empty()
+        {
+            let generic_params = self.enclosing_generic_params();
+            return plan
+                .slots
+                .iter()
+                .filter_map(|slot| match slot {
+                    crate::inference_provider::CallTypeArgPlan::Static {
+                        emission_ty,
+                        runtime_bindings,
+                        ..
+                    } => {
+                        for binding in runtime_bindings {
+                            self.emit_scoped_type_binding(binding);
+                        }
+                        Some(self.ty_to_template(emission_ty, &generic_params))
+                    }
+                    crate::inference_provider::CallTypeArgPlan::Runtime { .. } => None,
+                })
+                .collect();
+        }
+        self.generic_apply_type_arg_templates(type_args)
     }
 }
 
@@ -10715,6 +10897,7 @@ impl<'db> LoweringContext<'db> {
         spreads: &[baml_compiler2_ast::SpreadField],
         dest: Place,
     ) {
+        let type_arg_templates = self.object_class_type_arg_templates(expr_id, type_args);
         // Prefer the explicitly written type name. If absent (e.g., when the
         // type is a qualified path like `baml.errors.DevOther`), fall back to
         // the TIR-inferred type to get the short class name.
@@ -10780,7 +10963,6 @@ impl<'db> LoweringContext<'db> {
                     .map(|field| self.lower_to_operand(field.value))
                     .collect()
             };
-            let type_arg_templates = self.object_class_type_arg_templates(expr_id, type_args);
             self.builder.assign(
                 dest,
                 Rvalue::Aggregate {
@@ -10854,8 +11036,6 @@ impl<'db> LoweringContext<'db> {
                         .iter()
                         .map(|field| self.lower_to_operand(field.value))
                         .collect();
-                    let type_arg_templates =
-                        self.object_class_type_arg_templates(expr_id, type_args);
                     self.builder.assign(
                         dest,
                         Rvalue::Aggregate {
@@ -10904,7 +11084,6 @@ impl<'db> LoweringContext<'db> {
                 }
             }
 
-            let type_arg_templates = self.object_class_type_arg_templates(expr_id, type_args);
             self.builder.assign(
                 dest,
                 Rvalue::Aggregate {
@@ -12574,20 +12753,10 @@ impl LoweringContext<'_> {
                     .cloned()
                     .expect("a typed TypeBinding statement has a durable binding plan");
                 debug_assert_eq!(binding.name, name);
-                debug_assert_eq!(binding.operand, value);
-                let value = self.lower_to_operand(binding.operand);
+                self.emit_type_expr_runtime_bindings(&value);
                 self.runtime_type_binding_params
                     .push(binding.parameter.clone());
-                let slot = RuntimeGenericLayout::new(&self.enclosing_generic_params())
-                    .slot(&binding.parameter)
-                    .expect("a just-bound runtime type parameter has a frame slot");
-                self.builder.push_statement(
-                    StatementKind::Intrinsic {
-                        op: IntrinsicOp::BindType(slot as usize),
-                        args: vec![value],
-                    },
-                    self.builder.current_source_span,
-                );
+                self.emit_scoped_type_binding(&binding);
             }
 
             // `let PATTERN = init else { … };` — refutable binding lowered
@@ -12665,6 +12834,7 @@ impl LoweringContext<'_> {
                 initializer,
                 ..
             } if self.pattern_contains_structural(pattern) => {
+                self.emit_pattern_runtime_bindings_recursive(pattern);
                 let local_ty = self.pat_ty(pattern);
                 let scrutinee = self.builder.temp(local_ty);
 
@@ -12699,6 +12869,7 @@ impl LoweringContext<'_> {
                 initializer,
                 ..
             } => {
+                self.emit_pattern_runtime_bindings_recursive(pattern);
                 // Extract binding names from pattern. A simple `let x` has
                 // one name; a chain `let x: let y: let z` has three. The
                 // first name owns the declared slot (the init writes into
@@ -14665,6 +14836,7 @@ impl LoweringContext<'_> {
             scrutinee
         };
         let pat = self.body.patterns[pat_id].clone();
+        self.emit_pattern_runtime_bindings_direct(&pat);
 
         // Bind sub-pattern: `let x: <pattern>` defers to the sub-
         // pattern's runtime test (recursively). The bind itself doesn't
@@ -15410,10 +15582,7 @@ impl LoweringContext<'_> {
         if let Some(ty_expr) = ascription_ty {
             if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)) {
                 let resolved = self.resolved_aliases.convert(tir_ty);
-                if let Some(tags) = self.ty_to_type_tags_for_switch(&resolved, scrutinee_static_ty)
-                {
-                    return Some(tags);
-                }
+                return self.ty_to_type_tags_for_switch(&resolved, scrutinee_static_ty);
             }
             let resolved = self.resolve_type_annotation(&ty_expr);
             return self.ty_to_type_tags_for_switch(&resolved, scrutinee_static_ty);
@@ -15428,11 +15597,7 @@ impl LoweringContext<'_> {
             AstPattern::Type(_) => {
                 if let Some(tir_ty) = self.tir_pat_type(self.pat_metadata_key(pat_id)) {
                     let resolved = self.resolved_aliases.convert(tir_ty);
-                    if let Some(tags) =
-                        self.ty_to_type_tags_for_switch(&resolved, scrutinee_static_ty)
-                    {
-                        return Some(tags);
-                    }
+                    return self.ty_to_type_tags_for_switch(&resolved, scrutinee_static_ty);
                 }
                 if let AstPattern::Type(ty_expr) = pat {
                     let resolved = self.resolve_type_annotation(ty_expr);

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6020,8 +6020,14 @@ impl LoweringContext<'_> {
             }
 
             AstExpr::Match {
-                scrutinee, arms, ..
+                scrutinee,
+                scrutinee_type,
+                arms,
             } => {
+                if let Some(type_id) = scrutinee_type {
+                    let annotation = self.body.type_annotations[type_id].clone();
+                    self.emit_type_expr_runtime_bindings(&annotation);
+                }
                 let arms_owned = arms;
                 self.lower_match(expr_id, scrutinee, &arms_owned, dest);
             }
@@ -10693,11 +10699,33 @@ impl LoweringContext<'_> {
         if let Some(plan) = self.tir_call_plan(self.expr_metadata_key(expr_id)).cloned()
             && !plan.slots.is_empty()
         {
-            let generic_params = self.enclosing_generic_params();
-            return plan
+            let binding_scope_start = self.runtime_type_binding_params.len();
+            let runtime_params: Vec<Option<ParamTy>> = plan
                 .slots
                 .iter()
-                .filter_map(|slot| match slot {
+                .map(|slot| match slot {
+                    crate::inference_provider::CallTypeArgPlan::Runtime { .. } => {
+                        let count = self
+                            .synthetic_name_counts
+                            .entry("__generic_apply_runtime_type".to_string())
+                            .or_insert(0);
+                        let identity = u32::try_from(*count)
+                            .expect("runtime generic-apply slot count fits in u32");
+                        *count += 1;
+                        let name = Name::new(format!("$generic_apply${identity:08x}"));
+                        Some(ParamTy::new(0xb000_0000 | (identity & 0x0fff_ffff), name))
+                    }
+                    crate::inference_provider::CallTypeArgPlan::Static { .. } => None,
+                })
+                .collect();
+            self.runtime_type_binding_params
+                .extend(runtime_params.iter().flatten().cloned());
+            let generic_params = self.enclosing_generic_params();
+            let templates = plan
+                .slots
+                .iter()
+                .zip(&runtime_params)
+                .map(|(slot, runtime_param)| match slot {
                     crate::inference_provider::CallTypeArgPlan::Static {
                         emission_ty,
                         runtime_bindings,
@@ -10706,11 +10734,34 @@ impl LoweringContext<'_> {
                         for binding in runtime_bindings {
                             self.emit_scoped_type_binding(binding);
                         }
-                        Some(self.ty_to_template(emission_ty, &generic_params))
+                        self.ty_to_template(emission_ty, &generic_params)
                     }
-                    crate::inference_provider::CallTypeArgPlan::Runtime { .. } => None,
+                    crate::inference_provider::CallTypeArgPlan::Runtime {
+                        operand,
+                        occurrence_ty,
+                        ..
+                    } => {
+                        let parameter = runtime_param
+                            .as_ref()
+                            .expect("runtime slots have synthesized frame parameters");
+                        let binding = crate::inference_provider::ScopedTypeBinding {
+                            name: parameter.name().clone(),
+                            parameter: parameter.clone(),
+                            operand: Some(*operand),
+                            template_ty: None,
+                            occurrence_ty: occurrence_ty.clone(),
+                        };
+                        self.emit_scoped_type_binding(&binding);
+                        let slot = RuntimeGenericLayout::new(&generic_params)
+                            .slot(parameter)
+                            .expect("runtime generic-apply parameter has a frame slot");
+                        TyTemplate::TypeArgRef(slot)
+                    }
                 })
                 .collect();
+            self.runtime_type_binding_params
+                .truncate(binding_scope_start);
+            return templates;
         }
         self.generic_apply_type_arg_templates(type_args)
     }

--- a/baml_language/crates/baml_compiler2_ppir/src/ty.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/ty.rs
@@ -293,6 +293,7 @@ impl PpirTy {
                 attrs,
             },
             TypeExprKind::BuiltinUnknown { .. }
+            | TypeExprKind::Unreflect { .. }
             | TypeExprKind::AssociatedTypeProjection { .. }
             | TypeExprKind::Type { .. }
             | TypeExprKind::Function { .. }

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -254,7 +254,11 @@ impl<'a> AstGraphBuilder<'a> {
                 self.visit_expr(*expr_id);
             }
             ast::Stmt::TypeBinding { value, .. } => {
-                self.visit_expr(*value);
+                let mut operands = Vec::new();
+                value.unreflect_operands(&mut operands);
+                for operand in operands {
+                    self.visit_expr(operand);
+                }
             }
             ast::Stmt::Throw { value } => {
                 self.visit_expr(*value);
@@ -1029,7 +1033,11 @@ fn collect_callee_names_stmt(body: &ast::ExprBody, id: ast::StmtId, names: &mut 
     match &body.stmts[id] {
         ast::Stmt::Expr(expr) => collect_callee_names_expr(body, *expr, names),
         ast::Stmt::TypeBinding { value, .. } => {
-            collect_callee_names_expr(body, *value, names);
+            let mut operands = Vec::new();
+            value.unreflect_operands(&mut operands);
+            for operand in operands {
+                collect_callee_names_expr(body, operand, names);
+            }
         }
         ast::Stmt::Defer { body: defer_body } => {
             collect_callee_names_expr(body, *defer_body, names);

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -25,6 +25,32 @@ fn stmt_id_to_source_expr(id: ast::StmtId) -> u32 {
     STMT_SOURCE_EXPR_TAG | id.into_raw().into_u32()
 }
 
+fn expression_type_operands(body: &ast::ExprBody, expr: &ast::Expr) -> Vec<ast::ExprId> {
+    let mut operands = Vec::new();
+    match expr {
+        ast::Expr::Call { type_args, .. }
+        | ast::Expr::GenericApply { type_args, .. }
+        | ast::Expr::Object { type_args, .. } => {
+            for ty in type_args {
+                ty.unreflect_operands(&mut operands);
+            }
+        }
+        ast::Expr::Upcast { target, .. } => target.unreflect_operands(&mut operands),
+        ast::Expr::QualifiedPath {
+            qself, interface, ..
+        } => {
+            qself.unreflect_operands(&mut operands);
+            interface.unreflect_operands(&mut operands);
+        }
+        ast::Expr::Match {
+            scrutinee_type: Some(type_id),
+            ..
+        } => body.type_annotations[*type_id].unreflect_operands(&mut operands),
+        _ => {}
+    }
+    operands
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -150,6 +176,9 @@ impl<'a> AstGraphBuilder<'a> {
 
     fn visit_expr(&mut self, id: ast::ExprId) {
         let expr = self.body.exprs[id].clone();
+        for operand in expression_type_operands(self.body, &expr) {
+            self.visit_expr(operand);
+        }
         match &expr {
             ast::Expr::Block { stmts, tail_expr } => {
                 for stmt_id in stmts {
@@ -872,6 +901,9 @@ fn push_callee_name(names: &mut Vec<String>, name: String) {
 }
 
 fn collect_callee_names_expr(body: &ast::ExprBody, id: ast::ExprId, names: &mut Vec<String>) {
+    for operand in expression_type_operands(body, &body.exprs[id]) {
+        collect_callee_names_expr(body, operand, names);
+    }
     match &body.exprs[id] {
         ast::Expr::Call { callee, args, .. } => {
             push_callee_name(names, callee_display_name(body, *callee));

--- a/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
@@ -237,6 +237,15 @@ pub fn runtime_type_must_be_named() -> Diagnostic {
     )
 }
 
+/// E0168 — a runtime type atom was written in an item signature, where no
+/// executable body can own its frame slot.
+pub fn runtime_type_has_no_scope() -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticId::RuntimeTypeMustBeNamed,
+        "a runtime type has no scope here; bind it inside a function body: `type T = unreflect(…)`",
+    )
+}
+
 /// E0168 — the suggested rewrite, written with the user's own carrier
 /// expression whenever the reporting site could print it.
 pub fn runtime_type_must_be_named_help(rewrite: &RuntimeTypeNameRewrite) -> String {

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -5294,6 +5294,35 @@ impl<'a> Parser<'a> {
         let mut depth: i32 = 1;
         let mut i = self.skip_trivia_and_comments_from(start + 1);
         while i < self.tokens.len() {
+            // Runtime type operands are arbitrary expressions. Treat their
+            // balanced parentheses as opaque so comparisons inside the
+            // operand cannot perturb the surrounding generic-argument depth.
+            if self.tokens[i].kind == TokenKind::Word && self.tokens[i].text == "unreflect" {
+                let after_word = self.skip_trivia_and_comments_from(i + 1);
+                if self.tokens.get(after_word).map(|token| token.kind) == Some(TokenKind::LParen) {
+                    let mut paren_depth = 1_u32;
+                    let mut j = self.skip_trivia_and_comments_from(after_word + 1);
+                    while let Some(token) = self.tokens.get(j) {
+                        match token.kind {
+                            TokenKind::LParen => paren_depth += 1,
+                            TokenKind::RParen => {
+                                paren_depth -= 1;
+                                if paren_depth == 0 {
+                                    j += 1;
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                        j = self.skip_trivia_and_comments_from(j + 1);
+                    }
+                    if paren_depth != 0 {
+                        return None;
+                    }
+                    i = self.skip_trivia_and_comments_from(j);
+                    continue;
+                }
+            }
             match self.tokens[i].kind {
                 TokenKind::Less => depth += 1,
                 TokenKind::Greater => {
@@ -10880,6 +10909,31 @@ function Demo() -> int {
                 .descendants()
                 .all(|n| n.kind() != SyntaxKind::BINDING_PATTERN),
             "bare identifier should NOT produce a BINDING_PATTERN"
+        );
+    }
+
+    #[test]
+    fn destructure_generic_lookahead_ignores_unreflect_operand_comparisons() {
+        let source = r#"
+function Demo(x: unknown, a: int, b: int) -> bool {
+  match x {
+    Wrapper<unreflect(a < b && true)> { value } => true,
+    _ => false,
+  }
+}
+"#;
+
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        let first_arm = root
+            .descendants()
+            .find(|node| node.kind() == SyntaxKind::MATCH_ARM)
+            .expect("first match arm");
+        assert!(
+            first_arm
+                .descendants()
+                .any(|node| node.kind() == SyntaxKind::DESTRUCTURE_PATTERN),
+            "generic class pattern should retain its trailing destructure"
         );
     }
 

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -694,10 +694,13 @@ impl<'a> Parser<'a> {
                 // (see `kind_can_end_projection_self`). Without the gate,
                 // expressions like `(as).x` or `(1 + as).x` — where `as` is a
                 // variable — would be hijacked into the projection parse.
-                TokenKind::Word if token.text == "as" && paren_depth == 1 && angle_depth == 0 => {
-                    if previous_significant.is_some_and(Self::kind_can_end_projection_self) {
-                        saw_as = true;
-                    }
+                TokenKind::Word
+                    if token.text == "as"
+                        && paren_depth == 1
+                        && angle_depth == 0
+                        && previous_significant.is_some_and(Self::kind_can_end_projection_self) =>
+                {
+                    saw_as = true;
                 }
                 _ => {}
             }
@@ -2975,6 +2978,27 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_type_primary(&mut self, consume_union: bool) {
+        // `unreflect(expr)` is a type atom. Its legality is deliberately not
+        // a grammar decision: body positions lower it to a scoped runtime
+        // binding, while declaration signatures diagnose it in the checker.
+        if self.at_contextual_kw("unreflect")
+            && self
+                .peek(1)
+                .is_some_and(|token| token.kind == TokenKind::LParen)
+        {
+            self.with_node(SyntaxKind::UNREFLECT_TYPE, |p| {
+                p.bump();
+                p.expect(TokenKind::LParen);
+                if p.at(TokenKind::RParen) {
+                    p.error_here("`unreflect` requires an operand".to_string());
+                } else {
+                    p.parse_expr();
+                }
+                p.expect(TokenKind::RParen);
+            });
+            return;
+        }
+
         // Function values cannot declare their own generic parameters, so a
         // leading `<...>` on a function type is rejected. Recover by consuming the
         // list and parsing the `(...) -> R` so the rest of the file still parses.
@@ -4587,14 +4611,7 @@ impl<'a> Parser<'a> {
                 p.error_unexpected_token("type binding name".to_string());
             }
             p.expect(TokenKind::Equals);
-            if p.at_contextual_kw("unreflect") {
-                p.bump();
-            } else {
-                p.error_unexpected_token("'unreflect'".to_string());
-            }
-            p.expect(TokenKind::LParen);
-            p.parse_expr();
-            p.expect(TokenKind::RParen);
+            p.parse_type();
             p.eat(TokenKind::Semicolon);
         });
     }
@@ -5060,22 +5077,6 @@ impl<'a> Parser<'a> {
 
         if self.at_binding_intro_pattern() {
             self.parse_let_pattern();
-            return;
-        }
-
-        if self.at_contextual_kw("unreflect")
-            && self
-                .peek(1)
-                .is_some_and(|token| token.kind == TokenKind::LParen)
-        {
-            self.with_node(SyntaxKind::UNREFLECT_PATTERN, |p| {
-                p.bump();
-                p.expect(TokenKind::LParen);
-                if !p.at(TokenKind::RParen) {
-                    p.parse_expr();
-                }
-                p.expect(TokenKind::RParen);
-            });
             return;
         }
 
@@ -7130,14 +7131,14 @@ impl<'a> Parser<'a> {
 
             // Parse first type argument
             if !p.at(TokenKind::Greater) && !p.at(TokenKind::GreaterGreater) {
-                p.parse_generic_arg();
+                p.parse_type();
 
                 // Parse remaining type arguments
                 while p.eat(TokenKind::Comma) {
                     if p.at(TokenKind::Greater) || p.at(TokenKind::GreaterGreater) {
                         break; // Trailing comma
                     }
-                    p.parse_generic_arg();
+                    p.parse_type();
                 }
             }
 
@@ -7164,26 +7165,6 @@ impl<'a> Parser<'a> {
             }
             self.pending_greaters = 0;
             self.pending_greater_span = None;
-        }
-    }
-
-    /// Parse one call-site generic argument. `unreflect` remains an ordinary
-    /// identifier everywhere else; only the exact `unreflect(` shape in this
-    /// position activates the marker.
-    fn parse_generic_arg(&mut self) {
-        if self.at_contextual_kw("unreflect")
-            && self.peek(1).is_some_and(|t| t.kind == TokenKind::LParen)
-        {
-            self.with_node(SyntaxKind::UNREFLECT_ARG, |p| {
-                p.bump();
-                p.expect(TokenKind::LParen);
-                if !p.at(TokenKind::RParen) {
-                    p.parse_expr();
-                }
-                p.expect(TokenKind::RParen);
-            });
-        } else {
-            self.parse_type();
         }
     }
 
@@ -8357,28 +8338,13 @@ impl<'a> Parser<'a> {
             // Equals
             p.expect(TokenKind::Equals);
 
-            let runtime_binding = p.at_contextual_kw("unreflect")
-                && p.peek(1).map(|token| token.kind) == Some(TokenKind::LParen);
-            if runtime_binding {
-                p.error_here(
-                    "runtime type bindings are only allowed inside a function, lambda, or block"
-                        .to_string(),
-                );
-                // Consume the runtime operand as an expression so the explicit
-                // placement diagnostic does not cascade into unrelated
-                // top-level parse errors.
-                p.bump();
-                p.expect(TokenKind::LParen);
-                p.parse_expr();
-                p.expect(TokenKind::RParen);
-            } else {
-                // Type definition
-                p.parse_type();
+            // Type definition. Runtime type atoms are accepted here too; the
+            // declaration checker reports that they have no lexical scope.
+            p.parse_type();
 
-                // Optional attributes (not including those taken by the type)
-                while p.at(TokenKind::At) && !p.at(TokenKind::AtAt) {
-                    p.parse_at_attribute();
-                }
+            // Optional attributes (not including those taken by the type)
+            while p.at(TokenKind::At) && !p.at(TokenKind::AtAt) {
+                p.parse_at_attribute();
             }
 
             // Optional semicolon
@@ -8670,14 +8636,40 @@ mod tests {
     }
 
     #[test]
-    fn top_level_runtime_type_binding_has_an_explicit_diagnostic() {
+    fn top_level_runtime_type_atom_parses_for_checker_diagnostics() {
         let source = "type T = unreflect(reflect.Type.of<string>())\n";
-        let (_root, errors) = parse_source(source);
-        assert!(errors.iter().any(|error| matches!(
-            error,
-            ParseError::InvalidSyntax { message, .. }
-                if message.contains("runtime type bindings are only allowed inside")
-        )));
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        assert_eq!(
+            root.descendants()
+                .filter(|node| node.kind() == SyntaxKind::UNREFLECT_TYPE)
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn empty_unreflect_operand_reports_one_targeted_error() {
+        let source = "type T = unreflect()\n";
+        let (root, errors) = parse_source(source);
+        assert_eq!(
+            errors.len(),
+            1,
+            "empty unreflect must not cause a parse-error cascade: {errors:#?}"
+        );
+        assert!(
+            matches!(
+                &errors[0],
+                ParseError::InvalidSyntax { message, .. }
+                    if message == "`unreflect` requires an operand"
+            ),
+            "expected a targeted empty-unreflect diagnostic, got: {errors:#?}"
+        );
+        assert_eq!(
+            root.text().to_string(),
+            source,
+            "recovery must stay lossless"
+        );
     }
 
     /// Parsing must stay lossless: the original source — shebang included —

--- a/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
@@ -354,8 +354,6 @@ pub enum SyntaxKind {
     /// Bare type expression as a pattern (literals, paths, generics, arrays, …).
     /// Does NOT consume `|` — that belongs to `UNION_PATTERN` at the pattern level.
     TYPE_PATTERN,
-    /// Contextual runtime identity pattern: `unreflect(expr)`.
-    UNREFLECT_PATTERN,
     /// `'(' PATTERN ')'` — explicit grouping.
     PAREN_PATTERN,
     /// `'_'` (bare) or `'let' '_'` — wildcard / discard. Distinct from
@@ -417,9 +415,8 @@ pub enum SyntaxKind {
     CALL_ARGS,
     CALL_ARG,
     GENERIC_ARGS,
-    /// Contextual runtime type argument: `unreflect(expr)`. This is deliberately
-    /// a whole generic-argument node rather than a type-expression atom.
-    UNREFLECT_ARG,
+    /// Contextual runtime type atom: `unreflect(expr)`.
+    UNREFLECT_TYPE,
     /// Declaration-site generic type parameter list: `<T>` or `<K, V>` on class/function defs.
     GENERIC_PARAM_LIST,
     /// A single type parameter name inside a `GENERIC_PARAM_LIST`.

--- a/baml_language/crates/baml_db/src/check.rs
+++ b/baml_language/crates/baml_db/src/check.rs
@@ -1834,6 +1834,7 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::RuntimeTypeMustBeNamed { .. } => {
             runtime_type::runtime_type_must_be_named().id
         }
+        TirTypeError::RuntimeTypeHasNoScope => runtime_type::runtime_type_has_no_scope().id,
         TirTypeError::MountedPackageCallUnsupported { path } => {
             runtime_type::mounted_package_call_unsupported(path.as_str()).id
         }

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -4920,54 +4920,6 @@ pub struct GenericArgs {
 #[derive(Debug)]
 pub enum GenericArg {
     Type(crate::ast::Type),
-    Unreflect(UnreflectArg),
-}
-
-#[derive(Debug)]
-pub struct UnreflectArg {
-    pub keyword: t::Word,
-    pub open_paren: t::LParen,
-    pub expr: Box<Expression>,
-    pub close_paren: t::RParen,
-}
-
-impl FromCST for UnreflectArg {
-    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
-        let node = StrongAstError::assert_is_node(elem)?;
-        StrongAstError::assert_kind_node(&node, SyntaxKind::UNREFLECT_ARG)?;
-        let mut it = SyntaxNodeIter::new(&node);
-        let keyword = it.expect_parse()?;
-        let open_paren = it.expect_parse()?;
-        let expr = Box::new(Expression::from_cst(it.next().ok_or_else(|| {
-            StrongAstError::missing(SyntaxKind::PATH_EXPR, it.parent)
-        })?)?);
-        let close_paren = it.expect_parse()?;
-        it.expect_end()?;
-        Ok(Self {
-            keyword,
-            open_paren,
-            expr,
-            close_paren,
-        })
-    }
-}
-
-impl Printable for UnreflectArg {
-    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
-        printer.print_raw_token(&self.keyword);
-        printer.print_raw_token(&self.open_paren);
-        printer.print(self.expr.as_ref(), shape);
-        printer.print_raw_token(&self.close_paren);
-        PrintInfo::default_single_line()
-    }
-
-    fn leftmost_token(&self) -> TextRange {
-        self.keyword.span()
-    }
-
-    fn rightmost_token(&self) -> TextRange {
-        self.close_paren.span()
-    }
 }
 
 impl FromCST for GenericArgs {
@@ -4990,14 +4942,6 @@ impl FromCST for GenericArgs {
                 }
                 SyntaxKind::TYPE_EXPR => {
                     let arg = GenericArg::Type(crate::ast::Type::from_cst(elem)?);
-                    let comma = it
-                        .next_if_kind(SyntaxKind::COMMA)
-                        .map(t::Comma::from_cst)
-                        .transpose()?;
-                    args.push((arg, comma));
-                }
-                SyntaxKind::UNREFLECT_ARG => {
-                    let arg = GenericArg::Unreflect(UnreflectArg::from_cst(elem)?);
                     let comma = it
                         .next_if_kind(SyntaxKind::COMMA)
                         .map(t::Comma::from_cst)
@@ -5037,7 +4981,6 @@ impl GenericArgs {
         for (i, (arg, _)) in self.args.iter().enumerate() {
             let (left, right) = match arg {
                 GenericArg::Type(ty) => (ty.leftmost_token(), ty.rightmost_token()),
-                GenericArg::Unreflect(arg) => (arg.leftmost_token(), arg.rightmost_token()),
             };
             let arg_span = right.end() - left.start();
             len += usize::from(arg_span);
@@ -5061,7 +5004,6 @@ impl Printable for GenericArgs {
         for (i, (arg, _comma)) in self.args.iter().enumerate() {
             match arg {
                 GenericArg::Type(ty) => printer.print(ty, shape.clone()),
-                GenericArg::Unreflect(arg) => printer.print(arg, shape.clone()),
             };
             if i + 1 < self.args.len() {
                 printer.print_str(", ");

--- a/baml_language/crates/baml_fmt/src/ast/pattern.rs
+++ b/baml_language/crates/baml_fmt/src/ast/pattern.rs
@@ -10,7 +10,6 @@
 //!                | DESTRUCTURE_PATTERN
 //!                | ARRAY_PATTERN
 //!                | TYPE_PATTERN
-//!                | UNREFLECT_PATTERN
 //!                | PAREN_PATTERN
 //!                | WILDCARD_PATTERN
 //! ```
@@ -105,7 +104,6 @@ pub enum MatchPattern {
     Destructure(DestructurePattern),
     Array(ArrayPattern),
     Type(TypePattern),
-    Unreflect(UnreflectPattern),
     Paren(ParenPattern),
     Union(UnionPattern),
     Chain(ChainPattern),
@@ -136,9 +134,6 @@ impl MatchPattern {
                 BindingPattern::from_node(&node).map(MatchPattern::Binding)
             }
             SyntaxKind::TYPE_PATTERN => TypePattern::from_node(&node).map(MatchPattern::Type),
-            SyntaxKind::UNREFLECT_PATTERN => {
-                UnreflectPattern::from_node(&node).map(MatchPattern::Unreflect)
-            }
             SyntaxKind::ARRAY_PATTERN => ArrayPattern::from_node(&node).map(MatchPattern::Array),
             SyntaxKind::PAREN_PATTERN => ParenPattern::from_node(&node).map(MatchPattern::Paren),
             SyntaxKind::UNION_PATTERN => UnionPattern::from_node(&node).map(MatchPattern::Union),
@@ -169,7 +164,6 @@ impl Printable for MatchPattern {
             MatchPattern::Destructure(p) => p.print(shape, printer),
             MatchPattern::Array(p) => p.print(shape, printer),
             MatchPattern::Type(p) => p.print(shape, printer),
-            MatchPattern::Unreflect(p) => p.print(shape, printer),
             MatchPattern::Paren(p) => p.print(shape, printer),
             MatchPattern::Union(p) => p.print(shape, printer),
             MatchPattern::Chain(p) => p.print(shape, printer),
@@ -182,7 +176,6 @@ impl Printable for MatchPattern {
             MatchPattern::Destructure(p) => p.leftmost_token(),
             MatchPattern::Array(p) => p.leftmost_token(),
             MatchPattern::Type(p) => p.leftmost_token(),
-            MatchPattern::Unreflect(p) => p.leftmost_token(),
             MatchPattern::Paren(p) => p.leftmost_token(),
             MatchPattern::Union(p) => p.leftmost_token(),
             MatchPattern::Chain(p) => p.leftmost_token(),
@@ -195,7 +188,6 @@ impl Printable for MatchPattern {
             MatchPattern::Destructure(p) => p.rightmost_token(),
             MatchPattern::Array(p) => p.rightmost_token(),
             MatchPattern::Type(p) => p.rightmost_token(),
-            MatchPattern::Unreflect(p) => p.rightmost_token(),
             MatchPattern::Paren(p) => p.rightmost_token(),
             MatchPattern::Union(p) => p.rightmost_token(),
             MatchPattern::Chain(p) => p.rightmost_token(),
@@ -864,52 +856,6 @@ impl Printable for TypePattern {
     }
     fn rightmost_token(&self) -> TextRange {
         self.ty.rightmost_token()
-    }
-}
-
-/// `unreflect(expr)` runtime identity pattern.
-#[derive(Debug)]
-pub struct UnreflectPattern {
-    pub marker: t::Word,
-    pub open_paren: t::LParen,
-    pub operand: Box<crate::ast::Expression>,
-    pub close_paren: t::RParen,
-}
-
-impl UnreflectPattern {
-    fn from_node(node: &baml_db::baml_compiler_syntax::SyntaxNode) -> Result<Self, StrongAstError> {
-        let mut it = SyntaxNodeIter::new(node);
-        let marker = it.expect_parse()?;
-        let open_paren = it.expect_parse()?;
-        let operand = Box::new(crate::ast::Expression::from_cst(
-            it.expect_next("unreflect operand")?,
-        )?);
-        let close_paren = it.expect_parse()?;
-        it.expect_end()?;
-        Ok(Self {
-            marker,
-            open_paren,
-            operand,
-            close_paren,
-        })
-    }
-}
-
-impl Printable for UnreflectPattern {
-    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
-        printer.print_raw_token(&self.marker);
-        printer.print_raw_token(&self.open_paren);
-        let info = printer.print(&*self.operand, shape);
-        printer.print_raw_token(&self.close_paren);
-        info
-    }
-
-    fn leftmost_token(&self) -> TextRange {
-        self.marker.span()
-    }
-
-    fn rightmost_token(&self) -> TextRange {
-        self.close_paren.span()
     }
 }
 

--- a/baml_language/crates/baml_fmt/src/ast/types.rs
+++ b/baml_language/crates/baml_fmt/src/ast/types.rs
@@ -15,6 +15,7 @@ use crate::{
 /// Corresponds to a [`SyntaxKind::TYPE_EXPR`] node.
 #[derive(Debug)]
 pub enum Type {
+    Unreflect(UnreflectType),
     Paren(ParenType),
     Path(PathType),
     /// Generally only string literals are used in normal types,
@@ -42,6 +43,7 @@ impl Type {
     #[must_use]
     pub const fn multi_line_is_indented(&self) -> bool {
         match self {
+            Type::Unreflect(_) => false,
             Type::Paren(_) => false,
             Type::Path(_) => true,
             Type::Literal(_) => false,
@@ -115,6 +117,7 @@ impl KnownKind for Type {
 impl Printable for Type {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         match self {
+            Type::Unreflect(unreflect) => unreflect.print(shape, printer),
             Type::Paren(paren) => paren.print(shape, printer),
             Type::Path(path) => path.print(shape, printer),
             Type::Literal(literal) => literal.print(shape, printer),
@@ -136,6 +139,7 @@ impl Printable for Type {
     }
     fn leftmost_token(&self) -> TextRange {
         match self {
+            Type::Unreflect(unreflect) => unreflect.leftmost_token(),
             Type::Paren(paren) => paren.leftmost_token(),
             Type::Path(path) => path.leftmost_token(),
             Type::Literal(literal) => literal.leftmost_token(),
@@ -152,6 +156,7 @@ impl Printable for Type {
     }
     fn rightmost_token(&self) -> TextRange {
         match self {
+            Type::Unreflect(unreflect) => unreflect.rightmost_token(),
             Type::Paren(paren) => paren.rightmost_token(),
             Type::Path(path) => path.rightmost_token(),
             Type::Literal(literal) => literal.rightmost_token(),
@@ -165,6 +170,54 @@ impl Printable for Type {
             Type::Constrained(constrained) => constrained.rightmost_token(),
             Type::Unknown(range) => *range,
         }
+    }
+}
+
+/// `unreflect(expr)` runtime type atom.
+#[derive(Debug)]
+pub struct UnreflectType {
+    pub keyword: t::Word,
+    pub open_paren: t::LParen,
+    pub operand: Box<crate::ast::Expression>,
+    pub close_paren: t::RParen,
+}
+
+impl FromCST for UnreflectType {
+    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
+        let node = StrongAstError::assert_is_node(elem)?;
+        StrongAstError::assert_kind_node(&node, SyntaxKind::UNREFLECT_TYPE)?;
+        let mut it = SyntaxNodeIter::new(&node);
+        let keyword = it.expect_parse()?;
+        let open_paren = it.expect_parse()?;
+        let operand = Box::new(crate::ast::Expression::from_cst(
+            it.expect_next("unreflect operand")?,
+        )?);
+        let close_paren = it.expect_parse()?;
+        it.expect_end()?;
+        Ok(Self {
+            keyword,
+            open_paren,
+            operand,
+            close_paren,
+        })
+    }
+}
+
+impl Printable for UnreflectType {
+    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        printer.print_raw_token(&self.keyword);
+        printer.print_raw_token(&self.open_paren);
+        let info = printer.print(&*self.operand, shape);
+        printer.print_raw_token(&self.close_paren);
+        info
+    }
+
+    fn leftmost_token(&self) -> TextRange {
+        self.keyword.span()
+    }
+
+    fn rightmost_token(&self) -> TextRange {
+        self.close_paren.span()
     }
 }
 
@@ -436,6 +489,7 @@ impl Printable for UnionType {
 
 #[derive(Debug)]
 pub enum UnionTypeMember {
+    Unreflect(UnreflectType),
     Paren(ParenType),
     Path(PathType),
     Literal(Literal),
@@ -458,6 +512,9 @@ impl UnionTypeMember {
     fn take_base_type(it: &mut SyntaxNodeIter) -> Result<Self, StrongAstError> {
         let first = it.expect_next("a type")?;
         match first.kind() {
+            SyntaxKind::UNREFLECT_TYPE => {
+                UnreflectType::from_cst(first).map(UnionTypeMember::Unreflect)
+            }
             SyntaxKind::MINUS => {
                 let minus = t::Minus::from_cst(first)?;
                 let literal = it.expect_next("numeric literal after '-'")?;
@@ -681,6 +738,7 @@ impl UnionTypeMember {
 impl From<UnionTypeMember> for Type {
     fn from(member: UnionTypeMember) -> Self {
         match member {
+            UnionTypeMember::Unreflect(unreflect) => Type::Unreflect(unreflect),
             UnionTypeMember::Paren(paren) => Type::Paren(paren),
             UnionTypeMember::Path(path) => Type::Path(path),
             UnionTypeMember::Literal(literal) => Type::Literal(literal),
@@ -701,6 +759,7 @@ impl From<UnionTypeMember> for Type {
 impl Printable for UnionTypeMember {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         match self {
+            UnionTypeMember::Unreflect(unreflect) => unreflect.print(shape, printer),
             UnionTypeMember::Paren(paren) => paren.print(shape, printer),
             UnionTypeMember::Path(path) => path.print(shape, printer),
             UnionTypeMember::Literal(literal) => literal.print(shape, printer),
@@ -719,6 +778,7 @@ impl Printable for UnionTypeMember {
     }
     fn leftmost_token(&self) -> TextRange {
         match self {
+            UnionTypeMember::Unreflect(unreflect) => unreflect.leftmost_token(),
             UnionTypeMember::Paren(paren) => paren.leftmost_token(),
             UnionTypeMember::Path(path) => path.leftmost_token(),
             UnionTypeMember::Literal(lit) => lit.leftmost_token(),
@@ -734,6 +794,7 @@ impl Printable for UnionTypeMember {
     }
     fn rightmost_token(&self) -> TextRange {
         match self {
+            UnionTypeMember::Unreflect(unreflect) => unreflect.rightmost_token(),
             UnionTypeMember::Paren(paren) => paren.rightmost_token(),
             UnionTypeMember::Path(path) => path.rightmost_token(),
             UnionTypeMember::Literal(lit) => lit.rightmost_token(),

--- a/baml_language/crates/baml_fmt/src/ast/types.rs
+++ b/baml_language/crates/baml_fmt/src/ast/types.rs
@@ -178,7 +178,7 @@ impl Printable for Type {
 pub struct UnreflectType {
     pub keyword: t::Word,
     pub open_paren: t::LParen,
-    pub operand: Box<crate::ast::Expression>,
+    pub operand: Option<Box<crate::ast::Expression>>,
     pub close_paren: t::RParen,
 }
 
@@ -189,9 +189,13 @@ impl FromCST for UnreflectType {
         let mut it = SyntaxNodeIter::new(&node);
         let keyword = it.expect_parse()?;
         let open_paren = it.expect_parse()?;
-        let operand = Box::new(crate::ast::Expression::from_cst(
-            it.expect_next("unreflect operand")?,
-        )?);
+        let operand = if it.peek().map(SyntaxElement::kind) == Some(SyntaxKind::R_PAREN) {
+            None
+        } else {
+            Some(Box::new(crate::ast::Expression::from_cst(
+                it.expect_next("unreflect operand")?,
+            )?))
+        };
         let close_paren = it.expect_parse()?;
         it.expect_end()?;
         Ok(Self {
@@ -207,7 +211,11 @@ impl Printable for UnreflectType {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         printer.print_raw_token(&self.keyword);
         printer.print_raw_token(&self.open_paren);
-        let info = printer.print(&*self.operand, shape);
+        let info = self
+            .operand
+            .as_deref()
+            .map(|operand| printer.print(operand, shape))
+            .unwrap_or_else(PrintInfo::default_single_line);
         printer.print_raw_token(&self.close_paren);
         info
     }

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -939,19 +939,21 @@ implements<T extends Named> Printable for Box<T> {
     #[test]
     fn test_runtime_type_syntax_formatting_is_idempotent() {
         let source = r#"function f(t: reflect.Type, value: int) -> int {
-    type T = unreflect(t)
-    let result = identity<unreflect(t), string>(value)
+    type T = Wrapper<unreflect(t)>
+    let annotated: Wrapper<unreflect(t)>? = null
+    let result = identity<Wrapper<unreflect(t)>, string>(value)
     match (value) {
-        unreflect(t) => result,
+        Wrapper<unreflect(t)> => result,
         _ => 0
     }
 }
 "#;
         let options = FormatOptions::default();
         let formatted = format(source, &options).expect("runtime type syntax should format");
-        assert!(formatted.contains("type T = unreflect(t)"));
-        assert!(formatted.contains("identity<unreflect(t), string>"));
-        assert!(formatted.contains("unreflect(t) => result"));
+        assert!(formatted.contains("type T = Wrapper<unreflect(t)>"));
+        assert!(formatted.contains("let annotated: Wrapper<unreflect(t)>? = null"));
+        assert!(formatted.contains("identity<Wrapper<unreflect(t)>, string>"));
+        assert!(formatted.contains("Wrapper<unreflect(t)> => result"));
         let second = format(&formatted, &options).expect("formatter should be idempotent");
         assert_eq!(formatted, second);
     }

--- a/baml_language/crates/baml_ide/src/render.rs
+++ b/baml_language/crates/baml_ide/src/render.rs
@@ -276,6 +276,7 @@ fn display_type_ref_as_function_result(store: &TypeRefStore, id: TypeRefId) -> S
 pub fn display_type_ref(store: &TypeRefStore, id: TypeRefId) -> String {
     use baml_compiler2_hir::type_ref::TypeRefKind as K;
     let rendered = match &store[id].kind {
+        K::Unreflect { .. } => store.display(id).to_string(),
         K::Path { segments, .. } => segments
             .last()
             .map(|n| n.as_str().to_string())

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
@@ -249,10 +249,10 @@ function reflect.AnyClass.type(self: reflect.AnyClass) -> reflect.Type {
     return
 }
 
-function reflect.Package._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.Package {
+function reflect.Package._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.CompileArtifact {
 }
 
-function reflect.Package._finish(artifact: reflect.Package, packages: map<string, reflect.Package>) -> reflect.Package {
+function reflect.Package._finish(artifact: reflect.CompileArtifact, packages: map<string, reflect.Package>) -> reflect.Package {
 }
 
 function reflect.Package.classes(self: reflect.Package) -> map<string, reflect.class.Type> {
@@ -306,10 +306,10 @@ function reflect.Package.tests(self: reflect.Package) -> map<string, () -> null 
 function reflect.Package.with_types(self: reflect.Package, types: map<string, reflect.Type | reflect.TypeView>) -> reflect.Package {
 }
 
-function reflect.Session._compile(self: reflect.Session, source: string) -> reflect.Package {
+function reflect.Session._compile(self: reflect.Session, source: string) -> reflect.CompileArtifact {
 }
 
-function reflect.Session._finish(self: reflect.Session, artifact: reflect.Package) -> #0 {
+function reflect.Session._finish(self: reflect.Session, artifact: reflect.CompileArtifact) -> #0 {
 }
 
 function reflect.Session._new(packages: map<string, reflect.Package>) -> reflect.Session {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
@@ -590,8 +590,8 @@ fn reflect.Package.compile(files: map<string, string>, packages: map<string, ref
     let _1: map<string, string> // files // param
     let _2: map<string, reflect.Package> // packages // param
     let _3: bool
-    let _4: reflect.Package // artifact
-    let _5: reflect.Package
+    let _4: reflect.CompileArtifact // artifact
+    let _5: reflect.CompileArtifact
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -675,10 +675,10 @@ fn reflect.Session.eval(self: reflect.Session, source: string) -> T {
     let _0: T // _0 // return
     let _1: reflect.Session // self // param
     let _2: string // source // param
-    let _3: reflect.Package // artifact
+    let _3: reflect.CompileArtifact // artifact
     let _4: reflect.Type
     let _5: unknown // _
-    let _6: reflect.Package
+    let _6: reflect.CompileArtifact
     let _7: reflect.Type
     let _8: reflect.errors.EvaluationError
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/ppir.snap
@@ -221,6 +221,12 @@ class reflect.Arg$stream {
   name: string | null
   type: unknown
 }
+class reflect.CompileArtifact {
+  _inner: unknown
+}
+class reflect.CompileArtifact$stream {
+  _inner: unknown
+}
 class reflect.Diagnostic {
   code: string
   span: reflect.Span?
@@ -307,10 +313,10 @@ class reflect.WithMeta$stream {
 }
 type reflect.TypeKind = reflect.class.Type | reflect.enum.Type | reflect.union.Type | reflect.literal.Type | reflect.array.Type | reflect.map.Type | reflect.interface.Type | reflect.primitive.Type | reflect.function.Type
 type reflect.TypeKind$stream = reflect.class.Type$stream | reflect.enum.Type$stream | reflect.union.Type$stream | reflect.literal.Type$stream | reflect.array.Type$stream | reflect.map.Type$stream | reflect.interface.Type$stream | reflect.primitive.Type$stream | reflect.function.Type$stream
-function reflect._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
-function reflect._compile(self: ?, source: string) -> reflect.Package  [builtin]
-function reflect._finish(artifact: reflect.Package, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
-function reflect._finish(self: ?, artifact: reflect.Package) -> T  [builtin]
+function reflect._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.CompileArtifact  [builtin]
+function reflect._compile(self: ?, source: string) -> reflect.CompileArtifact  [builtin]
+function reflect._finish(artifact: reflect.CompileArtifact, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
+function reflect._finish(self: ?, artifact: reflect.CompileArtifact) -> T  [builtin]
 function reflect._new(packages: map<string, reflect.Package>) -> reflect.Session  [builtin]
 function reflect.as_type(self: ?) -> reflect.Type  [missing]
 function reflect.attributes(self: ?) -> reflect.Meta  [expr] {

--- a/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__nested_runtime_type_atoms_bind_slots_before_loading_templates.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__nested_runtime_type_atoms_bind_slots_before_loading_templates.snap
@@ -1,0 +1,98 @@
+---
+source: crates/baml_tests/src/compiler2_mir/mod.rs
+---
+fn user.erase() -> string {
+    // Locals:
+    let _0: string // _0 // return
+
+    bb0: {
+        _0 = const "ok";
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.f(t: reflect.Type, value: unknown) -> bool {
+    // Locals:
+    let _0: bool // _0 // return
+    let _1: reflect.Type // t // param
+    let _2: unknown // value // param
+    let _3: reflect.Type
+    let _4: null | Wrapper<$unreflect$d7b1576f> // annotated
+    let _5: bool
+    let _6: bool
+    let _7: bool
+    let _8: string
+    let _9: reflect.Type
+    let _10: null | Wrapper<$unreflect$d7b1576f>
+    let _11: bool
+    let _12: bool
+
+    bb0: {
+        bind_type(0, [Copy(Local(Local(1)))]);
+        _3 = load_type(Wrapper<#0>);
+        bind_type(5, [Copy(Local(Local(3)))]);
+        bind_type(4, [Copy(Local(Local(1)))]);
+        _4 = const null;
+        bind_type(1, [Copy(Local(Local(1)))]);
+        _9 = load_type(Wrapper<#1>);
+        _8 = call const fn user.erase<copy _9>(; runtime_type_check) -> [bb1];
+    }
+
+    bb1: {
+        _7 = copy _8 == const "ok";
+        _6 = short_circuit(&&) copy _7 -> [eval: bb2, join: bb3];
+    }
+
+    bb2: {
+        _10 = copy _4;
+        _6 = call const fn baml.ops.equals_equals(copy _10, const null) -> [bb3];
+    }
+
+    bb3: {
+        _5 = short_circuit(&&) copy _6 -> [eval: bb4, join: bb7];
+    }
+
+    bb4: {
+        bind_type(3, [Copy(Local(Local(1)))]);
+        _11 = is_type(copy _2, Wrapper<#3>);
+        branch copy _11 -> [bb6, bb5];
+    }
+
+    bb5: {
+        _5 = const false;
+        goto -> bb7;
+    }
+
+    bb6: {
+        _5 = const true;
+        goto -> bb7;
+    }
+
+    bb7: {
+        _0 = short_circuit(&&) copy _5 -> [eval: bb8, join: bb11];
+    }
+
+    bb8: {
+        bind_type(2, [Copy(Local(Local(1)))]);
+        _12 = is_type(copy _2, Wrapper<#2>);
+        branch copy _12 -> [bb10, bb9];
+    }
+
+    bb9: {
+        _0 = const false;
+        goto -> bb11;
+    }
+
+    bb10: {
+        _0 = const true;
+        goto -> bb11;
+    }
+
+    bb11: {
+        return;
+    }
+}

--- a/baml_language/crates/baml_tests/src/compiler2_mir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_mir/mod.rs
@@ -785,6 +785,36 @@ function f(t: reflect.Type, value: unknown) -> bool {
     );
 }
 
+#[test]
+fn nested_runtime_type_atoms_bind_slots_before_loading_templates() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Wrapper<T> { value T }
+
+function erase<T>() -> string { "ok" }
+
+function f(t: reflect.Type, value: unknown) -> bool {
+    type Bound = Wrapper<unreflect(t)>
+    let annotated: Wrapper<unreflect(t)>? = null
+    erase<Wrapper<unreflect(t)>>() == "ok"
+        && annotated == null
+        && value is Wrapper<unreflect(t)>
+        && match value {
+            Wrapper<unreflect(t)> => true,
+            _ => false,
+        }
+}
+"#,
+    );
+    baml_project::testing::assert_no_diagnostic_errors(&db);
+    mir_snapshot!(
+        "nested_runtime_type_atoms_bind_slots_before_loading_templates",
+        render_mir(&db, file)
+    );
+}
+
 /// A source-less callable keeps its symbolic package target all the way into
 /// MIR while runtime generic operands still come exclusively from the solved
 /// call plan.

--- a/baml_language/crates/baml_tests/src/compiler2_mir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_mir/mod.rs
@@ -788,7 +788,7 @@ function f(t: reflect.Type, value: unknown) -> bool {
 #[test]
 fn nested_runtime_type_atoms_bind_slots_before_loading_templates() {
     let mut db = make_db();
-    let file = db.add_file(
+    let file = db.file(
         "test.baml",
         r#"
 class Wrapper<T> { value T }
@@ -808,7 +808,7 @@ function f(t: reflect.Type, value: unknown) -> bool {
 }
 "#,
     );
-    baml_project::testing::assert_no_diagnostic_errors(&db);
+    baml_db::testing::assert_no_diagnostic_errors(&db);
     mir_snapshot!(
         "nested_runtime_type_atoms_bind_slots_before_loading_templates",
         render_mir(&db, file)

--- a/baml_language/crates/baml_tests/src/compiler2_tir/explicit_type_args.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/explicit_type_args.rs
@@ -9,8 +9,35 @@
 //! not the resolved arguments. Divergence from inference is therefore observed via the
 //! resulting expression *type*, not the call-site syntax.
 
-use super::support::{make_db, render_tir};
+use super::support::{make_db, render_ppir, render_tir};
 use crate::engine::TestDbExt;
+
+#[test]
+fn nested_runtime_type_binding_render_preserves_operand_name() {
+    let mut db = make_db();
+    let file = db.file(
+        "test.baml",
+        r#"
+class Wrapper<T> { value T }
+
+function caller(t: reflect.Type) -> bool {
+    type T = Wrapper<unreflect(t)>
+    true
+}
+"#,
+    );
+
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains("type T = Wrapper<unreflect(t)> : type"),
+        "typed rendering lost the nested operand:\n{tir}"
+    );
+    let ppir = render_ppir(&db, file);
+    assert!(
+        ppir.contains("type T = user.Wrapper<unreflect(t)>"),
+        "HIR rendering lost the nested operand:\n{ppir}"
+    );
+}
 
 /// Explicit type args bind T directly, distinct from what inference would produce.
 ///

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -257,11 +257,14 @@ pub(crate) mod support {
                 } else {
                     let tys: Vec<_> = type_args
                         .iter()
-                        .map(|arg| match arg {
-                            baml_compiler2_ast::TypeArg::Static(ty) => ty.to_string(),
-                            baml_compiler2_ast::TypeArg::Unreflect(operand) => {
+                        .map(|arg| match &arg.kind {
+                            baml_compiler2_ast::TypeExprKind::Unreflect {
+                                operand: Some(operand),
+                                ..
+                            } => {
                                 format!("unreflect({})", expr_desc(*operand, body))
                             }
+                            _ => arg.to_string(),
                         })
                         .collect();
                     format!("<{}>", tys.join(", "))
@@ -664,8 +667,14 @@ pub(crate) mod support {
         let stmt = &body.stmts[stmt_id];
         match stmt {
             Stmt::TypeBinding { name, value } => {
-                let operand = expr_desc(*value, body);
-                writeln!(output, "{pad}type {name} = unreflect({operand})").ok();
+                let value = match &value.kind {
+                    baml_compiler2_ast::TypeExprKind::Unreflect {
+                        operand: Some(operand),
+                        ..
+                    } => format!("unreflect({})", expr_desc(*operand, body)),
+                    _ => value.to_string(),
+                };
+                writeln!(output, "{pad}type {name} = {value}").ok();
             }
             Stmt::Let {
                 pattern,
@@ -812,13 +821,17 @@ pub(crate) mod support {
         let stmt = &body.stmts[stmt_id];
         match stmt {
             Stmt::TypeBinding { name, value } => {
-                let operand = expr_desc_rich(*value, body, inference);
-                let operand_ty = expr_ty(inference, *value);
-                writeln!(
-                    output,
-                    "{pad}type {name} = unreflect({operand}) : {operand_ty}"
-                )
-                .ok();
+                let (value_desc, value_ty) = match &value.kind {
+                    baml_compiler2_ast::TypeExprKind::Unreflect {
+                        operand: Some(operand),
+                        ..
+                    } => (
+                        format!("unreflect({})", expr_desc_rich(*operand, body, inference)),
+                        expr_ty(inference, *operand).to_string(),
+                    ),
+                    _ => (value.to_string(), "type".to_string()),
+                };
+                writeln!(output, "{pad}type {name} = {value_desc} : {value_ty}").ok();
             }
             Stmt::Let {
                 pattern,
@@ -1352,6 +1365,7 @@ pub(crate) mod support {
             }
 
             match &ty.kind {
+                baml_compiler2_ast::TypeExprKind::Unreflect { .. } => "unreflect(…)".into(),
                 baml_compiler2_ast::TypeExprKind::Path {
                     segments,
                     generic_args,
@@ -1510,6 +1524,7 @@ pub(crate) mod support {
             }
 
             match &store[id].kind {
+                K::Unreflect { .. } => "unreflect(…)".into(),
                 K::Path {
                     segments,
                     generic_args,
@@ -2043,10 +2058,16 @@ pub(crate) mod support {
             use baml_compiler2_ast::Stmt;
             let stmt = &body.stmts[stmt_id];
             match stmt {
-                Stmt::TypeBinding { name, value } => format!(
-                    "type {name} = unreflect({})",
-                    expr_desc_hir(*value, body, prefix, local_type_names)
-                ),
+                Stmt::TypeBinding { name, value } => match &value.kind {
+                    baml_compiler2_ast::TypeExprKind::Unreflect {
+                        operand: Some(operand),
+                        ..
+                    } => format!(
+                        "type {name} = unreflect({})",
+                        expr_desc_hir(*operand, body, prefix, local_type_names)
+                    ),
+                    _ => format!("type {name} = {value}"),
+                },
                 Stmt::Let {
                     pattern,
                     initializer,

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -134,6 +134,20 @@ pub(crate) mod support {
         }
     }
 
+    fn type_expr_desc(type_expr: &baml_compiler2_ast::TypeExpr, body: &ExprBody) -> String {
+        let mut rendered = type_expr.to_string();
+        let mut operands = Vec::new();
+        type_expr.unreflect_operands(&mut operands);
+        for operand in operands {
+            rendered = rendered.replacen(
+                "unreflect(…)",
+                &format!("unreflect({})", expr_desc(operand, body)),
+                1,
+            );
+        }
+        rendered
+    }
+
     fn expr_desc(expr_id: ExprId, body: &ExprBody) -> String {
         let expr = &body.exprs[expr_id];
         match expr {
@@ -257,15 +271,7 @@ pub(crate) mod support {
                 } else {
                     let tys: Vec<_> = type_args
                         .iter()
-                        .map(|arg| match &arg.kind {
-                            baml_compiler2_ast::TypeExprKind::Unreflect {
-                                operand: Some(operand),
-                                ..
-                            } => {
-                                format!("unreflect({})", expr_desc(*operand, body))
-                            }
-                            _ => arg.to_string(),
-                        })
+                        .map(|arg| type_expr_desc(arg, body))
                         .collect();
                     format!("<{}>", tys.join(", "))
                 };

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -673,13 +673,7 @@ pub(crate) mod support {
         let stmt = &body.stmts[stmt_id];
         match stmt {
             Stmt::TypeBinding { name, value } => {
-                let value = match &value.kind {
-                    baml_compiler2_ast::TypeExprKind::Unreflect {
-                        operand: Some(operand),
-                        ..
-                    } => format!("unreflect({})", expr_desc(*operand, body)),
-                    _ => value.to_string(),
-                };
+                let value = type_expr_desc(value, body);
                 writeln!(output, "{pad}type {name} = {value}").ok();
             }
             Stmt::Let {
@@ -835,7 +829,7 @@ pub(crate) mod support {
                         format!("unreflect({})", expr_desc_rich(*operand, body, inference)),
                         expr_ty(inference, *operand).to_string(),
                     ),
-                    _ => (value.to_string(), "type".to_string()),
+                    _ => (type_expr_desc(value, body), "type".to_string()),
                 };
                 writeln!(output, "{pad}type {name} = {value_desc} : {value_ty}").ok();
             }
@@ -2061,19 +2055,35 @@ pub(crate) mod support {
             prefix: &str,
             local_type_names: &std::collections::HashSet<&str>,
         ) -> String {
+            fn type_expr_desc_hir(
+                type_expr: &baml_compiler2_ast::TypeExpr,
+                body: &ExprBody,
+                prefix: &str,
+                local_type_names: &std::collections::HashSet<&str>,
+            ) -> String {
+                let mut rendered = type_expr_to_string_hir(type_expr, prefix, local_type_names);
+                let mut operands = Vec::new();
+                type_expr.unreflect_operands(&mut operands);
+                for operand in operands {
+                    rendered = rendered.replacen(
+                        "unreflect(…)",
+                        &format!(
+                            "unreflect({})",
+                            expr_desc_hir(operand, body, prefix, local_type_names)
+                        ),
+                        1,
+                    );
+                }
+                rendered
+            }
+
             use baml_compiler2_ast::Stmt;
             let stmt = &body.stmts[stmt_id];
             match stmt {
-                Stmt::TypeBinding { name, value } => match &value.kind {
-                    baml_compiler2_ast::TypeExprKind::Unreflect {
-                        operand: Some(operand),
-                        ..
-                    } => format!(
-                        "type {name} = unreflect({})",
-                        expr_desc_hir(*operand, body, prefix, local_type_names)
-                    ),
-                    _ => format!("type {name} = {value}"),
-                },
+                Stmt::TypeBinding { name, value } => format!(
+                    "type {name} = {}",
+                    type_expr_desc_hir(value, body, prefix, local_type_names)
+                ),
                 Stmt::Let {
                     pattern,
                     initializer,

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -2,10 +2,9 @@
 source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
-hir_ty error-channel entries: 3
+hir_ty error-channel entries: 2
 panics: 0
 
 == hir_ty error channel
 ns_optional_chain_type_args/optional_chain_type_args.baml:8220..8247 `animal(whi...peak<int>()`: expected user.optional_chain_type_args.Speaker, got user.optional_chain_type_args.Cat | user.optional_chain_type_args.Dog
 ns_optional_chain_type_args/optional_chain_type_args.baml:8638..8662 `pair(which)?.tag<bool>()`: expected user.optional_chain_type_args.Tagged, got user.optional_chain_type_args.Pair<int> | user.optional_chain_type_args.Pair<string>
-ns_runtime_type_binding_generic_calls/runtime_type_binding_generic_calls.baml:3109..3125 `EmptyOf<Bound>()`: expected Bound[], got Bound[]

--- a/baml_language/crates/baml_tests/src/type_spec/tables.rs
+++ b/baml_language/crates/baml_tests/src/type_spec/tables.rs
@@ -605,15 +605,18 @@ function scope_shape_bad(runtime_t: reflect.Type) -> null throws never {
         diagnostics.extend(result.diagnostics.iter().map(|diag| diag.error.clone()));
         runtime_checks += result.runtime_checks.len();
         for check in &result.runtime_checks {
-            assert!(matches!(
-                check,
-                baml_compiler2_hir_ty::infer::RuntimeCheck::Argument { expected, .. }
-                    if matches!(
-                        expected.kind(),
-                        baml_type::interned::TyKind::TypeVar(param, _)
-                            if param.index() & 0x8000_0000 != 0
-                    )
-            ));
+            assert!(
+                matches!(
+                    check,
+                    baml_compiler2_hir_ty::infer::RuntimeCheck::Argument { expected, .. }
+                        if matches!(
+                            expected.kind(),
+                            baml_type::interned::TyKind::TypeVar(param, _)
+                                if param.index() & 0x8000_0000 != 0
+                        )
+                ),
+                "unexpected runtime check: {check:?}"
+            );
         }
         saw_bad_operand |= result.diagnostics.iter().any(|diag| {
             matches!(

--- a/baml_language/crates/baml_tests/tests/reflect_call_any.rs
+++ b/baml_language/crates/baml_tests/tests/reflect_call_any.rs
@@ -646,6 +646,47 @@ async fn runtime_enum_renders_and_alias_round_trips_through_sap() {
 }
 
 #[tokio::test]
+async fn nested_unreflect_runtime_type_renders_through_a_generic_wrapper() {
+    let output = baml_test!(
+        r##"
+client TestClient = openai.ResponsesClient.new(
+    model = "gpt-4o-mini",
+    api_key = "test-key",
+    base_url = "http://localhost:1234",
+)
+
+class Wrapper<T> {
+    value T
+}
+
+function Extract<T>(input: string) -> T {
+    client: TestClient
+    prompt: `Extract ${input}.\n${ctx.output_format}`
+}
+
+function main() -> string {
+    let runtime_class = reflect.class.new("RuntimeTranscript", {
+        "speaker": reflect.Type.of<string>(),
+        "words": reflect.Type.of<string[]>(),
+    })
+    Extract$render_prompt<Wrapper<unreflect(runtime_class.as_type())>>("sample").text()
+}
+"##
+    );
+
+    let BexExternalValue::String(prompt) = output
+        .result
+        .expect("nested runtime type should render without executing a model call")
+    else {
+        panic!("expected rendered prompt text")
+    };
+    assert!(
+        prompt.contains("value:") && prompt.contains("speaker") && prompt.contains("words"),
+        "missing static wrapper or nested runtime class schema: {prompt}",
+    );
+}
+
+#[tokio::test]
 async fn runtime_enum_identity_and_metadata_are_preserved() {
     let output = baml_test!(
         r##"

--- a/baml_language/crates/baml_tests/tests/reflect_call_any.rs
+++ b/baml_language/crates/baml_tests/tests/reflect_call_any.rs
@@ -661,7 +661,7 @@ class Wrapper<T> {
 
 function Extract<T>(input: string) -> T {
     client: TestClient
-    prompt: `Extract ${input}.\n${ctx.output_format}`
+    prompt: `Extract ${input}.\n${ctx.output_format()}`
 }
 
 function main() -> string {

--- a/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
@@ -15,7 +15,7 @@ client TestClient = openai.ResponsesClient.new(
 
 function Extract<T>() -> T {
   client: TestClient
-  prompt: `${ctx.output_format}`
+  prompt: `${ctx.output_format()}`
 }
 
 function Check<T>(expected: reflect.Type, document: string) -> bool throws unknown {
@@ -32,20 +32,20 @@ class StaticInner {
 
 function main() -> bool throws unknown {
   let inner = reflect.class.new("Inner", { "x": reflect.Type.of<string>() })
-  let inner_array = inner.as_type().array()
+  let inner_array = inner.as_type().array().as_type()
   let holder_array = reflect.class.new("HolderArray", { "bs": inner_array }).as_type()
   let holder_map = reflect.class.new("HolderMap", {
     "by_name": reflect.map.new(reflect.Type.of<string>(), inner.as_type()).as_type(),
   }).as_type()
   let minted_enum = reflect.enum.new("MintedState", ["Ready", "Done"])
-  let enum_array = minted_enum.as_type().array()
+  let enum_array = minted_enum.as_type().array().as_type()
 
   let compiled_package = reflect.Package.compile({
     "compiled.baml": "class CompiledInner { x string }",
   })
   let compiled_inner = compiled_package.get_class("root.CompiledInner")
     ?? throw "missing CompiledInner"
-  let compiled_array = compiled_inner.as_type().array()
+  let compiled_array = compiled_inner.as_type().array().as_type()
   let compiled_holder_array = reflect.class.new("CompiledHolderArray", {
     "bs": compiled_array,
   }).as_type()
@@ -58,35 +58,35 @@ function main() -> bool throws unknown {
 
   let array_ok = {
     type T = unreflect(holder_array)
-    Check<T>(holder_array, #"{"bs":[{"x":"one"}]}"#)
+    Check<T>(holder_array, `{"bs":[{"x":"one"}]}`)
   }
   let empty_array_ok = {
     type T = unreflect(holder_array)
-    Check<T>(holder_array, #"{"bs":[]}"#)
+    Check<T>(holder_array, `{"bs":[]}`)
   }
   let map_ok = {
     type T = unreflect(holder_map)
-    Check<T>(holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+    Check<T>(holder_map, `{"by_name":{"one":{"x":"one"}}}`)
   }
   let enum_ok = {
     type T = unreflect(enum_array)
-    Check<T>(enum_array, #"["Ready","Done"]"#)
+    Check<T>(enum_array, `["Ready","Done"]`)
   }
   let top_level_array_ok = {
     type T = unreflect(inner_array)
-    Check<T>(inner_array, #"[{"x":"one"}]"#)
+    Check<T>(inner_array, `[{"x":"one"}]`)
   }
   let compiled_array_ok = {
     type T = unreflect(compiled_holder_array)
-    Check<T>(compiled_holder_array, #"{"bs":[{"x":"one"}]}"#)
+    Check<T>(compiled_holder_array, `{"bs":[{"x":"one"}]}`)
   }
   let compiled_map_ok = {
     type T = unreflect(compiled_holder_map)
-    Check<T>(compiled_holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+    Check<T>(compiled_holder_map, `{"by_name":{"one":{"x":"one"}}}`)
   }
   let static_control_ok = {
     type T = unreflect(static_holder)
-    Check<T>(static_holder, #"{"bs":[{"x":"one"}]}"#)
+    Check<T>(static_holder, `{"bs":[{"x":"one"}]}`)
   }
 
   array_ok && empty_array_ok && map_ok && enum_ok && top_level_array_ok

--- a/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
@@ -1,0 +1,99 @@
+//! B-1605 bug 9: every inbound type-bearing value arm must resolve through
+//! the call-local runtime declaration overlay, including empty containers.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn runtime_declarations_anchor_through_every_container_seam() {
+    let output = baml_test!(
+        r###"
+client TestClient = openai.ResponsesClient.new(
+  model = "unused",
+  api_key = "unused",
+)
+
+function Extract<T>() -> T {
+  client: TestClient
+  prompt: `${ctx.output_format}`
+}
+
+function Check<T>(expected: reflect.Type, document: string) -> bool throws unknown {
+  let direct = baml.sap.parse<T>(document)
+  let companion = Extract$parse<T>(document)
+  reflect.Type.of_value(direct) == expected
+    && reflect.Type.of_value(companion) == expected
+    && baml.json.encode(direct) == baml.json.encode(companion)
+}
+
+class StaticInner {
+  x string
+}
+
+function main() -> bool throws unknown {
+  let inner = reflect.class.new("Inner", { "x": reflect.Type.of<string>() })
+  let inner_array = inner.as_type().array()
+  let holder_array = reflect.class.new("HolderArray", { "bs": inner_array }).as_type()
+  let holder_map = reflect.class.new("HolderMap", {
+    "by_name": reflect.map.new(reflect.Type.of<string>(), inner.as_type()).as_type(),
+  }).as_type()
+  let minted_enum = reflect.enum.new("MintedState", ["Ready", "Done"])
+  let enum_array = minted_enum.as_type().array()
+
+  let compiled_package = reflect.Package.compile({
+    "compiled.baml": "class CompiledInner { x string }",
+  })
+  let compiled_inner = compiled_package.get_class("root.CompiledInner")
+    ?? throw "missing CompiledInner"
+  let compiled_array = compiled_inner.as_type().array()
+  let compiled_holder_array = reflect.class.new("CompiledHolderArray", {
+    "bs": compiled_array,
+  }).as_type()
+  let compiled_holder_map = reflect.class.new("CompiledHolderMap", {
+    "by_name": reflect.map.new(reflect.Type.of<string>(), compiled_inner.as_type()).as_type(),
+  }).as_type()
+  let static_holder = reflect.class.new("StaticHolder", {
+    "bs": reflect.Type.of<StaticInner[]>(),
+  }).as_type()
+
+  let array_ok = {
+    type T = unreflect(holder_array)
+    Check<T>(holder_array, #"{"bs":[{"x":"one"}]}"#)
+  }
+  let empty_array_ok = {
+    type T = unreflect(holder_array)
+    Check<T>(holder_array, #"{"bs":[]}"#)
+  }
+  let map_ok = {
+    type T = unreflect(holder_map)
+    Check<T>(holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+  }
+  let enum_ok = {
+    type T = unreflect(enum_array)
+    Check<T>(enum_array, #"["Ready","Done"]"#)
+  }
+  let top_level_array_ok = {
+    type T = unreflect(inner_array)
+    Check<T>(inner_array, #"[{"x":"one"}]"#)
+  }
+  let compiled_array_ok = {
+    type T = unreflect(compiled_holder_array)
+    Check<T>(compiled_holder_array, #"{"bs":[{"x":"one"}]}"#)
+  }
+  let compiled_map_ok = {
+    type T = unreflect(compiled_holder_map)
+    Check<T>(compiled_holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+  }
+  let static_control_ok = {
+    type T = unreflect(static_holder)
+    Check<T>(static_holder, #"{"bs":[{"x":"one"}]}"#)
+  }
+
+  array_ok && empty_array_ok && map_ok && enum_ok && top_level_array_ok
+    && compiled_array_ok && compiled_map_ok && static_control_ok
+}
+"###
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -132,6 +132,24 @@ class Broken { value MissingType }
 }
 "####;
 
+#[tokio::test]
+async fn package_finish_refuses_session_compile_artifact() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = session._compile<int>(#"1"#)
+  let rejected = false
+  let _ = reflect.Package._finish(artifact, {}) catch (_) {
+    _ => { rejected = true },
+  }
+  rejected && session.eval<int>(#"2"#) == 2
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
 const SCENARIO_6_SOURCE: &str = r####"
 class AgentState {
   goal string

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -138,12 +138,12 @@ async fn package_finish_refuses_session_compile_artifact() {
         r####"
 function main() -> bool throws unknown {
   let session = reflect.Session.new()
-  let artifact = session._compile<int>(#"1"#)
+  let artifact = session._compile<int>(`1`)
   let rejected = false
   let _ = reflect.Package._finish(artifact, {}) catch (_) {
     _ => { rejected = true },
   }
-  rejected && session.eval<int>(#"2"#) == 2
+  rejected && session.eval<int>(`2`) == 2
 }
 "####
     );

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -428,12 +428,38 @@ function main() -> bool throws unknown {
   })
   let app = reflect.Package.current().with_types({ "MountedTicket": mounted })
   let s = reflect.Session.new(packages = { "app": app })
-  s.eval(#"let ticket = app.MountedTicket { subject: "visible" }
-ticket.subject"#) == "visible"
+  s.eval(`let ticket = app.MountedTicket { subject: "visible" }
+ticket.subject`) == "visible"
 }
 "####
     );
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn session_export_alias_preserves_nested_mounted_field_types() {
+    let output = baml_test!(
+        r####"
+function main() -> string throws unknown {
+  let inner = reflect.class.new("MountedInner", {
+    "value": reflect.Type.of<string>(),
+  })
+  let outer = reflect.class.new("MountedOuter", {
+    "inner": inner.as_type(),
+  })
+  let app = reflect.Package.current().with_types({ "OuterAlias": outer })
+  let s = reflect.Session.new(packages = { "app": app })
+  s.eval<string>(`let outer = app.OuterAlias {
+  inner: app.MountedInner { value: "visible" },
+}
+outer.inner.value`)
+}
+"####
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("visible".into()))
+    );
 }
 
 #[tokio::test]

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -56,6 +56,22 @@ function main() -> bool throws unknown {
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
 
+#[tokio::test]
+async fn session_synthetic_step_names_do_not_collide_with_user_bindings() {
+    let output = baml_test!(
+        r####"
+function main() -> int throws unknown {
+  let session = reflect.Session.new()
+  session.eval(`let result = 5`)
+  session.eval(`let stmt_1 = 7
+log.info("keep the second generated step")`)
+  session.eval<int>(`result + stmt_1`)
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Int(12)));
+}
+
 const S11_LIVENESS_PROBE: &str = r#####"
 function escape_one_session_value() -> reflect.Type throws unknown {
   let dependency = reflect.Package.compile({

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -16,6 +16,46 @@ function main() -> int throws unknown {
 }
 "####;
 
+#[tokio::test]
+async fn session_compile_artifact_is_consumed_once() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = session._compile<int>(`1`)
+  let first = session._finish<int>(artifact)
+  let rejected = false
+  let _ = session._finish<int>(artifact) catch (_) {
+    _ => { rejected = true },
+  }
+  first == 1 && rejected
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn session_finish_refuses_package_compile_artifact() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = reflect.Package._compile(
+    { "main.baml": "function ready() -> bool { true }" },
+    {},
+  )
+  let rejected = false
+  let _ = session._finish<unknown>(artifact) catch (_) {
+    _ => { rejected = true },
+  }
+  rejected
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
 const S11_LIVENESS_PROBE: &str = r#####"
 function escape_one_session_value() -> reflect.Type throws unknown {
   let dependency = reflect.Package.compile({
@@ -511,12 +551,9 @@ async fn escaped_session_type_retains_provenance_only_while_handle_is_live() {
         let Object::Package(owner) = (unsafe { owner_ptr.get() }) else {
             panic!("escaped definition owner should be a Package")
         };
-        owner_is_session = owner.session.is_some();
-        session_history = owner
-            .session
-            .as_ref()
-            .map_or(0, |state| state.history.len());
-        let runtime = owner.runtime.as_ref().expect("runtime owner image");
+        owner_is_session = owner.session().is_some();
+        session_history = owner.session().map_or(0, |state| state.history.len());
+        let runtime = owner.runtime().expect("runtime owner image");
         retained_globals = runtime.globals.len();
         retained_objects = runtime.objects.len();
         retained_dependencies = runtime.dependencies.len();
@@ -524,10 +561,9 @@ async fn escaped_session_type_retains_provenance_only_while_handle_is_live() {
             .dependencies
             .iter()
             .map(|dependency| match unsafe { dependency.get() } {
-                Object::Package(package) => package
-                    .runtime
-                    .as_ref()
-                    .map_or(0, |runtime| runtime.objects.len()),
+                Object::Package(package) => {
+                    package.runtime().map_or(0, |runtime| runtime.objects.len())
+                }
                 _ => 0,
             })
             .sum::<usize>();

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -383,6 +383,60 @@ async fn session_reimports_instance_fields_without_changing_the_value() {
 }
 
 #[tokio::test]
+async fn session_reads_fields_from_mounted_return_types_inline_and_after_binding() {
+    let output = baml_test!(
+        r####"
+class Ticket {
+  subject string
+}
+
+class Envelope {
+  ticket Ticket
+}
+
+function GetTicket() -> Ticket {
+  Ticket { subject: "hello" }
+}
+
+function GetEnvelope() -> Envelope {
+  Envelope { ticket: GetTicket() }
+}
+
+function main() -> string throws unknown {
+  let s = reflect.Session.new(packages = { "app": reflect.Package.current() })
+  let inline = s.eval(`app.GetTicket().subject`)
+  s.eval(`let ticket = app.GetTicket()`)
+  let rebound = s.eval(`ticket.subject`)
+  let nested = s.eval(`app.GetEnvelope().ticket.subject`)
+  `${inline}|${rebound}|${nested}`
+}
+"####
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("hello|hello|hello".into()))
+    );
+}
+
+#[tokio::test]
+async fn session_compiler_sees_with_types_exports_from_dependencies() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let mounted = reflect.class.new("MountedTicket", {
+    "subject": reflect.Type.of<string>(),
+  })
+  let app = reflect.Package.current().with_types({ "MountedTicket": mounted })
+  let s = reflect.Session.new(packages = { "app": app })
+  s.eval(#"let ticket = app.MountedTicket { subject: "visible" }
+ticket.subject"#) == "visible"
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn scenario_7_verbatim_semantics_and_containment() {
     let output = baml_test!(baml: SCENARIO_7, entry: "scenario_7");
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -125,6 +125,27 @@ async fn scoped_type_binding_evaluates_once_types_contracts_and_widens_on_escape
 }
 
 #[tokio::test]
+async fn nested_unreflect_annotations_and_patterns_use_realized_templates() {
+    let output = baml_test!(
+        r#"
+class Wrapper<T> { value T }
+
+function main() -> bool {
+    let t = reflect.Type.of<string>()
+    let value = Wrapper<string> { value: "ok" }
+    let annotated: Wrapper<unreflect(t)> = value
+    annotated is Wrapper<unreflect(t)>
+        && match annotated {
+            Wrapper<unreflect(t)> => true,
+            _ => false,
+        }
+}
+"#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn type_bindings_work_in_lambdas_and_nested_shadowing_uses_distinct_slots() {
     let output = baml_test!(
         r#"
@@ -188,7 +209,7 @@ function main() -> bool {
 }
 
 #[tokio::test]
-#[should_panic(expected = "runtime type bindings are only allowed inside")]
+#[should_panic(expected = "a runtime type has no scope here")]
 async fn top_level_runtime_type_binding_is_rejected() {
     let _ = baml_test!(
         r#"

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -83,6 +83,33 @@ function Items() -> Item[] { [Item { value: "bound" }] }
 "####;
 
 #[tokio::test]
+async fn with_types_carries_runtime_witnesses_into_consumer_compilation() {
+    let output = baml_test!(
+        r####"
+interface Labelled {
+  label string
+}
+
+function main() -> bool throws unknown {
+  let witness = reflect.interface.implementation<Labelled>()
+    .field("label", class_field = "display_name")
+  let person = reflect.class.new("InternalPerson", {
+    "display_name": reflect.Type.of<string>(),
+  }, implementations = [witness])
+  let app = reflect.Package.current().with_types({ "PersonAlias": person })
+  let compiled = reflect.Package.compile({ "consumer.baml": `
+function as_label(value: app.PersonAlias) -> app.Labelled {
+  value
+}
+` }, packages = { "app": app })
+  compiled.functions().get("root.as_label") != null
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn scenario_four_pattern_two_mounts_a_runtime_type_as_a_static_name() {
     let output = baml_test!(PATTERN_TWO_SOURCE);
     assert_eq!(

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -161,6 +161,45 @@ function main() -> bool {
 }
 
 #[tokio::test]
+async fn runtime_generic_apply_values_preserve_their_type_argument_slot() {
+    let output = baml_test!(
+        r#"
+function has_types<A, B>(first: A, second: B) -> bool {
+    reflect.Type.of<A>() == reflect.Type.of_value(first)
+        && reflect.Type.of<B>() == reflect.Type.of_value(second)
+}
+
+function main() -> bool {
+    let first = reflect.Type.of<string>()
+    let second = reflect.Type.of<int>()
+    let check = has_types<unreflect(first), unreflect(second)>
+    check("ok", 42)
+}
+"#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn match_scrutinee_runtime_annotation_binds_before_pattern_dispatch() {
+    let output = baml_test!(
+        r#"
+class Wrapper<T> { value T }
+
+function main() -> bool {
+    let t = reflect.Type.of<string>()
+    let wrapped = Wrapper<string> { value: "ok" }
+    match (wrapped : Wrapper<unreflect(t)>) {
+        Wrapper<string> { value } => value == "ok",
+        _ => false,
+    }
+}
+"#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn type_bindings_work_in_lambdas_and_nested_shadowing_uses_distinct_slots() {
     let output = baml_test!(
         r#"

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -125,6 +125,32 @@ async fn scoped_type_binding_evaluates_once_types_contracts_and_widens_on_escape
 }
 
 #[tokio::test]
+async fn structural_let_or_pattern_evaluates_each_unreflect_operand_once() {
+    let output = baml_test!(
+        r#"
+class First<T> { value unknown }
+class Counter {
+    evaluations int
+
+    function operand(self) -> reflect.Type {
+        self.evaluations += 1
+        reflect.Type.of<string>()
+    }
+}
+
+function main() -> bool {
+    let counter = Counter { evaluations: 0 }
+    let candidate: unknown = First<string> { value: "ok" }
+    let First<unreflect(counter.operand())> { value: let bound }
+        | let bound = candidate
+    counter.evaluations == 1 && bound == "ok"
+}
+"#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn nested_unreflect_annotations_and_patterns_use_realized_templates() {
     let output = baml_test!(
         r#"

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -146,6 +146,21 @@ function main() -> bool {
 }
 
 #[tokio::test]
+async fn type_of_materializes_nested_unreflect_bindings_before_loading_the_template() {
+    let output = baml_test!(
+        r#"
+class Wrapper<T> { value T }
+
+function main() -> bool {
+    let t = reflect.Type.of<string>()
+    reflect.Type.of<Wrapper<unreflect(t)>>() == reflect.Type.of<Wrapper<string>>()
+}
+"#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn type_bindings_work_in_lambdas_and_nested_shadowing_uses_distinct_slots() {
     let output = baml_test!(
         r#"

--- a/baml_language/crates/baml_tests/tests/runtime_type_escape.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_escape.rs
@@ -59,6 +59,124 @@ fn assert_accepted(source: &str) {
     assert!(errors.is_empty(), "expected no errors, got: {errors:#?}");
 }
 
+#[test]
+fn nested_runtime_type_atoms_parse_and_typecheck_in_body_positions() {
+    assert_accepted(
+        r#"
+class Wrapper<T> { value T }
+
+function erase<T>(value: unknown) -> string { "ok" }
+
+function main(t: reflect.Type, value: unknown) -> bool throws unknown {
+    let call_ok = erase<Wrapper<unreflect(t)>>(value) == "ok"
+    let binding_ok = {
+        type T = Wrapper<unreflect(t)>
+        let values = baml.json.from_json<T[]>(baml.json.parse("[]"))
+        values.length() == 0
+    }
+    let annotated: Wrapper<unreflect(t)>? = null
+    call_ok
+        && binding_ok
+        && annotated == null
+        && value is Wrapper<unreflect(t)>
+        && match value {
+            Wrapper<unreflect(t)> => true,
+            _ => false,
+        }
+}
+"#,
+    );
+}
+
+#[test]
+fn nested_runtime_type_escape_uses_e0168_and_rewrites_only_the_hole() {
+    let source = r#"
+class Wrapper<T> { value T }
+
+function ident<T>() -> T throws string { throw "stop" }
+
+function main(t: reflect.Type) -> unknown throws unknown {
+    ident<Wrapper<unreflect(t)>>()
+}
+"#;
+    assert_single_escape(source);
+    let rendered = render_errors(source);
+    assert!(
+        rendered.contains("type Out = unreflect(t);") && rendered.contains("ident<Wrapper<Out>>()"),
+        "nested E0168 rewrite did not preserve the surrounding type:\n{rendered}",
+    );
+}
+
+#[test]
+fn nested_runtime_type_escape_through_throws_is_e0168() {
+    assert_single_escape(
+        r#"
+class Wrapper<T> { value T }
+class Boom<T> { payload T }
+
+function risky<T>() -> int throws Boom<T> { 0 }
+
+function main(t: reflect.Type) -> unknown throws unknown {
+    risky<Wrapper<unreflect(t)>>()
+}
+"#,
+    );
+}
+
+#[test]
+fn nested_runtime_type_escape_through_optional_chain_is_e0168() {
+    assert_single_escape(
+        r#"
+class Wrapper<T> { value T }
+
+class Source {
+    function pick<T>(self) -> T throws string { throw "stop" }
+}
+
+function main(t: reflect.Type, source: Source?) -> unknown throws unknown {
+    source?.pick<Wrapper<unreflect(t)>>()
+}
+"#,
+    );
+}
+
+#[test]
+fn item_signature_runtime_type_atoms_each_get_one_checker_diagnostic() {
+    let errors = compile_errors(
+        r#"
+class Wrapper<T> { value T }
+interface Marker<T> {}
+
+class FieldSite {
+    value Wrapper<unreflect(reflect.Type.of<string>())>
+}
+
+class ImplementsSite {
+    implements Marker<unreflect(reflect.Type.of<string>())> {}
+}
+
+function signature_site(
+    value: Wrapper<unreflect(reflect.Type.of<string>())>
+) -> Wrapper<unreflect(reflect.Type.of<string>())> {
+    value
+}
+
+function bound_site<T extends Wrapper<unreflect(reflect.Type.of<string>())>>() -> null { null }
+type AliasSite = Wrapper<unreflect(reflect.Type.of<string>())>
+"#,
+    );
+    assert_eq!(
+        errors.len(),
+        6,
+        "expected one diagnostic per item occurrence: {errors:#?}"
+    );
+    assert!(errors.iter().all(|(code, message)| {
+        code == "E0168"
+            && message
+                == "a runtime type has no scope here; bind it inside a function body: `type T = unreflect(…)`"
+    }));
+}
+
 /// The exact codes a source reports — for the audited shapes whose refusal is
 /// some other rule's to make, so a later change that hands them to E0168 (or
 /// to nothing at all) has to come through here.

--- a/baml_language/crates/baml_tests/tests/runtime_type_escape.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_escape.rs
@@ -291,7 +291,7 @@ fn agent_constructed_with_an_inline_runtime_type_is_refused() {
 
         function DynamicOutput<T>() -> T {{
             client: DefaultClient
-            prompt: `${{ctx.output_format}}`
+            prompt: `${{ctx.output_format()}}`
         }}
 
         function main(t: reflect.Type, c: ai.Client) -> unknown throws unknown {{

--- a/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
+++ b/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
@@ -43,3 +43,63 @@ function as_named(value: Person) -> Named<Value = string> {
 
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
+
+#[tokio::test]
+async fn same_named_runtime_declarations_round_trip_with_unique_source_names() {
+    let output = baml_test!(
+        r###"
+function main() -> bool throws unknown {
+  let first = reflect.class.new("Choice", { "left": reflect.Type.of<string>() })
+  let second = reflect.class.new("Choice", { "right": reflect.Type.of<int>() })
+  let combined = reflect.union.new([first.as_type(), second.as_type()])
+  let source = combined.as_type().to_baml()
+  let compiled = reflect.Package.compile({ "choices.baml": source })
+  compiled.get_class("root.Choice") != null
+    && compiled.get_class("root.Choice_2") != null
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn minted_and_compiled_same_named_declarations_round_trip() {
+    let output = baml_test!(
+        r###"
+function main() -> bool throws unknown {
+  let package = reflect.Package.compile({
+    "original.baml": "class Choice { compiled string }",
+  })
+  let compiled_choice = package.get_class("root.Choice") ?? throw "missing Choice"
+  let minted_choice = reflect.class.new("Choice", { "minted": reflect.Type.of<int>() })
+  let combined = reflect.union.new([compiled_choice.as_type(), minted_choice.as_type()])
+  let round_trip = reflect.Package.compile({ "choices.baml": combined.as_type().to_baml() })
+  round_trip.get_class("root.Choice") != null
+    && round_trip.get_class("root.Choice_2") != null
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn runtime_class_static_dependencies_are_declared_in_round_trip_source() {
+    let output = baml_test!(
+        r###"
+class StaticChild {
+  value string
+}
+
+function main() -> bool throws unknown {
+  let holder = reflect.class.new("RuntimeHolder", {
+    "child": reflect.Type.of<StaticChild>(),
+  })
+  let source = holder.as_type().to_baml()
+  let round_trip = reflect.Package.compile({ "holder.baml": source })
+  round_trip.get_class("root.RuntimeHolder") != null
+    && round_trip.get_class("root.StaticChild") != null
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
+++ b/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
@@ -45,17 +45,18 @@ function as_named(value: Person) -> Named<Value = string> {
 }
 
 #[tokio::test]
-async fn same_named_runtime_declarations_round_trip_with_unique_source_names() {
+async fn same_named_runtime_declarations_are_rejected() {
     let output = baml_test!(
         r###"
 function main() -> bool throws unknown {
   let first = reflect.class.new("Choice", { "left": reflect.Type.of<string>() })
   let second = reflect.class.new("Choice", { "right": reflect.Type.of<int>() })
   let combined = reflect.union.new([first.as_type(), second.as_type()])
-  let source = combined.as_type().to_baml()
-  let compiled = reflect.Package.compile({ "choices.baml": source })
-  compiled.get_class("root.Choice") != null
-    && compiled.get_class("root.Choice_2") != null
+  let result = combined.as_type().to_baml() catch (e) {
+    reflect.errors.CompilationError => e.diagnostics[0].code,
+    _ => "wrong error",
+  }
+  result == "E0162"
 }
 "###
     );
@@ -63,7 +64,7 @@ function main() -> bool throws unknown {
 }
 
 #[tokio::test]
-async fn minted_and_compiled_same_named_declarations_round_trip() {
+async fn minted_and_compiled_same_named_declarations_are_rejected() {
     let output = baml_test!(
         r###"
 function main() -> bool throws unknown {
@@ -73,9 +74,31 @@ function main() -> bool throws unknown {
   let compiled_choice = package.get_class("root.Choice") ?? throw "missing Choice"
   let minted_choice = reflect.class.new("Choice", { "minted": reflect.Type.of<int>() })
   let combined = reflect.union.new([compiled_choice.as_type(), minted_choice.as_type()])
-  let round_trip = reflect.Package.compile({ "choices.baml": combined.as_type().to_baml() })
-  round_trip.get_class("root.Choice") != null
-    && round_trip.get_class("root.Choice_2") != null
+  let result = combined.as_type().to_baml() catch (e) {
+    reflect.errors.CompilationError => e.diagnostics[0].code,
+    _ => "wrong error",
+  }
+  result == "E0162"
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn equivalent_same_named_runtime_declarations_fold_and_round_trip() {
+    let output = baml_test!(
+        r###"
+function main() -> bool throws unknown {
+  let first = reflect.class.new("Choice", { "value": reflect.Type.of<string>() })
+  let second = reflect.class.new("Choice", { "value": reflect.Type.of<string>() })
+  let combined = reflect.union.new([first.as_type(), second.as_type()])
+  let source = combined.as_type().to_baml()
+  let round_trip = reflect.Package.compile({ "choices.baml": source })
+  source.split("class Choice {").length() == 2
+    && round_trip.get_class("root.Choice") != null
+    && round_trip.get_class("root.Choice_2") == null
+    && round_trip.classes().length() == 1
 }
 "###
     );

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -99,18 +99,160 @@ pub(crate) fn anchor_wire_ty(
     })
 }
 
-fn realize_host_ty(
-    vm: &crate::BexVm,
-    ty: &RuntimeTy,
-) -> Result<bex_vm_types::RealizedTy, EngineError> {
-    // The single inbound anchor: a lane type's names become heads here, once,
-    // off the declarations this engine holds — so nothing downstream has to
-    // wonder whether a type it received is bound.
-    //
-    let anchored = anchor_wire_ty(vm, ty)?;
-    bex_vm_types::RealizedTy::try_from(anchored).map_err(|e| EngineError::TypeMismatch {
-        message: format!("host-supplied type is not realized: {e}"),
-    })
+#[derive(Clone, Copy)]
+enum InboundDeclarationKind {
+    Any,
+    Class,
+    Enum,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct InboundRuntimeOverlay<'a> {
+    dynamic_classes: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+    dynamic_enums: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+    runtime_named_objects: Option<&'a indexmap::IndexMap<String, HeapPtr>>,
+}
+
+impl<'a> InboundRuntimeOverlay<'a> {
+    pub(crate) fn new(
+        dynamic_classes: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+        dynamic_enums: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+        runtime_named_objects: Option<&'a indexmap::IndexMap<String, HeapPtr>>,
+    ) -> Self {
+        Self {
+            dynamic_classes,
+            dynamic_enums,
+            runtime_named_objects,
+        }
+    }
+}
+
+impl BexEngine {
+    /// Resolve one inbound overlay spelling through the same per-call cascade
+    /// used for external instances and variants, then through the VM's declared
+    /// package surface. Keeping this lookup shared prevents container/type
+    /// metadata from drifting from value allocation again.
+    fn resolve_inbound_declaration(
+        &self,
+        vm: &BexVm,
+        permit: PermitProof<'_>,
+        name: &str,
+        overlay: InboundRuntimeOverlay<'_>,
+        kind: InboundDeclarationKind,
+    ) -> Result<Option<HeapPtr>, EngineError> {
+        let dynamic = match kind {
+            InboundDeclarationKind::Class => overlay
+                .dynamic_classes
+                .get(name)
+                .map(|handle| ("class", handle)),
+            InboundDeclarationKind::Enum => overlay
+                .dynamic_enums
+                .get(name)
+                .map(|handle| ("enum", handle)),
+            InboundDeclarationKind::Any => overlay
+                .dynamic_classes
+                .get(name)
+                .map(|handle| ("class", handle))
+                .or_else(|| {
+                    overlay
+                        .dynamic_enums
+                        .get(name)
+                        .map(|handle| ("enum", handle))
+                }),
+        };
+        if let Some((kind_name, handle)) = dynamic {
+            return self
+                .resolve_handle(permit, handle)
+                .map(Some)
+                .ok_or_else(|| EngineError::TypeMismatch {
+                    message: format!(
+                        "Runtime {kind_name} `{name}` expired before its value landed"
+                    ),
+                });
+        }
+
+        if let Some(ptr) = overlay.runtime_named_objects.and_then(|objects| {
+            objects
+                .get(name)
+                .or_else(|| resolve_named_object(objects, name))
+        }) {
+            return Ok(Some(*ptr));
+        }
+
+        let statically_resolved = match kind {
+            InboundDeclarationKind::Class => self
+                .resolved_class_names
+                .get(name)
+                .or_else(|| resolve_named_object(&self.resolved_class_names, name)),
+            InboundDeclarationKind::Enum => self
+                .resolved_enum_names
+                .get(name)
+                .or_else(|| resolve_named_object(&self.resolved_enum_names, name)),
+            InboundDeclarationKind::Any => self
+                .resolved_class_names
+                .get(name)
+                .or_else(|| resolve_named_object(&self.resolved_class_names, name))
+                .or_else(|| self.resolved_enum_names.get(name))
+                .or_else(|| resolve_named_object(&self.resolved_enum_names, name)),
+        };
+        if let Some(ptr) = statically_resolved {
+            return Ok(Some(*ptr));
+        }
+
+        Ok(vm
+            .declaration_head(&baml_type::TypeName::from_dotted_path(name))
+            .map(bex_vm_types::TypeHead::ptr))
+    }
+
+    pub(crate) fn anchor_wire_ty_with_runtime(
+        &self,
+        vm: &BexVm,
+        permit: PermitProof<'_>,
+        ty: &RuntimeTy,
+        overlay: InboundRuntimeOverlay<'_>,
+    ) -> Result<bex_vm_types::RuntimeTy, EngineError> {
+        ty.try_map_heads(&mut |name: &baml_type::TypeName| {
+            let spelling = name.to_string();
+            let ptr = self
+                .resolve_inbound_declaration(
+                    vm,
+                    permit,
+                    &spelling,
+                    overlay,
+                    InboundDeclarationKind::Any,
+                )?
+                .ok_or_else(|| EngineError::TypeMismatch {
+                    message: format!("host-supplied type names unknown declaration `{name}`"),
+                })?;
+            let tag = match vm.get_object(ptr) {
+                Object::Class(class) => class.type_tag,
+                Object::Enum(enm) => enm.type_tag,
+                Object::Interface(interface) => interface.type_tag,
+                Object::TypeAlias(alias) => alias.type_tag,
+                _ => {
+                    return Err(EngineError::TypeMismatch {
+                        message: format!(
+                            "host-supplied type name `{name}` does not resolve to a declaration"
+                        ),
+                    });
+                }
+            };
+            Ok(bex_vm_types::TypeHead::new(ptr, tag))
+        })
+    }
+
+    fn realize_host_ty_with_runtime(
+        &self,
+        vm: &BexVm,
+        permit: PermitProof<'_>,
+        ty: &RuntimeTy,
+        overlay: InboundRuntimeOverlay<'_>,
+    ) -> Result<bex_vm_types::RealizedTy, EngineError> {
+        let anchored = self.anchor_wire_ty_with_runtime(vm, permit, ty, overlay)?;
+        bex_vm_types::RealizedTy::try_from(anchored).map_err(|e| EngineError::TypeMismatch {
+            message: format!("host-supplied type is not realized: {e}"),
+        })
+    }
 }
 
 /// The runtime declarations a type reaches, in the wire's pointer-free form.
@@ -1168,6 +1310,8 @@ impl BexEngine {
                 holder.holder_mut().tlab_mut().alloc_rust_data(arc),
             ));
         }
+        let overlay =
+            InboundRuntimeOverlay::new(dynamic_classes, dynamic_enums, runtime_named_objects);
         Ok(match external {
             BexExternalValue::Handle(handle) => Value::object(
                 self.resolve_handle(holder.proof(), &handle)
@@ -1238,7 +1382,12 @@ impl BexEngine {
                         )
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                let element_ty = realize_host_ty(&holder.holder_mut().vm, &runtime_element_ty)?;
+                let element_ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &runtime_element_ty,
+                    overlay,
+                )?;
                 Value::object(
                     holder
                         .holder_mut()
@@ -1257,7 +1406,12 @@ impl BexEngine {
                     }
                     _ => (key_type, value_type),
                 };
-                let key_ty = realize_host_ty(&holder.holder_mut().vm, &key_type)?;
+                let key_ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &key_type,
+                    overlay,
+                )?;
                 let declared_value_ty = expected_ty.and_then(peel_map_value_ty);
                 let runtime_value_ty = declared_value_ty.unwrap_or(&value_type).clone();
                 let values = entries
@@ -1278,7 +1432,12 @@ impl BexEngine {
                         .map(|v| (bex_vm_types::BexStr::from(k.as_str()), v))
                     })
                     .collect::<Result<indexmap::IndexMap<bex_vm_types::BexStr, Value>, _>>()?;
-                let value_ty = realize_host_ty(&holder.holder_mut().vm, &runtime_value_ty)?;
+                let value_ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &runtime_value_ty,
+                    overlay,
+                )?;
                 Value::object(
                     holder
                         .holder_mut()
@@ -1306,29 +1465,17 @@ impl BexEngine {
                         type_args.clone_from(expected_args);
                     }
                 }
-                let class_ptr = if let Some(handle) = dynamic_classes.get(&class_name) {
-                    self.resolve_handle(holder.proof(), handle).ok_or_else(|| {
-                        EngineError::TypeMismatch {
-                            message: format!(
-                                "Runtime class `{class_name}` expired before its value landed"
-                            ),
-                        }
-                    })?
-                } else {
-                    *runtime_named_objects
-                        .and_then(|objects| objects.get(&class_name))
-                        .or_else(|| {
-                            runtime_named_objects
-                                .and_then(|objects| resolve_named_object(objects, &class_name))
-                        })
-                        .or_else(|| self.resolved_class_names.get(&class_name))
-                        .or_else(|| resolve_named_object(&self.resolved_class_names, &class_name))
-                        .ok_or_else(|| EngineError::TypeMismatch {
-                            message: format!(
-                                "Unknown class `{class_name}` in external Instance value"
-                            ),
-                        })?
-                };
+                let class_ptr = self
+                    .resolve_inbound_declaration(
+                        &holder.holder().vm,
+                        holder.proof(),
+                        &class_name,
+                        overlay,
+                        InboundDeclarationKind::Class,
+                    )?
+                    .ok_or_else(|| EngineError::TypeMismatch {
+                        message: format!("Unknown class `{class_name}` in external Instance value"),
+                    })?;
 
                 // SAFETY: class_ptr points to a compile-time Class object
                 let class_fields = match unsafe { class_ptr.get() } {
@@ -1346,7 +1493,14 @@ impl BexEngine {
                 // works against the class's own head-typed templates.
                 let type_args = type_args
                     .iter()
-                    .map(|ty| anchor_wire_ty(&holder.holder_mut().vm, ty))
+                    .map(|ty| {
+                        self.anchor_wire_ty_with_runtime(
+                            &holder.holder().vm,
+                            holder.proof(),
+                            ty,
+                            overlay,
+                        )
+                    })
                     .collect::<Result<Vec<_>, _>>()?;
 
                 // Build field values in the order defined by the class.
@@ -1398,29 +1552,17 @@ impl BexEngine {
                 enum_name,
                 variant_name,
             } => {
-                let enum_ptr = if let Some(handle) = dynamic_enums.get(&enum_name) {
-                    self.resolve_handle(holder.proof(), handle).ok_or_else(|| {
-                        EngineError::TypeMismatch {
-                            message: format!(
-                                "Runtime enum `{enum_name}` expired before its value landed"
-                            ),
-                        }
-                    })?
-                } else {
-                    *runtime_named_objects
-                        .and_then(|objects| objects.get(&enum_name))
-                        .or_else(|| {
-                            runtime_named_objects
-                                .and_then(|objects| resolve_named_object(objects, &enum_name))
-                        })
-                        .or_else(|| self.resolved_enum_names.get(&enum_name))
-                        .or_else(|| resolve_named_object(&self.resolved_enum_names, &enum_name))
-                        .ok_or_else(|| EngineError::TypeMismatch {
-                            message: format!(
-                                "Unknown enum `{enum_name}` in external Variant value"
-                            ),
-                        })?
-                };
+                let enum_ptr = self
+                    .resolve_inbound_declaration(
+                        &holder.holder().vm,
+                        holder.proof(),
+                        &enum_name,
+                        overlay,
+                        InboundDeclarationKind::Enum,
+                    )?
+                    .ok_or_else(|| EngineError::TypeMismatch {
+                        message: format!("Unknown enum `{enum_name}` in external Variant value"),
+                    })?;
                 #[allow(unsafe_code)]
                 let bex_vm_types::Object::Enum(enum_obj) = (unsafe { enum_ptr.get() }) else {
                     return Err(EngineError::TypeMismatch {
@@ -1476,7 +1618,12 @@ impl BexEngine {
                             ),
                         })
                 })?;
-                let ty = realize_host_ty(&holder.holder_mut().vm, &named)?;
+                let ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &named,
+                    overlay,
+                )?;
                 // The wire carries the definition only (H-4); derive a fresh
                 // static identity with the receiving VM's complete fact context.
                 Value::object(
@@ -1649,17 +1796,29 @@ impl BexEngine {
                     .map(|param| {
                         Ok(bex_vm_types::RealizedFunctionParamTy {
                             name: param.name.clone(),
-                            ty: realize_host_ty(&holder.holder_mut().vm, &param.ty)?,
+                            ty: self.realize_host_ty_with_runtime(
+                                &holder.holder().vm,
+                                holder.proof(),
+                                &param.ty,
+                                overlay,
+                            )?,
                             mode: param.mode,
                         })
                     })
                     .collect::<Result<Vec<_>, EngineError>>()?;
                 let host_closure = bex_vm_types::HostClosure {
                     handle: arc,
-                    ret_ty: Box::new(realize_host_ty(&holder.holder_mut().vm, &ret)?),
-                    throws_ty: Box::new(realize_host_ty(
-                        &holder.holder_mut().vm,
+                    ret_ty: Box::new(self.realize_host_ty_with_runtime(
+                        &holder.holder().vm,
+                        holder.proof(),
+                        &ret,
+                        overlay,
+                    )?),
+                    throws_ty: Box::new(self.realize_host_ty_with_runtime(
+                        &holder.holder().vm,
+                        holder.proof(),
                         &normalized_throws,
+                        overlay,
                     )?),
                     arity: params.len(),
                     // Capture the declared params (names + optionality) so the VM

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -2876,7 +2876,7 @@ impl BexEngine {
             let Object::Package(package) = vm.get_object(owner) else {
                 continue;
             };
-            let Some(runtime) = package.runtime.as_ref() else {
+            let Some(runtime) = package.runtime() else {
                 continue;
             };
             pending.extend(runtime.dependencies.iter().copied());
@@ -7194,8 +7194,7 @@ impl BexEngine {
                 ));
             };
             package
-                .session
-                .as_ref()
+                .session()
                 .map(|state| state.busy.clone())
                 .ok_or_else(|| invalid("Session has an invalid runtime payload".to_string()))?
         };
@@ -7219,17 +7218,15 @@ impl BexEngine {
                     "Session has an invalid runtime payload".to_string(),
                 ));
             };
-            let state = package
-                .session
-                .as_mut()
-                .ok_or_else(|| invalid("Session has an invalid runtime payload".to_string()))?;
+            let bex_vm_types::types::PackageKind::Session { runtime, state } = &mut package.kind
+            else {
+                return Err(invalid(
+                    "Session has an invalid runtime payload".to_string(),
+                ));
+            };
             let sequence = state.submission_counter;
             state.submission_counter = state.submission_counter.saturating_add(1);
-            let dependencies = package
-                .runtime
-                .as_ref()
-                .map(|runtime| runtime.dependency_names.clone())
-                .unwrap_or_default();
+            let dependencies = runtime.dependency_names.clone();
             (
                 state.history.clone(),
                 state.visible.clone(),
@@ -7312,10 +7309,10 @@ impl BexEngine {
             };
             match compiler.compile(request) {
                 Ok(artifact) => Ok(BexExternalValue::Instance {
-                    class_name: "reflect.Package".to_string(),
+                    class_name: "reflect.CompileArtifact".to_string(),
                     type_args: Vec::new(),
                     fields: indexmap::indexmap! {
-                        "_inner".to_string() => BexExternalValue::RustData(Arc::new(artifact)),
+                        "_inner".to_string() => BexExternalValue::RustData(Arc::new(Mutex::new(Some(artifact)))),
                     },
                 }),
                 Err(diagnostics) => {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3967,10 +3967,31 @@ impl BexEngine {
         // Finish all fallible host type narrowing before durable run
         // admission. Once `run.meta` commits, the path below is straight-line
         // into the balanced root event loop.
+        let mut runtime_named_objects = indexmap::IndexMap::new();
+        for type_value in type_values.values() {
+            type_value.ty.visit_heads(&mut |head| {
+                if let Ok(name) = head.to_overlay_name() {
+                    runtime_named_objects
+                        .entry(name.to_string())
+                        .or_insert_with(|| head.ptr());
+                }
+            });
+        }
+        let dynamic_classes = indexmap::IndexMap::new();
+        let dynamic_enums = indexmap::IndexMap::new();
         let type_args = type_args
             .into_iter()
             .map(|(name, ty)| {
-                let anchored = crate::conversion::anchor_wire_ty(&thread.vm, &ty)?;
+                let anchored = self.anchor_wire_ty_with_runtime(
+                    &thread.vm,
+                    thread.proof(),
+                    &ty,
+                    crate::conversion::InboundRuntimeOverlay::new(
+                        &dynamic_classes,
+                        &dynamic_enums,
+                        Some(&runtime_named_objects),
+                    ),
+                )?;
                 match bex_vm_types::RealizedTy::try_from(&anchored) {
                     Ok(realized) => Ok((name, realized)),
                     Err(e) => Err(EngineError::VmInternalError(
@@ -6922,129 +6943,127 @@ impl BexEngine {
         }
     }
 
+    fn runtime_type_mount(
+        vm: &BexVm,
+        alias: &str,
+        export_name: &str,
+        ptr: bex_vm_types::HeapPtr,
+    ) -> Result<bex_vm_types::RuntimeTypeMount, EngineError> {
+        let Object::Type(value) = vm.get_object(ptr) else {
+            return Err(EngineError::TypeMismatch {
+                message: format!("with_types entry `{export_name}` is not a type"),
+            });
+        };
+        // In the consumer compile world, a runtime declaration is spelled
+        // `alias.<item name>`: the mount surface is the only channel that
+        // names it there, whatever its home world called it. Compiled
+        // declarations keep their own qualified names — those mean the
+        // same thing in every compile world.
+        let wire_head =
+            |head: &bex_vm_types::TypeHead| -> Result<baml_type::TypeName, EngineError> {
+                if !head.is_resolved() {
+                    return Err(EngineError::TypeMismatch {
+                        message: format!("mounted type `{export_name}` carries an unresolved head"),
+                    });
+                }
+                if vm.heap.is_compile_time_ptr(head.ptr()) {
+                    return head
+                        .declared_name()
+                        .ok_or_else(|| EngineError::TypeMismatch {
+                            message: format!(
+                                "mounted type `{export_name}` names an unnameable compiled head"
+                            ),
+                        });
+                }
+                let item = match vm.get_object(head.ptr()) {
+                    Object::Class(class) => class.name.item_name().clone(),
+                    Object::Enum(enm) => enm.name.item_name().clone(),
+                    Object::Interface(iface) => iface.name.name().clone(),
+                    Object::TypeAlias(alias_def) => alias_def.name.name().clone(),
+                    _ => {
+                        return Err(EngineError::TypeMismatch {
+                            message: format!(
+                                "mounted type `{export_name}` reaches a non-declaration head"
+                            ),
+                        });
+                    }
+                };
+                Ok(baml_type::QualifiedTypeName::new(
+                    baml_type::Name::new(alias),
+                    Vec::new(),
+                    item,
+                ))
+            };
+        let wire_ty = |ty: &bex_vm_types::RuntimeTy| -> Result<baml_type::Ty, EngineError> {
+            let mapped: baml_type::RuntimeTy = ty.try_map_heads(&mut |head| wire_head(head))?;
+            Ok(baml_type::Ty::from(&mapped))
+        };
+        // The mount describes the runtime declarations the type reaches;
+        // the walk over its heads is what finds them.
+        let (class_ptrs, enum_ptrs) = bex_vm::reachable::runtime_nominals(vm, &value.ty);
+        let classes = class_ptrs
+            .iter()
+            .map(|ptr| {
+                let Object::Class(class) = vm.get_object(*ptr) else {
+                    unreachable!("runtime_nominals returned a non-class in the class list")
+                };
+                Ok(bex_vm_types::RuntimeMountedClass {
+                    name: class.name.item_name().clone(),
+                    tag: class.type_tag,
+                    fields: class
+                        .fields
+                        .iter()
+                        .map(|field| {
+                            Ok((
+                                baml_type::Name::new(&field.name),
+                                wire_ty(&field.field_type)?,
+                                bex_vm_types::RuntimeMountedFieldAttrs {
+                                    alias: field.alias.clone(),
+                                    description: field.description.clone(),
+                                },
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, EngineError>>()?,
+                })
+            })
+            .collect::<Result<Vec<_>, EngineError>>()?;
+        let enums = enum_ptrs
+            .iter()
+            .map(|ptr| {
+                let Object::Enum(enm) = vm.get_object(*ptr) else {
+                    unreachable!("runtime_nominals returned a non-enum in the enum list")
+                };
+                Ok(bex_vm_types::RuntimeMountedEnum {
+                    name: enm.name.item_name().clone(),
+                    tag: enm.type_tag,
+                    variants: enm
+                        .variants
+                        .iter()
+                        .map(|variant| baml_type::Name::new(&variant.name))
+                        .collect(),
+                })
+            })
+            .collect::<Result<Vec<_>, EngineError>>()?;
+        // Witnesses live on the impl rules now, not beside the type; a
+        // mount no longer restates them.
+        let witnesses = Vec::new();
+        let ty = value
+            .ty
+            .try_map_heads(&mut |head| wire_head(head))
+            .map_err(|e: EngineError| e)?;
+        Ok(bex_vm_types::RuntimeTypeMount {
+            export_name: baml_type::Name::new(export_name),
+            ty,
+            classes,
+            enums,
+            witnesses,
+        })
+    }
+
     fn runtime_compile_request(
         vm: &BexVm,
         args: &[Value],
     ) -> Result<bex_vm_types::RuntimeCompileRequest, EngineError> {
-        fn type_mount(
-            vm: &BexVm,
-            alias: &str,
-            export_name: &str,
-            ptr: bex_vm_types::HeapPtr,
-        ) -> Result<bex_vm_types::RuntimeTypeMount, EngineError> {
-            let Object::Type(value) = vm.get_object(ptr) else {
-                return Err(EngineError::TypeMismatch {
-                    message: format!("with_types entry `{export_name}` is not a type"),
-                });
-            };
-            // In the consumer compile world, a runtime declaration is spelled
-            // `alias.<item name>`: the mount surface is the only channel that
-            // names it there, whatever its home world called it. Compiled
-            // declarations keep their own qualified names — those mean the
-            // same thing in every compile world.
-            let wire_head =
-                |head: &bex_vm_types::TypeHead| -> Result<baml_type::TypeName, EngineError> {
-                    if !head.is_resolved() {
-                        return Err(EngineError::TypeMismatch {
-                            message: format!(
-                                "mounted type `{export_name}` carries an unresolved head"
-                            ),
-                        });
-                    }
-                    if vm.heap.is_compile_time_ptr(head.ptr()) {
-                        return head
-                            .declared_name()
-                            .ok_or_else(|| EngineError::TypeMismatch {
-                                message: format!(
-                                    "mounted type `{export_name}` names an unnameable compiled head"
-                                ),
-                            });
-                    }
-                    let item = match vm.get_object(head.ptr()) {
-                        Object::Class(class) => class.name.item_name().clone(),
-                        Object::Enum(enm) => enm.name.item_name().clone(),
-                        Object::Interface(iface) => iface.name.name().clone(),
-                        Object::TypeAlias(alias_def) => alias_def.name.name().clone(),
-                        _ => {
-                            return Err(EngineError::TypeMismatch {
-                                message: format!(
-                                    "mounted type `{export_name}` reaches a non-declaration head"
-                                ),
-                            });
-                        }
-                    };
-                    Ok(baml_type::QualifiedTypeName::new(
-                        baml_type::Name::new(alias),
-                        Vec::new(),
-                        item,
-                    ))
-                };
-            let wire_ty = |ty: &bex_vm_types::RuntimeTy| -> Result<baml_type::Ty, EngineError> {
-                let mapped: baml_type::RuntimeTy = ty.try_map_heads(&mut |head| wire_head(head))?;
-                Ok(baml_type::Ty::from(&mapped))
-            };
-            // The mount describes the runtime declarations the type reaches;
-            // the walk over its heads is what finds them.
-            let (class_ptrs, enum_ptrs) = bex_vm::reachable::runtime_nominals(vm, &value.ty);
-            let classes = class_ptrs
-                .iter()
-                .map(|ptr| {
-                    let Object::Class(class) = vm.get_object(*ptr) else {
-                        unreachable!("runtime_nominals returned a non-class in the class list")
-                    };
-                    Ok(bex_vm_types::RuntimeMountedClass {
-                        name: class.name.item_name().clone(),
-                        tag: class.type_tag,
-                        fields: class
-                            .fields
-                            .iter()
-                            .map(|field| {
-                                Ok((
-                                    baml_type::Name::new(&field.name),
-                                    wire_ty(&field.field_type)?,
-                                    bex_vm_types::RuntimeMountedFieldAttrs {
-                                        alias: field.alias.clone(),
-                                        description: field.description.clone(),
-                                    },
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, EngineError>>()?,
-                    })
-                })
-                .collect::<Result<Vec<_>, EngineError>>()?;
-            let enums = enum_ptrs
-                .iter()
-                .map(|ptr| {
-                    let Object::Enum(enm) = vm.get_object(*ptr) else {
-                        unreachable!("runtime_nominals returned a non-enum in the enum list")
-                    };
-                    Ok(bex_vm_types::RuntimeMountedEnum {
-                        name: enm.name.item_name().clone(),
-                        tag: enm.type_tag,
-                        variants: enm
-                            .variants
-                            .iter()
-                            .map(|variant| baml_type::Name::new(&variant.name))
-                            .collect(),
-                    })
-                })
-                .collect::<Result<Vec<_>, EngineError>>()?;
-            // Witnesses live on the impl rules now, not beside the type; a
-            // mount no longer restates them.
-            let witnesses = Vec::new();
-            let ty = value
-                .ty
-                .try_map_heads(&mut |head| wire_head(head))
-                .map_err(|e: EngineError| e)?;
-            Ok(bex_vm_types::RuntimeTypeMount {
-                export_name: baml_type::Name::new(export_name),
-                ty,
-                classes,
-                enums,
-                witnesses,
-            })
-        }
-
         fn map_entries(
             vm: &BexVm,
             value: Value,
@@ -7121,7 +7140,7 @@ impl BexEngine {
             let types = package
                 .mounted_types
                 .iter()
-                .map(|(name, ptr)| type_mount(vm, alias.as_str(), name, *ptr))
+                .map(|(name, ptr)| Self::runtime_type_mount(vm, alias.as_str(), name, *ptr))
                 .collect::<Result<Vec<_>, _>>()?;
             packages.insert(
                 alias.to_string(),
@@ -7241,11 +7260,17 @@ impl BexEngine {
                     "Session dependency `{alias}` has an invalid runtime payload"
                 )));
             };
+            let types = package
+                .mounted_types
+                .iter()
+                .map(|(name, ptr)| Self::runtime_type_mount(vm, alias.as_str(), name, *ptr))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| invalid(error.to_string()))?;
             packages.insert(
                 alias,
                 bex_vm_types::RuntimePackageMount {
                     interface_blob: package.interface_blob.clone(),
-                    types: Vec::new(),
+                    types,
                 },
             );
         }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -6957,8 +6957,8 @@ impl BexEngine {
         // In the consumer compile world, a runtime declaration is spelled
         // `alias.<item name>`: the mount surface is the only channel that
         // names it there, whatever its home world called it. Compiled
-        // declarations keep their own qualified names — those mean the
-        // same thing in every compile world.
+        // declarations from another dependency keep their qualified names;
+        // declarations local to this mounted package relocate to its alias.
         let wire_head =
             |head: &bex_vm_types::TypeHead| -> Result<baml_type::TypeName, EngineError> {
                 if !head.is_resolved() {
@@ -6967,13 +6967,22 @@ impl BexEngine {
                     });
                 }
                 if vm.heap.is_compile_time_ptr(head.ptr()) {
-                    return head
+                    let name = head
                         .declared_name()
                         .ok_or_else(|| EngineError::TypeMismatch {
                             message: format!(
                                 "mounted type `{export_name}` names an unnameable compiled head"
                             ),
-                        });
+                        })?;
+                    return Ok(if name.is_local() {
+                        baml_type::QualifiedTypeName::new(
+                            baml_type::Name::new(alias),
+                            name.namespace().clone(),
+                            name.name().clone(),
+                        )
+                    } else {
+                        name
+                    });
                 }
                 let item = match vm.get_object(head.ptr()) {
                     Object::Class(class) => class.name.item_name().clone(),
@@ -7044,9 +7053,111 @@ impl BexEngine {
                 })
             })
             .collect::<Result<Vec<_>, EngineError>>()?;
-        // Witnesses live on the impl rules now, not beside the type; a
-        // mount no longer restates them.
-        let witnesses = Vec::new();
+        // Dynamic witness rules are heap objects rather than TypeValue sidecars,
+        // but the consumer compiler cannot see this VM's dispatch table. Project
+        // the root class's rules into the mount artifact so type checking in the
+        // consumer world sees the same conformances as runtime dispatch.
+        let witnesses = match &value.ty {
+            bex_vm_types::RealizedTy::Class(head, _, _) if head.is_resolved() => {
+                let Object::Class(class) = vm.get_object(head.ptr()) else {
+                    return Err(EngineError::TypeMismatch {
+                        message: format!(
+                            "mounted type `{export_name}` has a non-class declaration head"
+                        ),
+                    });
+                };
+                vm.dynamic_dispatch
+                    .rules_for_class(head.ptr())
+                    .into_iter()
+                    .map(|rule_ptr| {
+                        let Object::ImplRule(rule) = vm.get_object(rule_ptr) else {
+                            return Err(EngineError::TypeMismatch {
+                                message: format!(
+                                    "mounted type `{export_name}` has an invalid witness rule"
+                                ),
+                            });
+                        };
+                        let Object::Interface(interface) = vm.get_object(rule.interface_head)
+                        else {
+                            return Err(EngineError::TypeMismatch {
+                                message: format!(
+                                    "mounted type `{export_name}` has an invalid witness interface"
+                                ),
+                            });
+                        };
+                        if interface.fields.len() != rule.field_links.len() {
+                            return Err(EngineError::TypeMismatch {
+                                message: format!(
+                                    "mounted type `{export_name}` has an incomplete witness field map"
+                                ),
+                            });
+                        }
+                        let interface_head = bex_vm_types::TypeHead::new(
+                            rule.interface_head,
+                            interface.type_tag,
+                        );
+                        let interface_name = wire_head(&interface_head)?;
+                        let interface_args = rule
+                            .interface_args
+                            .iter()
+                            .map(|ty| {
+                                let ty = bex_vm_types::RealizedTy::try_from(ty).map_err(|error| {
+                                    EngineError::TypeMismatch {
+                                        message: format!(
+                                            "mounted type `{export_name}` has an unrealized witness argument: {error}"
+                                        ),
+                                    }
+                                })?;
+                                let ty = bex_vm_types::RuntimeTy::from(ty);
+                                wire_ty(&ty)
+                            })
+                            .collect::<Result<Vec<_>, EngineError>>()?;
+                        let associated_types = rule
+                            .interface_assoc
+                            .iter()
+                            .map(|(name, ty)| {
+                                let ty = bex_vm_types::RealizedTy::try_from(ty).map_err(|error| {
+                                    EngineError::TypeMismatch {
+                                        message: format!(
+                                            "mounted type `{export_name}` has an unrealized witness associated type: {error}"
+                                        ),
+                                    }
+                                })?;
+                                let ty = bex_vm_types::RuntimeTy::from(ty);
+                                Ok((name.clone(), wire_ty(&ty)?))
+                            })
+                            .collect::<Result<Vec<_>, EngineError>>()?;
+                        let field_links = interface
+                            .fields
+                            .iter()
+                            .zip(rule.field_links.iter())
+                            .map(|(field, slot)| {
+                                let class_field = class.fields.get(*slot as usize).ok_or_else(|| {
+                                    EngineError::TypeMismatch {
+                                        message: format!(
+                                            "mounted type `{export_name}` has an out-of-range witness field link"
+                                        ),
+                                    }
+                                })?;
+                                Ok((
+                                    field.name.clone(),
+                                    baml_type::Name::new(&class_field.name),
+                                ))
+                            })
+                            .collect::<Result<Vec<_>, EngineError>>()?;
+                        Ok((
+                            baml_type::Interface::new(
+                                interface_name,
+                                interface_args,
+                                associated_types,
+                            ),
+                            field_links,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, EngineError>>()?
+            }
+            _ => Vec::new(),
+        };
         let ty = value
             .ty
             .try_map_heads(&mut |head| wire_head(head))

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -27,7 +27,10 @@
 
 use std::{cell::UnsafeCell, collections::HashMap};
 
-use bex_vm_types::{FutureRead, HeapPtr, Object, Value, types::Future};
+use bex_vm_types::{
+    FutureRead, HeapPtr, Object, Value,
+    types::{Future, PackageKind},
+};
 
 use crate::{
     BexHeap,
@@ -679,19 +682,22 @@ impl BexHeap {
                     worklist.push(*interface);
                     worklist.extend(rules.iter().copied());
                 }
-                if let Some(runtime) = &package.runtime {
-                    worklist.extend(runtime.objects.iter().copied());
-                    worklist.extend(runtime.object_names.values().copied());
-                    worklist.extend(runtime.type_values.values().copied());
-                    worklist.extend(runtime.dependencies.iter().copied());
-                    worklist.extend(runtime.dependency_names.values().copied());
-                    worklist.extend(runtime.init);
-                    worklist.extend(
-                        runtime
-                            .globals
-                            .iter()
-                            .filter_map(|slot| slot.load().as_object_ptr()),
-                    );
+                match &package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        worklist.extend(runtime.objects.iter().copied());
+                        worklist.extend(runtime.object_names.values().copied());
+                        worklist.extend(runtime.type_values.values().copied());
+                        worklist.extend(runtime.dependencies.iter().copied());
+                        worklist.extend(runtime.dependency_names.values().copied());
+                        worklist.extend(runtime.init);
+                        worklist.extend(
+                            runtime
+                                .globals
+                                .iter()
+                                .filter_map(|slot| slot.load().as_object_ptr()),
+                        );
+                    }
                 }
             }
             Object::Function(function) => {
@@ -939,49 +945,52 @@ impl BexHeap {
                         (interface, rules)
                     })
                     .collect();
-                if let Some(runtime) = &mut package.runtime {
-                    for ptr in runtime.objects.iter_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
+                match &mut package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        for ptr in runtime.objects.iter_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        for ptr in runtime.object_names.values_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        // Keyed by the declaration each value names, so the keys
+                        // move too — rebuilt through the forwarding map rather than
+                        // mutated in place, as `impl_rules` above is.
+                        let old_type_values = std::mem::take(&mut runtime.type_values);
+                        runtime.type_values = old_type_values
+                            .into_iter()
+                            .map(|(declaration, value)| {
+                                (
+                                    forwarding.get(&declaration).copied().unwrap_or(declaration),
+                                    forwarding.get(&value).copied().unwrap_or(value),
+                                )
+                            })
+                            .collect();
+                        for ptr in runtime.dependencies.iter_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        for ptr in runtime.dependency_names.values_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        if let Some(ptr) = &mut runtime.init
+                            && let Some(&new_ptr) = forwarding.get(ptr)
+                        {
                             *ptr = new_ptr;
                         }
-                    }
-                    for ptr in runtime.object_names.values_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
+                        for slot in &runtime.globals {
+                            let mut value = slot.load();
+                            self.fixup_value(&mut value, forwarding);
+                            slot.store(value);
                         }
-                    }
-                    // Keyed by the declaration each value names, so the keys
-                    // move too — rebuilt through the forwarding map rather than
-                    // mutated in place, as `impl_rules` above is.
-                    let old_type_values = std::mem::take(&mut runtime.type_values);
-                    runtime.type_values = old_type_values
-                        .into_iter()
-                        .map(|(declaration, value)| {
-                            (
-                                forwarding.get(&declaration).copied().unwrap_or(declaration),
-                                forwarding.get(&value).copied().unwrap_or(value),
-                            )
-                        })
-                        .collect();
-                    for ptr in runtime.dependencies.iter_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
-                        }
-                    }
-                    for ptr in runtime.dependency_names.values_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
-                        }
-                    }
-                    if let Some(ptr) = &mut runtime.init
-                        && let Some(&new_ptr) = forwarding.get(ptr)
-                    {
-                        *ptr = new_ptr;
-                    }
-                    for slot in &runtime.globals {
-                        let mut value = slot.load();
-                        self.fixup_value(&mut value, forwarding);
-                        slot.store(value);
                     }
                 }
             }
@@ -1337,30 +1346,33 @@ impl BexHeap {
                 {
                     worklist.push(ptr);
                 }
-                if let Some(runtime) = &package.runtime {
-                    worklist.extend(
-                        runtime
-                            .objects
-                            .iter()
-                            .chain(runtime.object_names.values())
-                            .chain(runtime.type_values.values())
-                            .chain(runtime.dependencies.iter())
-                            .chain(runtime.dependency_names.values())
-                            .copied()
-                            .filter(|ptr| self.generation_of(*ptr).is_young()),
-                    );
-                    if let Some(ptr) = runtime.init
-                        && self.generation_of(ptr).is_young()
-                    {
-                        worklist.push(ptr);
+                match &package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        worklist.extend(
+                            runtime
+                                .objects
+                                .iter()
+                                .chain(runtime.object_names.values())
+                                .chain(runtime.type_values.values())
+                                .chain(runtime.dependencies.iter())
+                                .chain(runtime.dependency_names.values())
+                                .copied()
+                                .filter(|ptr| self.generation_of(*ptr).is_young()),
+                        );
+                        if let Some(ptr) = runtime.init
+                            && self.generation_of(ptr).is_young()
+                        {
+                            worklist.push(ptr);
+                        }
+                        worklist.extend(
+                            runtime
+                                .globals
+                                .iter()
+                                .filter_map(|slot| slot.load().as_object_ptr())
+                                .filter(|ptr| self.generation_of(*ptr).is_young()),
+                        );
                     }
-                    worklist.extend(
-                        runtime
-                            .globals
-                            .iter()
-                            .filter_map(|slot| slot.load().as_object_ptr())
-                            .filter(|ptr| self.generation_of(*ptr).is_young()),
-                    );
                 }
             }
             Object::Function(function) => {

--- a/baml_language/crates/bex_heap/tests/generational.rs
+++ b/baml_language/crates/bex_heap/tests/generational.rs
@@ -13,7 +13,7 @@ use bex_heap::{BexHeap, CollectionLevel, Generation, Tlab};
 use bex_vm_types::{
     Class, ClassField, GenericFunction, GlobalIndex, Object, RealizedTy,
     types::{
-        InterfaceDef, LocalName, MethodImpl, Package, RuntimeImplRule, RuntimePackage,
+        InterfaceDef, LocalName, MethodImpl, Package, PackageKind, RuntimeImplRule, RuntimePackage,
         TypeAliasDef, TypeValue,
     },
 };
@@ -118,7 +118,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
             interface_blob: Vec::new(),
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
+            kind: PackageKind::Runtime(Box::new(RuntimePackage {
                 objects: Box::new([]),
                 object_names: IndexMap::new(),
                 globals: Box::new([]),
@@ -130,7 +130,6 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
                 init: None,
                 initialized: true,
             })),
-            session: None,
         };
         let package_ptr = tlab.alloc(Object::Package(Box::new(package)));
         let class_name = QualifiedTypeName::local(Name::new("RuntimeClass"));
@@ -171,7 +170,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
             },
             class_ptr,
         );
-        let runtime = package.runtime.as_mut().expect("runtime image");
+        let runtime = package.runtime_mut().expect("runtime image");
         runtime.objects = vec![type_ptr, function_ptr, class_ptr].into_boxed_slice();
         runtime.type_values.insert(class_ptr, type_ptr);
         (tlab, package_ptr, function_ptr)
@@ -193,7 +192,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
         panic!("root ceased to be a package")
     };
     let moved_class = package.classes.values().next().copied().unwrap();
-    let moved_type = package.runtime.as_ref().unwrap().type_values[&moved_class];
+    let moved_type = package.runtime().unwrap().type_values[&moved_class];
     let Object::Type(type_value) = (unsafe { moved_type.get() }) else {
         panic!("package type value ceased to be a type")
     };
@@ -1048,8 +1047,7 @@ fn empty_package() -> Package {
         interface_blob: Vec::new(),
         test_init: None,
         mounted_types: IndexMap::new(),
-        runtime: None,
-        session: None,
+        kind: PackageKind::Static,
     }
 }
 

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -703,8 +703,13 @@ fn enrich_runtime_mount(
                             && fields.iter().all(|(name, ..)| source_identifier(name)) =>
                     {
                         let mut source = format!("class {} {{\n", mount.export_name);
-                        for (field, ..) in fields {
-                            writeln!(&mut source, "  {field} unknown")
+                        for (field, ty, _) in fields {
+                            let ty = if viewpoint.hides_type(ty) {
+                                "unknown".to_string()
+                            } else {
+                                ty.to_string()
+                            };
+                            writeln!(&mut source, "  {field} {ty}")
                                 .expect("writing to String is infallible");
                         }
                         source.push_str("}\n");

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -25,7 +25,8 @@ use bex_vm_types::{
     InitTail, RuntimeCompileArtifact, RuntimeCompileDiagnostic, RuntimeCompileMode,
     RuntimeCompileRequest, RuntimeDiagnosticSeverity, RuntimePackageMount,
     RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest, RuntimeSessionInitializer,
-    RuntimeSessionStep, RuntimeSourceSpan, SessionVisibleKind, SessionVisibleSymbol,
+    RuntimeSessionStep, RuntimeSessionStepKind, RuntimeSourceSpan, SessionVisibleKind,
+    SessionVisibleSymbol,
     bytecode::Instruction,
     relink::{IndexOperand, visit_object_operands},
 };
@@ -869,9 +870,7 @@ fn runtime_type_binding_parts(source: &str) -> Option<(String, &str)> {
 fn runtime_type_binding_prelude(bindings: &IndexMap<String, SessionVisibleSymbol>) -> String {
     let mut prelude = String::new();
     for symbol in bindings.values() {
-        if symbol.kind == SessionVisibleKind::TypeBinding
-            && let Some(type_value) = &symbol.type_value
-        {
+        if let SessionVisibleKind::TypeBinding { type_value } = &symbol.kind {
             let _ = writeln!(
                 prelude,
                 "type {} = unreflect({type_value});",
@@ -1145,7 +1144,6 @@ fn lower_session_submission(
             let symbol = SessionVisibleSymbol {
                 internal: internal(&name),
                 kind: SessionVisibleKind::Declaration,
-                type_value: None,
             };
             declaration_name_ranges.insert(range, symbol.internal.clone());
             declarations.insert(name, symbol);
@@ -1155,7 +1153,7 @@ fn lower_session_submission(
     let mut declaration_mapping = request
         .visible
         .iter()
-        .filter(|(_, symbol)| symbol.kind != SessionVisibleKind::Let)
+        .filter(|(_, symbol)| !matches!(symbol.kind, SessionVisibleKind::Let))
         .map(|(name, symbol)| (name.clone(), symbol.internal.clone()))
         .collect::<IndexMap<_, _>>();
     declaration_mapping.extend(
@@ -1259,11 +1257,12 @@ fn lower_session_submission(
     let mut active_type_bindings = request
         .visible
         .iter()
-        .filter(|(_, symbol)| symbol.kind == SessionVisibleKind::TypeBinding)
+        .filter(|(_, symbol)| matches!(symbol.kind, SessionVisibleKind::TypeBinding { .. }))
         .map(|(name, symbol)| (name.clone(), symbol.clone()))
         .collect::<IndexMap<_, _>>();
     let mut generated = declaration_source.clone();
     let mut steps = Vec::new();
+    let mut result_step = None;
 
     for (index, element) in elements.iter().enumerate() {
         let (node, wrapped_range, has_semicolon, is_statement) = match element {
@@ -1334,8 +1333,9 @@ fn lower_session_submission(
             let source = format!("let {backing_name} = {{\n{prelude}({operand})\n}}\n");
             let symbol = SessionVisibleSymbol {
                 internal: type_name,
-                kind: SessionVisibleKind::TypeBinding,
-                type_value: Some(backing_name.clone()),
+                kind: SessionVisibleKind::TypeBinding {
+                    type_value: backing_name.clone(),
+                },
             };
             (backing_name, source, None, Some((name, symbol)))
         } else {
@@ -1350,7 +1350,6 @@ fn lower_session_submission(
                 let symbol = SessionVisibleSymbol {
                     internal: internal_name.clone(),
                     kind: SessionVisibleKind::Let,
-                    type_value: None,
                 };
                 binding = Some((name, symbol));
                 internal_name
@@ -1362,7 +1361,8 @@ fn lower_session_submission(
                 .flatten()
                 .and_then(|(target, operator, rhs)| {
                     let symbol = request.visible.get(target)?;
-                    (symbol.kind == SessionVisibleKind::Let).then_some((symbol, operator, rhs))
+                    matches!(symbol.kind, SessionVisibleKind::Let)
+                        .then_some((symbol, operator, rhs))
                 });
             let (source, commit_global) = if let Some((target, operator, rhs)) = assignment {
                 let rhs = rewrite_identifiers(
@@ -1435,39 +1435,44 @@ fn lower_session_submission(
         generated.push_str(&step_source);
         let returns_value =
             index + 1 == elements.len() && !is_outer_let && !is_statement && !has_semicolon;
+        if returns_value {
+            result_step = Some(steps.len());
+        }
+        let kind = binding
+            .clone()
+            .map_or(RuntimeSessionStepKind::Expression, |(name, symbol)| {
+                RuntimeSessionStepKind::Binding {
+                    name,
+                    symbol,
+                    replay_source: step_source.clone(),
+                }
+            });
         steps.push(RuntimeSessionStep {
             global: format!("user.{generated_name}"),
             commit_global,
-            binding: binding.clone(),
-            replay_source: binding.as_ref().map(|_| step_source),
-            returns_value,
+            kind,
         });
         if let Some((name, symbol)) = binding {
             visible_mapping.insert(name.clone(), symbol.internal.clone());
-            if symbol.kind == SessionVisibleKind::TypeBinding {
+            if matches!(symbol.kind, SessionVisibleKind::TypeBinding { .. }) {
                 active_type_bindings.insert(name, symbol);
             }
         }
     }
 
-    if !steps.iter().any(|step| step.returns_value) {
+    if result_step.is_none() {
         let generated_name = format!("__baml_session_{sequence}_result");
         let step_source = format!("let {generated_name} = null\n");
         generated.push_str(&step_source);
+        result_step = Some(steps.len());
         steps.push(RuntimeSessionStep {
             global: format!("user.{generated_name}"),
             commit_global: None,
-            binding: None,
-            replay_source: None,
-            returns_value: true,
+            kind: RuntimeSessionStepKind::Expression,
         });
     }
-    let result_global = steps
-        .iter()
-        .find(|step| step.returns_value)
-        .expect("session lowering always has a result")
-        .global
-        .clone();
+    let result_step = result_step.expect("session lowering always has a result");
+    let result_global = steps[result_step].global.clone();
     Ok(LoweredSession {
         source: generated,
         artifact: RuntimeSessionCompileArtifact {
@@ -1475,6 +1480,7 @@ fn lower_session_submission(
             declaration_source,
             declarations,
             steps,
+            result_step: Some(result_step),
             initializers: Vec::new(),
         },
         result_global,
@@ -1942,17 +1948,17 @@ impl RuntimeCompiler for ProjectRuntimeCompiler {
             }
             session.artifact.initializers = initializers;
         }
-        // The public artifact still carries these as two independent `Option`s,
-        // so the pair splits here — once, at the boundary that demands it —
-        // rather than being threaded through the function as separate values.
-        let (session_artifact, session_lease) =
-            session.map_or((None, None), |s| (Some(s.artifact), Some(s.lease)));
+        let kind = session.map_or(bex_vm_types::ArtifactKind::Package, |session| {
+            bex_vm_types::ArtifactKind::Session {
+                meta: session.artifact,
+                lease: session.lease,
+            }
+        });
         Ok(RuntimeCompileArtifact {
             units,
             interface_blob,
             diagnostics,
-            session: session_artifact,
-            session_lease,
+            kind,
         })
     }
 }

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -188,6 +188,35 @@ fn enrich_runtime_mount(
             && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
     }
 
+    fn relocated_name(
+        name: &baml_type::QualifiedTypeName,
+        alias: &Name,
+    ) -> baml_type::QualifiedTypeName {
+        if name.is_local() {
+            baml_type::QualifiedTypeName::new(
+                alias.clone(),
+                name.namespace().clone(),
+                name.name().clone(),
+            )
+        } else {
+            name.clone()
+        }
+    }
+
+    fn relocate_ty(ty: &mut baml_type::Ty, alias: &Name) {
+        *ty = ty.map_heads(&mut |name| relocated_name(name, alias));
+    }
+
+    fn relocate_interface(interface: &mut baml_type::Interface, alias: &Name) {
+        *interface = interface.map_heads(&mut |name| relocated_name(name, alias));
+    }
+
+    fn relocate_bounds(bounds: &mut [Vec<baml_type::Interface>], alias: &Name) {
+        for interface in bounds.iter_mut().flatten() {
+            relocate_interface(interface, alias);
+        }
+    }
+
     fn relocate_function(
         function: &mut ExportedFunction,
         alias: &Name,
@@ -195,6 +224,17 @@ fn enrich_runtime_mount(
         stubs: &mut Vec<(Vec<Name>, Name, String)>,
     ) {
         use baml_compiler2_hir_ty::callable::{ExternalCallTarget, ExternalLinkability};
+
+        for param in &mut function.params {
+            *param = param.map_heads(&mut |name| relocated_name(name, alias));
+        }
+        relocate_ty(&mut function.return_type, alias);
+        if let Some(throws) = &mut function.declared_throws {
+            relocate_ty(throws, alias);
+        }
+        relocate_ty(&mut function.callable_throws, alias);
+        relocate_bounds(&mut function.generic_param_bounds, alias);
+
         if !matches!(function.linkability, ExternalLinkability::Linkable) {
             return;
         }
@@ -305,6 +345,20 @@ fn enrich_runtime_mount(
     let alias = Name::new(alias);
     let viewpoint = StubViewpoint { aliases };
     let mut stubs = Vec::new();
+    for throw_set in interface
+        .throw_sets
+        .direct
+        .values_mut()
+        .chain(interface.throw_sets.transitive.values_mut())
+    {
+        *throw_set = std::mem::take(throw_set)
+            .into_iter()
+            .map(|mut ty| {
+                relocate_ty(&mut ty, &alias);
+                ty
+            })
+            .collect();
+    }
     for function in interface
         .functions
         .values_mut()
@@ -316,11 +370,17 @@ fn enrich_runtime_mount(
         for (export_name, exported) in exported_types {
             match exported {
                 ExportedType::Class {
+                    qtn,
                     fields,
                     methods,
                     generic_params,
-                    ..
+                    generic_param_bounds,
                 } => {
+                    *qtn = relocated_name(qtn, &alias);
+                    for (_, ty, _) in fields.iter_mut() {
+                        relocate_ty(ty, &alias);
+                    }
+                    relocate_bounds(generic_param_bounds, &alias);
                     // The emitter needs a concrete class object in the mounted
                     // package's discarded source units so a consumer literal
                     // decomposes to an external object reference. At runtime
@@ -342,12 +402,18 @@ fn enrich_runtime_mount(
                             format!("<{}>", generics.join(", "))
                         };
                         let mut source = format!("class {export_name}{generic_suffix} {{\n");
-                        for (field, ..) in fields.iter() {
-                            // Mounted inference owns the exact field type. The
-                            // source stub exists only to allocate/link the
-                            // positional class object, so `unknown` avoids
-                            // re-spelling hidden runtime-qualified names.
-                            writeln!(&mut source, "  {field} unknown")
+                        for (field, ty, _) in fields.iter() {
+                            // Source-backed lookup wins before the mounted
+                            // interface in HIR. Preserve every spellable field
+                            // type here so nested projections see the same ABI;
+                            // only genuinely hidden package names degrade to
+                            // `unknown` in the link-only source.
+                            let ty = if viewpoint.hides_type(ty) {
+                                "unknown".to_string()
+                            } else {
+                                ty.to_string()
+                            };
+                            writeln!(&mut source, "  {field} {ty}")
                                 .expect("writing to String is infallible");
                         }
                         source.push_str("}\n");
@@ -360,12 +426,29 @@ fn enrich_runtime_mount(
                 ExportedType::Interface {
                     qtn,
                     generic_params,
+                    param_bounds,
+                    requires,
                     associated_types,
                     fields,
                     required_methods,
                     default_methods,
                     ..
                 } => {
+                    relocate_bounds(param_bounds, &alias);
+                    for interface in requires {
+                        relocate_interface(interface, &alias);
+                    }
+                    for associated in associated_types.iter_mut() {
+                        if let Some(bound) = &mut associated.bound {
+                            relocate_interface(bound, &alias);
+                        }
+                        if let Some(default) = &mut associated.default {
+                            relocate_ty(default, &alias);
+                        }
+                    }
+                    for (_, ty, _) in fields.iter_mut() {
+                        relocate_ty(ty, &alias);
+                    }
                     for function in required_methods.iter_mut().chain(default_methods) {
                         relocate_function(function, &alias, &viewpoint, &mut stubs);
                     }
@@ -405,7 +488,8 @@ fn enrich_runtime_mount(
                     source.push_str("}\n");
                     stubs.push((namespace, name, source));
                 }
-                ExportedType::Enum { variants, .. } => {
+                ExportedType::Enum { qtn, variants } => {
+                    *qtn = relocated_name(qtn, &alias);
                     if source_identifier(export_name)
                         && export_namespace.iter().all(source_identifier)
                         && variants.iter().all(source_identifier)
@@ -419,11 +503,23 @@ fn enrich_runtime_mount(
                         stubs.push((export_namespace.clone(), export_name.clone(), source));
                     }
                 }
-                ExportedType::TypeAlias { .. } => {}
+                ExportedType::TypeAlias { qtn, resolved } => {
+                    *qtn = relocated_name(qtn, &alias);
+                    relocate_ty(resolved, &alias);
+                }
             }
         }
     }
     for implementation in &mut interface.impls {
+        relocate_interface(&mut implementation.interface, &alias);
+        relocate_ty(&mut implementation.for_ty_pattern, &alias);
+        relocate_bounds(&mut implementation.param_bounds, &alias);
+        for (_, ty) in &mut implementation.associated_types {
+            relocate_ty(ty, &alias);
+        }
+        if let ExportedImplOrigin::InBodyClass { class_qtn } = &mut implementation.origin {
+            *class_qtn = relocated_name(class_qtn, &alias);
+        }
         for function in &mut implementation.methods {
             relocate_function(function, &alias, &viewpoint, &mut stubs);
         }
@@ -518,8 +614,8 @@ fn enrich_runtime_mount(
     }
     // Every mounted row gets a source link stub so a consumer literal can
     // decompose to an external object reference; runtime linking resolves it
-    // to the live declaration. Mounted inference owns the real field types, so
-    // stub fields are `unknown`.
+    // to the live declaration. Source-backed lookup wins before the mounted
+    // interface in HIR, so preserve spellable field types here as well.
     for (name, row) in &minted_rows {
         match row {
             ExportedType::Class { fields, .. }
@@ -527,8 +623,13 @@ fn enrich_runtime_mount(
                     && fields.iter().all(|(field, ..)| source_identifier(field)) =>
             {
                 let mut source = format!("class {name} {{\n");
-                for (field, ..) in fields {
-                    writeln!(&mut source, "  {field} unknown")
+                for (field, ty, _) in fields {
+                    let ty = if viewpoint.hides_type(ty) {
+                        "unknown".to_string()
+                    } else {
+                        ty.to_string()
+                    };
+                    writeln!(&mut source, "  {field} {ty}")
                         .expect("writing to String is infallible");
                 }
                 source.push_str("}\n");
@@ -1859,8 +1960,20 @@ impl RuntimeCompiler for ProjectRuntimeCompiler {
                 .result_global
                 .strip_prefix("user.")
                 .unwrap_or(session.result_global.as_str());
-            let actual =
-                let_initializer_type(&db, result_name).unwrap_or_else(baml_type::Ty::unknown);
+            let Some(actual) = let_initializer_type(&db, result_name) else {
+                return Err(vec![RuntimeCompileDiagnostic {
+                    code: "E_RUNTIME_SESSION".to_string(),
+                    message: format!(
+                        "internal compiler error: Session result binding `{result_name}` has no initializer type"
+                    ),
+                    severity: RuntimeDiagnosticSeverity::Error,
+                    span: Some(RuntimeSourceSpan {
+                        file: file.to_string(),
+                        start: 0,
+                        end: 0,
+                    }),
+                }]);
+            };
             // The check runs in the compiler's context, which names declarations
             // rather than pointing at them. `eval<T>` can be handed a
             // runtime-created type, which has no name to recover — the engine

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -1354,7 +1354,10 @@ fn lower_session_submission(
                 binding = Some((name, symbol));
                 internal_name
             } else {
-                format!("__baml_session_{sequence}_stmt_{index}")
+                // Synthetic step globals must live outside `internal()`'s
+                // namespace so a user binding such as `stmt_1` cannot mint
+                // the same name.
+                format!("__baml_stmt_{sequence}_{index}")
             };
             let assignment = is_statement
                 .then(|| assignment_parts(raw))
@@ -1461,7 +1464,9 @@ fn lower_session_submission(
     }
 
     if result_step.is_none() {
-        let generated_name = format!("__baml_session_{sequence}_result");
+        // This fallback must likewise be outside `internal()`'s namespace:
+        // otherwise a user binding called `result` collides with it.
+        let generated_name = format!("__baml_result_{sequence}");
         let step_source = format!("let {generated_name} = null\n");
         generated.push_str(&step_source);
         result_step = Some(steps.len());

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -123,7 +123,7 @@ impl<'vm> ImplResolver<'vm> {
             if let Some(rules) = package.impl_rules.get(&iface_ptr) {
                 pointers.extend(rules);
             }
-            if let Some(runtime) = &package.runtime {
+            if let Some(runtime) = package.runtime() {
                 packages.extend(runtime.dependencies.iter().copied());
             }
         }

--- a/baml_language/crates/bex_vm/src/package_load.rs
+++ b/baml_language/crates/bex_vm/src/package_load.rs
@@ -23,7 +23,10 @@ use baml_type::Name;
 use bex_heap::{BexHeap, Generation};
 use bex_vm_types::{
     GlobalIndex, HeapPtr, Object, ObjectIndex,
-    types::{LocalName, MethodImpl, Package, ProgramImplRule, ProgramPackage, RuntimeImplRule},
+    types::{
+        LocalName, MethodImpl, Package, PackageKind, ProgramImplRule, ProgramPackage,
+        RuntimeImplRule,
+    },
 };
 use indexmap::IndexMap;
 
@@ -427,8 +430,7 @@ fn fill_package_slots(
                 .test_init
                 .map(|index| heap.compile_time_ptr(index.into_raw())),
             mounted_types: IndexMap::new(),
-            runtime: None,
-            session: None,
+            kind: PackageKind::Static,
         };
         heap.set_compile_time_object(slots.package_slot, Object::Package(Box::new(package)));
         index

--- a/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
@@ -20,13 +20,14 @@ use baml_compiler_diagnostics::{
 use baml_type::{TyAttr, normalize, normalize::TypeContext};
 use bex_heap::TlabHolder;
 use bex_vm_types::{
-    AtomicValueSlot, HeapPtr, Interface, Object, RealizedTy, RuntimeCompileArtifact,
-    RuntimeSessionCompileArtifact, SessionEvalLease, Ty,
+    ArtifactKind, AtomicValueSlot, HeapPtr, Interface, Object, RealizedTy, RuntimeCompileArtifact,
+    RuntimeCompileArtifactSlot, RuntimeSessionCompileArtifact, RuntimeSessionStepKind,
+    SessionEvalLease, Ty,
     link::link_dynamic,
     relink::{IndexOperand, visit_object_operands},
     types::{
-        LocalName, MethodImpl, Package, RuntimeImplRule, RuntimePackage, SessionState, TypeValue,
-        Value,
+        LocalName, MethodImpl, Package, PackageKind, RuntimeImplRule, RuntimePackage, SessionState,
+        TypeValue, Value,
     },
 };
 use indexmap::IndexMap;
@@ -92,9 +93,6 @@ fn package_ptr(vm: &BexVm, value: Value) -> Result<HeapPtr, VmRustFnError> {
         }
         .into());
     };
-    if matches!(vm.get_object(wrapper_ptr), Object::Package(_)) {
-        return Ok(wrapper_ptr);
-    }
     let Object::Instance(wrapper) = vm.get_object(wrapper_ptr) else {
         return Err(VmBamlError::InvalidArgument {
             message: "reflect.Package receiver is not an instance".to_string(),
@@ -114,6 +112,39 @@ fn package_ptr(vm: &BexVm, value: Value) -> Result<HeapPtr, VmRustFnError> {
         .into());
     }
     Ok(ptr)
+}
+
+fn take_compile_artifact(
+    vm: &BexVm,
+    value: Value,
+    invalid_message: &str,
+    consumed_message: &str,
+) -> Result<RuntimeCompileArtifact, VmRustFnError> {
+    let Some(inner) = value
+        .as_object_ptr()
+        .and_then(|pointer| match vm.get_object(pointer) {
+            Object::Instance(instance) => Some(instance.load_field(0)),
+            _ => None,
+        })
+    else {
+        return Err(VmBamlError::InvalidArgument {
+            message: invalid_message.to_string(),
+        }
+        .into());
+    };
+    let slot = vm
+        .as_rust_data::<RuntimeCompileArtifactSlot>(&inner)
+        .map_err(|_| VmBamlError::InvalidArgument {
+            message: invalid_message.to_string(),
+        })?;
+    let mut slot = slot.lock().map_err(|_| VmBamlError::InvalidArgument {
+        message: format!("{invalid_message}: artifact state is unavailable"),
+    })?;
+    slot.take().ok_or_else(|| {
+        VmRustFnError::from(VmBamlError::InvalidArgument {
+            message: consumed_message.to_string(),
+        })
+    })
 }
 
 fn local_name(path: &str) -> Option<LocalName> {
@@ -152,12 +183,7 @@ fn stored_package_type(package: &Package, name: &LocalName) -> Option<HeapPtr> {
                 .get(name)
                 .or_else(|| package.enums.get(name))
                 .or_else(|| package.interfaces.get(name))?;
-            package
-                .runtime
-                .as_ref()?
-                .type_values
-                .get(declaration)
-                .copied()
+            package.runtime()?.type_values.get(declaration).copied()
         })
 }
 
@@ -394,7 +420,7 @@ fn package_function_value(vm: &mut BexVm, package_ptr: HeapPtr, name: &LocalName
         .collect::<Vec<_>>()
         .join(".");
     let (slot, runtime_package) = match vm.get_object(package_ptr) {
-        Object::Package(package) => match package.runtime.as_ref() {
+        Object::Package(package) => match package.runtime() {
             Some(runtime) => {
                 let slot = runtime
                     .global_names
@@ -563,8 +589,7 @@ impl Continuation for FinishPackage {
             unreachable!("finish continuation retained a Package")
         };
         package
-            .runtime
-            .as_mut()
+            .runtime_mut()
             .expect("runtime package has an image")
             .initialized = true;
         NativeCallResult::Done(Value::object(self.wrapper))
@@ -690,23 +715,21 @@ impl BamlClassPackage for PackageReflectImpl {
         artifact: &Value,
         packages: &IndexMap<bex_str::BexStr, Value>,
     ) -> NativeCallResult {
-        let Some(artifact_inner) =
-            artifact
-                .as_object_ptr()
-                .and_then(|ptr| match vm.get_object(ptr) {
-                    Object::Instance(instance) => Some(instance.load_field(0)),
-                    _ => None,
-                })
-        else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "reflect.Package._finish received an invalid artifact".to_string(),
-            })
-            .into();
-        };
-        let artifact = match vm.as_rust_data::<RuntimeCompileArtifact>(&artifact_inner) {
-            Ok(artifact) => artifact.clone(),
+        let artifact = match take_compile_artifact(
+            vm,
+            *artifact,
+            "reflect.Package._finish received an invalid artifact",
+            "Package compile artifact has already been consumed",
+        ) {
+            Ok(artifact) => artifact,
             Err(error) => return error.into(),
         };
+        if !matches!(&artifact.kind, ArtifactKind::Package) {
+            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                message: "reflect.Package._finish received a Session.eval artifact".to_string(),
+            })
+            .into();
+        }
         let plan = match link_dynamic(&artifact.units) {
             Ok(plan) => plan,
             Err(error) => {
@@ -755,7 +778,7 @@ impl BamlClassPackage for PackageReflectImpl {
             interface_blob: artifact.interface_blob,
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
+            kind: PackageKind::Runtime(Box::new(RuntimePackage {
                 objects: Box::new([]),
                 object_names: IndexMap::new(),
                 globals: Box::new([]),
@@ -767,7 +790,6 @@ impl BamlClassPackage for PackageReflectImpl {
                 init: None,
                 initialized: false,
             })),
-            session: None,
         };
         let package_ptr = vm.alloc(Object::Package(Box::new(package)));
 
@@ -886,7 +908,7 @@ impl BamlClassPackage for PackageReflectImpl {
                         else {
                             return None;
                         };
-                        if let Some(runtime) = package.runtime.as_ref() {
+                        if let Some(runtime) = package.runtime() {
                             let index = runtime
                                 .global_names
                                 .get(&format!("user.{local}"))
@@ -1010,7 +1032,7 @@ impl BamlClassPackage for PackageReflectImpl {
         package.impl_rules = impl_rules;
         package.functions = functions;
         package.test_init = test_init;
-        let runtime = package.runtime.as_mut().expect("runtime package image");
+        let runtime = package.runtime_mut().expect("runtime package image");
         runtime.objects = objects.into_boxed_slice();
         runtime.globals = globals.into_boxed_slice();
         runtime.global_names = global_names;
@@ -1038,7 +1060,7 @@ impl BamlClassPackage for PackageReflectImpl {
             let Object::Package(package) = vm.get_object_mut(package_ptr) else {
                 unreachable!()
             };
-            package.runtime.as_mut().expect("runtime image").initialized = true;
+            package.runtime_mut().expect("runtime image").initialized = true;
             NativeCallResult::Done(wrapper)
         }
     }
@@ -1330,8 +1352,7 @@ impl BamlClassPackage for PackageReflectImpl {
         };
         let diagnostics = match vm.get_object(ptr) {
             Object::Package(package) => package
-                .runtime
-                .as_ref()
+                .runtime()
                 .map(|runtime| runtime.diagnostics.clone())
                 .unwrap_or_default(),
             _ => Vec::new(),
@@ -1574,8 +1595,7 @@ fn session_external_object(
 ) -> Option<HeapPtr> {
     if let Object::Package(package) = vm.get_object(session)
         && let Some(pointer) = package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.object_names.get(name))
     {
         return Some(*pointer);
@@ -1593,7 +1613,7 @@ fn session_external_global(
     name: &str,
 ) -> Option<Value> {
     if let Object::Package(package) = vm.get_object(session)
-        && let Some(runtime) = package.runtime.as_ref()
+        && let Some(runtime) = package.runtime()
         && let Some(index) = runtime.global_names.get(name)
     {
         return runtime.load_global(*index);
@@ -1607,7 +1627,7 @@ fn session_external_global(
             let Object::Package(package) = vm.get_object(dependency) else {
                 return None;
             };
-            if let Some(runtime) = package.runtime.as_ref() {
+            if let Some(runtime) = package.runtime() {
                 let index = runtime
                     .global_names
                     .get(&format!("user.{local}"))
@@ -1667,23 +1687,27 @@ impl Continuation for SessionExecution {
             let Object::Package(package) = vm.get_object_mut(self.package) else {
                 unreachable!("Session continuation retained its package")
             };
-            let runtime = package.runtime.as_mut().expect("Session runtime image");
+            let PackageKind::Session { runtime, state } = &mut package.kind else {
+                unreachable!("Session continuation retained a Session package")
+            };
             runtime.globals[action.target].store(value);
 
             if let Some(step_index) = action.step {
                 let step = &self.metadata.steps[step_index];
-                let state = package.session.as_mut().expect("Session state");
-                if let Some(source) = &step.replay_source {
+                if let RuntimeSessionStepKind::Binding {
+                    name,
+                    symbol,
+                    replay_source,
+                } = &step.kind
+                {
                     state
                         .history
                         .entry(self.metadata.submission_name.clone())
                         .or_default()
-                        .push_str(source);
-                }
-                if let Some((name, symbol)) = &step.binding {
+                        .push_str(replay_source);
                     state.visible.insert(name.clone(), symbol.clone());
                 }
-                if step.returns_value {
+                if self.metadata.result_step == Some(step_index) {
                     self.result = value;
                 }
             }
@@ -1735,7 +1759,7 @@ fn graft_session_submission(
         let Object::Package(package) = vm.get_object(package_ptr) else {
             unreachable!("Session payload is a Package")
         };
-        let runtime = package.runtime.as_ref().expect("Session runtime image");
+        let runtime = package.runtime().expect("Session runtime image");
         (
             runtime.dependency_names.clone(),
             runtime.global_names.clone(),
@@ -1988,7 +2012,7 @@ fn graft_session_submission(
     // A session's earlier evals published their declarations under fully
     // qualified names; a later eval's type positions name them the same way.
     if let Object::Package(package) = vm.get_object(package_ptr)
-        && let Some(runtime) = package.runtime.as_ref()
+        && let Some(runtime) = package.runtime()
     {
         named_surfaces.extend(
             runtime
@@ -2103,7 +2127,9 @@ fn graft_session_submission(
             .extend(rules);
     }
     package.interface_blob.clone_from(&artifact.interface_blob);
-    let state = package.session.as_mut().expect("Session state");
+    let PackageKind::Session { runtime, state } = &mut package.kind else {
+        unreachable!("Session graft target changed package kind")
+    };
     if !metadata.declaration_source.trim().is_empty() {
         state.history.insert(
             metadata.submission_name.clone(),
@@ -2111,7 +2137,6 @@ fn graft_session_submission(
         );
     }
     state.visible.extend(metadata.declarations.clone());
-    let runtime = package.runtime.as_mut().expect("Session runtime image");
     let mut globals = runtime.globals.to_vec();
     globals.extend(appended.into_iter().map(AtomicValueSlot::new));
     runtime.globals = globals.into_boxed_slice();
@@ -2166,25 +2191,27 @@ impl BamlClassSession for PackageReflectImpl {
             interface_blob: Vec::new(),
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
-                objects: Box::new([]),
-                object_names: IndexMap::new(),
-                globals: Box::new([]),
-                global_names: IndexMap::new(),
-                type_values: IndexMap::new(),
-                diagnostics: Vec::new(),
-                dependencies: dependencies.values().copied().collect(),
-                dependency_names: dependencies,
-                init: None,
-                // Session cells intentionally stay mutable between evals.
-                initialized: false,
-            })),
-            session: Some(Box::new(SessionState {
-                history: IndexMap::new(),
-                visible: IndexMap::new(),
-                busy: Arc::new(AtomicBool::new(false)),
-                submission_counter: 0,
-            })),
+            kind: PackageKind::Session {
+                runtime: Box::new(RuntimePackage {
+                    objects: Box::new([]),
+                    object_names: IndexMap::new(),
+                    globals: Box::new([]),
+                    global_names: IndexMap::new(),
+                    type_values: IndexMap::new(),
+                    diagnostics: Vec::new(),
+                    dependencies: dependencies.values().copied().collect(),
+                    dependency_names: dependencies,
+                    init: None,
+                    // Session cells intentionally stay mutable between evals.
+                    initialized: false,
+                }),
+                state: Box::new(SessionState {
+                    history: IndexMap::new(),
+                    visible: IndexMap::new(),
+                    busy: Arc::new(AtomicBool::new(false)),
+                    submission_counter: 0,
+                }),
+            },
         };
         let package = vm.alloc(Object::Package(Box::new(package)));
         Ok(copy::Session {
@@ -2198,34 +2225,24 @@ impl BamlClassSession for PackageReflectImpl {
             Ok(package) => package,
             Err(error) => return error.into(),
         };
-        let Some(artifact_inner) =
-            artifact
-                .as_object_ptr()
-                .and_then(|pointer| match vm.get_object(pointer) {
-                    Object::Instance(instance) => Some(instance.load_field(0)),
-                    _ => None,
-                })
-        else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session._finish received an invalid artifact".to_string(),
-            })
-            .into();
-        };
-        let mut artifact = match vm.as_rust_data::<RuntimeCompileArtifact>(&artifact_inner) {
-            Ok(artifact) => artifact.clone(),
+        let mut artifact = match take_compile_artifact(
+            vm,
+            *artifact,
+            "Session._finish received an invalid artifact",
+            "Session artifact has already been consumed",
+        ) {
+            Ok(artifact) => artifact,
             Err(error) => return error.into(),
         };
-        let Some(metadata) = artifact.session.clone() else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session._finish received a Package.compile artifact".to_string(),
-            })
-            .into();
-        };
-        let Some(lease) = artifact.session_lease.take() else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session artifact has already been consumed".to_string(),
-            })
-            .into();
+        let kind = std::mem::replace(&mut artifact.kind, ArtifactKind::Package);
+        let (metadata, lease) = match kind {
+            ArtifactKind::Session { meta, lease } => (meta, lease),
+            ArtifactKind::Package => {
+                return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                    message: "Session._finish received a Package.compile artifact".to_string(),
+                })
+                .into();
+            }
         };
         let actions = match graft_session_submission(vm, package, &artifact, &metadata) {
             Ok(actions) => actions,
@@ -2255,8 +2272,7 @@ impl BamlClassSession for PackageReflectImpl {
         };
         let diagnostics = match vm.get_object(package) {
             Object::Package(package) => package
-                .runtime
-                .as_ref()
+                .runtime()
                 .map(|runtime| runtime.diagnostics.clone())
                 .unwrap_or_default(),
             _ => Vec::new(),

--- a/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
@@ -1023,47 +1023,67 @@ fn render_meta_suffix(alias: Option<&str>, description: Option<&str>) -> String 
     out
 }
 
-fn render_ty_source(ty: &bex_vm_types::RealizedTy) -> String {
+fn render_ty_source(
+    ty: &bex_vm_types::RealizedTy,
+    spellings: &indexmap::IndexMap<baml_type::typetag::TypeTag, String>,
+) -> String {
+    let ty = ty.map_heads(&mut |head| {
+        let name = spellings.get(&head.tag()).map_or_else(
+            || {
+                head.tagged_name()
+                    .map(|tagged| tagged.name().clone())
+                    .unwrap_or_else(|| unreachable!("a live type head names a declaration"))
+            },
+            |name| baml_type::DeclarationName::Anonymous(baml_type::Name::new(name)),
+        );
+        baml_type::TaggedTypeName::new(head.tag(), name)
+    });
+    render_named_ty_source(&ty)
+}
+
+fn render_named_ty_source(ty: &baml_type::RealizedTy<baml_type::TaggedTypeName>) -> String {
     match ty {
-        bex_vm_types::RealizedTy::Union(members, _) => {
+        baml_type::RealizedTy::Union(members, _) => {
             let mut non_null: Vec<_> = members.iter().filter(|member| !member.is_null()).collect();
             let has_null = non_null.len() != members.len();
             if has_null && non_null.len() == 1 {
                 let member = non_null
                     .pop()
                     .unwrap_or_else(|| unreachable!("length checked"));
-                let rendered = render_ty_source(member);
-                if matches!(member, bex_vm_types::RealizedTy::Function { .. }) {
+                let rendered = render_named_ty_source(member);
+                if matches!(member, baml_type::RealizedTy::Function { .. }) {
                     format!("({rendered})?")
                 } else {
                     format!("{rendered}?")
                 }
             } else {
                 let mut rendered: Vec<String> =
-                    non_null.into_iter().map(render_ty_source).collect();
+                    non_null.into_iter().map(render_named_ty_source).collect();
                 if has_null {
                     rendered.push("null".to_string());
                 }
                 rendered.join(" | ")
             }
         }
-        bex_vm_types::RealizedTy::List(element, _) => {
-            let rendered = render_ty_source(element);
-            if matches!(element.as_ref(), bex_vm_types::RealizedTy::Union(..)) {
+        baml_type::RealizedTy::List(element, _) => {
+            let rendered = render_named_ty_source(element);
+            if matches!(element.as_ref(), baml_type::RealizedTy::Union(..)) {
                 format!("({rendered})[]")
             } else {
                 format!("{rendered}[]")
             }
         }
-        bex_vm_types::RealizedTy::Map { key, value, .. } => {
+        baml_type::RealizedTy::Map { key, value, .. } => {
             format!(
                 "map<{}, {}>",
-                render_ty_source(key),
-                render_ty_source(value)
+                render_named_ty_source(key),
+                render_named_ty_source(value)
             )
         }
-        bex_vm_types::RealizedTy::Class(head, args, _) if args.is_empty() => head_name(head),
-        bex_vm_types::RealizedTy::Enum(head, _) => head_name(head),
+        baml_type::RealizedTy::Class(head, args, _) if args.is_empty() => {
+            head.display_name().to_string()
+        }
+        baml_type::RealizedTy::Enum(head, _) => head.display_name().to_string(),
         other => other.to_string(),
     }
 }
@@ -1075,7 +1095,12 @@ fn render_ty_source(ty: &bex_vm_types::RealizedTy) -> String {
 /// instead, so what this prints and what a virtual call resolves cannot
 /// disagree. A rule's `field_links` are physical field slots, so the interface's
 /// declared field order supplies the left-hand names and `class` the right.
-fn render_witness_sources(vm: &BexVm, source: &mut String, class_ptr: bex_vm_types::HeapPtr) {
+fn render_witness_sources(
+    vm: &BexVm,
+    source: &mut String,
+    class_ptr: bex_vm_types::HeapPtr,
+    spellings: &indexmap::IndexMap<baml_type::typetag::TypeTag, String>,
+) {
     let Object::Class(class) = vm.get_object(class_ptr) else {
         return;
     };
@@ -1092,7 +1117,7 @@ fn render_witness_sources(vm: &BexVm, source: &mut String, class_ptr: bex_vm_typ
             .interface_args
             .iter()
             .filter_map(|arg| bex_vm_types::RealizedTy::try_from(arg).ok())
-            .map(|arg| render_ty_source(&arg))
+            .map(|arg| render_ty_source(&arg, spellings))
             .collect::<Vec<_>>();
         if !args.is_empty() {
             source.push('<');
@@ -1117,7 +1142,7 @@ fn render_witness_sources(vm: &BexVm, source: &mut String, class_ptr: bex_vm_typ
             source.push_str("\n    type ");
             source.push_str(name.as_str());
             source.push_str(" = ");
-            source.push_str(&render_ty_source(&ty));
+            source.push_str(&render_ty_source(&ty, spellings));
         }
         for (declared, slot) in interface.fields.iter().zip(&*rule.field_links) {
             let Some(field) = class.fields.get(*slot as usize) else {
@@ -1138,18 +1163,18 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
     // to render is a walk, not a table. A package contributes its whole surface
     // (a `Package.compile` result renders as the source it was compiled from),
     // minus the `$stream` companions, which are synthesized rather than written.
-    let (mut class_ptrs, mut enum_ptrs) = crate::reachable::runtime_nominals(vm, &type_value.ty);
-    let mut owners = class_ptrs
+    let (mut class_ptrs, mut enum_ptrs) = crate::reachable::all_nominals(vm, &type_value.ty);
+    let owners = class_ptrs
         .iter()
         .chain(&enum_ptrs)
+        .filter(|ptr| !vm.heap.is_compile_time_ptr(**ptr))
         .filter_map(|ptr| match vm.get_object(*ptr) {
             Object::Class(class) => Some(class.owner),
             Object::Enum(enm) => Some(enm.owner),
             _ => None,
         })
         .filter(|owner| !owner.is_null())
-        .collect::<Vec<_>>();
-    owners.dedup();
+        .collect::<indexmap::IndexSet<_>>();
     for owner in owners {
         let Object::Package(package) = vm.get_object(owner) else {
             continue;
@@ -1171,12 +1196,74 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         }
     }
 
+    // Package expansion can add declarations whose fields reach static
+    // classes. Close that graph too so every rendered reference has a block.
+    let mut class_index = 0;
+    while class_index < class_ptrs.len() {
+        let ptr = class_ptrs[class_index];
+        class_index += 1;
+        let Object::Class(class) = vm.get_object(ptr) else {
+            continue;
+        };
+        for field in &class.fields {
+            let field_ty = field
+                .runtime_type
+                .as_ref()
+                .map(|runtime| runtime.ty.clone())
+                .or_else(|| bex_vm_types::RealizedTy::try_from(&field.field_type).ok());
+            let Some(field_ty) = field_ty else {
+                continue;
+            };
+            let (reached_classes, reached_enums) = crate::reachable::all_nominals(vm, &field_ty);
+            for reached in reached_classes {
+                if !class_ptrs.contains(&reached) {
+                    class_ptrs.push(reached);
+                }
+            }
+            for reached in reached_enums {
+                if !enum_ptrs.contains(&reached) {
+                    enum_ptrs.push(reached);
+                }
+            }
+        }
+    }
+
+    let mut spellings = indexmap::IndexMap::new();
+    let mut used = std::collections::HashSet::new();
+    let mut next_suffix = indexmap::IndexMap::<String, usize>::new();
+    for ptr in enum_ptrs.iter().chain(&class_ptrs) {
+        let (tag, base) = match vm.get_object(*ptr) {
+            Object::Class(class) => (class.type_tag, class.name.display_name().to_string()),
+            Object::Enum(enm) => (enm.type_tag, enm.name.display_name().to_string()),
+            _ => continue,
+        };
+        if spellings.contains_key(&tag) {
+            continue;
+        }
+        let next = next_suffix.entry(base.clone()).or_insert(1);
+        let mut candidate = if *next == 1 {
+            base.clone()
+        } else {
+            format!("{base}_{next}")
+        };
+        while used.contains(&candidate) {
+            *next += 1;
+            candidate = format!("{base}_{next}");
+        }
+        *next += 1;
+        used.insert(candidate.clone());
+        spellings.insert(tag, candidate);
+    }
+
     let mut declarations = Vec::new();
     for ptr in &enum_ptrs {
         let Object::Enum(enm) = vm.get_object(*ptr) else {
             continue;
         };
-        let mut source = format!("enum {} {{", enm.name.display_name());
+        let name = spellings
+            .get(&enm.type_tag)
+            .map_or_else(|| enm.name.display_name().to_string(), Clone::clone);
+        let mut source = format!("enum {name} {{");
         for variant in &enm.variants {
             source.push_str("\n  ");
             source.push_str(&variant.name);
@@ -1202,15 +1289,18 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         let Object::Class(class) = vm.get_object(*ptr) else {
             continue;
         };
-        let mut source = format!("class {} {{", class.name.display_name());
+        let name = spellings
+            .get(&class.type_tag)
+            .map_or_else(|| class.name.display_name().to_string(), Clone::clone);
+        let mut source = format!("class {name} {{");
         for field in &class.fields {
             source.push_str("\n  ");
             source.push_str(&field.name);
             source.push(' ');
             if let Some(field_type) = &field.runtime_type {
-                source.push_str(&render_ty_source(&field_type.ty));
+                source.push_str(&render_ty_source(&field_type.ty, &spellings));
             } else if let Ok(field_type) = bex_vm_types::RealizedTy::try_from(&field.field_type) {
-                source.push_str(&render_ty_source(&field_type));
+                source.push_str(&render_ty_source(&field_type, &spellings));
             } else {
                 source.push_str(&field.field_type.to_string());
             }
@@ -1219,7 +1309,7 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
                 field.description.as_deref(),
             ));
         }
-        render_witness_sources(vm, &mut source, *ptr);
+        render_witness_sources(vm, &mut source, *ptr, &spellings);
         if let Some(alias) = class.alias.as_deref() {
             source.push_str("\n  @@alias(");
             source.push_str(&quoted(alias));
@@ -1241,7 +1331,7 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
     if !root_is_declared {
         declarations.push(format!(
             "type RuntimeType = {}",
-            render_ty_source(&type_value.ty)
+            render_ty_source(&type_value.ty, &spellings)
         ));
     }
     declarations.join("\n\n")

--- a/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
@@ -61,7 +61,7 @@ impl BamlClassType for PackageReflectImpl {
 
     fn to_baml(vm: &mut BexVm, self_value: &Value) -> Result<bex_str::BexStr, VmRustFnError> {
         let type_value = cloned_type_value(vm, *self_value);
-        reject_first_render_schema_error(vm, &type_value.ty)?;
+        reject_first_type_value_render_schema_error(vm, &type_value)?;
         Ok(bex_str::BexStr::from(render_type_value_source(
             vm,
             &type_value,
@@ -445,7 +445,11 @@ impl RenderDefinitionValidator<'_> {
 /// name shared by non-equivalent declarations, a non-regular recursive generic
 /// (whose specializations would grow forever), or two distinct recursive
 /// classes hoisted under one rendered name.
-fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Option<String> {
+fn first_render_schema_error_with_definitions(
+    vm: &BexVm,
+    ty: &bex_vm_types::RealizedTy,
+    definitions: impl IntoIterator<Item = RenderDefinition>,
+) -> Option<String> {
     let mut validator = RenderDefinitionValidator {
         vm,
         by_display_name: std::collections::HashMap::new(),
@@ -454,16 +458,51 @@ fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Optio
         recursive_classes: std::collections::HashSet::new(),
         rendered_classes: Vec::new(),
     };
-    validator
-        .visit(ty, &RenderOrigins::root())
-        .or_else(|| validator.first_recursive_alias_collision())
+    if let Some(error) = validator.visit(ty, &RenderOrigins::root()) {
+        return Some(error);
+    }
+    for definition in definitions {
+        if let Some(error) = validator.check_name(&definition) {
+            return Some(error);
+        }
+    }
+    validator.first_recursive_alias_collision()
+}
+
+fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Option<String> {
+    first_render_schema_error_with_definitions(vm, ty, std::iter::empty())
+}
+
+fn first_type_value_render_schema_error(vm: &BexVm, type_value: &TypeValue) -> Option<String> {
+    let (class_ptrs, enum_ptrs) = expanded_type_value_nominals(vm, type_value);
+    let definitions = enum_ptrs
+        .into_iter()
+        .map(RenderDefinition::Enum)
+        .chain(class_ptrs.into_iter().map(RenderDefinition::Class));
+    first_render_schema_error_with_definitions(vm, &type_value.ty, definitions)
 }
 
 fn reject_first_render_schema_error(
     vm: &mut BexVm,
     ty: &bex_vm_types::RealizedTy,
 ) -> Result<(), VmRustFnError> {
-    let Some(message) = first_render_schema_error(vm, ty) else {
+    let message = first_render_schema_error(vm, ty);
+    reject_render_schema_error(vm, message)
+}
+
+fn reject_first_type_value_render_schema_error(
+    vm: &mut BexVm,
+    type_value: &TypeValue,
+) -> Result<(), VmRustFnError> {
+    let message = first_type_value_render_schema_error(vm, type_value);
+    reject_render_schema_error(vm, message)
+}
+
+fn reject_render_schema_error(
+    vm: &mut BexVm,
+    message: Option<String>,
+) -> Result<(), VmRustFnError> {
+    let Some(message) = message else {
         return Ok(());
     };
     let diagnostic = super::type_kinds::compiler_diagnostic(
@@ -1169,7 +1208,10 @@ fn render_witness_sources(
     }
 }
 
-fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
+fn expanded_type_value_nominals(
+    vm: &BexVm,
+    type_value: &TypeValue,
+) -> (Vec<bex_vm_types::HeapPtr>, Vec<bex_vm_types::HeapPtr>) {
     // The type's heads reach every declaration it depends on, and each runtime
     // declaration's `owner` reaches the package that declared it — so the set
     // to render is a walk, not a table. A package contributes its whole surface
@@ -1239,6 +1281,12 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
             }
         }
     }
+
+    (class_ptrs, enum_ptrs)
+}
+
+fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
+    let (class_ptrs, enum_ptrs) = expanded_type_value_nominals(vm, type_value);
 
     let mut spellings = indexmap::IndexMap::new();
     for ptr in enum_ptrs.iter().chain(&class_ptrs) {
@@ -1395,6 +1443,102 @@ mod renderability_tests {
 
     fn attr() -> baml_type::TyAttr {
         baml_type::TyAttr::default()
+    }
+
+    fn empty_package() -> bex_vm_types::types::Package {
+        bex_vm_types::types::Package {
+            exported_names: Vec::new(),
+            classes: indexmap::IndexMap::new(),
+            enums: indexmap::IndexMap::new(),
+            interfaces: indexmap::IndexMap::new(),
+            impl_rules: indexmap::IndexMap::new(),
+            functions: indexmap::IndexMap::new(),
+            type_aliases: indexmap::IndexMap::new(),
+            interface_blob: Vec::new(),
+            test_init: None,
+            mounted_types: indexmap::IndexMap::new(),
+            kind: bex_vm_types::types::PackageKind::default(),
+        }
+    }
+
+    fn alloc_test_class(
+        vm: &mut BexVm,
+        name: &str,
+        description: Option<&str>,
+        owner: bex_vm_types::HeapPtr,
+    ) -> (bex_vm_types::HeapPtr, baml_type::typetag::TypeTag) {
+        let type_tag = baml_type::typetag::TypeTag::fresh_dynamic();
+        let ptr = vm.tlab.alloc(Object::Class(Box::new(bex_vm_types::Class {
+            name: bex_vm_types::DeclarationName::Anonymous(baml_type::Name::new(name)),
+            fields: Vec::new(),
+            description: description.map(str::to_string),
+            alias: None,
+            docstring: None,
+            other: indexmap::IndexMap::new(),
+            type_tag,
+            ty_attr: attr(),
+            has_cleanup: false,
+            generic_param_count: 0,
+            owner,
+        })));
+        (ptr, type_tag)
+    }
+
+    fn package_member_name(name: &str) -> bex_vm_types::types::LocalName {
+        bex_vm_types::types::LocalName {
+            namespace: Vec::new(),
+            name: baml_type::Name::new(name),
+        }
+    }
+
+    #[test]
+    fn package_expansion_rejects_non_equivalent_same_name_members() {
+        let mut vm = crate::vm::tests::test_vm(Vec::new());
+        let first_package = vm.tlab.alloc(Object::Package(Box::new(empty_package())));
+        let second_package = vm.tlab.alloc(Object::Package(Box::new(empty_package())));
+
+        let (first_root, first_root_tag) =
+            alloc_test_class(&mut vm, "FirstRoot", None, first_package);
+        let (second_root, second_root_tag) =
+            alloc_test_class(&mut vm, "SecondRoot", None, second_package);
+        let (first_shared, _) =
+            alloc_test_class(&mut vm, "Shared", Some("first definition"), first_package);
+        let (second_shared, _) =
+            alloc_test_class(&mut vm, "Shared", Some("second definition"), second_package);
+
+        let Object::Package(package) = vm.get_object_mut(first_package) else {
+            unreachable!("test package pointer")
+        };
+        package
+            .classes
+            .insert(package_member_name("Shared"), first_shared);
+        let Object::Package(package) = vm.get_object_mut(second_package) else {
+            unreachable!("test package pointer")
+        };
+        package
+            .classes
+            .insert(package_member_name("Shared"), second_shared);
+
+        let type_value = TypeValue::new(bex_vm_types::RealizedTy::Union(
+            vec![
+                bex_vm_types::RealizedTy::Class(
+                    bex_vm_types::TypeHead::new(first_root, first_root_tag),
+                    Vec::new(),
+                    attr(),
+                ),
+                bex_vm_types::RealizedTy::Class(
+                    bex_vm_types::TypeHead::new(second_root, second_root_tag),
+                    Vec::new(),
+                    attr(),
+                ),
+            ],
+            attr(),
+        ));
+
+        assert_eq!(
+            first_type_value_render_schema_error(&vm, &type_value).as_deref(),
+            Some("type `Shared` has non-equivalent definitions in the same LLM render context")
+        );
     }
 
     #[test]

--- a/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
@@ -59,9 +59,13 @@ impl BamlClassType for PackageReflectImpl {
         super::type_kinds::alloc_kind_view(vm, baml_type::type_kind::TypeKind::Union, union_ty)
     }
 
-    fn to_baml(vm: &BexVm, self_value: &Value) -> bex_str::BexStr {
+    fn to_baml(vm: &mut BexVm, self_value: &Value) -> Result<bex_str::BexStr, VmRustFnError> {
         let type_value = cloned_type_value(vm, *self_value);
-        bex_str::BexStr::from(render_type_value_source(vm, &type_value))
+        reject_first_render_schema_error(vm, &type_value.ty)?;
+        Ok(bex_str::BexStr::from(render_type_value_source(
+            vm,
+            &type_value,
+        )))
     }
 
     fn meta(
@@ -137,15 +141,7 @@ impl BamlClassType for PackageReflectImpl {
         // Run the bounded specialization analysis first: the subsequent structural
         // interface walk keys every realization and would otherwise follow a
         // non-regular generic transform forever.
-        if let Some(message) = first_render_schema_error(vm, &type_value.ty) {
-            let diagnostic = super::type_kinds::compiler_diagnostic(
-                baml_compiler_diagnostics::DiagnosticId::ConflictingTypeDefinitionAtRender,
-                message,
-            );
-            return Err(VmRustFnError::thrown_fresh(
-                super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
-            ));
-        }
+        reject_first_render_schema_error(vm, &type_value.ty)?;
         let mut visited = std::collections::HashSet::new();
         if let Some((field, open_ty)) =
             first_open_interface(vm, &type_value.ty, &root, &mut visited)
@@ -461,6 +457,22 @@ fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Optio
     validator
         .visit(ty, &RenderOrigins::root())
         .or_else(|| validator.first_recursive_alias_collision())
+}
+
+fn reject_first_render_schema_error(
+    vm: &mut BexVm,
+    ty: &bex_vm_types::RealizedTy,
+) -> Result<(), VmRustFnError> {
+    let Some(message) = first_render_schema_error(vm, ty) else {
+        return Ok(());
+    };
+    let diagnostic = super::type_kinds::compiler_diagnostic(
+        baml_compiler_diagnostics::DiagnosticId::ConflictingTypeDefinitionAtRender,
+        message,
+    );
+    Err(VmRustFnError::thrown_fresh(
+        super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
+    ))
 }
 
 fn render_definition_display_name(vm: &BexVm, definition: &RenderDefinition) -> String {
@@ -1229,8 +1241,6 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
     }
 
     let mut spellings = indexmap::IndexMap::new();
-    let mut used = std::collections::HashSet::new();
-    let mut next_suffix = indexmap::IndexMap::<String, usize>::new();
     for ptr in enum_ptrs.iter().chain(&class_ptrs) {
         let (tag, base) = match vm.get_object(*ptr) {
             Object::Class(class) => (class.type_tag, class.name.display_name().to_string()),
@@ -1240,22 +1250,11 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         if spellings.contains_key(&tag) {
             continue;
         }
-        let next = next_suffix.entry(base.clone()).or_insert(1);
-        let mut candidate = if *next == 1 {
-            base.clone()
-        } else {
-            format!("{base}_{next}")
-        };
-        while used.contains(&candidate) {
-            *next += 1;
-            candidate = format!("{base}_{next}");
-        }
-        *next += 1;
-        used.insert(candidate.clone());
-        spellings.insert(tag, candidate);
+        spellings.insert(tag, base);
     }
 
     let mut declarations = Vec::new();
+    let mut rendered_declarations = std::collections::HashSet::new();
     for ptr in &enum_ptrs {
         let Object::Enum(enm) = vm.get_object(*ptr) else {
             continue;
@@ -1263,6 +1262,9 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         let name = spellings
             .get(&enm.type_tag)
             .map_or_else(|| enm.name.display_name().to_string(), Clone::clone);
+        if !rendered_declarations.insert(name.clone()) {
+            continue;
+        }
         let mut source = format!("enum {name} {{");
         for variant in &enm.variants {
             source.push_str("\n  ");
@@ -1292,6 +1294,9 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         let name = spellings
             .get(&class.type_tag)
             .map_or_else(|| class.name.display_name().to_string(), Clone::clone);
+        if !rendered_declarations.insert(name.clone()) {
+            continue;
+        }
         let mut source = format!("class {name} {{");
         for field in &class.fields {
             source.push_str("\n  ");

--- a/baml_language/crates/bex_vm/src/reachable.rs
+++ b/baml_language/crates/bex_vm/src/reachable.rs
@@ -120,3 +120,46 @@ pub fn runtime_nominals_under_permit(
     }
     (classes, enums)
 }
+
+/// Every class and enum `ty` reaches, including compile-time declarations.
+///
+/// Most runtime consumers intentionally stop at the immutable program image,
+/// but source rendering must emit a standalone graph: a runtime class field
+/// that names a static class needs that static declaration in the output too.
+#[must_use]
+pub fn all_nominals(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> (Vec<HeapPtr>, Vec<HeapPtr>) {
+    let mut found = Vec::new();
+    let mut pending = Vec::new();
+    ty.visit_heads(&mut |head| {
+        if head.is_resolved() {
+            pending.push(head.ptr());
+        }
+    });
+    pending.reverse();
+    while let Some(ptr) = pending.pop() {
+        if found.contains(&ptr) {
+            continue;
+        }
+        found.push(ptr);
+        let mut next = Vec::new();
+        let object = vm.get_object(ptr);
+        bex_vm_types::head_walk::visit_object_heads(object, &mut |head| {
+            if head.is_resolved() {
+                next.push(head.ptr());
+            }
+        });
+        next.reverse();
+        pending.extend(next);
+    }
+
+    let mut classes = Vec::new();
+    let mut enums = Vec::new();
+    for ptr in found {
+        match vm.get_object(ptr) {
+            Object::Class(_) => classes.push(ptr),
+            Object::Enum(_) => enums.push(ptr),
+            _ => {}
+        }
+    }
+    (classes, enums)
+}

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2309,7 +2309,7 @@ impl BexVm {
             if baml_builtins2::stdlib_package_names().contains(&qtn.package().as_str()) {
                 return self.package(qtn.package());
             }
-            let runtime = current.runtime.as_ref()?;
+            let runtime = current.runtime()?;
             if let Some(dependency) = runtime.dependency_names.get(qtn.package().as_str()) {
                 return self.get_object(*dependency).as_package();
             }
@@ -2526,12 +2526,7 @@ impl BexVm {
         // The head *is* the key: a declaration this package created has an
         // entry, and one it merely imported or composed does not — which is
         // exactly the set that must reuse the created-once value.
-        let ptr = package
-            .runtime
-            .as_ref()?
-            .type_values
-            .get(&head.ptr())
-            .copied()?;
+        let ptr = package.runtime()?.type_values.get(&head.ptr()).copied()?;
         match self.get_object(ptr) {
             Object::Type(value) if &value.ty == ty => Some(ptr),
             _ => None,
@@ -2546,8 +2541,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.load_global(index.raw()))
             .expect("runtime global index was validated by dynamic link")
     }
@@ -2567,8 +2561,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         let runtime = package
-            .runtime
-            .as_ref()
+            .runtime()
             .expect("runtime function owner has a runtime image");
         if runtime.initialized {
             return Err(VmInternalError::StoreGlobalAfterInit);
@@ -2595,8 +2588,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.objects.get(idx.raw()))
             .copied()
             .expect("runtime object index was validated by dynamic link")

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -35,10 +35,11 @@ pub use indexable::{
 pub use link::LinkError;
 pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use runtime_compile::{
-    RuntimeCompileArtifact, RuntimeCompileDiagnostic, RuntimeCompileMode, RuntimeCompileRequest,
-    RuntimeDiagnosticSeverity, RuntimeMountedClass, RuntimeMountedEnum, RuntimeMountedFieldAttrs,
-    RuntimePackageMount, RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest,
-    RuntimeSessionInitializer, RuntimeSessionStep, RuntimeSourceSpan, RuntimeTypeMount,
+    ArtifactKind, RuntimeCompileArtifact, RuntimeCompileArtifactSlot, RuntimeCompileDiagnostic,
+    RuntimeCompileMode, RuntimeCompileRequest, RuntimeDiagnosticSeverity, RuntimeMountedClass,
+    RuntimeMountedEnum, RuntimeMountedFieldAttrs, RuntimePackageMount,
+    RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest, RuntimeSessionInitializer,
+    RuntimeSessionStep, RuntimeSessionStepKind, RuntimeSourceSpan, RuntimeTypeMount,
     SessionContract, SessionEvalLease, SessionVisibleKind, SessionVisibleSymbol,
 };
 pub use task_group::{TaskGroupInner, TaskGroupPermit, TaskGroupTicket};

--- a/baml_language/crates/bex_vm_types/src/runtime_compile.rs
+++ b/baml_language/crates/bex_vm_types/src/runtime_compile.rs
@@ -5,7 +5,7 @@
 //! compiler implementation is assembled in `bex_project`.
 
 use std::sync::{
-    Arc, Weak,
+    Arc, Mutex, Weak,
     atomic::{AtomicBool, Ordering},
 };
 
@@ -63,11 +63,11 @@ pub struct RuntimePackageMount {
 }
 
 /// The kind of a name retained in a Session's compile-time scope.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionVisibleKind {
     Declaration,
     Let,
-    TypeBinding,
+    TypeBinding { type_value: String },
 }
 
 /// One source-visible name and the hygienic name used in replayed source.
@@ -75,8 +75,6 @@ pub enum SessionVisibleKind {
 pub struct SessionVisibleSymbol {
     pub internal: String,
     pub kind: SessionVisibleKind,
-    /// Backing top-level value for a scoped runtime type binding.
-    pub type_value: Option<String>,
 }
 
 /// The `eval<T>` contract, spelled for the compiler's name-headed world.
@@ -122,12 +120,20 @@ pub struct RuntimeSessionStep {
     /// Existing Session cell to update after this initializer succeeds. `None`
     /// means the generated global itself receives the value.
     pub commit_global: Option<String>,
-    /// Source-visible binding committed by this step, if it is a `let`.
-    pub binding: Option<(String, SessionVisibleSymbol)>,
-    /// Replayed source fragment to append only after this step succeeds.
-    pub replay_source: Option<String>,
-    /// Whether this step is the submission's observable final expression.
-    pub returns_value: bool,
+    pub kind: RuntimeSessionStepKind,
+}
+
+/// The two legal commit shapes of a Session initializer step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeSessionStepKind {
+    Expression,
+    Binding {
+        /// Source-visible binding committed by this step.
+        name: String,
+        symbol: SessionVisibleSymbol,
+        /// Replayed source fragment appended only after this step succeeds.
+        replay_source: String,
+    },
 }
 
 /// Compiler-owned Session metadata retained after the fresh database drops.
@@ -138,6 +144,8 @@ pub struct RuntimeSessionCompileArtifact {
     pub declaration_source: String,
     pub declarations: IndexMap<String, SessionVisibleSymbol>,
     pub steps: Vec<RuntimeSessionStep>,
+    /// The step whose value is the submission's observable result.
+    pub result_step: Option<usize>,
     /// Current-submission initializer helpers in execution order. `helper_slot`
     /// addresses the anonymous helper-slot list retained in the pruned tail.
     pub initializers: Vec<RuntimeSessionInitializer>,
@@ -243,7 +251,7 @@ pub struct RuntimeCompileDiagnostic {
 }
 
 /// Successful compiler output retained by the runtime.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct RuntimeCompileArtifact {
     /// Relocatable user units. Builtin/dependency definitions remain imports.
     pub units: Vec<CompilationUnit>,
@@ -252,8 +260,19 @@ pub struct RuntimeCompileArtifact {
     pub interface_blob: Vec<u8>,
     /// Non-error diagnostics produced by the successful compilation.
     pub diagnostics: Vec<RuntimeCompileDiagnostic>,
-    /// Present only for `reflect.Session.eval`.
-    pub session: Option<RuntimeSessionCompileArtifact>,
-    /// S-9 permit transferred from the request to the successful artifact.
-    pub session_lease: Option<SessionEvalLease>,
+    pub kind: ArtifactKind,
 }
+
+/// Which runtime compilation door produced an artifact.
+#[derive(Debug)]
+pub enum ArtifactKind {
+    Package,
+    Session {
+        meta: RuntimeSessionCompileArtifact,
+        /// S-9 permit transferred from the request to the successful artifact.
+        lease: SessionEvalLease,
+    },
+}
+
+/// One-shot storage used by the BAML `CompileArtifact` wrapper.
+pub type RuntimeCompileArtifactSlot = Mutex<Option<RuntimeCompileArtifact>>;

--- a/baml_language/crates/bex_vm_types/src/types/package.rs
+++ b/baml_language/crates/bex_vm_types/src/types/package.rs
@@ -49,12 +49,55 @@ pub struct Package {
     /// Exact runtime type values attached by `Package.with_types`.
     #[borsh(skip)]
     pub mounted_types: IndexMap<String, HeapPtr>,
-    /// Present only for a package produced by `reflect.Package.compile`.
+    /// Runtime-only state, discriminated so a package cannot be both an
+    /// ordinary runtime package and a Session (or a Session without an image).
     #[borsh(skip)]
-    pub runtime: Option<Box<RuntimePackage>>,
-    /// Present only for the package-shaped payload owned by a Session.
-    #[borsh(skip)]
-    pub session: Option<Box<SessionState>>,
+    pub kind: PackageKind,
+}
+
+/// The three legal runtime shapes of a [`Package`].
+#[derive(Clone, Debug, Default)]
+pub enum PackageKind {
+    /// A package loaded from the serialized program image.
+    #[default]
+    Static,
+    /// A package produced by `reflect.Package.compile`.
+    Runtime(Box<RuntimePackage>),
+    /// The package-shaped runtime image and persistent state owned by a Session.
+    Session {
+        runtime: Box<RuntimePackage>,
+        state: Box<SessionState>,
+    },
+}
+
+impl Package {
+    pub fn runtime(&self) -> Option<&RuntimePackage> {
+        match &self.kind {
+            PackageKind::Static => None,
+            PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => Some(runtime),
+        }
+    }
+
+    pub fn runtime_mut(&mut self) -> Option<&mut RuntimePackage> {
+        match &mut self.kind {
+            PackageKind::Static => None,
+            PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => Some(runtime),
+        }
+    }
+
+    pub fn session(&self) -> Option<&SessionState> {
+        match &self.kind {
+            PackageKind::Session { state, .. } => Some(state),
+            PackageKind::Static | PackageKind::Runtime(_) => None,
+        }
+    }
+
+    pub fn session_mut(&mut self) -> Option<&mut SessionState> {
+        match &mut self.kind {
+            PackageKind::Session { state, .. } => Some(state),
+            PackageKind::Static | PackageKind::Runtime(_) => None,
+        }
+    }
 }
 
 /// Compiler-free persistent state of one `reflect.Session`.
@@ -103,7 +146,8 @@ pub struct RuntimePackage {
     pub dependency_names: IndexMap<String, HeapPtr>,
     /// The candidate `$init`, if one exists.
     pub init: Option<HeapPtr>,
-    /// False while `$init` may write package globals; true after commit.
+    /// False while `$init` may write package globals; true after commit. A
+    /// Session keeps this false because its globals remain mutable across evals.
     pub initialized: bool,
 }
 

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -34,7 +34,7 @@ impl io::IoClassReflectPackage for NativeSysOps {
         _files: indexmap::IndexMap<String, String>,
         _packages: indexmap::IndexMap<String, io::owned::reflect::Package>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         SysOpOutput::err(VmBamlError::Unsupported {
             message: "runtime compiler is not installed".to_string(),
         })
@@ -50,7 +50,7 @@ impl io::IoClassReflectSession for NativeSysOps {
         _source: String,
         _type_arg_0: ::sys_types::SapTy,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         SysOpOutput::err(VmBamlError::Unsupported {
             message: "runtime compiler is not installed".to_string(),
         })

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -985,7 +985,7 @@ impl io::IoClassReflectPackage for DefaultIoOps {
         _files: indexmap::IndexMap<String, String>,
         _packages: indexmap::IndexMap<String, io::owned::reflect::Package>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         // BexEngine intercepts this operation and delegates to its injected
         // RuntimeCompiler before the provider table is consulted.
         SysOpOutput::err(VmBamlError::Unsupported {
@@ -1003,7 +1003,7 @@ impl io::IoClassReflectSession for DefaultIoOps {
         _source: String,
         _type_arg_0: ::sys_types::SapTy,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         // BexEngine intercepts Session compilation for the same reason as
         // Package.compile: the concrete compiler is injected above sys_ops.
         SysOpOutput::err(VmBamlError::Unsupported {

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -1034,8 +1034,7 @@ pub fn build_output_format_content(
 ) -> self::OutputFormatContent {
     use std::collections::HashSet;
 
-    let mut names = OutputNames::default();
-    let mut content = self::OutputFormatContent::new(names.rename_ty(ty));
+    let mut content = self::OutputFormatContent::new(ty.clone());
     let mut visited = HashSet::new();
     let mut ancestry = Vec::new();
 
@@ -1046,7 +1045,6 @@ pub fn build_output_format_content(
         &mut content,
         &mut visited,
         &mut ancestry,
-        &mut names,
     ) {
         content.build_error = Some(error);
     }
@@ -1095,48 +1093,6 @@ enum OutputVisitKey {
 /// declaration identities the walk keys on.
 type LaneOrigins = baml_type::template::TyTemplateOrigins<::sys_types::DefKey>;
 
-#[derive(Default)]
-struct OutputNames {
-    by_head: IndexMap<::sys_types::DefKey, baml_type::Name>,
-    used: std::collections::HashSet<String>,
-    next_suffix: IndexMap<String, usize>,
-}
-
-impl OutputNames {
-    fn name(&mut self, head: &::sys_types::DefKey) -> baml_type::Name {
-        if let Some(name) = self.by_head.get(head) {
-            return name.clone();
-        }
-        let base = head.display_name().to_string();
-        let next = self.next_suffix.entry(base.clone()).or_insert(1);
-        let mut candidate = if *next == 1 {
-            base.clone()
-        } else {
-            format!("{base}_{next}")
-        };
-        while self.used.contains(&candidate) {
-            *next += 1;
-            candidate = format!("{base}_{next}");
-        }
-        *next += 1;
-        self.used.insert(candidate.clone());
-        let name = baml_type::Name::new(candidate);
-        self.by_head.insert(head.clone(), name.clone());
-        name
-    }
-
-    fn head(&mut self, head: &::sys_types::DefKey) -> ::sys_types::DefKey {
-        ::sys_types::DefKey::new(
-            head.tag(),
-            baml_type::DeclarationName::Anonymous(self.name(head)),
-        )
-    }
-
-    fn rename_ty(&mut self, ty: &SapTy) -> SapTy {
-        ty.map_heads(&mut |head| self.head(head))
-    }
-}
-
 struct ClassFrame {
     ty: SapTy,
     head: ::sys_types::DefKey,
@@ -1155,13 +1111,11 @@ fn walk_ty(
     content: &mut self::OutputFormatContent,
     visited: &mut std::collections::HashSet<OutputVisitKey>,
     ancestry: &mut Vec<ClassFrame>,
-    names: &mut OutputNames,
 ) -> Result<(), RenderError> {
     match ty {
         SapTy::Class(type_name, type_args, _) => {
-            let rendered_ty = names.rename_ty(ty);
-            let output_key = class_instantiation_key(&rendered_ty);
-            let output_name = names.name(type_name).to_string();
+            let output_key = class_instantiation_key(ty);
+            let output_name = type_name.display_name().to_string();
 
             // If this class is already on the ancestry stack, it's a recursive cycle.
             // Only mark classes from the cycle start, not unrelated ancestors.
@@ -1208,7 +1162,7 @@ fn walk_ty(
                     .map(|(field, field_type)| self::ClassField {
                         name: field.name.clone(),
                         alias: field.alias.clone(),
-                        field_type: names.rename_ty(field_type),
+                        field_type: field_type.clone(),
                         description: field.description.clone(),
                     })
                     .collect();
@@ -1241,15 +1195,7 @@ fn walk_ty(
                     } else {
                         LaneOrigins::opaque(ancestry.len())
                     };
-                    walk_ty(
-                        field_type,
-                        &field_origins,
-                        ctx,
-                        content,
-                        visited,
-                        ancestry,
-                        names,
-                    )?;
+                    walk_ty(field_type, &field_origins, ctx, content, visited, ancestry)?;
                 }
                 ancestry.pop();
             }
@@ -1260,7 +1206,7 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(enum_def) = find_enum_definition(ctx, type_name) {
-                let output_name = names.name(type_name).to_string();
+                let output_name = type_name.display_name().to_string();
                 // Skipped variants are already filtered out in bex_engine extraction.
                 let values: Vec<self::EnumValue> = enum_def
                     .variants
@@ -1299,60 +1245,28 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(target_ty) = find_type_alias_definition(ctx, type_name) {
-                let output_name = names.name(type_name).to_string();
+                let output_name = type_name.display_name().to_string();
                 content
                     .recursive_type_aliases
-                    .insert(output_name, names.rename_ty(target_ty));
+                    .insert(output_name, target_ty.clone());
                 let target_origins = LaneOrigins::opaque(ancestry.len());
-                walk_ty(
-                    target_ty,
-                    &target_origins,
-                    ctx,
-                    content,
-                    visited,
-                    ancestry,
-                    names,
-                )?;
+                walk_ty(target_ty, &target_origins, ctx, content, visited, ancestry)?;
             }
         }
         SapTy::List(inner, _) => {
             let inner_origins = origins.list_element();
-            walk_ty(
-                inner,
-                &inner_origins,
-                ctx,
-                content,
-                visited,
-                ancestry,
-                names,
-            )?;
+            walk_ty(inner, &inner_origins, ctx, content, visited, ancestry)?;
         }
         SapTy::Map { key, value, .. } => {
             let key_origins = origins.map_key();
             let value_origins = origins.map_value();
-            walk_ty(key, &key_origins, ctx, content, visited, ancestry, names)?;
-            walk_ty(
-                value,
-                &value_origins,
-                ctx,
-                content,
-                visited,
-                ancestry,
-                names,
-            )?;
+            walk_ty(key, &key_origins, ctx, content, visited, ancestry)?;
+            walk_ty(value, &value_origins, ctx, content, visited, ancestry)?;
         }
         SapTy::Union(members, _) => {
             for (index, member) in members.iter().enumerate() {
                 let member_origins = origins.union_member(index);
-                walk_ty(
-                    member,
-                    &member_origins,
-                    ctx,
-                    content,
-                    visited,
-                    ancestry,
-                    names,
-                )?;
+                walk_ty(member, &member_origins, ctx, content, visited, ancestry)?;
             }
         }
         _ => {}
@@ -1387,46 +1301,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn same_named_declarations_keep_distinct_output_schema_entries() {
-        let first = dynamic_key("Choice");
-        let second = dynamic_key("Choice");
-        let target = RuntimeTy::Union(
-            vec![
-                RuntimeTy::Class(first.clone(), Vec::new(), TyAttr::default()),
-                RuntimeTy::Class(second.clone(), Vec::new(), TyAttr::default()),
-            ],
-            TyAttr::default(),
-        );
-        let mut classes = indexmap::IndexMap::new();
-        classes.insert(
-            first.clone(),
-            ctx_class_definition(&first, vec![ctx_class_field("left", ty_string(), None)]),
-        );
-        classes.insert(
-            second.clone(),
-            ctx_class_definition(&second, vec![ctx_class_field("right", ty_int(), None)]),
-        );
-        let mut ctx = sys_types::SysOpContext::empty();
-        ctx.class_definitions = Arc::new(classes);
-
-        let content = build_output_format_content(&target, &ctx);
-        assert!(content.classes.contains_key("Choice"));
-        assert!(content.classes.contains_key("Choice_2"));
-        let rendered = content
-            .render(&RenderOptions {
-                hoist_classes: HoistClasses::All,
-                ..RenderOptions::default()
-            })
-            .unwrap()
-            .unwrap();
-        assert!(rendered.contains("Choice {"));
-        assert!(rendered.contains("Choice_2 {"));
-    }
-
-    #[test]
     fn duplicate_hoisted_enum_aliases_are_rejected() {
         let first = dynamic_key("Choice");
-        let second = dynamic_key("Choice");
+        let second = dynamic_key("Choice_2");
         let target = RuntimeTy::Union(
             vec![
                 RuntimeTy::Enum(first.clone(), TyAttr::default()),
@@ -1446,7 +1323,7 @@ mod tests {
         };
         let mut enums = indexmap::IndexMap::new();
         enums.insert(first, definition("Choice"));
-        enums.insert(second, definition("Choice"));
+        enums.insert(second, definition("Choice_2"));
         let mut ctx = sys_types::SysOpContext::empty();
         ctx.enum_definitions = Arc::new(enums);
 
@@ -1470,7 +1347,7 @@ mod tests {
     #[test]
     fn class_and_enum_hoisted_alias_collision_is_rejected() {
         let class_key = dynamic_key("Choice");
-        let enum_key = dynamic_key("Choice");
+        let enum_key = dynamic_key("Choice_2");
         let target = RuntimeTy::Union(
             vec![
                 RuntimeTy::Class(class_key.clone(), Vec::new(), TyAttr::default()),
@@ -1489,7 +1366,7 @@ mod tests {
         enums.insert(
             enum_key,
             sys_types::EnumDefinition {
-                name: "Choice".to_string(),
+                name: "Choice_2".to_string(),
                 description: None,
                 alias: Some("SharedChoice".to_string()),
                 variants: vec![sys_types::EnumVariantDefinition {

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -1010,7 +1010,8 @@ pub fn build_output_format_content(
 ) -> self::OutputFormatContent {
     use std::collections::HashSet;
 
-    let mut content = self::OutputFormatContent::new(ty.clone());
+    let mut names = OutputNames::default();
+    let mut content = self::OutputFormatContent::new(names.rename_ty(ty));
     let mut visited = HashSet::new();
     let mut ancestry = Vec::new();
 
@@ -1021,6 +1022,7 @@ pub fn build_output_format_content(
         &mut content,
         &mut visited,
         &mut ancestry,
+        &mut names,
     ) {
         content.build_error = Some(error);
     }
@@ -1069,6 +1071,48 @@ enum OutputVisitKey {
 /// declaration identities the walk keys on.
 type LaneOrigins = baml_type::template::TyTemplateOrigins<::sys_types::DefKey>;
 
+#[derive(Default)]
+struct OutputNames {
+    by_head: IndexMap<::sys_types::DefKey, baml_type::Name>,
+    used: std::collections::HashSet<String>,
+    next_suffix: IndexMap<String, usize>,
+}
+
+impl OutputNames {
+    fn name(&mut self, head: &::sys_types::DefKey) -> baml_type::Name {
+        if let Some(name) = self.by_head.get(head) {
+            return name.clone();
+        }
+        let base = head.display_name().to_string();
+        let next = self.next_suffix.entry(base.clone()).or_insert(1);
+        let mut candidate = if *next == 1 {
+            base.clone()
+        } else {
+            format!("{base}_{next}")
+        };
+        while self.used.contains(&candidate) {
+            *next += 1;
+            candidate = format!("{base}_{next}");
+        }
+        *next += 1;
+        self.used.insert(candidate.clone());
+        let name = baml_type::Name::new(candidate);
+        self.by_head.insert(head.clone(), name.clone());
+        name
+    }
+
+    fn head(&mut self, head: &::sys_types::DefKey) -> ::sys_types::DefKey {
+        ::sys_types::DefKey::new(
+            head.tag(),
+            baml_type::DeclarationName::Anonymous(self.name(head)),
+        )
+    }
+
+    fn rename_ty(&mut self, ty: &SapTy) -> SapTy {
+        ty.map_heads(&mut |head| self.head(head))
+    }
+}
+
 struct ClassFrame {
     ty: SapTy,
     head: ::sys_types::DefKey,
@@ -1087,10 +1131,13 @@ fn walk_ty(
     content: &mut self::OutputFormatContent,
     visited: &mut std::collections::HashSet<OutputVisitKey>,
     ancestry: &mut Vec<ClassFrame>,
+    names: &mut OutputNames,
 ) -> Result<(), RenderError> {
     match ty {
         SapTy::Class(type_name, type_args, _) => {
-            let output_key = class_instantiation_key(ty);
+            let rendered_ty = names.rename_ty(ty);
+            let output_key = class_instantiation_key(&rendered_ty);
+            let output_name = names.name(type_name).to_string();
 
             // If this class is already on the ancestry stack, it's a recursive cycle.
             // Only mark classes from the cycle start, not unrelated ancestors.
@@ -1106,7 +1153,7 @@ fn walk_ty(
                     && origins.class_transform_expands(index, type_name, ancestor.arity)
                 {
                     return Err(RenderError::NonRegularRecursiveGeneric {
-                        class: type_name.display_name().to_string(),
+                        class: output_name,
                         ancestor: ancestor.output_name.clone(),
                         instantiation: output_key,
                     });
@@ -1137,7 +1184,7 @@ fn walk_ty(
                     .map(|(field, field_type)| self::ClassField {
                         name: field.name.clone(),
                         alias: field.alias.clone(),
-                        field_type: field_type.clone(),
+                        field_type: names.rename_ty(field_type),
                         description: field.description.clone(),
                     })
                     .collect();
@@ -1145,7 +1192,7 @@ fn walk_ty(
                 content.classes.insert(
                     output_key.clone(),
                     self::Class {
-                        name: type_name.display_name().to_string(),
+                        name: output_name,
                         alias: class_def.alias.clone(),
                         description: class_def.description.clone(),
                         fields,
@@ -1170,7 +1217,15 @@ fn walk_ty(
                     } else {
                         LaneOrigins::opaque(ancestry.len())
                     };
-                    walk_ty(field_type, &field_origins, ctx, content, visited, ancestry)?;
+                    walk_ty(
+                        field_type,
+                        &field_origins,
+                        ctx,
+                        content,
+                        visited,
+                        ancestry,
+                        names,
+                    )?;
                 }
                 ancestry.pop();
             }
@@ -1181,6 +1236,7 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(enum_def) = find_enum_definition(ctx, type_name) {
+                let output_name = names.name(type_name).to_string();
                 // Skipped variants are already filtered out in bex_engine extraction.
                 let values: Vec<self::EnumValue> = enum_def
                     .variants
@@ -1193,9 +1249,9 @@ fn walk_ty(
                     .collect();
 
                 content.enums.insert(
-                    type_name.display_name().to_string(),
+                    output_name.clone(),
                     self::Enum {
-                        name: type_name.display_name().to_string(),
+                        name: output_name,
                         alias: enum_def.alias.clone(),
                         description: enum_def.description.clone(),
                         values,
@@ -1219,27 +1275,60 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(target_ty) = find_type_alias_definition(ctx, type_name) {
+                let output_name = names.name(type_name).to_string();
                 content
                     .recursive_type_aliases
-                    .insert(type_name.display_name().to_string(), target_ty.clone());
+                    .insert(output_name, names.rename_ty(target_ty));
                 let target_origins = LaneOrigins::opaque(ancestry.len());
-                walk_ty(target_ty, &target_origins, ctx, content, visited, ancestry)?;
+                walk_ty(
+                    target_ty,
+                    &target_origins,
+                    ctx,
+                    content,
+                    visited,
+                    ancestry,
+                    names,
+                )?;
             }
         }
         SapTy::List(inner, _) => {
             let inner_origins = origins.list_element();
-            walk_ty(inner, &inner_origins, ctx, content, visited, ancestry)?;
+            walk_ty(
+                inner,
+                &inner_origins,
+                ctx,
+                content,
+                visited,
+                ancestry,
+                names,
+            )?;
         }
         SapTy::Map { key, value, .. } => {
             let key_origins = origins.map_key();
             let value_origins = origins.map_value();
-            walk_ty(key, &key_origins, ctx, content, visited, ancestry)?;
-            walk_ty(value, &value_origins, ctx, content, visited, ancestry)?;
+            walk_ty(key, &key_origins, ctx, content, visited, ancestry, names)?;
+            walk_ty(
+                value,
+                &value_origins,
+                ctx,
+                content,
+                visited,
+                ancestry,
+                names,
+            )?;
         }
         SapTy::Union(members, _) => {
             for (index, member) in members.iter().enumerate() {
                 let member_origins = origins.union_member(index);
-                walk_ty(member, &member_origins, ctx, content, visited, ancestry)?;
+                walk_ty(
+                    member,
+                    &member_origins,
+                    ctx,
+                    content,
+                    visited,
+                    ancestry,
+                    names,
+                )?;
             }
         }
         _ => {}
@@ -1264,7 +1353,51 @@ mod tests {
         )
     }
 
+    fn dynamic_key(name: &str) -> DefKey {
+        DefKey::new(
+            baml_type::typetag::TypeTag::fresh_dynamic(),
+            DeclarationName::Anonymous(baml_type::Name::new(name)),
+        )
+    }
+
     use super::*;
+
+    #[test]
+    fn same_named_declarations_keep_distinct_output_schema_entries() {
+        let first = dynamic_key("Choice");
+        let second = dynamic_key("Choice");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::Class(first.clone(), Vec::new(), TyAttr::default()),
+                RuntimeTy::Class(second.clone(), Vec::new(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut classes = indexmap::IndexMap::new();
+        classes.insert(
+            first.clone(),
+            ctx_class_definition(&first, vec![ctx_class_field("left", ty_string(), None)]),
+        );
+        classes.insert(
+            second.clone(),
+            ctx_class_definition(&second, vec![ctx_class_field("right", ty_int(), None)]),
+        );
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.class_definitions = Arc::new(classes);
+
+        let content = build_output_format_content(&target, &ctx);
+        assert!(content.classes.contains_key("Choice"));
+        assert!(content.classes.contains_key("Choice_2"));
+        let rendered = content
+            .render(&RenderOptions {
+                hoist_classes: HoistClasses::All,
+                ..RenderOptions::default()
+            })
+            .unwrap()
+            .unwrap();
+        assert!(rendered.contains("Choice {"));
+        assert!(rendered.contains("Choice_2 {"));
+    }
 
     // -------------------------------------------------------------------------
     // Phase 3: json alias sentinel

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -30,6 +30,12 @@ pub enum RenderError {
         first: String,
         second: String,
     },
+    #[error("Enums '{first}' and '{second}' both render as '{rendered_name}' in the output schema")]
+    RenderedEnumNameCollision {
+        rendered_name: String,
+        first: String,
+        second: String,
+    },
 }
 
 /// A value within an enum definition for output format rendering.
@@ -152,6 +158,7 @@ impl OutputFormatContent {
         let hoisted_classes = self.compute_hoisted_classes(options);
         let hoisted_enums = self.compute_hoisted_enums(options);
         self.validate_hoisted_class_names(&hoisted_classes)?;
+        self.validate_hoisted_enum_names(&hoisted_enums)?;
 
         let prefix = self.get_prefix(options, &hoisted_classes);
 
@@ -380,6 +387,31 @@ impl OutputFormatContent {
             if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
                 if first != definition_key {
                     return Err(RenderError::RenderedClassNameCollision {
+                        rendered_name,
+                        first: first.clone(),
+                        second: definition_key.clone(),
+                    });
+                }
+            } else {
+                definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_hoisted_enum_names(
+        &self,
+        hoisted: &indexmap::IndexSet<String>,
+    ) -> Result<(), RenderError> {
+        let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
+        for definition_key in hoisted {
+            let Some(enm) = self.find_enum(definition_key) else {
+                continue;
+            };
+            let rendered_name = rendered_name(&enm.name, enm.alias.as_ref()).to_string();
+            if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
+                if first != definition_key {
+                    return Err(RenderError::RenderedEnumNameCollision {
                         rendered_name,
                         first: first.clone(),
                         second: definition_key.clone(),
@@ -1397,6 +1429,50 @@ mod tests {
             .unwrap();
         assert!(rendered.contains("Choice {"));
         assert!(rendered.contains("Choice_2 {"));
+    }
+
+    #[test]
+    fn duplicate_hoisted_enum_aliases_are_rejected() {
+        let first = dynamic_key("Choice");
+        let second = dynamic_key("Choice");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::Enum(first.clone(), TyAttr::default()),
+                RuntimeTy::Enum(second.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let definition = |name: &str| sys_types::EnumDefinition {
+            name: name.to_string(),
+            description: None,
+            alias: Some("SharedChoice".to_string()),
+            variants: vec![sys_types::EnumVariantDefinition {
+                name: "Value".to_string(),
+                description: None,
+                alias: None,
+            }],
+        };
+        let mut enums = indexmap::IndexMap::new();
+        enums.insert(first, definition("Choice"));
+        enums.insert(second, definition("Choice"));
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.enum_definitions = Arc::new(enums);
+
+        let content = build_output_format_content(&target, &ctx);
+        let error = content
+            .render(&RenderOptions {
+                always_hoist_enums: RenderSetting::Always(true),
+                ..RenderOptions::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedEnumNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedChoice" && first == "Choice" && second == "Choice_2"
+        ));
     }
 
     // -------------------------------------------------------------------------

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -23,7 +23,7 @@ pub enum RenderError {
         instantiation: String,
     },
     #[error(
-        "Classes '{first}' and '{second}' both render as '{rendered_name}' in the output schema"
+        "Output definitions '{first}' and '{second}' both render as '{rendered_name}' in the output schema"
     )]
     RenderedClassNameCollision {
         rendered_name: String,
@@ -380,23 +380,24 @@ impl OutputFormatContent {
         hoisted_classes: &indexmap::IndexSet<String>,
         hoisted_enums: &indexmap::IndexSet<String>,
     ) -> Result<(), RenderError> {
-        let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
+        let mut definitions_by_rendered_name = self
+            .recursive_type_aliases
+            .keys()
+            .map(|name| (name.clone(), name.clone()))
+            .collect::<IndexMap<String, String>>();
         for definition_key in hoisted_classes {
             let Some(cls) = self.find_class(definition_key) else {
                 continue;
             };
             let rendered_name = rendered_hoisted_definition_name(definition_key, cls);
             if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
-                if first != definition_key {
-                    return Err(RenderError::RenderedClassNameCollision {
-                        rendered_name,
-                        first: first.clone(),
-                        second: definition_key.clone(),
-                    });
-                }
-            } else {
-                definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
+                return Err(RenderError::RenderedClassNameCollision {
+                    rendered_name,
+                    first: first.clone(),
+                    second: definition_key.clone(),
+                });
             }
+            definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
         }
         for definition_key in hoisted_enums {
             let Some(enm) = self.find_enum(definition_key) else {
@@ -404,16 +405,13 @@ impl OutputFormatContent {
             };
             let rendered_name = rendered_name(&enm.name, enm.alias.as_ref()).to_string();
             if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
-                if first != definition_key {
-                    return Err(RenderError::RenderedEnumNameCollision {
-                        rendered_name,
-                        first: first.clone(),
-                        second: definition_key.clone(),
-                    });
-                }
-            } else {
-                definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
+                return Err(RenderError::RenderedEnumNameCollision {
+                    rendered_name,
+                    first: first.clone(),
+                    second: definition_key.clone(),
+                });
             }
+            definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
         }
         Ok(())
     }
@@ -1520,6 +1518,31 @@ mod tests {
                 first,
                 second,
             } if rendered_name == "SharedChoice" && first == "Choice" && second == "Choice_2"
+        ));
+    }
+
+    #[test]
+    fn type_alias_and_hoisted_class_alias_collision_is_rejected() {
+        let mut class = mk_class("Choice", vec![("value", ty_string())]);
+        class.alias = Some("SharedChoice".to_string());
+        let mut content = OutputFormatContent::new(ty_class("Choice")).with_class(class);
+        content
+            .recursive_type_aliases
+            .insert("SharedChoice".to_string(), ty_string());
+
+        let error = content
+            .render(&RenderOptions {
+                hoist_classes: HoistClasses::All,
+                ..RenderOptions::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedClassNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedChoice" && first == "SharedChoice" && second == "Choice"
         ));
     }
 

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -38,6 +38,14 @@ pub enum RenderError {
         first: String,
         second: String,
     },
+    #[error(
+        "Type alias definitions for '{rendered_name}' have non-equivalent targets '{first}' and '{second}'"
+    )]
+    RenderedTypeAliasNameCollision {
+        rendered_name: String,
+        first: String,
+        second: String,
+    },
 }
 
 /// A value within an enum definition for output format rendering.
@@ -1246,9 +1254,19 @@ fn walk_ty(
             }
             if let Some(target_ty) = find_type_alias_definition(ctx, type_name) {
                 let output_name = type_name.display_name().to_string();
-                content
-                    .recursive_type_aliases
-                    .insert(output_name, target_ty.clone());
+                if let Some(first) = content.recursive_type_aliases.get(&output_name) {
+                    if first != target_ty {
+                        return Err(RenderError::RenderedTypeAliasNameCollision {
+                            rendered_name: output_name,
+                            first: first.to_string(),
+                            second: target_ty.to_string(),
+                        });
+                    }
+                } else {
+                    content
+                        .recursive_type_aliases
+                        .insert(output_name, target_ty.clone());
+                }
                 let target_origins = LaneOrigins::opaque(ancestry.len());
                 walk_ty(target_ty, &target_origins, ctx, content, visited, ancestry)?;
             }
@@ -1421,6 +1439,58 @@ mod tests {
                 second,
             } if rendered_name == "SharedChoice" && first == "SharedChoice" && second == "Choice"
         ));
+    }
+
+    #[test]
+    fn same_name_type_aliases_with_different_targets_are_rejected() {
+        let first = dynamic_key("SharedAlias");
+        let second = dynamic_key("SharedAlias");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::TypeAlias(first.clone(), TyAttr::default()),
+                RuntimeTy::TypeAlias(second.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut aliases = indexmap::IndexMap::new();
+        aliases.insert(first, ty_string());
+        aliases.insert(second, ty_int());
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.type_alias_definitions = Arc::new(aliases);
+
+        let error = build_output_format_content(&target, &ctx)
+            .render(&RenderOptions::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedTypeAliasNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedAlias" && first == "string" && second == "int"
+        ));
+    }
+
+    #[test]
+    fn same_name_type_aliases_with_equivalent_targets_fold_once() {
+        let first = dynamic_key("SharedAlias");
+        let second = dynamic_key("SharedAlias");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::TypeAlias(first.clone(), TyAttr::default()),
+                RuntimeTy::TypeAlias(second.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut aliases = indexmap::IndexMap::new();
+        aliases.insert(first, ty_string());
+        aliases.insert(second, ty_string());
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.type_alias_definitions = Arc::new(aliases);
+
+        let content = build_output_format_content(&target, &ctx);
+        assert_eq!(content.recursive_type_aliases.len(), 1);
+        assert!(content.render(&RenderOptions::default()).is_ok());
     }
 
     // -------------------------------------------------------------------------

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -30,7 +30,9 @@ pub enum RenderError {
         first: String,
         second: String,
     },
-    #[error("Enums '{first}' and '{second}' both render as '{rendered_name}' in the output schema")]
+    #[error(
+        "Output definitions '{first}' and '{second}' both render as '{rendered_name}' in the output schema"
+    )]
     RenderedEnumNameCollision {
         rendered_name: String,
         first: String,
@@ -157,8 +159,7 @@ impl OutputFormatContent {
         // Compute which classes and enums to hoist
         let hoisted_classes = self.compute_hoisted_classes(options);
         let hoisted_enums = self.compute_hoisted_enums(options);
-        self.validate_hoisted_class_names(&hoisted_classes)?;
-        self.validate_hoisted_enum_names(&hoisted_enums)?;
+        self.validate_hoisted_definition_names(&hoisted_classes, &hoisted_enums)?;
 
         let prefix = self.get_prefix(options, &hoisted_classes);
 
@@ -374,12 +375,13 @@ impl OutputFormatContent {
         hoisted
     }
 
-    fn validate_hoisted_class_names(
+    fn validate_hoisted_definition_names(
         &self,
-        hoisted: &indexmap::IndexSet<String>,
+        hoisted_classes: &indexmap::IndexSet<String>,
+        hoisted_enums: &indexmap::IndexSet<String>,
     ) -> Result<(), RenderError> {
         let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
-        for definition_key in hoisted {
+        for definition_key in hoisted_classes {
             let Some(cls) = self.find_class(definition_key) else {
                 continue;
             };
@@ -396,15 +398,7 @@ impl OutputFormatContent {
                 definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
             }
         }
-        Ok(())
-    }
-
-    fn validate_hoisted_enum_names(
-        &self,
-        hoisted: &indexmap::IndexSet<String>,
-    ) -> Result<(), RenderError> {
-        let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
-        for definition_key in hoisted {
+        for definition_key in hoisted_enums {
             let Some(enm) = self.find_enum(definition_key) else {
                 continue;
             };
@@ -1461,6 +1455,60 @@ mod tests {
         let content = build_output_format_content(&target, &ctx);
         let error = content
             .render(&RenderOptions {
+                always_hoist_enums: RenderSetting::Always(true),
+                ..RenderOptions::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedEnumNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedChoice" && first == "Choice" && second == "Choice_2"
+        ));
+    }
+
+    #[test]
+    fn class_and_enum_hoisted_alias_collision_is_rejected() {
+        let class_key = dynamic_key("Choice");
+        let enum_key = dynamic_key("Choice");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::Class(class_key.clone(), Vec::new(), TyAttr::default()),
+                RuntimeTy::Enum(enum_key.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut class = ctx_class_definition(
+            &class_key,
+            vec![ctx_class_field("value", ty_string(), None)],
+        );
+        class.alias = Some("SharedChoice".to_string());
+        let mut classes = indexmap::IndexMap::new();
+        classes.insert(class_key, class);
+        let mut enums = indexmap::IndexMap::new();
+        enums.insert(
+            enum_key,
+            sys_types::EnumDefinition {
+                name: "Choice".to_string(),
+                description: None,
+                alias: Some("SharedChoice".to_string()),
+                variants: vec![sys_types::EnumVariantDefinition {
+                    name: "Value".to_string(),
+                    description: None,
+                    alias: None,
+                }],
+            },
+        );
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.class_definitions = Arc::new(classes);
+        ctx.enum_definitions = Arc::new(enums);
+
+        let content = build_output_format_content(&target, &ctx);
+        let error = content
+            .render(&RenderOptions {
+                hoist_classes: HoistClasses::All,
                 always_hoist_enums: RenderSetting::Always(true),
                 ..RenderOptions::default()
             })


### PR DESCRIPTION
`unreflect(expr)` now parses as a type atom in any type position. Nested occurrences lower to scoped runtime type bindings, while item-signature occurrences report E0168 because no body scope can own them.

Before:

```baml
type T = unreflect(t)
Extract<Wrapper<T>>(doc)
```

After:

```baml
Extract<Wrapper<unreflect(t)>>(doc)
```

B-1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using `unreflect(...)` runtime types within nested type expressions, including generics, unions, patterns, annotations, and match expressions.
  * Runtime-created types now retain their bindings through compilation and rendering.
  * Formatting and type displays now preserve and show nested runtime type syntax.

* **Bug Fixes**
  * Improved validation and diagnostics when runtime types are used outside executable scope.
  * Corrected handling of nested runtime types and single-evaluation patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->