### PR TITLE
Preserve runtime type identity across reflection seams

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/reflect/reflect.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/reflect/reflect.baml
@@ -187,6 +187,11 @@ class InvalidArgumentError {
   got reflect.Type
 }
 
+/// One-shot compiler output consumed by Package._finish or Session._finish.
+class CompileArtifact {
+  _inner unknown
+}
+
 /// An isolated runtime-compiled package.
 class Package {
   _inner unknown
@@ -201,13 +206,13 @@ class Package {
     Package._finish(artifact, packages)
   }
 
-  function _compile(files: map<string, string>, packages: map<string, Package>) -> Package throws reflect.errors.CompilationError {
+  function _compile(files: map<string, string>, packages: map<string, Package>) -> CompileArtifact throws reflect.errors.CompilationError {
     $rust_io_function
   }
 
   //baml:mut_vm
   //baml:may_yield
-  function _finish(artifact: Package, packages: map<string, Package>) -> Package throws unknown {
+  function _finish(artifact: CompileArtifact, packages: map<string, Package>) -> Package throws unknown {
     $rust_function
   }
 
@@ -297,13 +302,13 @@ class Session {
     }
   }
 
-  function _compile<T>(self, source: string) -> Package throws reflect.errors.CompilationError | reflect.errors.SessionBusy {
+  function _compile<T>(self, source: string) -> CompileArtifact throws reflect.errors.CompilationError | reflect.errors.SessionBusy {
     $rust_io_function
   }
 
   //baml:mut_vm
   //baml:may_yield
-  function _finish<T>(self, artifact: Package) -> T throws unknown {
+  function _finish<T>(self, artifact: CompileArtifact) -> T throws unknown {
     $rust_function
   }
 

--- a/baml_language/crates/baml_builtins2/baml_std/reflect/type.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/reflect/type.baml
@@ -31,8 +31,9 @@ class Type {
     function optional(self) -> reflect.union.Type throws never { $rust_function }
 
     /// Render deterministic canonical BAML source for this definition.
-    //baml:vm
-    function to_baml(self) -> string throws never { $rust_function }
+    /// Non-equivalent declarations with the same display name are rejected.
+    //baml:mut_vm
+    function to_baml(self) -> string throws reflect.errors.CompilationError { $rust_function }
 
     /// Returns the precise kind view of this type value: a freshly
     /// allocated view instance wrapping the receiver in its `_ty` field.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_reflect_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_reflect_package_listing.snap
@@ -13,10 +13,11 @@ interface        reflect.AnyFunction              <builtin>/reflect/reflect.baml
 interface        reflect.AnyClass                 <builtin>/reflect/reflect.baml:73
 class            reflect.Signature                <builtin>/reflect/reflect.baml:162
 class            reflect.InvalidArgumentError     <builtin>/reflect/reflect.baml:184
-class            reflect.Package                  <builtin>/reflect/reflect.baml:191
-class            reflect.Session                  <builtin>/reflect/reflect.baml:281
-function         reflect.signature                <builtin>/reflect/reflect.baml:323
-function         reflect.call_any                 <builtin>/reflect/reflect.baml:339
+class            reflect.CompileArtifact          <builtin>/reflect/reflect.baml:191
+class            reflect.Package                  <builtin>/reflect/reflect.baml:196
+class            reflect.Session                  <builtin>/reflect/reflect.baml:286
+function         reflect.signature                <builtin>/reflect/reflect.baml:328
+function         reflect.call_any                 <builtin>/reflect/reflect.baml:344
 class            reflect.Type                     <builtin>/reflect/type.baml:8
 class            reflect.array.Type               <builtin>/reflect/ns_array/array.baml:2
 class            reflect.class.Field              <builtin>/reflect/ns_class/class.baml:1

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6817,7 +6817,7 @@ impl<'db> LoweringContext<'db> {
                 self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
             {
                 debug_assert!(
-                    self.class_fields.contains_key(&tn),
+                    self.is_interface_type_name(&tn) || self.class_fields.contains_key(&tn),
                     "MIR field-access lowering has no class_fields row for `{tn}`"
                 );
                 if let Some(fields) = self.class_fields.get(&tn) {
@@ -11100,7 +11100,7 @@ impl<'db> LoweringContext<'db> {
         // Look up field index from class_fields
         let field_idx = if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
             debug_assert!(
-                self.class_fields.contains_key(tn),
+                self.is_interface_type_name(tn) || self.class_fields.contains_key(tn),
                 "MIR field-access lowering has no class_fields row for `{tn}`"
             );
             self.class_fields
@@ -13109,7 +13109,7 @@ impl LoweringContext<'_> {
                         self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
                     {
                         debug_assert!(
-                            self.class_fields.contains_key(&tn),
+                            self.is_interface_type_name(&tn) || self.class_fields.contains_key(&tn),
                             "MIR field-access lowering has no class_fields row for `{tn}`"
                         );
                         if let Some(fields) = self.class_fields.get(&tn) {
@@ -13248,7 +13248,7 @@ impl LoweringContext<'_> {
                 let unwrapped_ty = base_ty.strip_null();
                 if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
                     debug_assert!(
-                        self.class_fields.contains_key(tn),
+                        self.is_interface_type_name(tn) || self.class_fields.contains_key(tn),
                         "MIR field-access lowering has no class_fields row for `{tn}`"
                     );
                     if let Some(fields) = self.class_fields.get(tn) {

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -6816,6 +6816,10 @@ impl<'db> LoweringContext<'db> {
             if let Some((tn, class_type_args)) =
                 self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
             {
+                debug_assert!(
+                    self.class_fields.contains_key(&tn),
+                    "MIR field-access lowering has no class_fields row for `{tn}`"
+                );
                 if let Some(fields) = self.class_fields.get(&tn) {
                     if let Some(&idx) = fields.get(seg.as_str()) {
                         // Substitute the receiver's class type-args into the
@@ -11095,6 +11099,10 @@ impl<'db> LoweringContext<'db> {
 
         // Look up field index from class_fields
         let field_idx = if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
+            debug_assert!(
+                self.class_fields.contains_key(tn),
+                "MIR field-access lowering has no class_fields row for `{tn}`"
+            );
             self.class_fields
                 .get(tn)
                 .and_then(|fields| fields.get(&field_str))
@@ -13100,6 +13108,10 @@ impl LoweringContext<'_> {
                     if let Some((tn, class_type_args)) =
                         self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
                     {
+                        debug_assert!(
+                            self.class_fields.contains_key(&tn),
+                            "MIR field-access lowering has no class_fields row for `{tn}`"
+                        );
                         if let Some(fields) = self.class_fields.get(&tn) {
                             if let Some(&idx) = fields.get(seg.as_str()) {
                                 let next_ty = self.class_field_ty(&tn, seg, &class_type_args);
@@ -13235,6 +13247,10 @@ impl LoweringContext<'_> {
                 // Unwrap Optional — we've already null-checked, so use the inner type.
                 let unwrapped_ty = base_ty.strip_null();
                 if let RuntimeTy::Class(tn, _, _) = &unwrapped_ty {
+                    debug_assert!(
+                        self.class_fields.contains_key(tn),
+                        "MIR field-access lowering has no class_fields row for `{tn}`"
+                    );
                     if let Some(fields) = self.class_fields.get(tn) {
                         if let Some(&idx) = fields.get(member_name.as_str()) {
                             return Place::Field {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
@@ -249,10 +249,10 @@ function reflect.AnyClass.type(self: reflect.AnyClass) -> reflect.Type {
     return
 }
 
-function reflect.Package._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.Package {
+function reflect.Package._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.CompileArtifact {
 }
 
-function reflect.Package._finish(artifact: reflect.Package, packages: map<string, reflect.Package>) -> reflect.Package {
+function reflect.Package._finish(artifact: reflect.CompileArtifact, packages: map<string, reflect.Package>) -> reflect.Package {
 }
 
 function reflect.Package.classes(self: reflect.Package) -> map<string, reflect.class.Type> {
@@ -306,10 +306,10 @@ function reflect.Package.tests(self: reflect.Package) -> map<string, () -> null 
 function reflect.Package.with_types(self: reflect.Package, types: map<string, reflect.Type | reflect.TypeView>) -> reflect.Package {
 }
 
-function reflect.Session._compile(self: reflect.Session, source: string) -> reflect.Package {
+function reflect.Session._compile(self: reflect.Session, source: string) -> reflect.CompileArtifact {
 }
 
-function reflect.Session._finish(self: reflect.Session, artifact: reflect.Package) -> #0 {
+function reflect.Session._finish(self: reflect.Session, artifact: reflect.CompileArtifact) -> #0 {
 }
 
 function reflect.Session._new(packages: map<string, reflect.Package>) -> reflect.Session {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
@@ -590,8 +590,8 @@ fn reflect.Package.compile(files: map<string, string>, packages: map<string, ref
     let _1: map<string, string> // files // param
     let _2: map<string, reflect.Package> // packages // param
     let _3: bool
-    let _4: reflect.Package // artifact
-    let _5: reflect.Package
+    let _4: reflect.CompileArtifact // artifact
+    let _5: reflect.CompileArtifact
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -675,10 +675,10 @@ fn reflect.Session.eval(self: reflect.Session, source: string) -> T {
     let _0: T // _0 // return
     let _1: reflect.Session // self // param
     let _2: string // source // param
-    let _3: reflect.Package // artifact
+    let _3: reflect.CompileArtifact // artifact
     let _4: reflect.Type
     let _5: unknown // _
-    let _6: reflect.Package
+    let _6: reflect.CompileArtifact
     let _7: reflect.Type
     let _8: reflect.errors.EvaluationError
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/ppir.snap
@@ -221,6 +221,12 @@ class reflect.Arg$stream {
   name: string | null
   type: unknown
 }
+class reflect.CompileArtifact {
+  _inner: unknown
+}
+class reflect.CompileArtifact$stream {
+  _inner: unknown
+}
 class reflect.Diagnostic {
   code: string
   span: reflect.Span?
@@ -307,10 +313,10 @@ class reflect.WithMeta$stream {
 }
 type reflect.TypeKind = reflect.class.Type | reflect.enum.Type | reflect.union.Type | reflect.literal.Type | reflect.array.Type | reflect.map.Type | reflect.interface.Type | reflect.primitive.Type | reflect.function.Type
 type reflect.TypeKind$stream = reflect.class.Type$stream | reflect.enum.Type$stream | reflect.union.Type$stream | reflect.literal.Type$stream | reflect.array.Type$stream | reflect.map.Type$stream | reflect.interface.Type$stream | reflect.primitive.Type$stream | reflect.function.Type$stream
-function reflect._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
-function reflect._compile(self: ?, source: string) -> reflect.Package  [builtin]
-function reflect._finish(artifact: reflect.Package, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
-function reflect._finish(self: ?, artifact: reflect.Package) -> T  [builtin]
+function reflect._compile(files: map<string, string>, packages: map<string, reflect.Package>) -> reflect.CompileArtifact  [builtin]
+function reflect._compile(self: ?, source: string) -> reflect.CompileArtifact  [builtin]
+function reflect._finish(artifact: reflect.CompileArtifact, packages: map<string, reflect.Package>) -> reflect.Package  [builtin]
+function reflect._finish(self: ?, artifact: reflect.CompileArtifact) -> T  [builtin]
 function reflect._new(packages: map<string, reflect.Package>) -> reflect.Session  [builtin]
 function reflect.as_type(self: ?) -> reflect.Type  [missing]
 function reflect.attributes(self: ?) -> reflect.Meta  [expr] {

--- a/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
@@ -15,7 +15,7 @@ client TestClient = openai.ResponsesClient.new(
 
 function Extract<T>() -> T {
   client: TestClient
-  prompt: `${ctx.output_format}`
+  prompt: `${ctx.output_format()}`
 }
 
 function Check<T>(expected: reflect.Type, document: string) -> bool throws unknown {
@@ -32,20 +32,20 @@ class StaticInner {
 
 function main() -> bool throws unknown {
   let inner = reflect.class.new("Inner", { "x": reflect.Type.of<string>() })
-  let inner_array = inner.as_type().array()
+  let inner_array = inner.as_type().array().as_type()
   let holder_array = reflect.class.new("HolderArray", { "bs": inner_array }).as_type()
   let holder_map = reflect.class.new("HolderMap", {
     "by_name": reflect.map.new(reflect.Type.of<string>(), inner.as_type()).as_type(),
   }).as_type()
   let minted_enum = reflect.enum.new("MintedState", ["Ready", "Done"])
-  let enum_array = minted_enum.as_type().array()
+  let enum_array = minted_enum.as_type().array().as_type()
 
   let compiled_package = reflect.Package.compile({
     "compiled.baml": "class CompiledInner { x string }",
   })
   let compiled_inner = compiled_package.get_class("root.CompiledInner")
     ?? throw "missing CompiledInner"
-  let compiled_array = compiled_inner.as_type().array()
+  let compiled_array = compiled_inner.as_type().array().as_type()
   let compiled_holder_array = reflect.class.new("CompiledHolderArray", {
     "bs": compiled_array,
   }).as_type()
@@ -58,35 +58,35 @@ function main() -> bool throws unknown {
 
   let array_ok = {
     type T = unreflect(holder_array)
-    Check<T>(holder_array, #"{"bs":[{"x":"one"}]}"#)
+    Check<T>(holder_array, `{"bs":[{"x":"one"}]}`)
   }
   let empty_array_ok = {
     type T = unreflect(holder_array)
-    Check<T>(holder_array, #"{"bs":[]}"#)
+    Check<T>(holder_array, `{"bs":[]}`)
   }
   let map_ok = {
     type T = unreflect(holder_map)
-    Check<T>(holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+    Check<T>(holder_map, `{"by_name":{"one":{"x":"one"}}}`)
   }
   let enum_ok = {
     type T = unreflect(enum_array)
-    Check<T>(enum_array, #"["Ready","Done"]"#)
+    Check<T>(enum_array, `["Ready","Done"]`)
   }
   let top_level_array_ok = {
     type T = unreflect(inner_array)
-    Check<T>(inner_array, #"[{"x":"one"}]"#)
+    Check<T>(inner_array, `[{"x":"one"}]`)
   }
   let compiled_array_ok = {
     type T = unreflect(compiled_holder_array)
-    Check<T>(compiled_holder_array, #"{"bs":[{"x":"one"}]}"#)
+    Check<T>(compiled_holder_array, `{"bs":[{"x":"one"}]}`)
   }
   let compiled_map_ok = {
     type T = unreflect(compiled_holder_map)
-    Check<T>(compiled_holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+    Check<T>(compiled_holder_map, `{"by_name":{"one":{"x":"one"}}}`)
   }
   let static_control_ok = {
     type T = unreflect(static_holder)
-    Check<T>(static_holder, #"{"bs":[{"x":"one"}]}"#)
+    Check<T>(static_holder, `{"bs":[{"x":"one"}]}`)
   }
 
   array_ok && empty_array_ok && map_ok && enum_ok && top_level_array_ok

--- a/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_identity_seams.rs
@@ -1,0 +1,99 @@
+//! B-1605 bug 9: every inbound type-bearing value arm must resolve through
+//! the call-local runtime declaration overlay, including empty containers.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn runtime_declarations_anchor_through_every_container_seam() {
+    let output = baml_test!(
+        r###"
+client TestClient = openai.ResponsesClient.new(
+  model = "unused",
+  api_key = "unused",
+)
+
+function Extract<T>() -> T {
+  client: TestClient
+  prompt: `${ctx.output_format}`
+}
+
+function Check<T>(expected: reflect.Type, document: string) -> bool throws unknown {
+  let direct = baml.sap.parse<T>(document)
+  let companion = Extract$parse<T>(document)
+  reflect.Type.of_value(direct) == expected
+    && reflect.Type.of_value(companion) == expected
+    && baml.json.encode(direct) == baml.json.encode(companion)
+}
+
+class StaticInner {
+  x string
+}
+
+function main() -> bool throws unknown {
+  let inner = reflect.class.new("Inner", { "x": reflect.Type.of<string>() })
+  let inner_array = inner.as_type().array()
+  let holder_array = reflect.class.new("HolderArray", { "bs": inner_array }).as_type()
+  let holder_map = reflect.class.new("HolderMap", {
+    "by_name": reflect.map.new(reflect.Type.of<string>(), inner.as_type()).as_type(),
+  }).as_type()
+  let minted_enum = reflect.enum.new("MintedState", ["Ready", "Done"])
+  let enum_array = minted_enum.as_type().array()
+
+  let compiled_package = reflect.Package.compile({
+    "compiled.baml": "class CompiledInner { x string }",
+  })
+  let compiled_inner = compiled_package.get_class("root.CompiledInner")
+    ?? throw "missing CompiledInner"
+  let compiled_array = compiled_inner.as_type().array()
+  let compiled_holder_array = reflect.class.new("CompiledHolderArray", {
+    "bs": compiled_array,
+  }).as_type()
+  let compiled_holder_map = reflect.class.new("CompiledHolderMap", {
+    "by_name": reflect.map.new(reflect.Type.of<string>(), compiled_inner.as_type()).as_type(),
+  }).as_type()
+  let static_holder = reflect.class.new("StaticHolder", {
+    "bs": reflect.Type.of<StaticInner[]>(),
+  }).as_type()
+
+  let array_ok = {
+    type T = unreflect(holder_array)
+    Check<T>(holder_array, #"{"bs":[{"x":"one"}]}"#)
+  }
+  let empty_array_ok = {
+    type T = unreflect(holder_array)
+    Check<T>(holder_array, #"{"bs":[]}"#)
+  }
+  let map_ok = {
+    type T = unreflect(holder_map)
+    Check<T>(holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+  }
+  let enum_ok = {
+    type T = unreflect(enum_array)
+    Check<T>(enum_array, #"["Ready","Done"]"#)
+  }
+  let top_level_array_ok = {
+    type T = unreflect(inner_array)
+    Check<T>(inner_array, #"[{"x":"one"}]"#)
+  }
+  let compiled_array_ok = {
+    type T = unreflect(compiled_holder_array)
+    Check<T>(compiled_holder_array, #"{"bs":[{"x":"one"}]}"#)
+  }
+  let compiled_map_ok = {
+    type T = unreflect(compiled_holder_map)
+    Check<T>(compiled_holder_map, #"{"by_name":{"one":{"x":"one"}}}"#)
+  }
+  let static_control_ok = {
+    type T = unreflect(static_holder)
+    Check<T>(static_holder, #"{"bs":[{"x":"one"}]}"#)
+  }
+
+  array_ok && empty_array_ok && map_ok && enum_ok && top_level_array_ok
+    && compiled_array_ok && compiled_map_ok && static_control_ok
+}
+"###
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -132,6 +132,24 @@ class Broken { value MissingType }
 }
 "####;
 
+#[tokio::test]
+async fn package_finish_refuses_session_compile_artifact() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = session._compile<int>(#"1"#)
+  let rejected = false
+  let _ = reflect.Package._finish(artifact, {}) catch (_) {
+    _ => { rejected = true },
+  }
+  rejected && session.eval<int>(#"2"#) == 2
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
 const SCENARIO_6_SOURCE: &str = r####"
 class AgentState {
   goal string

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -138,12 +138,12 @@ async fn package_finish_refuses_session_compile_artifact() {
         r####"
 function main() -> bool throws unknown {
   let session = reflect.Session.new()
-  let artifact = session._compile<int>(#"1"#)
+  let artifact = session._compile<int>(`1`)
   let rejected = false
   let _ = reflect.Package._finish(artifact, {}) catch (_) {
     _ => { rejected = true },
   }
-  rejected && session.eval<int>(#"2"#) == 2
+  rejected && session.eval<int>(`2`) == 2
 }
 "####
     );

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -428,12 +428,38 @@ function main() -> bool throws unknown {
   })
   let app = reflect.Package.current().with_types({ "MountedTicket": mounted })
   let s = reflect.Session.new(packages = { "app": app })
-  s.eval(#"let ticket = app.MountedTicket { subject: "visible" }
-ticket.subject"#) == "visible"
+  s.eval(`let ticket = app.MountedTicket { subject: "visible" }
+ticket.subject`) == "visible"
 }
 "####
     );
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn session_export_alias_preserves_nested_mounted_field_types() {
+    let output = baml_test!(
+        r####"
+function main() -> string throws unknown {
+  let inner = reflect.class.new("MountedInner", {
+    "value": reflect.Type.of<string>(),
+  })
+  let outer = reflect.class.new("MountedOuter", {
+    "inner": inner.as_type(),
+  })
+  let app = reflect.Package.current().with_types({ "OuterAlias": outer })
+  let s = reflect.Session.new(packages = { "app": app })
+  s.eval<string>(`let outer = app.OuterAlias {
+  inner: app.MountedInner { value: "visible" },
+}
+outer.inner.value`)
+}
+"####
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("visible".into()))
+    );
 }
 
 #[tokio::test]

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -56,6 +56,22 @@ function main() -> bool throws unknown {
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
 
+#[tokio::test]
+async fn session_synthetic_step_names_do_not_collide_with_user_bindings() {
+    let output = baml_test!(
+        r####"
+function main() -> int throws unknown {
+  let session = reflect.Session.new()
+  session.eval(`let result = 5`)
+  session.eval(`let stmt_1 = 7
+log.info("keep the second generated step")`)
+  session.eval<int>(`result + stmt_1`)
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Int(12)));
+}
+
 const S11_LIVENESS_PROBE: &str = r#####"
 function escape_one_session_value() -> reflect.Type throws unknown {
   let dependency = reflect.Package.compile({

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -16,6 +16,46 @@ function main() -> int throws unknown {
 }
 "####;
 
+#[tokio::test]
+async fn session_compile_artifact_is_consumed_once() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = session._compile<int>(`1`)
+  let first = session._finish<int>(artifact)
+  let rejected = false
+  let _ = session._finish<int>(artifact) catch (_) {
+    _ => { rejected = true },
+  }
+  first == 1 && rejected
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn session_finish_refuses_package_compile_artifact() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let session = reflect.Session.new()
+  let artifact = reflect.Package._compile(
+    { "main.baml": "function ready() -> bool { true }" },
+    {},
+  )
+  let rejected = false
+  let _ = session._finish<unknown>(artifact) catch (_) {
+    _ => { rejected = true },
+  }
+  rejected
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
 const S11_LIVENESS_PROBE: &str = r#####"
 function escape_one_session_value() -> reflect.Type throws unknown {
   let dependency = reflect.Package.compile({
@@ -511,12 +551,9 @@ async fn escaped_session_type_retains_provenance_only_while_handle_is_live() {
         let Object::Package(owner) = (unsafe { owner_ptr.get() }) else {
             panic!("escaped definition owner should be a Package")
         };
-        owner_is_session = owner.session.is_some();
-        session_history = owner
-            .session
-            .as_ref()
-            .map_or(0, |state| state.history.len());
-        let runtime = owner.runtime.as_ref().expect("runtime owner image");
+        owner_is_session = owner.session().is_some();
+        session_history = owner.session().map_or(0, |state| state.history.len());
+        let runtime = owner.runtime().expect("runtime owner image");
         retained_globals = runtime.globals.len();
         retained_objects = runtime.objects.len();
         retained_dependencies = runtime.dependencies.len();
@@ -524,10 +561,9 @@ async fn escaped_session_type_retains_provenance_only_while_handle_is_live() {
             .dependencies
             .iter()
             .map(|dependency| match unsafe { dependency.get() } {
-                Object::Package(package) => package
-                    .runtime
-                    .as_ref()
-                    .map_or(0, |runtime| runtime.objects.len()),
+                Object::Package(package) => {
+                    package.runtime().map_or(0, |runtime| runtime.objects.len())
+                }
                 _ => 0,
             })
             .sum::<usize>();

--- a/baml_language/crates/baml_tests/tests/runtime_session.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_session.rs
@@ -383,6 +383,60 @@ async fn session_reimports_instance_fields_without_changing_the_value() {
 }
 
 #[tokio::test]
+async fn session_reads_fields_from_mounted_return_types_inline_and_after_binding() {
+    let output = baml_test!(
+        r####"
+class Ticket {
+  subject string
+}
+
+class Envelope {
+  ticket Ticket
+}
+
+function GetTicket() -> Ticket {
+  Ticket { subject: "hello" }
+}
+
+function GetEnvelope() -> Envelope {
+  Envelope { ticket: GetTicket() }
+}
+
+function main() -> string throws unknown {
+  let s = reflect.Session.new(packages = { "app": reflect.Package.current() })
+  let inline = s.eval(`app.GetTicket().subject`)
+  s.eval(`let ticket = app.GetTicket()`)
+  let rebound = s.eval(`ticket.subject`)
+  let nested = s.eval(`app.GetEnvelope().ticket.subject`)
+  `${inline}|${rebound}|${nested}`
+}
+"####
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("hello|hello|hello".into()))
+    );
+}
+
+#[tokio::test]
+async fn session_compiler_sees_with_types_exports_from_dependencies() {
+    let output = baml_test!(
+        r####"
+function main() -> bool throws unknown {
+  let mounted = reflect.class.new("MountedTicket", {
+    "subject": reflect.Type.of<string>(),
+  })
+  let app = reflect.Package.current().with_types({ "MountedTicket": mounted })
+  let s = reflect.Session.new(packages = { "app": app })
+  s.eval(#"let ticket = app.MountedTicket { subject: "visible" }
+ticket.subject"#) == "visible"
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn scenario_7_verbatim_semantics_and_containment() {
     let output = baml_test!(baml: SCENARIO_7, entry: "scenario_7");
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -83,6 +83,33 @@ function Items() -> Item[] { [Item { value: "bound" }] }
 "####;
 
 #[tokio::test]
+async fn with_types_carries_runtime_witnesses_into_consumer_compilation() {
+    let output = baml_test!(
+        r####"
+interface Labelled {
+  label string
+}
+
+function main() -> bool throws unknown {
+  let witness = reflect.interface.implementation<Labelled>()
+    .field("label", class_field = "display_name")
+  let person = reflect.class.new("InternalPerson", {
+    "display_name": reflect.Type.of<string>(),
+  }, implementations = [witness])
+  let app = reflect.Package.current().with_types({ "PersonAlias": person })
+  let compiled = reflect.Package.compile({ "consumer.baml": `
+function as_label(value: app.PersonAlias) -> app.Labelled {
+  value
+}
+` }, packages = { "app": app })
+  compiled.functions().get("root.as_label") != null
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
 async fn scenario_four_pattern_two_mounts_a_runtime_type_as_a_static_name() {
     let output = baml_test!(PATTERN_TWO_SOURCE);
     assert_eq!(

--- a/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
+++ b/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
@@ -43,3 +43,63 @@ function as_named(value: Person) -> Named<Value = string> {
 
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
+
+#[tokio::test]
+async fn same_named_runtime_declarations_round_trip_with_unique_source_names() {
+    let output = baml_test!(
+        r###"
+function main() -> bool throws unknown {
+  let first = reflect.class.new("Choice", { "left": reflect.Type.of<string>() })
+  let second = reflect.class.new("Choice", { "right": reflect.Type.of<int>() })
+  let combined = reflect.union.new([first.as_type(), second.as_type()])
+  let source = combined.as_type().to_baml()
+  let compiled = reflect.Package.compile({ "choices.baml": source })
+  compiled.get_class("root.Choice") != null
+    && compiled.get_class("root.Choice_2") != null
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn minted_and_compiled_same_named_declarations_round_trip() {
+    let output = baml_test!(
+        r###"
+function main() -> bool throws unknown {
+  let package = reflect.Package.compile({
+    "original.baml": "class Choice { compiled string }",
+  })
+  let compiled_choice = package.get_class("root.Choice") ?? throw "missing Choice"
+  let minted_choice = reflect.class.new("Choice", { "minted": reflect.Type.of<int>() })
+  let combined = reflect.union.new([compiled_choice.as_type(), minted_choice.as_type()])
+  let round_trip = reflect.Package.compile({ "choices.baml": combined.as_type().to_baml() })
+  round_trip.get_class("root.Choice") != null
+    && round_trip.get_class("root.Choice_2") != null
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn runtime_class_static_dependencies_are_declared_in_round_trip_source() {
+    let output = baml_test!(
+        r###"
+class StaticChild {
+  value string
+}
+
+function main() -> bool throws unknown {
+  let holder = reflect.class.new("RuntimeHolder", {
+    "child": reflect.Type.of<StaticChild>(),
+  })
+  let source = holder.as_type().to_baml()
+  let round_trip = reflect.Package.compile({ "holder.baml": source })
+  round_trip.get_class("root.RuntimeHolder") != null
+    && round_trip.get_class("root.StaticChild") != null
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
+++ b/baml_language/crates/baml_tests/tests/to_baml_witness_roundtrip.rs
@@ -45,17 +45,18 @@ function as_named(value: Person) -> Named<Value = string> {
 }
 
 #[tokio::test]
-async fn same_named_runtime_declarations_round_trip_with_unique_source_names() {
+async fn same_named_runtime_declarations_are_rejected() {
     let output = baml_test!(
         r###"
 function main() -> bool throws unknown {
   let first = reflect.class.new("Choice", { "left": reflect.Type.of<string>() })
   let second = reflect.class.new("Choice", { "right": reflect.Type.of<int>() })
   let combined = reflect.union.new([first.as_type(), second.as_type()])
-  let source = combined.as_type().to_baml()
-  let compiled = reflect.Package.compile({ "choices.baml": source })
-  compiled.get_class("root.Choice") != null
-    && compiled.get_class("root.Choice_2") != null
+  let result = combined.as_type().to_baml() catch (e) {
+    reflect.errors.CompilationError => e.diagnostics[0].code,
+    _ => "wrong error",
+  }
+  result == "E0162"
 }
 "###
     );
@@ -63,7 +64,7 @@ function main() -> bool throws unknown {
 }
 
 #[tokio::test]
-async fn minted_and_compiled_same_named_declarations_round_trip() {
+async fn minted_and_compiled_same_named_declarations_are_rejected() {
     let output = baml_test!(
         r###"
 function main() -> bool throws unknown {
@@ -73,9 +74,31 @@ function main() -> bool throws unknown {
   let compiled_choice = package.get_class("root.Choice") ?? throw "missing Choice"
   let minted_choice = reflect.class.new("Choice", { "minted": reflect.Type.of<int>() })
   let combined = reflect.union.new([compiled_choice.as_type(), minted_choice.as_type()])
-  let round_trip = reflect.Package.compile({ "choices.baml": combined.as_type().to_baml() })
-  round_trip.get_class("root.Choice") != null
-    && round_trip.get_class("root.Choice_2") != null
+  let result = combined.as_type().to_baml() catch (e) {
+    reflect.errors.CompilationError => e.diagnostics[0].code,
+    _ => "wrong error",
+  }
+  result == "E0162"
+}
+"###
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn equivalent_same_named_runtime_declarations_fold_and_round_trip() {
+    let output = baml_test!(
+        r###"
+function main() -> bool throws unknown {
+  let first = reflect.class.new("Choice", { "value": reflect.Type.of<string>() })
+  let second = reflect.class.new("Choice", { "value": reflect.Type.of<string>() })
+  let combined = reflect.union.new([first.as_type(), second.as_type()])
+  let source = combined.as_type().to_baml()
+  let round_trip = reflect.Package.compile({ "choices.baml": source })
+  source.split("class Choice {").length() == 2
+    && round_trip.get_class("root.Choice") != null
+    && round_trip.get_class("root.Choice_2") == null
+    && round_trip.classes().length() == 1
 }
 "###
     );

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -99,18 +99,160 @@ pub(crate) fn anchor_wire_ty(
     })
 }
 
-fn realize_host_ty(
-    vm: &crate::BexVm,
-    ty: &RuntimeTy,
-) -> Result<bex_vm_types::RealizedTy, EngineError> {
-    // The single inbound anchor: a lane type's names become heads here, once,
-    // off the declarations this engine holds — so nothing downstream has to
-    // wonder whether a type it received is bound.
-    //
-    let anchored = anchor_wire_ty(vm, ty)?;
-    bex_vm_types::RealizedTy::try_from(anchored).map_err(|e| EngineError::TypeMismatch {
-        message: format!("host-supplied type is not realized: {e}"),
-    })
+#[derive(Clone, Copy)]
+enum InboundDeclarationKind {
+    Any,
+    Class,
+    Enum,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct InboundRuntimeOverlay<'a> {
+    dynamic_classes: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+    dynamic_enums: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+    runtime_named_objects: Option<&'a indexmap::IndexMap<String, HeapPtr>>,
+}
+
+impl<'a> InboundRuntimeOverlay<'a> {
+    pub(crate) fn new(
+        dynamic_classes: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+        dynamic_enums: &'a indexmap::IndexMap<String, bex_external_types::Handle>,
+        runtime_named_objects: Option<&'a indexmap::IndexMap<String, HeapPtr>>,
+    ) -> Self {
+        Self {
+            dynamic_classes,
+            dynamic_enums,
+            runtime_named_objects,
+        }
+    }
+}
+
+impl BexEngine {
+    /// Resolve one inbound overlay spelling through the same per-call cascade
+    /// used for external instances and variants, then through the VM's declared
+    /// package surface. Keeping this lookup shared prevents container/type
+    /// metadata from drifting from value allocation again.
+    fn resolve_inbound_declaration(
+        &self,
+        vm: &BexVm,
+        permit: PermitProof<'_>,
+        name: &str,
+        overlay: InboundRuntimeOverlay<'_>,
+        kind: InboundDeclarationKind,
+    ) -> Result<Option<HeapPtr>, EngineError> {
+        let dynamic = match kind {
+            InboundDeclarationKind::Class => overlay
+                .dynamic_classes
+                .get(name)
+                .map(|handle| ("class", handle)),
+            InboundDeclarationKind::Enum => overlay
+                .dynamic_enums
+                .get(name)
+                .map(|handle| ("enum", handle)),
+            InboundDeclarationKind::Any => overlay
+                .dynamic_classes
+                .get(name)
+                .map(|handle| ("class", handle))
+                .or_else(|| {
+                    overlay
+                        .dynamic_enums
+                        .get(name)
+                        .map(|handle| ("enum", handle))
+                }),
+        };
+        if let Some((kind_name, handle)) = dynamic {
+            return self
+                .resolve_handle(permit, handle)
+                .map(Some)
+                .ok_or_else(|| EngineError::TypeMismatch {
+                    message: format!(
+                        "Runtime {kind_name} `{name}` expired before its value landed"
+                    ),
+                });
+        }
+
+        if let Some(ptr) = overlay.runtime_named_objects.and_then(|objects| {
+            objects
+                .get(name)
+                .or_else(|| resolve_named_object(objects, name))
+        }) {
+            return Ok(Some(*ptr));
+        }
+
+        let statically_resolved = match kind {
+            InboundDeclarationKind::Class => self
+                .resolved_class_names
+                .get(name)
+                .or_else(|| resolve_named_object(&self.resolved_class_names, name)),
+            InboundDeclarationKind::Enum => self
+                .resolved_enum_names
+                .get(name)
+                .or_else(|| resolve_named_object(&self.resolved_enum_names, name)),
+            InboundDeclarationKind::Any => self
+                .resolved_class_names
+                .get(name)
+                .or_else(|| resolve_named_object(&self.resolved_class_names, name))
+                .or_else(|| self.resolved_enum_names.get(name))
+                .or_else(|| resolve_named_object(&self.resolved_enum_names, name)),
+        };
+        if let Some(ptr) = statically_resolved {
+            return Ok(Some(*ptr));
+        }
+
+        Ok(vm
+            .declaration_head(&baml_type::TypeName::from_dotted_path(name))
+            .map(bex_vm_types::TypeHead::ptr))
+    }
+
+    pub(crate) fn anchor_wire_ty_with_runtime(
+        &self,
+        vm: &BexVm,
+        permit: PermitProof<'_>,
+        ty: &RuntimeTy,
+        overlay: InboundRuntimeOverlay<'_>,
+    ) -> Result<bex_vm_types::RuntimeTy, EngineError> {
+        ty.try_map_heads(&mut |name: &baml_type::TypeName| {
+            let spelling = name.to_string();
+            let ptr = self
+                .resolve_inbound_declaration(
+                    vm,
+                    permit,
+                    &spelling,
+                    overlay,
+                    InboundDeclarationKind::Any,
+                )?
+                .ok_or_else(|| EngineError::TypeMismatch {
+                    message: format!("host-supplied type names unknown declaration `{name}`"),
+                })?;
+            let tag = match vm.get_object(ptr) {
+                Object::Class(class) => class.type_tag,
+                Object::Enum(enm) => enm.type_tag,
+                Object::Interface(interface) => interface.type_tag,
+                Object::TypeAlias(alias) => alias.type_tag,
+                _ => {
+                    return Err(EngineError::TypeMismatch {
+                        message: format!(
+                            "host-supplied type name `{name}` does not resolve to a declaration"
+                        ),
+                    });
+                }
+            };
+            Ok(bex_vm_types::TypeHead::new(ptr, tag))
+        })
+    }
+
+    fn realize_host_ty_with_runtime(
+        &self,
+        vm: &BexVm,
+        permit: PermitProof<'_>,
+        ty: &RuntimeTy,
+        overlay: InboundRuntimeOverlay<'_>,
+    ) -> Result<bex_vm_types::RealizedTy, EngineError> {
+        let anchored = self.anchor_wire_ty_with_runtime(vm, permit, ty, overlay)?;
+        bex_vm_types::RealizedTy::try_from(anchored).map_err(|e| EngineError::TypeMismatch {
+            message: format!("host-supplied type is not realized: {e}"),
+        })
+    }
 }
 
 /// The runtime declarations a type reaches, in the wire's pointer-free form.
@@ -1168,6 +1310,8 @@ impl BexEngine {
                 holder.holder_mut().tlab_mut().alloc_rust_data(arc),
             ));
         }
+        let overlay =
+            InboundRuntimeOverlay::new(dynamic_classes, dynamic_enums, runtime_named_objects);
         Ok(match external {
             BexExternalValue::Handle(handle) => Value::object(
                 self.resolve_handle(holder.proof(), &handle)
@@ -1238,7 +1382,12 @@ impl BexEngine {
                         )
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                let element_ty = realize_host_ty(&holder.holder_mut().vm, &runtime_element_ty)?;
+                let element_ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &runtime_element_ty,
+                    overlay,
+                )?;
                 Value::object(
                     holder
                         .holder_mut()
@@ -1257,7 +1406,12 @@ impl BexEngine {
                     }
                     _ => (key_type, value_type),
                 };
-                let key_ty = realize_host_ty(&holder.holder_mut().vm, &key_type)?;
+                let key_ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &key_type,
+                    overlay,
+                )?;
                 let declared_value_ty = expected_ty.and_then(peel_map_value_ty);
                 let runtime_value_ty = declared_value_ty.unwrap_or(&value_type).clone();
                 let values = entries
@@ -1278,7 +1432,12 @@ impl BexEngine {
                         .map(|v| (bex_vm_types::BexStr::from(k.as_str()), v))
                     })
                     .collect::<Result<indexmap::IndexMap<bex_vm_types::BexStr, Value>, _>>()?;
-                let value_ty = realize_host_ty(&holder.holder_mut().vm, &runtime_value_ty)?;
+                let value_ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &runtime_value_ty,
+                    overlay,
+                )?;
                 Value::object(
                     holder
                         .holder_mut()
@@ -1306,29 +1465,17 @@ impl BexEngine {
                         type_args.clone_from(expected_args);
                     }
                 }
-                let class_ptr = if let Some(handle) = dynamic_classes.get(&class_name) {
-                    self.resolve_handle(holder.proof(), handle).ok_or_else(|| {
-                        EngineError::TypeMismatch {
-                            message: format!(
-                                "Runtime class `{class_name}` expired before its value landed"
-                            ),
-                        }
-                    })?
-                } else {
-                    *runtime_named_objects
-                        .and_then(|objects| objects.get(&class_name))
-                        .or_else(|| {
-                            runtime_named_objects
-                                .and_then(|objects| resolve_named_object(objects, &class_name))
-                        })
-                        .or_else(|| self.resolved_class_names.get(&class_name))
-                        .or_else(|| resolve_named_object(&self.resolved_class_names, &class_name))
-                        .ok_or_else(|| EngineError::TypeMismatch {
-                            message: format!(
-                                "Unknown class `{class_name}` in external Instance value"
-                            ),
-                        })?
-                };
+                let class_ptr = self
+                    .resolve_inbound_declaration(
+                        &holder.holder().vm,
+                        holder.proof(),
+                        &class_name,
+                        overlay,
+                        InboundDeclarationKind::Class,
+                    )?
+                    .ok_or_else(|| EngineError::TypeMismatch {
+                        message: format!("Unknown class `{class_name}` in external Instance value"),
+                    })?;
 
                 // SAFETY: class_ptr points to a compile-time Class object
                 let class_fields = match unsafe { class_ptr.get() } {
@@ -1346,7 +1493,14 @@ impl BexEngine {
                 // works against the class's own head-typed templates.
                 let type_args = type_args
                     .iter()
-                    .map(|ty| anchor_wire_ty(&holder.holder_mut().vm, ty))
+                    .map(|ty| {
+                        self.anchor_wire_ty_with_runtime(
+                            &holder.holder().vm,
+                            holder.proof(),
+                            ty,
+                            overlay,
+                        )
+                    })
                     .collect::<Result<Vec<_>, _>>()?;
 
                 // Build field values in the order defined by the class.
@@ -1398,29 +1552,17 @@ impl BexEngine {
                 enum_name,
                 variant_name,
             } => {
-                let enum_ptr = if let Some(handle) = dynamic_enums.get(&enum_name) {
-                    self.resolve_handle(holder.proof(), handle).ok_or_else(|| {
-                        EngineError::TypeMismatch {
-                            message: format!(
-                                "Runtime enum `{enum_name}` expired before its value landed"
-                            ),
-                        }
-                    })?
-                } else {
-                    *runtime_named_objects
-                        .and_then(|objects| objects.get(&enum_name))
-                        .or_else(|| {
-                            runtime_named_objects
-                                .and_then(|objects| resolve_named_object(objects, &enum_name))
-                        })
-                        .or_else(|| self.resolved_enum_names.get(&enum_name))
-                        .or_else(|| resolve_named_object(&self.resolved_enum_names, &enum_name))
-                        .ok_or_else(|| EngineError::TypeMismatch {
-                            message: format!(
-                                "Unknown enum `{enum_name}` in external Variant value"
-                            ),
-                        })?
-                };
+                let enum_ptr = self
+                    .resolve_inbound_declaration(
+                        &holder.holder().vm,
+                        holder.proof(),
+                        &enum_name,
+                        overlay,
+                        InboundDeclarationKind::Enum,
+                    )?
+                    .ok_or_else(|| EngineError::TypeMismatch {
+                        message: format!("Unknown enum `{enum_name}` in external Variant value"),
+                    })?;
                 #[allow(unsafe_code)]
                 let bex_vm_types::Object::Enum(enum_obj) = (unsafe { enum_ptr.get() }) else {
                     return Err(EngineError::TypeMismatch {
@@ -1476,7 +1618,12 @@ impl BexEngine {
                             ),
                         })
                 })?;
-                let ty = realize_host_ty(&holder.holder_mut().vm, &named)?;
+                let ty = self.realize_host_ty_with_runtime(
+                    &holder.holder().vm,
+                    holder.proof(),
+                    &named,
+                    overlay,
+                )?;
                 // The wire carries the definition only (H-4); derive a fresh
                 // static identity with the receiving VM's complete fact context.
                 Value::object(
@@ -1649,17 +1796,29 @@ impl BexEngine {
                     .map(|param| {
                         Ok(bex_vm_types::RealizedFunctionParamTy {
                             name: param.name.clone(),
-                            ty: realize_host_ty(&holder.holder_mut().vm, &param.ty)?,
+                            ty: self.realize_host_ty_with_runtime(
+                                &holder.holder().vm,
+                                holder.proof(),
+                                &param.ty,
+                                overlay,
+                            )?,
                             mode: param.mode,
                         })
                     })
                     .collect::<Result<Vec<_>, EngineError>>()?;
                 let host_closure = bex_vm_types::HostClosure {
                     handle: arc,
-                    ret_ty: Box::new(realize_host_ty(&holder.holder_mut().vm, &ret)?),
-                    throws_ty: Box::new(realize_host_ty(
-                        &holder.holder_mut().vm,
+                    ret_ty: Box::new(self.realize_host_ty_with_runtime(
+                        &holder.holder().vm,
+                        holder.proof(),
+                        &ret,
+                        overlay,
+                    )?),
+                    throws_ty: Box::new(self.realize_host_ty_with_runtime(
+                        &holder.holder().vm,
+                        holder.proof(),
                         &normalized_throws,
+                        overlay,
                     )?),
                     arity: params.len(),
                     // Capture the declared params (names + optionality) so the VM

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -2876,7 +2876,7 @@ impl BexEngine {
             let Object::Package(package) = vm.get_object(owner) else {
                 continue;
             };
-            let Some(runtime) = package.runtime.as_ref() else {
+            let Some(runtime) = package.runtime() else {
                 continue;
             };
             pending.extend(runtime.dependencies.iter().copied());
@@ -7194,8 +7194,7 @@ impl BexEngine {
                 ));
             };
             package
-                .session
-                .as_ref()
+                .session()
                 .map(|state| state.busy.clone())
                 .ok_or_else(|| invalid("Session has an invalid runtime payload".to_string()))?
         };
@@ -7219,17 +7218,15 @@ impl BexEngine {
                     "Session has an invalid runtime payload".to_string(),
                 ));
             };
-            let state = package
-                .session
-                .as_mut()
-                .ok_or_else(|| invalid("Session has an invalid runtime payload".to_string()))?;
+            let bex_vm_types::types::PackageKind::Session { runtime, state } = &mut package.kind
+            else {
+                return Err(invalid(
+                    "Session has an invalid runtime payload".to_string(),
+                ));
+            };
             let sequence = state.submission_counter;
             state.submission_counter = state.submission_counter.saturating_add(1);
-            let dependencies = package
-                .runtime
-                .as_ref()
-                .map(|runtime| runtime.dependency_names.clone())
-                .unwrap_or_default();
+            let dependencies = runtime.dependency_names.clone();
             (
                 state.history.clone(),
                 state.visible.clone(),
@@ -7312,10 +7309,10 @@ impl BexEngine {
             };
             match compiler.compile(request) {
                 Ok(artifact) => Ok(BexExternalValue::Instance {
-                    class_name: "reflect.Package".to_string(),
+                    class_name: "reflect.CompileArtifact".to_string(),
                     type_args: Vec::new(),
                     fields: indexmap::indexmap! {
-                        "_inner".to_string() => BexExternalValue::RustData(Arc::new(artifact)),
+                        "_inner".to_string() => BexExternalValue::RustData(Arc::new(Mutex::new(Some(artifact)))),
                     },
                 }),
                 Err(diagnostics) => {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3967,10 +3967,31 @@ impl BexEngine {
         // Finish all fallible host type narrowing before durable run
         // admission. Once `run.meta` commits, the path below is straight-line
         // into the balanced root event loop.
+        let mut runtime_named_objects = indexmap::IndexMap::new();
+        for type_value in type_values.values() {
+            type_value.ty.visit_heads(&mut |head| {
+                if let Ok(name) = head.to_overlay_name() {
+                    runtime_named_objects
+                        .entry(name.to_string())
+                        .or_insert_with(|| head.ptr());
+                }
+            });
+        }
+        let dynamic_classes = indexmap::IndexMap::new();
+        let dynamic_enums = indexmap::IndexMap::new();
         let type_args = type_args
             .into_iter()
             .map(|(name, ty)| {
-                let anchored = crate::conversion::anchor_wire_ty(&thread.vm, &ty)?;
+                let anchored = self.anchor_wire_ty_with_runtime(
+                    &thread.vm,
+                    thread.proof(),
+                    &ty,
+                    crate::conversion::InboundRuntimeOverlay::new(
+                        &dynamic_classes,
+                        &dynamic_enums,
+                        Some(&runtime_named_objects),
+                    ),
+                )?;
                 match bex_vm_types::RealizedTy::try_from(&anchored) {
                     Ok(realized) => Ok((name, realized)),
                     Err(e) => Err(EngineError::VmInternalError(
@@ -6922,129 +6943,127 @@ impl BexEngine {
         }
     }
 
+    fn runtime_type_mount(
+        vm: &BexVm,
+        alias: &str,
+        export_name: &str,
+        ptr: bex_vm_types::HeapPtr,
+    ) -> Result<bex_vm_types::RuntimeTypeMount, EngineError> {
+        let Object::Type(value) = vm.get_object(ptr) else {
+            return Err(EngineError::TypeMismatch {
+                message: format!("with_types entry `{export_name}` is not a type"),
+            });
+        };
+        // In the consumer compile world, a runtime declaration is spelled
+        // `alias.<item name>`: the mount surface is the only channel that
+        // names it there, whatever its home world called it. Compiled
+        // declarations keep their own qualified names — those mean the
+        // same thing in every compile world.
+        let wire_head =
+            |head: &bex_vm_types::TypeHead| -> Result<baml_type::TypeName, EngineError> {
+                if !head.is_resolved() {
+                    return Err(EngineError::TypeMismatch {
+                        message: format!("mounted type `{export_name}` carries an unresolved head"),
+                    });
+                }
+                if vm.heap.is_compile_time_ptr(head.ptr()) {
+                    return head
+                        .declared_name()
+                        .ok_or_else(|| EngineError::TypeMismatch {
+                            message: format!(
+                                "mounted type `{export_name}` names an unnameable compiled head"
+                            ),
+                        });
+                }
+                let item = match vm.get_object(head.ptr()) {
+                    Object::Class(class) => class.name.item_name().clone(),
+                    Object::Enum(enm) => enm.name.item_name().clone(),
+                    Object::Interface(iface) => iface.name.name().clone(),
+                    Object::TypeAlias(alias_def) => alias_def.name.name().clone(),
+                    _ => {
+                        return Err(EngineError::TypeMismatch {
+                            message: format!(
+                                "mounted type `{export_name}` reaches a non-declaration head"
+                            ),
+                        });
+                    }
+                };
+                Ok(baml_type::QualifiedTypeName::new(
+                    baml_type::Name::new(alias),
+                    Vec::new(),
+                    item,
+                ))
+            };
+        let wire_ty = |ty: &bex_vm_types::RuntimeTy| -> Result<baml_type::Ty, EngineError> {
+            let mapped: baml_type::RuntimeTy = ty.try_map_heads(&mut |head| wire_head(head))?;
+            Ok(baml_type::Ty::from(&mapped))
+        };
+        // The mount describes the runtime declarations the type reaches;
+        // the walk over its heads is what finds them.
+        let (class_ptrs, enum_ptrs) = bex_vm::reachable::runtime_nominals(vm, &value.ty);
+        let classes = class_ptrs
+            .iter()
+            .map(|ptr| {
+                let Object::Class(class) = vm.get_object(*ptr) else {
+                    unreachable!("runtime_nominals returned a non-class in the class list")
+                };
+                Ok(bex_vm_types::RuntimeMountedClass {
+                    name: class.name.item_name().clone(),
+                    tag: class.type_tag,
+                    fields: class
+                        .fields
+                        .iter()
+                        .map(|field| {
+                            Ok((
+                                baml_type::Name::new(&field.name),
+                                wire_ty(&field.field_type)?,
+                                bex_vm_types::RuntimeMountedFieldAttrs {
+                                    alias: field.alias.clone(),
+                                    description: field.description.clone(),
+                                },
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, EngineError>>()?,
+                })
+            })
+            .collect::<Result<Vec<_>, EngineError>>()?;
+        let enums = enum_ptrs
+            .iter()
+            .map(|ptr| {
+                let Object::Enum(enm) = vm.get_object(*ptr) else {
+                    unreachable!("runtime_nominals returned a non-enum in the enum list")
+                };
+                Ok(bex_vm_types::RuntimeMountedEnum {
+                    name: enm.name.item_name().clone(),
+                    tag: enm.type_tag,
+                    variants: enm
+                        .variants
+                        .iter()
+                        .map(|variant| baml_type::Name::new(&variant.name))
+                        .collect(),
+                })
+            })
+            .collect::<Result<Vec<_>, EngineError>>()?;
+        // Witnesses live on the impl rules now, not beside the type; a
+        // mount no longer restates them.
+        let witnesses = Vec::new();
+        let ty = value
+            .ty
+            .try_map_heads(&mut |head| wire_head(head))
+            .map_err(|e: EngineError| e)?;
+        Ok(bex_vm_types::RuntimeTypeMount {
+            export_name: baml_type::Name::new(export_name),
+            ty,
+            classes,
+            enums,
+            witnesses,
+        })
+    }
+
     fn runtime_compile_request(
         vm: &BexVm,
         args: &[Value],
     ) -> Result<bex_vm_types::RuntimeCompileRequest, EngineError> {
-        fn type_mount(
-            vm: &BexVm,
-            alias: &str,
-            export_name: &str,
-            ptr: bex_vm_types::HeapPtr,
-        ) -> Result<bex_vm_types::RuntimeTypeMount, EngineError> {
-            let Object::Type(value) = vm.get_object(ptr) else {
-                return Err(EngineError::TypeMismatch {
-                    message: format!("with_types entry `{export_name}` is not a type"),
-                });
-            };
-            // In the consumer compile world, a runtime declaration is spelled
-            // `alias.<item name>`: the mount surface is the only channel that
-            // names it there, whatever its home world called it. Compiled
-            // declarations keep their own qualified names — those mean the
-            // same thing in every compile world.
-            let wire_head =
-                |head: &bex_vm_types::TypeHead| -> Result<baml_type::TypeName, EngineError> {
-                    if !head.is_resolved() {
-                        return Err(EngineError::TypeMismatch {
-                            message: format!(
-                                "mounted type `{export_name}` carries an unresolved head"
-                            ),
-                        });
-                    }
-                    if vm.heap.is_compile_time_ptr(head.ptr()) {
-                        return head
-                            .declared_name()
-                            .ok_or_else(|| EngineError::TypeMismatch {
-                                message: format!(
-                                    "mounted type `{export_name}` names an unnameable compiled head"
-                                ),
-                            });
-                    }
-                    let item = match vm.get_object(head.ptr()) {
-                        Object::Class(class) => class.name.item_name().clone(),
-                        Object::Enum(enm) => enm.name.item_name().clone(),
-                        Object::Interface(iface) => iface.name.name().clone(),
-                        Object::TypeAlias(alias_def) => alias_def.name.name().clone(),
-                        _ => {
-                            return Err(EngineError::TypeMismatch {
-                                message: format!(
-                                    "mounted type `{export_name}` reaches a non-declaration head"
-                                ),
-                            });
-                        }
-                    };
-                    Ok(baml_type::QualifiedTypeName::new(
-                        baml_type::Name::new(alias),
-                        Vec::new(),
-                        item,
-                    ))
-                };
-            let wire_ty = |ty: &bex_vm_types::RuntimeTy| -> Result<baml_type::Ty, EngineError> {
-                let mapped: baml_type::RuntimeTy = ty.try_map_heads(&mut |head| wire_head(head))?;
-                Ok(baml_type::Ty::from(&mapped))
-            };
-            // The mount describes the runtime declarations the type reaches;
-            // the walk over its heads is what finds them.
-            let (class_ptrs, enum_ptrs) = bex_vm::reachable::runtime_nominals(vm, &value.ty);
-            let classes = class_ptrs
-                .iter()
-                .map(|ptr| {
-                    let Object::Class(class) = vm.get_object(*ptr) else {
-                        unreachable!("runtime_nominals returned a non-class in the class list")
-                    };
-                    Ok(bex_vm_types::RuntimeMountedClass {
-                        name: class.name.item_name().clone(),
-                        tag: class.type_tag,
-                        fields: class
-                            .fields
-                            .iter()
-                            .map(|field| {
-                                Ok((
-                                    baml_type::Name::new(&field.name),
-                                    wire_ty(&field.field_type)?,
-                                    bex_vm_types::RuntimeMountedFieldAttrs {
-                                        alias: field.alias.clone(),
-                                        description: field.description.clone(),
-                                    },
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, EngineError>>()?,
-                    })
-                })
-                .collect::<Result<Vec<_>, EngineError>>()?;
-            let enums = enum_ptrs
-                .iter()
-                .map(|ptr| {
-                    let Object::Enum(enm) = vm.get_object(*ptr) else {
-                        unreachable!("runtime_nominals returned a non-enum in the enum list")
-                    };
-                    Ok(bex_vm_types::RuntimeMountedEnum {
-                        name: enm.name.item_name().clone(),
-                        tag: enm.type_tag,
-                        variants: enm
-                            .variants
-                            .iter()
-                            .map(|variant| baml_type::Name::new(&variant.name))
-                            .collect(),
-                    })
-                })
-                .collect::<Result<Vec<_>, EngineError>>()?;
-            // Witnesses live on the impl rules now, not beside the type; a
-            // mount no longer restates them.
-            let witnesses = Vec::new();
-            let ty = value
-                .ty
-                .try_map_heads(&mut |head| wire_head(head))
-                .map_err(|e: EngineError| e)?;
-            Ok(bex_vm_types::RuntimeTypeMount {
-                export_name: baml_type::Name::new(export_name),
-                ty,
-                classes,
-                enums,
-                witnesses,
-            })
-        }
-
         fn map_entries(
             vm: &BexVm,
             value: Value,
@@ -7121,7 +7140,7 @@ impl BexEngine {
             let types = package
                 .mounted_types
                 .iter()
-                .map(|(name, ptr)| type_mount(vm, alias.as_str(), name, *ptr))
+                .map(|(name, ptr)| Self::runtime_type_mount(vm, alias.as_str(), name, *ptr))
                 .collect::<Result<Vec<_>, _>>()?;
             packages.insert(
                 alias.to_string(),
@@ -7241,11 +7260,17 @@ impl BexEngine {
                     "Session dependency `{alias}` has an invalid runtime payload"
                 )));
             };
+            let types = package
+                .mounted_types
+                .iter()
+                .map(|(name, ptr)| Self::runtime_type_mount(vm, alias.as_str(), name, *ptr))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| invalid(error.to_string()))?;
             packages.insert(
                 alias,
                 bex_vm_types::RuntimePackageMount {
                     interface_blob: package.interface_blob.clone(),
-                    types: Vec::new(),
+                    types,
                 },
             );
         }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -6957,8 +6957,8 @@ impl BexEngine {
         // In the consumer compile world, a runtime declaration is spelled
         // `alias.<item name>`: the mount surface is the only channel that
         // names it there, whatever its home world called it. Compiled
-        // declarations keep their own qualified names — those mean the
-        // same thing in every compile world.
+        // declarations from another dependency keep their qualified names;
+        // declarations local to this mounted package relocate to its alias.
         let wire_head =
             |head: &bex_vm_types::TypeHead| -> Result<baml_type::TypeName, EngineError> {
                 if !head.is_resolved() {
@@ -6967,13 +6967,22 @@ impl BexEngine {
                     });
                 }
                 if vm.heap.is_compile_time_ptr(head.ptr()) {
-                    return head
+                    let name = head
                         .declared_name()
                         .ok_or_else(|| EngineError::TypeMismatch {
                             message: format!(
                                 "mounted type `{export_name}` names an unnameable compiled head"
                             ),
-                        });
+                        })?;
+                    return Ok(if name.is_local() {
+                        baml_type::QualifiedTypeName::new(
+                            baml_type::Name::new(alias),
+                            name.namespace().clone(),
+                            name.name().clone(),
+                        )
+                    } else {
+                        name
+                    });
                 }
                 let item = match vm.get_object(head.ptr()) {
                     Object::Class(class) => class.name.item_name().clone(),
@@ -7044,9 +7053,111 @@ impl BexEngine {
                 })
             })
             .collect::<Result<Vec<_>, EngineError>>()?;
-        // Witnesses live on the impl rules now, not beside the type; a
-        // mount no longer restates them.
-        let witnesses = Vec::new();
+        // Dynamic witness rules are heap objects rather than TypeValue sidecars,
+        // but the consumer compiler cannot see this VM's dispatch table. Project
+        // the root class's rules into the mount artifact so type checking in the
+        // consumer world sees the same conformances as runtime dispatch.
+        let witnesses = match &value.ty {
+            bex_vm_types::RealizedTy::Class(head, _, _) if head.is_resolved() => {
+                let Object::Class(class) = vm.get_object(head.ptr()) else {
+                    return Err(EngineError::TypeMismatch {
+                        message: format!(
+                            "mounted type `{export_name}` has a non-class declaration head"
+                        ),
+                    });
+                };
+                vm.dynamic_dispatch
+                    .rules_for_class(head.ptr())
+                    .into_iter()
+                    .map(|rule_ptr| {
+                        let Object::ImplRule(rule) = vm.get_object(rule_ptr) else {
+                            return Err(EngineError::TypeMismatch {
+                                message: format!(
+                                    "mounted type `{export_name}` has an invalid witness rule"
+                                ),
+                            });
+                        };
+                        let Object::Interface(interface) = vm.get_object(rule.interface_head)
+                        else {
+                            return Err(EngineError::TypeMismatch {
+                                message: format!(
+                                    "mounted type `{export_name}` has an invalid witness interface"
+                                ),
+                            });
+                        };
+                        if interface.fields.len() != rule.field_links.len() {
+                            return Err(EngineError::TypeMismatch {
+                                message: format!(
+                                    "mounted type `{export_name}` has an incomplete witness field map"
+                                ),
+                            });
+                        }
+                        let interface_head = bex_vm_types::TypeHead::new(
+                            rule.interface_head,
+                            interface.type_tag,
+                        );
+                        let interface_name = wire_head(&interface_head)?;
+                        let interface_args = rule
+                            .interface_args
+                            .iter()
+                            .map(|ty| {
+                                let ty = bex_vm_types::RealizedTy::try_from(ty).map_err(|error| {
+                                    EngineError::TypeMismatch {
+                                        message: format!(
+                                            "mounted type `{export_name}` has an unrealized witness argument: {error}"
+                                        ),
+                                    }
+                                })?;
+                                let ty = bex_vm_types::RuntimeTy::from(ty);
+                                wire_ty(&ty)
+                            })
+                            .collect::<Result<Vec<_>, EngineError>>()?;
+                        let associated_types = rule
+                            .interface_assoc
+                            .iter()
+                            .map(|(name, ty)| {
+                                let ty = bex_vm_types::RealizedTy::try_from(ty).map_err(|error| {
+                                    EngineError::TypeMismatch {
+                                        message: format!(
+                                            "mounted type `{export_name}` has an unrealized witness associated type: {error}"
+                                        ),
+                                    }
+                                })?;
+                                let ty = bex_vm_types::RuntimeTy::from(ty);
+                                Ok((name.clone(), wire_ty(&ty)?))
+                            })
+                            .collect::<Result<Vec<_>, EngineError>>()?;
+                        let field_links = interface
+                            .fields
+                            .iter()
+                            .zip(rule.field_links.iter())
+                            .map(|(field, slot)| {
+                                let class_field = class.fields.get(*slot as usize).ok_or_else(|| {
+                                    EngineError::TypeMismatch {
+                                        message: format!(
+                                            "mounted type `{export_name}` has an out-of-range witness field link"
+                                        ),
+                                    }
+                                })?;
+                                Ok((
+                                    field.name.clone(),
+                                    baml_type::Name::new(&class_field.name),
+                                ))
+                            })
+                            .collect::<Result<Vec<_>, EngineError>>()?;
+                        Ok((
+                            baml_type::Interface::new(
+                                interface_name,
+                                interface_args,
+                                associated_types,
+                            ),
+                            field_links,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, EngineError>>()?
+            }
+            _ => Vec::new(),
+        };
         let ty = value
             .ty
             .try_map_heads(&mut |head| wire_head(head))

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -27,7 +27,10 @@
 
 use std::{cell::UnsafeCell, collections::HashMap};
 
-use bex_vm_types::{FutureRead, HeapPtr, Object, Value, types::Future};
+use bex_vm_types::{
+    FutureRead, HeapPtr, Object, Value,
+    types::{Future, PackageKind},
+};
 
 use crate::{
     BexHeap,
@@ -679,19 +682,22 @@ impl BexHeap {
                     worklist.push(*interface);
                     worklist.extend(rules.iter().copied());
                 }
-                if let Some(runtime) = &package.runtime {
-                    worklist.extend(runtime.objects.iter().copied());
-                    worklist.extend(runtime.object_names.values().copied());
-                    worklist.extend(runtime.type_values.values().copied());
-                    worklist.extend(runtime.dependencies.iter().copied());
-                    worklist.extend(runtime.dependency_names.values().copied());
-                    worklist.extend(runtime.init);
-                    worklist.extend(
-                        runtime
-                            .globals
-                            .iter()
-                            .filter_map(|slot| slot.load().as_object_ptr()),
-                    );
+                match &package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        worklist.extend(runtime.objects.iter().copied());
+                        worklist.extend(runtime.object_names.values().copied());
+                        worklist.extend(runtime.type_values.values().copied());
+                        worklist.extend(runtime.dependencies.iter().copied());
+                        worklist.extend(runtime.dependency_names.values().copied());
+                        worklist.extend(runtime.init);
+                        worklist.extend(
+                            runtime
+                                .globals
+                                .iter()
+                                .filter_map(|slot| slot.load().as_object_ptr()),
+                        );
+                    }
                 }
             }
             Object::Function(function) => {
@@ -939,49 +945,52 @@ impl BexHeap {
                         (interface, rules)
                     })
                     .collect();
-                if let Some(runtime) = &mut package.runtime {
-                    for ptr in runtime.objects.iter_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
+                match &mut package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        for ptr in runtime.objects.iter_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        for ptr in runtime.object_names.values_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        // Keyed by the declaration each value names, so the keys
+                        // move too — rebuilt through the forwarding map rather than
+                        // mutated in place, as `impl_rules` above is.
+                        let old_type_values = std::mem::take(&mut runtime.type_values);
+                        runtime.type_values = old_type_values
+                            .into_iter()
+                            .map(|(declaration, value)| {
+                                (
+                                    forwarding.get(&declaration).copied().unwrap_or(declaration),
+                                    forwarding.get(&value).copied().unwrap_or(value),
+                                )
+                            })
+                            .collect();
+                        for ptr in runtime.dependencies.iter_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        for ptr in runtime.dependency_names.values_mut() {
+                            if let Some(&new_ptr) = forwarding.get(ptr) {
+                                *ptr = new_ptr;
+                            }
+                        }
+                        if let Some(ptr) = &mut runtime.init
+                            && let Some(&new_ptr) = forwarding.get(ptr)
+                        {
                             *ptr = new_ptr;
                         }
-                    }
-                    for ptr in runtime.object_names.values_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
+                        for slot in &runtime.globals {
+                            let mut value = slot.load();
+                            self.fixup_value(&mut value, forwarding);
+                            slot.store(value);
                         }
-                    }
-                    // Keyed by the declaration each value names, so the keys
-                    // move too — rebuilt through the forwarding map rather than
-                    // mutated in place, as `impl_rules` above is.
-                    let old_type_values = std::mem::take(&mut runtime.type_values);
-                    runtime.type_values = old_type_values
-                        .into_iter()
-                        .map(|(declaration, value)| {
-                            (
-                                forwarding.get(&declaration).copied().unwrap_or(declaration),
-                                forwarding.get(&value).copied().unwrap_or(value),
-                            )
-                        })
-                        .collect();
-                    for ptr in runtime.dependencies.iter_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
-                        }
-                    }
-                    for ptr in runtime.dependency_names.values_mut() {
-                        if let Some(&new_ptr) = forwarding.get(ptr) {
-                            *ptr = new_ptr;
-                        }
-                    }
-                    if let Some(ptr) = &mut runtime.init
-                        && let Some(&new_ptr) = forwarding.get(ptr)
-                    {
-                        *ptr = new_ptr;
-                    }
-                    for slot in &runtime.globals {
-                        let mut value = slot.load();
-                        self.fixup_value(&mut value, forwarding);
-                        slot.store(value);
                     }
                 }
             }
@@ -1337,30 +1346,33 @@ impl BexHeap {
                 {
                     worklist.push(ptr);
                 }
-                if let Some(runtime) = &package.runtime {
-                    worklist.extend(
-                        runtime
-                            .objects
-                            .iter()
-                            .chain(runtime.object_names.values())
-                            .chain(runtime.type_values.values())
-                            .chain(runtime.dependencies.iter())
-                            .chain(runtime.dependency_names.values())
-                            .copied()
-                            .filter(|ptr| self.generation_of(*ptr).is_young()),
-                    );
-                    if let Some(ptr) = runtime.init
-                        && self.generation_of(ptr).is_young()
-                    {
-                        worklist.push(ptr);
+                match &package.kind {
+                    PackageKind::Static => {}
+                    PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => {
+                        worklist.extend(
+                            runtime
+                                .objects
+                                .iter()
+                                .chain(runtime.object_names.values())
+                                .chain(runtime.type_values.values())
+                                .chain(runtime.dependencies.iter())
+                                .chain(runtime.dependency_names.values())
+                                .copied()
+                                .filter(|ptr| self.generation_of(*ptr).is_young()),
+                        );
+                        if let Some(ptr) = runtime.init
+                            && self.generation_of(ptr).is_young()
+                        {
+                            worklist.push(ptr);
+                        }
+                        worklist.extend(
+                            runtime
+                                .globals
+                                .iter()
+                                .filter_map(|slot| slot.load().as_object_ptr())
+                                .filter(|ptr| self.generation_of(*ptr).is_young()),
+                        );
                     }
-                    worklist.extend(
-                        runtime
-                            .globals
-                            .iter()
-                            .filter_map(|slot| slot.load().as_object_ptr())
-                            .filter(|ptr| self.generation_of(*ptr).is_young()),
-                    );
                 }
             }
             Object::Function(function) => {

--- a/baml_language/crates/bex_heap/tests/generational.rs
+++ b/baml_language/crates/bex_heap/tests/generational.rs
@@ -13,7 +13,7 @@ use bex_heap::{BexHeap, CollectionLevel, Generation, Tlab};
 use bex_vm_types::{
     Class, ClassField, GenericFunction, GlobalIndex, Object, RealizedTy,
     types::{
-        InterfaceDef, LocalName, MethodImpl, Package, RuntimeImplRule, RuntimePackage,
+        InterfaceDef, LocalName, MethodImpl, Package, PackageKind, RuntimeImplRule, RuntimePackage,
         TypeAliasDef, TypeValue,
     },
 };
@@ -118,7 +118,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
             interface_blob: Vec::new(),
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
+            kind: PackageKind::Runtime(Box::new(RuntimePackage {
                 objects: Box::new([]),
                 object_names: IndexMap::new(),
                 globals: Box::new([]),
@@ -130,7 +130,6 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
                 init: None,
                 initialized: true,
             })),
-            session: None,
         };
         let package_ptr = tlab.alloc(Object::Package(Box::new(package)));
         let class_name = QualifiedTypeName::local(Name::new("RuntimeClass"));
@@ -171,7 +170,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
             },
             class_ptr,
         );
-        let runtime = package.runtime.as_mut().expect("runtime image");
+        let runtime = package.runtime_mut().expect("runtime image");
         runtime.objects = vec![type_ptr, function_ptr, class_ptr].into_boxed_slice();
         runtime.type_values.insert(class_ptr, type_ptr);
         (tlab, package_ptr, function_ptr)
@@ -193,7 +192,7 @@ fn runtime_package_mint_cycle_survives_when_rooted_and_collects_when_dropped() {
         panic!("root ceased to be a package")
     };
     let moved_class = package.classes.values().next().copied().unwrap();
-    let moved_type = package.runtime.as_ref().unwrap().type_values[&moved_class];
+    let moved_type = package.runtime().unwrap().type_values[&moved_class];
     let Object::Type(type_value) = (unsafe { moved_type.get() }) else {
         panic!("package type value ceased to be a type")
     };
@@ -1048,8 +1047,7 @@ fn empty_package() -> Package {
         interface_blob: Vec::new(),
         test_init: None,
         mounted_types: IndexMap::new(),
-        runtime: None,
-        session: None,
+        kind: PackageKind::Static,
     }
 }
 

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -703,8 +703,13 @@ fn enrich_runtime_mount(
                             && fields.iter().all(|(name, ..)| source_identifier(name)) =>
                     {
                         let mut source = format!("class {} {{\n", mount.export_name);
-                        for (field, ..) in fields {
-                            writeln!(&mut source, "  {field} unknown")
+                        for (field, ty, _) in fields {
+                            let ty = if viewpoint.hides_type(ty) {
+                                "unknown".to_string()
+                            } else {
+                                ty.to_string()
+                            };
+                            writeln!(&mut source, "  {field} {ty}")
                                 .expect("writing to String is infallible");
                         }
                         source.push_str("}\n");

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -25,7 +25,8 @@ use bex_vm_types::{
     InitTail, RuntimeCompileArtifact, RuntimeCompileDiagnostic, RuntimeCompileMode,
     RuntimeCompileRequest, RuntimeDiagnosticSeverity, RuntimePackageMount,
     RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest, RuntimeSessionInitializer,
-    RuntimeSessionStep, RuntimeSourceSpan, SessionVisibleKind, SessionVisibleSymbol,
+    RuntimeSessionStep, RuntimeSessionStepKind, RuntimeSourceSpan, SessionVisibleKind,
+    SessionVisibleSymbol,
     bytecode::Instruction,
     relink::{IndexOperand, visit_object_operands},
 };
@@ -869,9 +870,7 @@ fn runtime_type_binding_parts(source: &str) -> Option<(String, &str)> {
 fn runtime_type_binding_prelude(bindings: &IndexMap<String, SessionVisibleSymbol>) -> String {
     let mut prelude = String::new();
     for symbol in bindings.values() {
-        if symbol.kind == SessionVisibleKind::TypeBinding
-            && let Some(type_value) = &symbol.type_value
-        {
+        if let SessionVisibleKind::TypeBinding { type_value } = &symbol.kind {
             let _ = writeln!(
                 prelude,
                 "type {} = unreflect({type_value});",
@@ -1145,7 +1144,6 @@ fn lower_session_submission(
             let symbol = SessionVisibleSymbol {
                 internal: internal(&name),
                 kind: SessionVisibleKind::Declaration,
-                type_value: None,
             };
             declaration_name_ranges.insert(range, symbol.internal.clone());
             declarations.insert(name, symbol);
@@ -1155,7 +1153,7 @@ fn lower_session_submission(
     let mut declaration_mapping = request
         .visible
         .iter()
-        .filter(|(_, symbol)| symbol.kind != SessionVisibleKind::Let)
+        .filter(|(_, symbol)| !matches!(symbol.kind, SessionVisibleKind::Let))
         .map(|(name, symbol)| (name.clone(), symbol.internal.clone()))
         .collect::<IndexMap<_, _>>();
     declaration_mapping.extend(
@@ -1259,11 +1257,12 @@ fn lower_session_submission(
     let mut active_type_bindings = request
         .visible
         .iter()
-        .filter(|(_, symbol)| symbol.kind == SessionVisibleKind::TypeBinding)
+        .filter(|(_, symbol)| matches!(symbol.kind, SessionVisibleKind::TypeBinding { .. }))
         .map(|(name, symbol)| (name.clone(), symbol.clone()))
         .collect::<IndexMap<_, _>>();
     let mut generated = declaration_source.clone();
     let mut steps = Vec::new();
+    let mut result_step = None;
 
     for (index, element) in elements.iter().enumerate() {
         let (node, wrapped_range, has_semicolon, is_statement) = match element {
@@ -1334,8 +1333,9 @@ fn lower_session_submission(
             let source = format!("let {backing_name} = {{\n{prelude}({operand})\n}}\n");
             let symbol = SessionVisibleSymbol {
                 internal: type_name,
-                kind: SessionVisibleKind::TypeBinding,
-                type_value: Some(backing_name.clone()),
+                kind: SessionVisibleKind::TypeBinding {
+                    type_value: backing_name.clone(),
+                },
             };
             (backing_name, source, None, Some((name, symbol)))
         } else {
@@ -1350,7 +1350,6 @@ fn lower_session_submission(
                 let symbol = SessionVisibleSymbol {
                     internal: internal_name.clone(),
                     kind: SessionVisibleKind::Let,
-                    type_value: None,
                 };
                 binding = Some((name, symbol));
                 internal_name
@@ -1362,7 +1361,8 @@ fn lower_session_submission(
                 .flatten()
                 .and_then(|(target, operator, rhs)| {
                     let symbol = request.visible.get(target)?;
-                    (symbol.kind == SessionVisibleKind::Let).then_some((symbol, operator, rhs))
+                    matches!(symbol.kind, SessionVisibleKind::Let)
+                        .then_some((symbol, operator, rhs))
                 });
             let (source, commit_global) = if let Some((target, operator, rhs)) = assignment {
                 let rhs = rewrite_identifiers(
@@ -1435,39 +1435,44 @@ fn lower_session_submission(
         generated.push_str(&step_source);
         let returns_value =
             index + 1 == elements.len() && !is_outer_let && !is_statement && !has_semicolon;
+        if returns_value {
+            result_step = Some(steps.len());
+        }
+        let kind = binding
+            .clone()
+            .map_or(RuntimeSessionStepKind::Expression, |(name, symbol)| {
+                RuntimeSessionStepKind::Binding {
+                    name,
+                    symbol,
+                    replay_source: step_source.clone(),
+                }
+            });
         steps.push(RuntimeSessionStep {
             global: format!("user.{generated_name}"),
             commit_global,
-            binding: binding.clone(),
-            replay_source: binding.as_ref().map(|_| step_source),
-            returns_value,
+            kind,
         });
         if let Some((name, symbol)) = binding {
             visible_mapping.insert(name.clone(), symbol.internal.clone());
-            if symbol.kind == SessionVisibleKind::TypeBinding {
+            if matches!(symbol.kind, SessionVisibleKind::TypeBinding { .. }) {
                 active_type_bindings.insert(name, symbol);
             }
         }
     }
 
-    if !steps.iter().any(|step| step.returns_value) {
+    if result_step.is_none() {
         let generated_name = format!("__baml_session_{sequence}_result");
         let step_source = format!("let {generated_name} = null\n");
         generated.push_str(&step_source);
+        result_step = Some(steps.len());
         steps.push(RuntimeSessionStep {
             global: format!("user.{generated_name}"),
             commit_global: None,
-            binding: None,
-            replay_source: None,
-            returns_value: true,
+            kind: RuntimeSessionStepKind::Expression,
         });
     }
-    let result_global = steps
-        .iter()
-        .find(|step| step.returns_value)
-        .expect("session lowering always has a result")
-        .global
-        .clone();
+    let result_step = result_step.expect("session lowering always has a result");
+    let result_global = steps[result_step].global.clone();
     Ok(LoweredSession {
         source: generated,
         artifact: RuntimeSessionCompileArtifact {
@@ -1475,6 +1480,7 @@ fn lower_session_submission(
             declaration_source,
             declarations,
             steps,
+            result_step: Some(result_step),
             initializers: Vec::new(),
         },
         result_global,
@@ -1942,17 +1948,17 @@ impl RuntimeCompiler for ProjectRuntimeCompiler {
             }
             session.artifact.initializers = initializers;
         }
-        // The public artifact still carries these as two independent `Option`s,
-        // so the pair splits here — once, at the boundary that demands it —
-        // rather than being threaded through the function as separate values.
-        let (session_artifact, session_lease) =
-            session.map_or((None, None), |s| (Some(s.artifact), Some(s.lease)));
+        let kind = session.map_or(bex_vm_types::ArtifactKind::Package, |session| {
+            bex_vm_types::ArtifactKind::Session {
+                meta: session.artifact,
+                lease: session.lease,
+            }
+        });
         Ok(RuntimeCompileArtifact {
             units,
             interface_blob,
             diagnostics,
-            session: session_artifact,
-            session_lease,
+            kind,
         })
     }
 }

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -188,6 +188,35 @@ fn enrich_runtime_mount(
             && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
     }
 
+    fn relocated_name(
+        name: &baml_type::QualifiedTypeName,
+        alias: &Name,
+    ) -> baml_type::QualifiedTypeName {
+        if name.is_local() {
+            baml_type::QualifiedTypeName::new(
+                alias.clone(),
+                name.namespace().clone(),
+                name.name().clone(),
+            )
+        } else {
+            name.clone()
+        }
+    }
+
+    fn relocate_ty(ty: &mut baml_type::Ty, alias: &Name) {
+        *ty = ty.map_heads(&mut |name| relocated_name(name, alias));
+    }
+
+    fn relocate_interface(interface: &mut baml_type::Interface, alias: &Name) {
+        *interface = interface.map_heads(&mut |name| relocated_name(name, alias));
+    }
+
+    fn relocate_bounds(bounds: &mut [Vec<baml_type::Interface>], alias: &Name) {
+        for interface in bounds.iter_mut().flatten() {
+            relocate_interface(interface, alias);
+        }
+    }
+
     fn relocate_function(
         function: &mut ExportedFunction,
         alias: &Name,
@@ -195,6 +224,17 @@ fn enrich_runtime_mount(
         stubs: &mut Vec<(Vec<Name>, Name, String)>,
     ) {
         use baml_compiler2_hir_ty::callable::{ExternalCallTarget, ExternalLinkability};
+
+        for param in &mut function.params {
+            *param = param.map_heads(&mut |name| relocated_name(name, alias));
+        }
+        relocate_ty(&mut function.return_type, alias);
+        if let Some(throws) = &mut function.declared_throws {
+            relocate_ty(throws, alias);
+        }
+        relocate_ty(&mut function.callable_throws, alias);
+        relocate_bounds(&mut function.generic_param_bounds, alias);
+
         if !matches!(function.linkability, ExternalLinkability::Linkable) {
             return;
         }
@@ -305,6 +345,20 @@ fn enrich_runtime_mount(
     let alias = Name::new(alias);
     let viewpoint = StubViewpoint { aliases };
     let mut stubs = Vec::new();
+    for throw_set in interface
+        .throw_sets
+        .direct
+        .values_mut()
+        .chain(interface.throw_sets.transitive.values_mut())
+    {
+        *throw_set = std::mem::take(throw_set)
+            .into_iter()
+            .map(|mut ty| {
+                relocate_ty(&mut ty, &alias);
+                ty
+            })
+            .collect();
+    }
     for function in interface
         .functions
         .values_mut()
@@ -316,11 +370,17 @@ fn enrich_runtime_mount(
         for (export_name, exported) in exported_types {
             match exported {
                 ExportedType::Class {
+                    qtn,
                     fields,
                     methods,
                     generic_params,
-                    ..
+                    generic_param_bounds,
                 } => {
+                    *qtn = relocated_name(qtn, &alias);
+                    for (_, ty, _) in fields.iter_mut() {
+                        relocate_ty(ty, &alias);
+                    }
+                    relocate_bounds(generic_param_bounds, &alias);
                     // The emitter needs a concrete class object in the mounted
                     // package's discarded source units so a consumer literal
                     // decomposes to an external object reference. At runtime
@@ -342,12 +402,18 @@ fn enrich_runtime_mount(
                             format!("<{}>", generics.join(", "))
                         };
                         let mut source = format!("class {export_name}{generic_suffix} {{\n");
-                        for (field, ..) in fields.iter() {
-                            // Mounted inference owns the exact field type. The
-                            // source stub exists only to allocate/link the
-                            // positional class object, so `unknown` avoids
-                            // re-spelling hidden runtime-qualified names.
-                            writeln!(&mut source, "  {field} unknown")
+                        for (field, ty, _) in fields.iter() {
+                            // Source-backed lookup wins before the mounted
+                            // interface in HIR. Preserve every spellable field
+                            // type here so nested projections see the same ABI;
+                            // only genuinely hidden package names degrade to
+                            // `unknown` in the link-only source.
+                            let ty = if viewpoint.hides_type(ty) {
+                                "unknown".to_string()
+                            } else {
+                                ty.to_string()
+                            };
+                            writeln!(&mut source, "  {field} {ty}")
                                 .expect("writing to String is infallible");
                         }
                         source.push_str("}\n");
@@ -360,12 +426,29 @@ fn enrich_runtime_mount(
                 ExportedType::Interface {
                     qtn,
                     generic_params,
+                    param_bounds,
+                    requires,
                     associated_types,
                     fields,
                     required_methods,
                     default_methods,
                     ..
                 } => {
+                    relocate_bounds(param_bounds, &alias);
+                    for interface in requires {
+                        relocate_interface(interface, &alias);
+                    }
+                    for associated in associated_types.iter_mut() {
+                        if let Some(bound) = &mut associated.bound {
+                            relocate_interface(bound, &alias);
+                        }
+                        if let Some(default) = &mut associated.default {
+                            relocate_ty(default, &alias);
+                        }
+                    }
+                    for (_, ty, _) in fields.iter_mut() {
+                        relocate_ty(ty, &alias);
+                    }
                     for function in required_methods.iter_mut().chain(default_methods) {
                         relocate_function(function, &alias, &viewpoint, &mut stubs);
                     }
@@ -405,7 +488,8 @@ fn enrich_runtime_mount(
                     source.push_str("}\n");
                     stubs.push((namespace, name, source));
                 }
-                ExportedType::Enum { variants, .. } => {
+                ExportedType::Enum { qtn, variants } => {
+                    *qtn = relocated_name(qtn, &alias);
                     if source_identifier(export_name)
                         && export_namespace.iter().all(source_identifier)
                         && variants.iter().all(source_identifier)
@@ -419,11 +503,23 @@ fn enrich_runtime_mount(
                         stubs.push((export_namespace.clone(), export_name.clone(), source));
                     }
                 }
-                ExportedType::TypeAlias { .. } => {}
+                ExportedType::TypeAlias { qtn, resolved } => {
+                    *qtn = relocated_name(qtn, &alias);
+                    relocate_ty(resolved, &alias);
+                }
             }
         }
     }
     for implementation in &mut interface.impls {
+        relocate_interface(&mut implementation.interface, &alias);
+        relocate_ty(&mut implementation.for_ty_pattern, &alias);
+        relocate_bounds(&mut implementation.param_bounds, &alias);
+        for (_, ty) in &mut implementation.associated_types {
+            relocate_ty(ty, &alias);
+        }
+        if let ExportedImplOrigin::InBodyClass { class_qtn } = &mut implementation.origin {
+            *class_qtn = relocated_name(class_qtn, &alias);
+        }
         for function in &mut implementation.methods {
             relocate_function(function, &alias, &viewpoint, &mut stubs);
         }
@@ -518,8 +614,8 @@ fn enrich_runtime_mount(
     }
     // Every mounted row gets a source link stub so a consumer literal can
     // decompose to an external object reference; runtime linking resolves it
-    // to the live declaration. Mounted inference owns the real field types, so
-    // stub fields are `unknown`.
+    // to the live declaration. Source-backed lookup wins before the mounted
+    // interface in HIR, so preserve spellable field types here as well.
     for (name, row) in &minted_rows {
         match row {
             ExportedType::Class { fields, .. }
@@ -527,8 +623,13 @@ fn enrich_runtime_mount(
                     && fields.iter().all(|(field, ..)| source_identifier(field)) =>
             {
                 let mut source = format!("class {name} {{\n");
-                for (field, ..) in fields {
-                    writeln!(&mut source, "  {field} unknown")
+                for (field, ty, _) in fields {
+                    let ty = if viewpoint.hides_type(ty) {
+                        "unknown".to_string()
+                    } else {
+                        ty.to_string()
+                    };
+                    writeln!(&mut source, "  {field} {ty}")
                         .expect("writing to String is infallible");
                 }
                 source.push_str("}\n");
@@ -1859,8 +1960,20 @@ impl RuntimeCompiler for ProjectRuntimeCompiler {
                 .result_global
                 .strip_prefix("user.")
                 .unwrap_or(session.result_global.as_str());
-            let actual =
-                let_initializer_type(&db, result_name).unwrap_or_else(baml_type::Ty::unknown);
+            let Some(actual) = let_initializer_type(&db, result_name) else {
+                return Err(vec![RuntimeCompileDiagnostic {
+                    code: "E_RUNTIME_SESSION".to_string(),
+                    message: format!(
+                        "internal compiler error: Session result binding `{result_name}` has no initializer type"
+                    ),
+                    severity: RuntimeDiagnosticSeverity::Error,
+                    span: Some(RuntimeSourceSpan {
+                        file: file.to_string(),
+                        start: 0,
+                        end: 0,
+                    }),
+                }]);
+            };
             // The check runs in the compiler's context, which names declarations
             // rather than pointing at them. `eval<T>` can be handed a
             // runtime-created type, which has no name to recover — the engine

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -1354,7 +1354,10 @@ fn lower_session_submission(
                 binding = Some((name, symbol));
                 internal_name
             } else {
-                format!("__baml_session_{sequence}_stmt_{index}")
+                // Synthetic step globals must live outside `internal()`'s
+                // namespace so a user binding such as `stmt_1` cannot mint
+                // the same name.
+                format!("__baml_stmt_{sequence}_{index}")
             };
             let assignment = is_statement
                 .then(|| assignment_parts(raw))
@@ -1461,7 +1464,9 @@ fn lower_session_submission(
     }
 
     if result_step.is_none() {
-        let generated_name = format!("__baml_session_{sequence}_result");
+        // This fallback must likewise be outside `internal()`'s namespace:
+        // otherwise a user binding called `result` collides with it.
+        let generated_name = format!("__baml_result_{sequence}");
         let step_source = format!("let {generated_name} = null\n");
         generated.push_str(&step_source);
         result_step = Some(steps.len());

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -123,7 +123,7 @@ impl<'vm> ImplResolver<'vm> {
             if let Some(rules) = package.impl_rules.get(&iface_ptr) {
                 pointers.extend(rules);
             }
-            if let Some(runtime) = &package.runtime {
+            if let Some(runtime) = package.runtime() {
                 packages.extend(runtime.dependencies.iter().copied());
             }
         }

--- a/baml_language/crates/bex_vm/src/package_load.rs
+++ b/baml_language/crates/bex_vm/src/package_load.rs
@@ -23,7 +23,10 @@ use baml_type::Name;
 use bex_heap::{BexHeap, Generation};
 use bex_vm_types::{
     GlobalIndex, HeapPtr, Object, ObjectIndex,
-    types::{LocalName, MethodImpl, Package, ProgramImplRule, ProgramPackage, RuntimeImplRule},
+    types::{
+        LocalName, MethodImpl, Package, PackageKind, ProgramImplRule, ProgramPackage,
+        RuntimeImplRule,
+    },
 };
 use indexmap::IndexMap;
 
@@ -427,8 +430,7 @@ fn fill_package_slots(
                 .test_init
                 .map(|index| heap.compile_time_ptr(index.into_raw())),
             mounted_types: IndexMap::new(),
-            runtime: None,
-            session: None,
+            kind: PackageKind::Static,
         };
         heap.set_compile_time_object(slots.package_slot, Object::Package(Box::new(package)));
         index

--- a/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
@@ -20,13 +20,14 @@ use baml_compiler_diagnostics::{
 use baml_type::{TyAttr, normalize, normalize::TypeContext};
 use bex_heap::TlabHolder;
 use bex_vm_types::{
-    AtomicValueSlot, HeapPtr, Interface, Object, RealizedTy, RuntimeCompileArtifact,
-    RuntimeSessionCompileArtifact, SessionEvalLease, Ty,
+    ArtifactKind, AtomicValueSlot, HeapPtr, Interface, Object, RealizedTy, RuntimeCompileArtifact,
+    RuntimeCompileArtifactSlot, RuntimeSessionCompileArtifact, RuntimeSessionStepKind,
+    SessionEvalLease, Ty,
     link::link_dynamic,
     relink::{IndexOperand, visit_object_operands},
     types::{
-        LocalName, MethodImpl, Package, RuntimeImplRule, RuntimePackage, SessionState, TypeValue,
-        Value,
+        LocalName, MethodImpl, Package, PackageKind, RuntimeImplRule, RuntimePackage, SessionState,
+        TypeValue, Value,
     },
 };
 use indexmap::IndexMap;
@@ -92,9 +93,6 @@ fn package_ptr(vm: &BexVm, value: Value) -> Result<HeapPtr, VmRustFnError> {
         }
         .into());
     };
-    if matches!(vm.get_object(wrapper_ptr), Object::Package(_)) {
-        return Ok(wrapper_ptr);
-    }
     let Object::Instance(wrapper) = vm.get_object(wrapper_ptr) else {
         return Err(VmBamlError::InvalidArgument {
             message: "reflect.Package receiver is not an instance".to_string(),
@@ -114,6 +112,39 @@ fn package_ptr(vm: &BexVm, value: Value) -> Result<HeapPtr, VmRustFnError> {
         .into());
     }
     Ok(ptr)
+}
+
+fn take_compile_artifact(
+    vm: &BexVm,
+    value: Value,
+    invalid_message: &str,
+    consumed_message: &str,
+) -> Result<RuntimeCompileArtifact, VmRustFnError> {
+    let Some(inner) = value
+        .as_object_ptr()
+        .and_then(|pointer| match vm.get_object(pointer) {
+            Object::Instance(instance) => Some(instance.load_field(0)),
+            _ => None,
+        })
+    else {
+        return Err(VmBamlError::InvalidArgument {
+            message: invalid_message.to_string(),
+        }
+        .into());
+    };
+    let slot = vm
+        .as_rust_data::<RuntimeCompileArtifactSlot>(&inner)
+        .map_err(|_| VmBamlError::InvalidArgument {
+            message: invalid_message.to_string(),
+        })?;
+    let mut slot = slot.lock().map_err(|_| VmBamlError::InvalidArgument {
+        message: format!("{invalid_message}: artifact state is unavailable"),
+    })?;
+    slot.take().ok_or_else(|| {
+        VmRustFnError::from(VmBamlError::InvalidArgument {
+            message: consumed_message.to_string(),
+        })
+    })
 }
 
 fn local_name(path: &str) -> Option<LocalName> {
@@ -152,12 +183,7 @@ fn stored_package_type(package: &Package, name: &LocalName) -> Option<HeapPtr> {
                 .get(name)
                 .or_else(|| package.enums.get(name))
                 .or_else(|| package.interfaces.get(name))?;
-            package
-                .runtime
-                .as_ref()?
-                .type_values
-                .get(declaration)
-                .copied()
+            package.runtime()?.type_values.get(declaration).copied()
         })
 }
 
@@ -394,7 +420,7 @@ fn package_function_value(vm: &mut BexVm, package_ptr: HeapPtr, name: &LocalName
         .collect::<Vec<_>>()
         .join(".");
     let (slot, runtime_package) = match vm.get_object(package_ptr) {
-        Object::Package(package) => match package.runtime.as_ref() {
+        Object::Package(package) => match package.runtime() {
             Some(runtime) => {
                 let slot = runtime
                     .global_names
@@ -563,8 +589,7 @@ impl Continuation for FinishPackage {
             unreachable!("finish continuation retained a Package")
         };
         package
-            .runtime
-            .as_mut()
+            .runtime_mut()
             .expect("runtime package has an image")
             .initialized = true;
         NativeCallResult::Done(Value::object(self.wrapper))
@@ -690,23 +715,21 @@ impl BamlClassPackage for PackageReflectImpl {
         artifact: &Value,
         packages: &IndexMap<bex_str::BexStr, Value>,
     ) -> NativeCallResult {
-        let Some(artifact_inner) =
-            artifact
-                .as_object_ptr()
-                .and_then(|ptr| match vm.get_object(ptr) {
-                    Object::Instance(instance) => Some(instance.load_field(0)),
-                    _ => None,
-                })
-        else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "reflect.Package._finish received an invalid artifact".to_string(),
-            })
-            .into();
-        };
-        let artifact = match vm.as_rust_data::<RuntimeCompileArtifact>(&artifact_inner) {
-            Ok(artifact) => artifact.clone(),
+        let artifact = match take_compile_artifact(
+            vm,
+            *artifact,
+            "reflect.Package._finish received an invalid artifact",
+            "Package compile artifact has already been consumed",
+        ) {
+            Ok(artifact) => artifact,
             Err(error) => return error.into(),
         };
+        if !matches!(&artifact.kind, ArtifactKind::Package) {
+            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                message: "reflect.Package._finish received a Session.eval artifact".to_string(),
+            })
+            .into();
+        }
         let plan = match link_dynamic(&artifact.units) {
             Ok(plan) => plan,
             Err(error) => {
@@ -755,7 +778,7 @@ impl BamlClassPackage for PackageReflectImpl {
             interface_blob: artifact.interface_blob,
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
+            kind: PackageKind::Runtime(Box::new(RuntimePackage {
                 objects: Box::new([]),
                 object_names: IndexMap::new(),
                 globals: Box::new([]),
@@ -767,7 +790,6 @@ impl BamlClassPackage for PackageReflectImpl {
                 init: None,
                 initialized: false,
             })),
-            session: None,
         };
         let package_ptr = vm.alloc(Object::Package(Box::new(package)));
 
@@ -886,7 +908,7 @@ impl BamlClassPackage for PackageReflectImpl {
                         else {
                             return None;
                         };
-                        if let Some(runtime) = package.runtime.as_ref() {
+                        if let Some(runtime) = package.runtime() {
                             let index = runtime
                                 .global_names
                                 .get(&format!("user.{local}"))
@@ -1010,7 +1032,7 @@ impl BamlClassPackage for PackageReflectImpl {
         package.impl_rules = impl_rules;
         package.functions = functions;
         package.test_init = test_init;
-        let runtime = package.runtime.as_mut().expect("runtime package image");
+        let runtime = package.runtime_mut().expect("runtime package image");
         runtime.objects = objects.into_boxed_slice();
         runtime.globals = globals.into_boxed_slice();
         runtime.global_names = global_names;
@@ -1038,7 +1060,7 @@ impl BamlClassPackage for PackageReflectImpl {
             let Object::Package(package) = vm.get_object_mut(package_ptr) else {
                 unreachable!()
             };
-            package.runtime.as_mut().expect("runtime image").initialized = true;
+            package.runtime_mut().expect("runtime image").initialized = true;
             NativeCallResult::Done(wrapper)
         }
     }
@@ -1330,8 +1352,7 @@ impl BamlClassPackage for PackageReflectImpl {
         };
         let diagnostics = match vm.get_object(ptr) {
             Object::Package(package) => package
-                .runtime
-                .as_ref()
+                .runtime()
                 .map(|runtime| runtime.diagnostics.clone())
                 .unwrap_or_default(),
             _ => Vec::new(),
@@ -1574,8 +1595,7 @@ fn session_external_object(
 ) -> Option<HeapPtr> {
     if let Object::Package(package) = vm.get_object(session)
         && let Some(pointer) = package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.object_names.get(name))
     {
         return Some(*pointer);
@@ -1593,7 +1613,7 @@ fn session_external_global(
     name: &str,
 ) -> Option<Value> {
     if let Object::Package(package) = vm.get_object(session)
-        && let Some(runtime) = package.runtime.as_ref()
+        && let Some(runtime) = package.runtime()
         && let Some(index) = runtime.global_names.get(name)
     {
         return runtime.load_global(*index);
@@ -1607,7 +1627,7 @@ fn session_external_global(
             let Object::Package(package) = vm.get_object(dependency) else {
                 return None;
             };
-            if let Some(runtime) = package.runtime.as_ref() {
+            if let Some(runtime) = package.runtime() {
                 let index = runtime
                     .global_names
                     .get(&format!("user.{local}"))
@@ -1667,23 +1687,27 @@ impl Continuation for SessionExecution {
             let Object::Package(package) = vm.get_object_mut(self.package) else {
                 unreachable!("Session continuation retained its package")
             };
-            let runtime = package.runtime.as_mut().expect("Session runtime image");
+            let PackageKind::Session { runtime, state } = &mut package.kind else {
+                unreachable!("Session continuation retained a Session package")
+            };
             runtime.globals[action.target].store(value);
 
             if let Some(step_index) = action.step {
                 let step = &self.metadata.steps[step_index];
-                let state = package.session.as_mut().expect("Session state");
-                if let Some(source) = &step.replay_source {
+                if let RuntimeSessionStepKind::Binding {
+                    name,
+                    symbol,
+                    replay_source,
+                } = &step.kind
+                {
                     state
                         .history
                         .entry(self.metadata.submission_name.clone())
                         .or_default()
-                        .push_str(source);
-                }
-                if let Some((name, symbol)) = &step.binding {
+                        .push_str(replay_source);
                     state.visible.insert(name.clone(), symbol.clone());
                 }
-                if step.returns_value {
+                if self.metadata.result_step == Some(step_index) {
                     self.result = value;
                 }
             }
@@ -1735,7 +1759,7 @@ fn graft_session_submission(
         let Object::Package(package) = vm.get_object(package_ptr) else {
             unreachable!("Session payload is a Package")
         };
-        let runtime = package.runtime.as_ref().expect("Session runtime image");
+        let runtime = package.runtime().expect("Session runtime image");
         (
             runtime.dependency_names.clone(),
             runtime.global_names.clone(),
@@ -1988,7 +2012,7 @@ fn graft_session_submission(
     // A session's earlier evals published their declarations under fully
     // qualified names; a later eval's type positions name them the same way.
     if let Object::Package(package) = vm.get_object(package_ptr)
-        && let Some(runtime) = package.runtime.as_ref()
+        && let Some(runtime) = package.runtime()
     {
         named_surfaces.extend(
             runtime
@@ -2103,7 +2127,9 @@ fn graft_session_submission(
             .extend(rules);
     }
     package.interface_blob.clone_from(&artifact.interface_blob);
-    let state = package.session.as_mut().expect("Session state");
+    let PackageKind::Session { runtime, state } = &mut package.kind else {
+        unreachable!("Session graft target changed package kind")
+    };
     if !metadata.declaration_source.trim().is_empty() {
         state.history.insert(
             metadata.submission_name.clone(),
@@ -2111,7 +2137,6 @@ fn graft_session_submission(
         );
     }
     state.visible.extend(metadata.declarations.clone());
-    let runtime = package.runtime.as_mut().expect("Session runtime image");
     let mut globals = runtime.globals.to_vec();
     globals.extend(appended.into_iter().map(AtomicValueSlot::new));
     runtime.globals = globals.into_boxed_slice();
@@ -2166,25 +2191,27 @@ impl BamlClassSession for PackageReflectImpl {
             interface_blob: Vec::new(),
             test_init: None,
             mounted_types: IndexMap::new(),
-            runtime: Some(Box::new(RuntimePackage {
-                objects: Box::new([]),
-                object_names: IndexMap::new(),
-                globals: Box::new([]),
-                global_names: IndexMap::new(),
-                type_values: IndexMap::new(),
-                diagnostics: Vec::new(),
-                dependencies: dependencies.values().copied().collect(),
-                dependency_names: dependencies,
-                init: None,
-                // Session cells intentionally stay mutable between evals.
-                initialized: false,
-            })),
-            session: Some(Box::new(SessionState {
-                history: IndexMap::new(),
-                visible: IndexMap::new(),
-                busy: Arc::new(AtomicBool::new(false)),
-                submission_counter: 0,
-            })),
+            kind: PackageKind::Session {
+                runtime: Box::new(RuntimePackage {
+                    objects: Box::new([]),
+                    object_names: IndexMap::new(),
+                    globals: Box::new([]),
+                    global_names: IndexMap::new(),
+                    type_values: IndexMap::new(),
+                    diagnostics: Vec::new(),
+                    dependencies: dependencies.values().copied().collect(),
+                    dependency_names: dependencies,
+                    init: None,
+                    // Session cells intentionally stay mutable between evals.
+                    initialized: false,
+                }),
+                state: Box::new(SessionState {
+                    history: IndexMap::new(),
+                    visible: IndexMap::new(),
+                    busy: Arc::new(AtomicBool::new(false)),
+                    submission_counter: 0,
+                }),
+            },
         };
         let package = vm.alloc(Object::Package(Box::new(package)));
         Ok(copy::Session {
@@ -2198,34 +2225,24 @@ impl BamlClassSession for PackageReflectImpl {
             Ok(package) => package,
             Err(error) => return error.into(),
         };
-        let Some(artifact_inner) =
-            artifact
-                .as_object_ptr()
-                .and_then(|pointer| match vm.get_object(pointer) {
-                    Object::Instance(instance) => Some(instance.load_field(0)),
-                    _ => None,
-                })
-        else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session._finish received an invalid artifact".to_string(),
-            })
-            .into();
-        };
-        let mut artifact = match vm.as_rust_data::<RuntimeCompileArtifact>(&artifact_inner) {
-            Ok(artifact) => artifact.clone(),
+        let mut artifact = match take_compile_artifact(
+            vm,
+            *artifact,
+            "Session._finish received an invalid artifact",
+            "Session artifact has already been consumed",
+        ) {
+            Ok(artifact) => artifact,
             Err(error) => return error.into(),
         };
-        let Some(metadata) = artifact.session.clone() else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session._finish received a Package.compile artifact".to_string(),
-            })
-            .into();
-        };
-        let Some(lease) = artifact.session_lease.take() else {
-            return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
-                message: "Session artifact has already been consumed".to_string(),
-            })
-            .into();
+        let kind = std::mem::replace(&mut artifact.kind, ArtifactKind::Package);
+        let (metadata, lease) = match kind {
+            ArtifactKind::Session { meta, lease } => (meta, lease),
+            ArtifactKind::Package => {
+                return VmRustFnError::BamlError(VmBamlError::InvalidArgument {
+                    message: "Session._finish received a Package.compile artifact".to_string(),
+                })
+                .into();
+            }
         };
         let actions = match graft_session_submission(vm, package, &artifact, &metadata) {
             Ok(actions) => actions,
@@ -2255,8 +2272,7 @@ impl BamlClassSession for PackageReflectImpl {
         };
         let diagnostics = match vm.get_object(package) {
             Object::Package(package) => package
-                .runtime
-                .as_ref()
+                .runtime()
                 .map(|runtime| runtime.diagnostics.clone())
                 .unwrap_or_default(),
             _ => Vec::new(),

--- a/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
@@ -1023,47 +1023,67 @@ fn render_meta_suffix(alias: Option<&str>, description: Option<&str>) -> String 
     out
 }
 
-fn render_ty_source(ty: &bex_vm_types::RealizedTy) -> String {
+fn render_ty_source(
+    ty: &bex_vm_types::RealizedTy,
+    spellings: &indexmap::IndexMap<baml_type::typetag::TypeTag, String>,
+) -> String {
+    let ty = ty.map_heads(&mut |head| {
+        let name = spellings.get(&head.tag()).map_or_else(
+            || {
+                head.tagged_name()
+                    .map(|tagged| tagged.name().clone())
+                    .unwrap_or_else(|| unreachable!("a live type head names a declaration"))
+            },
+            |name| baml_type::DeclarationName::Anonymous(baml_type::Name::new(name)),
+        );
+        baml_type::TaggedTypeName::new(head.tag(), name)
+    });
+    render_named_ty_source(&ty)
+}
+
+fn render_named_ty_source(ty: &baml_type::RealizedTy<baml_type::TaggedTypeName>) -> String {
     match ty {
-        bex_vm_types::RealizedTy::Union(members, _) => {
+        baml_type::RealizedTy::Union(members, _) => {
             let mut non_null: Vec<_> = members.iter().filter(|member| !member.is_null()).collect();
             let has_null = non_null.len() != members.len();
             if has_null && non_null.len() == 1 {
                 let member = non_null
                     .pop()
                     .unwrap_or_else(|| unreachable!("length checked"));
-                let rendered = render_ty_source(member);
-                if matches!(member, bex_vm_types::RealizedTy::Function { .. }) {
+                let rendered = render_named_ty_source(member);
+                if matches!(member, baml_type::RealizedTy::Function { .. }) {
                     format!("({rendered})?")
                 } else {
                     format!("{rendered}?")
                 }
             } else {
                 let mut rendered: Vec<String> =
-                    non_null.into_iter().map(render_ty_source).collect();
+                    non_null.into_iter().map(render_named_ty_source).collect();
                 if has_null {
                     rendered.push("null".to_string());
                 }
                 rendered.join(" | ")
             }
         }
-        bex_vm_types::RealizedTy::List(element, _) => {
-            let rendered = render_ty_source(element);
-            if matches!(element.as_ref(), bex_vm_types::RealizedTy::Union(..)) {
+        baml_type::RealizedTy::List(element, _) => {
+            let rendered = render_named_ty_source(element);
+            if matches!(element.as_ref(), baml_type::RealizedTy::Union(..)) {
                 format!("({rendered})[]")
             } else {
                 format!("{rendered}[]")
             }
         }
-        bex_vm_types::RealizedTy::Map { key, value, .. } => {
+        baml_type::RealizedTy::Map { key, value, .. } => {
             format!(
                 "map<{}, {}>",
-                render_ty_source(key),
-                render_ty_source(value)
+                render_named_ty_source(key),
+                render_named_ty_source(value)
             )
         }
-        bex_vm_types::RealizedTy::Class(head, args, _) if args.is_empty() => head_name(head),
-        bex_vm_types::RealizedTy::Enum(head, _) => head_name(head),
+        baml_type::RealizedTy::Class(head, args, _) if args.is_empty() => {
+            head.display_name().to_string()
+        }
+        baml_type::RealizedTy::Enum(head, _) => head.display_name().to_string(),
         other => other.to_string(),
     }
 }
@@ -1075,7 +1095,12 @@ fn render_ty_source(ty: &bex_vm_types::RealizedTy) -> String {
 /// instead, so what this prints and what a virtual call resolves cannot
 /// disagree. A rule's `field_links` are physical field slots, so the interface's
 /// declared field order supplies the left-hand names and `class` the right.
-fn render_witness_sources(vm: &BexVm, source: &mut String, class_ptr: bex_vm_types::HeapPtr) {
+fn render_witness_sources(
+    vm: &BexVm,
+    source: &mut String,
+    class_ptr: bex_vm_types::HeapPtr,
+    spellings: &indexmap::IndexMap<baml_type::typetag::TypeTag, String>,
+) {
     let Object::Class(class) = vm.get_object(class_ptr) else {
         return;
     };
@@ -1092,7 +1117,7 @@ fn render_witness_sources(vm: &BexVm, source: &mut String, class_ptr: bex_vm_typ
             .interface_args
             .iter()
             .filter_map(|arg| bex_vm_types::RealizedTy::try_from(arg).ok())
-            .map(|arg| render_ty_source(&arg))
+            .map(|arg| render_ty_source(&arg, spellings))
             .collect::<Vec<_>>();
         if !args.is_empty() {
             source.push('<');
@@ -1117,7 +1142,7 @@ fn render_witness_sources(vm: &BexVm, source: &mut String, class_ptr: bex_vm_typ
             source.push_str("\n    type ");
             source.push_str(name.as_str());
             source.push_str(" = ");
-            source.push_str(&render_ty_source(&ty));
+            source.push_str(&render_ty_source(&ty, spellings));
         }
         for (declared, slot) in interface.fields.iter().zip(&*rule.field_links) {
             let Some(field) = class.fields.get(*slot as usize) else {
@@ -1138,18 +1163,18 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
     // to render is a walk, not a table. A package contributes its whole surface
     // (a `Package.compile` result renders as the source it was compiled from),
     // minus the `$stream` companions, which are synthesized rather than written.
-    let (mut class_ptrs, mut enum_ptrs) = crate::reachable::runtime_nominals(vm, &type_value.ty);
-    let mut owners = class_ptrs
+    let (mut class_ptrs, mut enum_ptrs) = crate::reachable::all_nominals(vm, &type_value.ty);
+    let owners = class_ptrs
         .iter()
         .chain(&enum_ptrs)
+        .filter(|ptr| !vm.heap.is_compile_time_ptr(**ptr))
         .filter_map(|ptr| match vm.get_object(*ptr) {
             Object::Class(class) => Some(class.owner),
             Object::Enum(enm) => Some(enm.owner),
             _ => None,
         })
         .filter(|owner| !owner.is_null())
-        .collect::<Vec<_>>();
-    owners.dedup();
+        .collect::<indexmap::IndexSet<_>>();
     for owner in owners {
         let Object::Package(package) = vm.get_object(owner) else {
             continue;
@@ -1171,12 +1196,74 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         }
     }
 
+    // Package expansion can add declarations whose fields reach static
+    // classes. Close that graph too so every rendered reference has a block.
+    let mut class_index = 0;
+    while class_index < class_ptrs.len() {
+        let ptr = class_ptrs[class_index];
+        class_index += 1;
+        let Object::Class(class) = vm.get_object(ptr) else {
+            continue;
+        };
+        for field in &class.fields {
+            let field_ty = field
+                .runtime_type
+                .as_ref()
+                .map(|runtime| runtime.ty.clone())
+                .or_else(|| bex_vm_types::RealizedTy::try_from(&field.field_type).ok());
+            let Some(field_ty) = field_ty else {
+                continue;
+            };
+            let (reached_classes, reached_enums) = crate::reachable::all_nominals(vm, &field_ty);
+            for reached in reached_classes {
+                if !class_ptrs.contains(&reached) {
+                    class_ptrs.push(reached);
+                }
+            }
+            for reached in reached_enums {
+                if !enum_ptrs.contains(&reached) {
+                    enum_ptrs.push(reached);
+                }
+            }
+        }
+    }
+
+    let mut spellings = indexmap::IndexMap::new();
+    let mut used = std::collections::HashSet::new();
+    let mut next_suffix = indexmap::IndexMap::<String, usize>::new();
+    for ptr in enum_ptrs.iter().chain(&class_ptrs) {
+        let (tag, base) = match vm.get_object(*ptr) {
+            Object::Class(class) => (class.type_tag, class.name.display_name().to_string()),
+            Object::Enum(enm) => (enm.type_tag, enm.name.display_name().to_string()),
+            _ => continue,
+        };
+        if spellings.contains_key(&tag) {
+            continue;
+        }
+        let next = next_suffix.entry(base.clone()).or_insert(1);
+        let mut candidate = if *next == 1 {
+            base.clone()
+        } else {
+            format!("{base}_{next}")
+        };
+        while used.contains(&candidate) {
+            *next += 1;
+            candidate = format!("{base}_{next}");
+        }
+        *next += 1;
+        used.insert(candidate.clone());
+        spellings.insert(tag, candidate);
+    }
+
     let mut declarations = Vec::new();
     for ptr in &enum_ptrs {
         let Object::Enum(enm) = vm.get_object(*ptr) else {
             continue;
         };
-        let mut source = format!("enum {} {{", enm.name.display_name());
+        let name = spellings
+            .get(&enm.type_tag)
+            .map_or_else(|| enm.name.display_name().to_string(), Clone::clone);
+        let mut source = format!("enum {name} {{");
         for variant in &enm.variants {
             source.push_str("\n  ");
             source.push_str(&variant.name);
@@ -1202,15 +1289,18 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         let Object::Class(class) = vm.get_object(*ptr) else {
             continue;
         };
-        let mut source = format!("class {} {{", class.name.display_name());
+        let name = spellings
+            .get(&class.type_tag)
+            .map_or_else(|| class.name.display_name().to_string(), Clone::clone);
+        let mut source = format!("class {name} {{");
         for field in &class.fields {
             source.push_str("\n  ");
             source.push_str(&field.name);
             source.push(' ');
             if let Some(field_type) = &field.runtime_type {
-                source.push_str(&render_ty_source(&field_type.ty));
+                source.push_str(&render_ty_source(&field_type.ty, &spellings));
             } else if let Ok(field_type) = bex_vm_types::RealizedTy::try_from(&field.field_type) {
-                source.push_str(&render_ty_source(&field_type));
+                source.push_str(&render_ty_source(&field_type, &spellings));
             } else {
                 source.push_str(&field.field_type.to_string());
             }
@@ -1219,7 +1309,7 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
                 field.description.as_deref(),
             ));
         }
-        render_witness_sources(vm, &mut source, *ptr);
+        render_witness_sources(vm, &mut source, *ptr, &spellings);
         if let Some(alias) = class.alias.as_deref() {
             source.push_str("\n  @@alias(");
             source.push_str(&quoted(alias));
@@ -1241,7 +1331,7 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
     if !root_is_declared {
         declarations.push(format!(
             "type RuntimeType = {}",
-            render_ty_source(&type_value.ty)
+            render_ty_source(&type_value.ty, &spellings)
         ));
     }
     declarations.join("\n\n")

--- a/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
@@ -61,7 +61,7 @@ impl BamlClassType for PackageReflectImpl {
 
     fn to_baml(vm: &mut BexVm, self_value: &Value) -> Result<bex_str::BexStr, VmRustFnError> {
         let type_value = cloned_type_value(vm, *self_value);
-        reject_first_render_schema_error(vm, &type_value.ty)?;
+        reject_first_type_value_render_schema_error(vm, &type_value)?;
         Ok(bex_str::BexStr::from(render_type_value_source(
             vm,
             &type_value,
@@ -445,7 +445,11 @@ impl RenderDefinitionValidator<'_> {
 /// name shared by non-equivalent declarations, a non-regular recursive generic
 /// (whose specializations would grow forever), or two distinct recursive
 /// classes hoisted under one rendered name.
-fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Option<String> {
+fn first_render_schema_error_with_definitions(
+    vm: &BexVm,
+    ty: &bex_vm_types::RealizedTy,
+    definitions: impl IntoIterator<Item = RenderDefinition>,
+) -> Option<String> {
     let mut validator = RenderDefinitionValidator {
         vm,
         by_display_name: std::collections::HashMap::new(),
@@ -454,16 +458,51 @@ fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Optio
         recursive_classes: std::collections::HashSet::new(),
         rendered_classes: Vec::new(),
     };
-    validator
-        .visit(ty, &RenderOrigins::root())
-        .or_else(|| validator.first_recursive_alias_collision())
+    if let Some(error) = validator.visit(ty, &RenderOrigins::root()) {
+        return Some(error);
+    }
+    for definition in definitions {
+        if let Some(error) = validator.check_name(&definition) {
+            return Some(error);
+        }
+    }
+    validator.first_recursive_alias_collision()
+}
+
+fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Option<String> {
+    first_render_schema_error_with_definitions(vm, ty, std::iter::empty())
+}
+
+fn first_type_value_render_schema_error(vm: &BexVm, type_value: &TypeValue) -> Option<String> {
+    let (class_ptrs, enum_ptrs) = expanded_type_value_nominals(vm, type_value);
+    let definitions = enum_ptrs
+        .into_iter()
+        .map(RenderDefinition::Enum)
+        .chain(class_ptrs.into_iter().map(RenderDefinition::Class));
+    first_render_schema_error_with_definitions(vm, &type_value.ty, definitions)
 }
 
 fn reject_first_render_schema_error(
     vm: &mut BexVm,
     ty: &bex_vm_types::RealizedTy,
 ) -> Result<(), VmRustFnError> {
-    let Some(message) = first_render_schema_error(vm, ty) else {
+    let message = first_render_schema_error(vm, ty);
+    reject_render_schema_error(vm, message)
+}
+
+fn reject_first_type_value_render_schema_error(
+    vm: &mut BexVm,
+    type_value: &TypeValue,
+) -> Result<(), VmRustFnError> {
+    let message = first_type_value_render_schema_error(vm, type_value);
+    reject_render_schema_error(vm, message)
+}
+
+fn reject_render_schema_error(
+    vm: &mut BexVm,
+    message: Option<String>,
+) -> Result<(), VmRustFnError> {
+    let Some(message) = message else {
         return Ok(());
     };
     let diagnostic = super::type_kinds::compiler_diagnostic(
@@ -1169,7 +1208,10 @@ fn render_witness_sources(
     }
 }
 
-fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
+fn expanded_type_value_nominals(
+    vm: &BexVm,
+    type_value: &TypeValue,
+) -> (Vec<bex_vm_types::HeapPtr>, Vec<bex_vm_types::HeapPtr>) {
     // The type's heads reach every declaration it depends on, and each runtime
     // declaration's `owner` reaches the package that declared it — so the set
     // to render is a walk, not a table. A package contributes its whole surface
@@ -1239,6 +1281,12 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
             }
         }
     }
+
+    (class_ptrs, enum_ptrs)
+}
+
+fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
+    let (class_ptrs, enum_ptrs) = expanded_type_value_nominals(vm, type_value);
 
     let mut spellings = indexmap::IndexMap::new();
     for ptr in enum_ptrs.iter().chain(&class_ptrs) {
@@ -1395,6 +1443,102 @@ mod renderability_tests {
 
     fn attr() -> baml_type::TyAttr {
         baml_type::TyAttr::default()
+    }
+
+    fn empty_package() -> bex_vm_types::types::Package {
+        bex_vm_types::types::Package {
+            exported_names: Vec::new(),
+            classes: indexmap::IndexMap::new(),
+            enums: indexmap::IndexMap::new(),
+            interfaces: indexmap::IndexMap::new(),
+            impl_rules: indexmap::IndexMap::new(),
+            functions: indexmap::IndexMap::new(),
+            type_aliases: indexmap::IndexMap::new(),
+            interface_blob: Vec::new(),
+            test_init: None,
+            mounted_types: indexmap::IndexMap::new(),
+            kind: bex_vm_types::types::PackageKind::default(),
+        }
+    }
+
+    fn alloc_test_class(
+        vm: &mut BexVm,
+        name: &str,
+        description: Option<&str>,
+        owner: bex_vm_types::HeapPtr,
+    ) -> (bex_vm_types::HeapPtr, baml_type::typetag::TypeTag) {
+        let type_tag = baml_type::typetag::TypeTag::fresh_dynamic();
+        let ptr = vm.tlab.alloc(Object::Class(Box::new(bex_vm_types::Class {
+            name: bex_vm_types::DeclarationName::Anonymous(baml_type::Name::new(name)),
+            fields: Vec::new(),
+            description: description.map(str::to_string),
+            alias: None,
+            docstring: None,
+            other: indexmap::IndexMap::new(),
+            type_tag,
+            ty_attr: attr(),
+            has_cleanup: false,
+            generic_param_count: 0,
+            owner,
+        })));
+        (ptr, type_tag)
+    }
+
+    fn package_member_name(name: &str) -> bex_vm_types::types::LocalName {
+        bex_vm_types::types::LocalName {
+            namespace: Vec::new(),
+            name: baml_type::Name::new(name),
+        }
+    }
+
+    #[test]
+    fn package_expansion_rejects_non_equivalent_same_name_members() {
+        let mut vm = crate::vm::tests::test_vm(Vec::new());
+        let first_package = vm.tlab.alloc(Object::Package(Box::new(empty_package())));
+        let second_package = vm.tlab.alloc(Object::Package(Box::new(empty_package())));
+
+        let (first_root, first_root_tag) =
+            alloc_test_class(&mut vm, "FirstRoot", None, first_package);
+        let (second_root, second_root_tag) =
+            alloc_test_class(&mut vm, "SecondRoot", None, second_package);
+        let (first_shared, _) =
+            alloc_test_class(&mut vm, "Shared", Some("first definition"), first_package);
+        let (second_shared, _) =
+            alloc_test_class(&mut vm, "Shared", Some("second definition"), second_package);
+
+        let Object::Package(package) = vm.get_object_mut(first_package) else {
+            unreachable!("test package pointer")
+        };
+        package
+            .classes
+            .insert(package_member_name("Shared"), first_shared);
+        let Object::Package(package) = vm.get_object_mut(second_package) else {
+            unreachable!("test package pointer")
+        };
+        package
+            .classes
+            .insert(package_member_name("Shared"), second_shared);
+
+        let type_value = TypeValue::new(bex_vm_types::RealizedTy::Union(
+            vec![
+                bex_vm_types::RealizedTy::Class(
+                    bex_vm_types::TypeHead::new(first_root, first_root_tag),
+                    Vec::new(),
+                    attr(),
+                ),
+                bex_vm_types::RealizedTy::Class(
+                    bex_vm_types::TypeHead::new(second_root, second_root_tag),
+                    Vec::new(),
+                    attr(),
+                ),
+            ],
+            attr(),
+        ));
+
+        assert_eq!(
+            first_type_value_render_schema_error(&vm, &type_value).as_deref(),
+            Some("type `Shared` has non-equivalent definitions in the same LLM render context")
+        );
     }
 
     #[test]

--- a/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/type_class.rs
@@ -59,9 +59,13 @@ impl BamlClassType for PackageReflectImpl {
         super::type_kinds::alloc_kind_view(vm, baml_type::type_kind::TypeKind::Union, union_ty)
     }
 
-    fn to_baml(vm: &BexVm, self_value: &Value) -> bex_str::BexStr {
+    fn to_baml(vm: &mut BexVm, self_value: &Value) -> Result<bex_str::BexStr, VmRustFnError> {
         let type_value = cloned_type_value(vm, *self_value);
-        bex_str::BexStr::from(render_type_value_source(vm, &type_value))
+        reject_first_render_schema_error(vm, &type_value.ty)?;
+        Ok(bex_str::BexStr::from(render_type_value_source(
+            vm,
+            &type_value,
+        )))
     }
 
     fn meta(
@@ -137,15 +141,7 @@ impl BamlClassType for PackageReflectImpl {
         // Run the bounded specialization analysis first: the subsequent structural
         // interface walk keys every realization and would otherwise follow a
         // non-regular generic transform forever.
-        if let Some(message) = first_render_schema_error(vm, &type_value.ty) {
-            let diagnostic = super::type_kinds::compiler_diagnostic(
-                baml_compiler_diagnostics::DiagnosticId::ConflictingTypeDefinitionAtRender,
-                message,
-            );
-            return Err(VmRustFnError::thrown_fresh(
-                super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
-            ));
-        }
+        reject_first_render_schema_error(vm, &type_value.ty)?;
         let mut visited = std::collections::HashSet::new();
         if let Some((field, open_ty)) =
             first_open_interface(vm, &type_value.ty, &root, &mut visited)
@@ -461,6 +457,22 @@ fn first_render_schema_error(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> Optio
     validator
         .visit(ty, &RenderOrigins::root())
         .or_else(|| validator.first_recursive_alias_collision())
+}
+
+fn reject_first_render_schema_error(
+    vm: &mut BexVm,
+    ty: &bex_vm_types::RealizedTy,
+) -> Result<(), VmRustFnError> {
+    let Some(message) = first_render_schema_error(vm, ty) else {
+        return Ok(());
+    };
+    let diagnostic = super::type_kinds::compiler_diagnostic(
+        baml_compiler_diagnostics::DiagnosticId::ConflictingTypeDefinitionAtRender,
+        message,
+    );
+    Err(VmRustFnError::thrown_fresh(
+        super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
+    ))
 }
 
 fn render_definition_display_name(vm: &BexVm, definition: &RenderDefinition) -> String {
@@ -1229,8 +1241,6 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
     }
 
     let mut spellings = indexmap::IndexMap::new();
-    let mut used = std::collections::HashSet::new();
-    let mut next_suffix = indexmap::IndexMap::<String, usize>::new();
     for ptr in enum_ptrs.iter().chain(&class_ptrs) {
         let (tag, base) = match vm.get_object(*ptr) {
             Object::Class(class) => (class.type_tag, class.name.display_name().to_string()),
@@ -1240,22 +1250,11 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         if spellings.contains_key(&tag) {
             continue;
         }
-        let next = next_suffix.entry(base.clone()).or_insert(1);
-        let mut candidate = if *next == 1 {
-            base.clone()
-        } else {
-            format!("{base}_{next}")
-        };
-        while used.contains(&candidate) {
-            *next += 1;
-            candidate = format!("{base}_{next}");
-        }
-        *next += 1;
-        used.insert(candidate.clone());
-        spellings.insert(tag, candidate);
+        spellings.insert(tag, base);
     }
 
     let mut declarations = Vec::new();
+    let mut rendered_declarations = std::collections::HashSet::new();
     for ptr in &enum_ptrs {
         let Object::Enum(enm) = vm.get_object(*ptr) else {
             continue;
@@ -1263,6 +1262,9 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         let name = spellings
             .get(&enm.type_tag)
             .map_or_else(|| enm.name.display_name().to_string(), Clone::clone);
+        if !rendered_declarations.insert(name.clone()) {
+            continue;
+        }
         let mut source = format!("enum {name} {{");
         for variant in &enm.variants {
             source.push_str("\n  ");
@@ -1292,6 +1294,9 @@ fn render_type_value_source(vm: &BexVm, type_value: &TypeValue) -> String {
         let name = spellings
             .get(&class.type_tag)
             .map_or_else(|| class.name.display_name().to_string(), Clone::clone);
+        if !rendered_declarations.insert(name.clone()) {
+            continue;
+        }
         let mut source = format!("class {name} {{");
         for field in &class.fields {
             source.push_str("\n  ");

--- a/baml_language/crates/bex_vm/src/reachable.rs
+++ b/baml_language/crates/bex_vm/src/reachable.rs
@@ -120,3 +120,46 @@ pub fn runtime_nominals_under_permit(
     }
     (classes, enums)
 }
+
+/// Every class and enum `ty` reaches, including compile-time declarations.
+///
+/// Most runtime consumers intentionally stop at the immutable program image,
+/// but source rendering must emit a standalone graph: a runtime class field
+/// that names a static class needs that static declaration in the output too.
+#[must_use]
+pub fn all_nominals(vm: &BexVm, ty: &bex_vm_types::RealizedTy) -> (Vec<HeapPtr>, Vec<HeapPtr>) {
+    let mut found = Vec::new();
+    let mut pending = Vec::new();
+    ty.visit_heads(&mut |head| {
+        if head.is_resolved() {
+            pending.push(head.ptr());
+        }
+    });
+    pending.reverse();
+    while let Some(ptr) = pending.pop() {
+        if found.contains(&ptr) {
+            continue;
+        }
+        found.push(ptr);
+        let mut next = Vec::new();
+        let object = vm.get_object(ptr);
+        bex_vm_types::head_walk::visit_object_heads(object, &mut |head| {
+            if head.is_resolved() {
+                next.push(head.ptr());
+            }
+        });
+        next.reverse();
+        pending.extend(next);
+    }
+
+    let mut classes = Vec::new();
+    let mut enums = Vec::new();
+    for ptr in found {
+        match vm.get_object(ptr) {
+            Object::Class(_) => classes.push(ptr),
+            Object::Enum(_) => enums.push(ptr),
+            _ => {}
+        }
+    }
+    (classes, enums)
+}

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2309,7 +2309,7 @@ impl BexVm {
             if baml_builtins2::stdlib_package_names().contains(&qtn.package().as_str()) {
                 return self.package(qtn.package());
             }
-            let runtime = current.runtime.as_ref()?;
+            let runtime = current.runtime()?;
             if let Some(dependency) = runtime.dependency_names.get(qtn.package().as_str()) {
                 return self.get_object(*dependency).as_package();
             }
@@ -2526,12 +2526,7 @@ impl BexVm {
         // The head *is* the key: a declaration this package created has an
         // entry, and one it merely imported or composed does not — which is
         // exactly the set that must reuse the created-once value.
-        let ptr = package
-            .runtime
-            .as_ref()?
-            .type_values
-            .get(&head.ptr())
-            .copied()?;
+        let ptr = package.runtime()?.type_values.get(&head.ptr()).copied()?;
         match self.get_object(ptr) {
             Object::Type(value) if &value.ty == ty => Some(ptr),
             _ => None,
@@ -2546,8 +2541,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.load_global(index.raw()))
             .expect("runtime global index was validated by dynamic link")
     }
@@ -2567,8 +2561,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         let runtime = package
-            .runtime
-            .as_ref()
+            .runtime()
             .expect("runtime function owner has a runtime image");
         if runtime.initialized {
             return Err(VmInternalError::StoreGlobalAfterInit);
@@ -2595,8 +2588,7 @@ impl BexVm {
             unreachable!("runtime owner does not point to Object::Package")
         };
         package
-            .runtime
-            .as_ref()
+            .runtime()
             .and_then(|runtime| runtime.objects.get(idx.raw()))
             .copied()
             .expect("runtime object index was validated by dynamic link")

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -35,10 +35,11 @@ pub use indexable::{
 pub use link::LinkError;
 pub use roots::{PermitProof, RootHaver, WriteBarrier};
 pub use runtime_compile::{
-    RuntimeCompileArtifact, RuntimeCompileDiagnostic, RuntimeCompileMode, RuntimeCompileRequest,
-    RuntimeDiagnosticSeverity, RuntimeMountedClass, RuntimeMountedEnum, RuntimeMountedFieldAttrs,
-    RuntimePackageMount, RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest,
-    RuntimeSessionInitializer, RuntimeSessionStep, RuntimeSourceSpan, RuntimeTypeMount,
+    ArtifactKind, RuntimeCompileArtifact, RuntimeCompileArtifactSlot, RuntimeCompileDiagnostic,
+    RuntimeCompileMode, RuntimeCompileRequest, RuntimeDiagnosticSeverity, RuntimeMountedClass,
+    RuntimeMountedEnum, RuntimeMountedFieldAttrs, RuntimePackageMount,
+    RuntimeSessionCompileArtifact, RuntimeSessionCompileRequest, RuntimeSessionInitializer,
+    RuntimeSessionStep, RuntimeSessionStepKind, RuntimeSourceSpan, RuntimeTypeMount,
     SessionContract, SessionEvalLease, SessionVisibleKind, SessionVisibleSymbol,
 };
 pub use task_group::{TaskGroupInner, TaskGroupPermit, TaskGroupTicket};

--- a/baml_language/crates/bex_vm_types/src/runtime_compile.rs
+++ b/baml_language/crates/bex_vm_types/src/runtime_compile.rs
@@ -5,7 +5,7 @@
 //! compiler implementation is assembled in `bex_project`.
 
 use std::sync::{
-    Arc, Weak,
+    Arc, Mutex, Weak,
     atomic::{AtomicBool, Ordering},
 };
 
@@ -63,11 +63,11 @@ pub struct RuntimePackageMount {
 }
 
 /// The kind of a name retained in a Session's compile-time scope.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SessionVisibleKind {
     Declaration,
     Let,
-    TypeBinding,
+    TypeBinding { type_value: String },
 }
 
 /// One source-visible name and the hygienic name used in replayed source.
@@ -75,8 +75,6 @@ pub enum SessionVisibleKind {
 pub struct SessionVisibleSymbol {
     pub internal: String,
     pub kind: SessionVisibleKind,
-    /// Backing top-level value for a scoped runtime type binding.
-    pub type_value: Option<String>,
 }
 
 /// The `eval<T>` contract, spelled for the compiler's name-headed world.
@@ -122,12 +120,20 @@ pub struct RuntimeSessionStep {
     /// Existing Session cell to update after this initializer succeeds. `None`
     /// means the generated global itself receives the value.
     pub commit_global: Option<String>,
-    /// Source-visible binding committed by this step, if it is a `let`.
-    pub binding: Option<(String, SessionVisibleSymbol)>,
-    /// Replayed source fragment to append only after this step succeeds.
-    pub replay_source: Option<String>,
-    /// Whether this step is the submission's observable final expression.
-    pub returns_value: bool,
+    pub kind: RuntimeSessionStepKind,
+}
+
+/// The two legal commit shapes of a Session initializer step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RuntimeSessionStepKind {
+    Expression,
+    Binding {
+        /// Source-visible binding committed by this step.
+        name: String,
+        symbol: SessionVisibleSymbol,
+        /// Replayed source fragment appended only after this step succeeds.
+        replay_source: String,
+    },
 }
 
 /// Compiler-owned Session metadata retained after the fresh database drops.
@@ -138,6 +144,8 @@ pub struct RuntimeSessionCompileArtifact {
     pub declaration_source: String,
     pub declarations: IndexMap<String, SessionVisibleSymbol>,
     pub steps: Vec<RuntimeSessionStep>,
+    /// The step whose value is the submission's observable result.
+    pub result_step: Option<usize>,
     /// Current-submission initializer helpers in execution order. `helper_slot`
     /// addresses the anonymous helper-slot list retained in the pruned tail.
     pub initializers: Vec<RuntimeSessionInitializer>,
@@ -243,7 +251,7 @@ pub struct RuntimeCompileDiagnostic {
 }
 
 /// Successful compiler output retained by the runtime.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct RuntimeCompileArtifact {
     /// Relocatable user units. Builtin/dependency definitions remain imports.
     pub units: Vec<CompilationUnit>,
@@ -252,8 +260,19 @@ pub struct RuntimeCompileArtifact {
     pub interface_blob: Vec<u8>,
     /// Non-error diagnostics produced by the successful compilation.
     pub diagnostics: Vec<RuntimeCompileDiagnostic>,
-    /// Present only for `reflect.Session.eval`.
-    pub session: Option<RuntimeSessionCompileArtifact>,
-    /// S-9 permit transferred from the request to the successful artifact.
-    pub session_lease: Option<SessionEvalLease>,
+    pub kind: ArtifactKind,
 }
+
+/// Which runtime compilation door produced an artifact.
+#[derive(Debug)]
+pub enum ArtifactKind {
+    Package,
+    Session {
+        meta: RuntimeSessionCompileArtifact,
+        /// S-9 permit transferred from the request to the successful artifact.
+        lease: SessionEvalLease,
+    },
+}
+
+/// One-shot storage used by the BAML `CompileArtifact` wrapper.
+pub type RuntimeCompileArtifactSlot = Mutex<Option<RuntimeCompileArtifact>>;

--- a/baml_language/crates/bex_vm_types/src/types/package.rs
+++ b/baml_language/crates/bex_vm_types/src/types/package.rs
@@ -49,12 +49,55 @@ pub struct Package {
     /// Exact runtime type values attached by `Package.with_types`.
     #[borsh(skip)]
     pub mounted_types: IndexMap<String, HeapPtr>,
-    /// Present only for a package produced by `reflect.Package.compile`.
+    /// Runtime-only state, discriminated so a package cannot be both an
+    /// ordinary runtime package and a Session (or a Session without an image).
     #[borsh(skip)]
-    pub runtime: Option<Box<RuntimePackage>>,
-    /// Present only for the package-shaped payload owned by a Session.
-    #[borsh(skip)]
-    pub session: Option<Box<SessionState>>,
+    pub kind: PackageKind,
+}
+
+/// The three legal runtime shapes of a [`Package`].
+#[derive(Clone, Debug, Default)]
+pub enum PackageKind {
+    /// A package loaded from the serialized program image.
+    #[default]
+    Static,
+    /// A package produced by `reflect.Package.compile`.
+    Runtime(Box<RuntimePackage>),
+    /// The package-shaped runtime image and persistent state owned by a Session.
+    Session {
+        runtime: Box<RuntimePackage>,
+        state: Box<SessionState>,
+    },
+}
+
+impl Package {
+    pub fn runtime(&self) -> Option<&RuntimePackage> {
+        match &self.kind {
+            PackageKind::Static => None,
+            PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => Some(runtime),
+        }
+    }
+
+    pub fn runtime_mut(&mut self) -> Option<&mut RuntimePackage> {
+        match &mut self.kind {
+            PackageKind::Static => None,
+            PackageKind::Runtime(runtime) | PackageKind::Session { runtime, .. } => Some(runtime),
+        }
+    }
+
+    pub fn session(&self) -> Option<&SessionState> {
+        match &self.kind {
+            PackageKind::Session { state, .. } => Some(state),
+            PackageKind::Static | PackageKind::Runtime(_) => None,
+        }
+    }
+
+    pub fn session_mut(&mut self) -> Option<&mut SessionState> {
+        match &mut self.kind {
+            PackageKind::Session { state, .. } => Some(state),
+            PackageKind::Static | PackageKind::Runtime(_) => None,
+        }
+    }
 }
 
 /// Compiler-free persistent state of one `reflect.Session`.
@@ -103,7 +146,8 @@ pub struct RuntimePackage {
     pub dependency_names: IndexMap<String, HeapPtr>,
     /// The candidate `$init`, if one exists.
     pub init: Option<HeapPtr>,
-    /// False while `$init` may write package globals; true after commit.
+    /// False while `$init` may write package globals; true after commit. A
+    /// Session keeps this false because its globals remain mutable across evals.
     pub initialized: bool,
 }
 

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -34,7 +34,7 @@ impl io::IoClassReflectPackage for NativeSysOps {
         _files: indexmap::IndexMap<String, String>,
         _packages: indexmap::IndexMap<String, io::owned::reflect::Package>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         SysOpOutput::err(VmBamlError::Unsupported {
             message: "runtime compiler is not installed".to_string(),
         })
@@ -50,7 +50,7 @@ impl io::IoClassReflectSession for NativeSysOps {
         _source: String,
         _type_arg_0: ::sys_types::SapTy,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         SysOpOutput::err(VmBamlError::Unsupported {
             message: "runtime compiler is not installed".to_string(),
         })

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -985,7 +985,7 @@ impl io::IoClassReflectPackage for DefaultIoOps {
         _files: indexmap::IndexMap<String, String>,
         _packages: indexmap::IndexMap<String, io::owned::reflect::Package>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         // BexEngine intercepts this operation and delegates to its injected
         // RuntimeCompiler before the provider table is consulted.
         SysOpOutput::err(VmBamlError::Unsupported {
@@ -1003,7 +1003,7 @@ impl io::IoClassReflectSession for DefaultIoOps {
         _source: String,
         _type_arg_0: ::sys_types::SapTy,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::reflect::Package> {
+    ) -> SysOpOutput<io::owned::reflect::CompileArtifact> {
         // BexEngine intercepts Session compilation for the same reason as
         // Package.compile: the concrete compiler is injected above sys_ops.
         SysOpOutput::err(VmBamlError::Unsupported {

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -1034,8 +1034,7 @@ pub fn build_output_format_content(
 ) -> self::OutputFormatContent {
     use std::collections::HashSet;
 
-    let mut names = OutputNames::default();
-    let mut content = self::OutputFormatContent::new(names.rename_ty(ty));
+    let mut content = self::OutputFormatContent::new(ty.clone());
     let mut visited = HashSet::new();
     let mut ancestry = Vec::new();
 
@@ -1046,7 +1045,6 @@ pub fn build_output_format_content(
         &mut content,
         &mut visited,
         &mut ancestry,
-        &mut names,
     ) {
         content.build_error = Some(error);
     }
@@ -1095,48 +1093,6 @@ enum OutputVisitKey {
 /// declaration identities the walk keys on.
 type LaneOrigins = baml_type::template::TyTemplateOrigins<::sys_types::DefKey>;
 
-#[derive(Default)]
-struct OutputNames {
-    by_head: IndexMap<::sys_types::DefKey, baml_type::Name>,
-    used: std::collections::HashSet<String>,
-    next_suffix: IndexMap<String, usize>,
-}
-
-impl OutputNames {
-    fn name(&mut self, head: &::sys_types::DefKey) -> baml_type::Name {
-        if let Some(name) = self.by_head.get(head) {
-            return name.clone();
-        }
-        let base = head.display_name().to_string();
-        let next = self.next_suffix.entry(base.clone()).or_insert(1);
-        let mut candidate = if *next == 1 {
-            base.clone()
-        } else {
-            format!("{base}_{next}")
-        };
-        while self.used.contains(&candidate) {
-            *next += 1;
-            candidate = format!("{base}_{next}");
-        }
-        *next += 1;
-        self.used.insert(candidate.clone());
-        let name = baml_type::Name::new(candidate);
-        self.by_head.insert(head.clone(), name.clone());
-        name
-    }
-
-    fn head(&mut self, head: &::sys_types::DefKey) -> ::sys_types::DefKey {
-        ::sys_types::DefKey::new(
-            head.tag(),
-            baml_type::DeclarationName::Anonymous(self.name(head)),
-        )
-    }
-
-    fn rename_ty(&mut self, ty: &SapTy) -> SapTy {
-        ty.map_heads(&mut |head| self.head(head))
-    }
-}
-
 struct ClassFrame {
     ty: SapTy,
     head: ::sys_types::DefKey,
@@ -1155,13 +1111,11 @@ fn walk_ty(
     content: &mut self::OutputFormatContent,
     visited: &mut std::collections::HashSet<OutputVisitKey>,
     ancestry: &mut Vec<ClassFrame>,
-    names: &mut OutputNames,
 ) -> Result<(), RenderError> {
     match ty {
         SapTy::Class(type_name, type_args, _) => {
-            let rendered_ty = names.rename_ty(ty);
-            let output_key = class_instantiation_key(&rendered_ty);
-            let output_name = names.name(type_name).to_string();
+            let output_key = class_instantiation_key(ty);
+            let output_name = type_name.display_name().to_string();
 
             // If this class is already on the ancestry stack, it's a recursive cycle.
             // Only mark classes from the cycle start, not unrelated ancestors.
@@ -1208,7 +1162,7 @@ fn walk_ty(
                     .map(|(field, field_type)| self::ClassField {
                         name: field.name.clone(),
                         alias: field.alias.clone(),
-                        field_type: names.rename_ty(field_type),
+                        field_type: field_type.clone(),
                         description: field.description.clone(),
                     })
                     .collect();
@@ -1241,15 +1195,7 @@ fn walk_ty(
                     } else {
                         LaneOrigins::opaque(ancestry.len())
                     };
-                    walk_ty(
-                        field_type,
-                        &field_origins,
-                        ctx,
-                        content,
-                        visited,
-                        ancestry,
-                        names,
-                    )?;
+                    walk_ty(field_type, &field_origins, ctx, content, visited, ancestry)?;
                 }
                 ancestry.pop();
             }
@@ -1260,7 +1206,7 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(enum_def) = find_enum_definition(ctx, type_name) {
-                let output_name = names.name(type_name).to_string();
+                let output_name = type_name.display_name().to_string();
                 // Skipped variants are already filtered out in bex_engine extraction.
                 let values: Vec<self::EnumValue> = enum_def
                     .variants
@@ -1299,60 +1245,28 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(target_ty) = find_type_alias_definition(ctx, type_name) {
-                let output_name = names.name(type_name).to_string();
+                let output_name = type_name.display_name().to_string();
                 content
                     .recursive_type_aliases
-                    .insert(output_name, names.rename_ty(target_ty));
+                    .insert(output_name, target_ty.clone());
                 let target_origins = LaneOrigins::opaque(ancestry.len());
-                walk_ty(
-                    target_ty,
-                    &target_origins,
-                    ctx,
-                    content,
-                    visited,
-                    ancestry,
-                    names,
-                )?;
+                walk_ty(target_ty, &target_origins, ctx, content, visited, ancestry)?;
             }
         }
         SapTy::List(inner, _) => {
             let inner_origins = origins.list_element();
-            walk_ty(
-                inner,
-                &inner_origins,
-                ctx,
-                content,
-                visited,
-                ancestry,
-                names,
-            )?;
+            walk_ty(inner, &inner_origins, ctx, content, visited, ancestry)?;
         }
         SapTy::Map { key, value, .. } => {
             let key_origins = origins.map_key();
             let value_origins = origins.map_value();
-            walk_ty(key, &key_origins, ctx, content, visited, ancestry, names)?;
-            walk_ty(
-                value,
-                &value_origins,
-                ctx,
-                content,
-                visited,
-                ancestry,
-                names,
-            )?;
+            walk_ty(key, &key_origins, ctx, content, visited, ancestry)?;
+            walk_ty(value, &value_origins, ctx, content, visited, ancestry)?;
         }
         SapTy::Union(members, _) => {
             for (index, member) in members.iter().enumerate() {
                 let member_origins = origins.union_member(index);
-                walk_ty(
-                    member,
-                    &member_origins,
-                    ctx,
-                    content,
-                    visited,
-                    ancestry,
-                    names,
-                )?;
+                walk_ty(member, &member_origins, ctx, content, visited, ancestry)?;
             }
         }
         _ => {}
@@ -1387,46 +1301,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn same_named_declarations_keep_distinct_output_schema_entries() {
-        let first = dynamic_key("Choice");
-        let second = dynamic_key("Choice");
-        let target = RuntimeTy::Union(
-            vec![
-                RuntimeTy::Class(first.clone(), Vec::new(), TyAttr::default()),
-                RuntimeTy::Class(second.clone(), Vec::new(), TyAttr::default()),
-            ],
-            TyAttr::default(),
-        );
-        let mut classes = indexmap::IndexMap::new();
-        classes.insert(
-            first.clone(),
-            ctx_class_definition(&first, vec![ctx_class_field("left", ty_string(), None)]),
-        );
-        classes.insert(
-            second.clone(),
-            ctx_class_definition(&second, vec![ctx_class_field("right", ty_int(), None)]),
-        );
-        let mut ctx = sys_types::SysOpContext::empty();
-        ctx.class_definitions = Arc::new(classes);
-
-        let content = build_output_format_content(&target, &ctx);
-        assert!(content.classes.contains_key("Choice"));
-        assert!(content.classes.contains_key("Choice_2"));
-        let rendered = content
-            .render(&RenderOptions {
-                hoist_classes: HoistClasses::All,
-                ..RenderOptions::default()
-            })
-            .unwrap()
-            .unwrap();
-        assert!(rendered.contains("Choice {"));
-        assert!(rendered.contains("Choice_2 {"));
-    }
-
-    #[test]
     fn duplicate_hoisted_enum_aliases_are_rejected() {
         let first = dynamic_key("Choice");
-        let second = dynamic_key("Choice");
+        let second = dynamic_key("Choice_2");
         let target = RuntimeTy::Union(
             vec![
                 RuntimeTy::Enum(first.clone(), TyAttr::default()),
@@ -1446,7 +1323,7 @@ mod tests {
         };
         let mut enums = indexmap::IndexMap::new();
         enums.insert(first, definition("Choice"));
-        enums.insert(second, definition("Choice"));
+        enums.insert(second, definition("Choice_2"));
         let mut ctx = sys_types::SysOpContext::empty();
         ctx.enum_definitions = Arc::new(enums);
 
@@ -1470,7 +1347,7 @@ mod tests {
     #[test]
     fn class_and_enum_hoisted_alias_collision_is_rejected() {
         let class_key = dynamic_key("Choice");
-        let enum_key = dynamic_key("Choice");
+        let enum_key = dynamic_key("Choice_2");
         let target = RuntimeTy::Union(
             vec![
                 RuntimeTy::Class(class_key.clone(), Vec::new(), TyAttr::default()),
@@ -1489,7 +1366,7 @@ mod tests {
         enums.insert(
             enum_key,
             sys_types::EnumDefinition {
-                name: "Choice".to_string(),
+                name: "Choice_2".to_string(),
                 description: None,
                 alias: Some("SharedChoice".to_string()),
                 variants: vec![sys_types::EnumVariantDefinition {

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -1010,7 +1010,8 @@ pub fn build_output_format_content(
 ) -> self::OutputFormatContent {
     use std::collections::HashSet;
 
-    let mut content = self::OutputFormatContent::new(ty.clone());
+    let mut names = OutputNames::default();
+    let mut content = self::OutputFormatContent::new(names.rename_ty(ty));
     let mut visited = HashSet::new();
     let mut ancestry = Vec::new();
 
@@ -1021,6 +1022,7 @@ pub fn build_output_format_content(
         &mut content,
         &mut visited,
         &mut ancestry,
+        &mut names,
     ) {
         content.build_error = Some(error);
     }
@@ -1069,6 +1071,48 @@ enum OutputVisitKey {
 /// declaration identities the walk keys on.
 type LaneOrigins = baml_type::template::TyTemplateOrigins<::sys_types::DefKey>;
 
+#[derive(Default)]
+struct OutputNames {
+    by_head: IndexMap<::sys_types::DefKey, baml_type::Name>,
+    used: std::collections::HashSet<String>,
+    next_suffix: IndexMap<String, usize>,
+}
+
+impl OutputNames {
+    fn name(&mut self, head: &::sys_types::DefKey) -> baml_type::Name {
+        if let Some(name) = self.by_head.get(head) {
+            return name.clone();
+        }
+        let base = head.display_name().to_string();
+        let next = self.next_suffix.entry(base.clone()).or_insert(1);
+        let mut candidate = if *next == 1 {
+            base.clone()
+        } else {
+            format!("{base}_{next}")
+        };
+        while self.used.contains(&candidate) {
+            *next += 1;
+            candidate = format!("{base}_{next}");
+        }
+        *next += 1;
+        self.used.insert(candidate.clone());
+        let name = baml_type::Name::new(candidate);
+        self.by_head.insert(head.clone(), name.clone());
+        name
+    }
+
+    fn head(&mut self, head: &::sys_types::DefKey) -> ::sys_types::DefKey {
+        ::sys_types::DefKey::new(
+            head.tag(),
+            baml_type::DeclarationName::Anonymous(self.name(head)),
+        )
+    }
+
+    fn rename_ty(&mut self, ty: &SapTy) -> SapTy {
+        ty.map_heads(&mut |head| self.head(head))
+    }
+}
+
 struct ClassFrame {
     ty: SapTy,
     head: ::sys_types::DefKey,
@@ -1087,10 +1131,13 @@ fn walk_ty(
     content: &mut self::OutputFormatContent,
     visited: &mut std::collections::HashSet<OutputVisitKey>,
     ancestry: &mut Vec<ClassFrame>,
+    names: &mut OutputNames,
 ) -> Result<(), RenderError> {
     match ty {
         SapTy::Class(type_name, type_args, _) => {
-            let output_key = class_instantiation_key(ty);
+            let rendered_ty = names.rename_ty(ty);
+            let output_key = class_instantiation_key(&rendered_ty);
+            let output_name = names.name(type_name).to_string();
 
             // If this class is already on the ancestry stack, it's a recursive cycle.
             // Only mark classes from the cycle start, not unrelated ancestors.
@@ -1106,7 +1153,7 @@ fn walk_ty(
                     && origins.class_transform_expands(index, type_name, ancestor.arity)
                 {
                     return Err(RenderError::NonRegularRecursiveGeneric {
-                        class: type_name.display_name().to_string(),
+                        class: output_name,
                         ancestor: ancestor.output_name.clone(),
                         instantiation: output_key,
                     });
@@ -1137,7 +1184,7 @@ fn walk_ty(
                     .map(|(field, field_type)| self::ClassField {
                         name: field.name.clone(),
                         alias: field.alias.clone(),
-                        field_type: field_type.clone(),
+                        field_type: names.rename_ty(field_type),
                         description: field.description.clone(),
                     })
                     .collect();
@@ -1145,7 +1192,7 @@ fn walk_ty(
                 content.classes.insert(
                     output_key.clone(),
                     self::Class {
-                        name: type_name.display_name().to_string(),
+                        name: output_name,
                         alias: class_def.alias.clone(),
                         description: class_def.description.clone(),
                         fields,
@@ -1170,7 +1217,15 @@ fn walk_ty(
                     } else {
                         LaneOrigins::opaque(ancestry.len())
                     };
-                    walk_ty(field_type, &field_origins, ctx, content, visited, ancestry)?;
+                    walk_ty(
+                        field_type,
+                        &field_origins,
+                        ctx,
+                        content,
+                        visited,
+                        ancestry,
+                        names,
+                    )?;
                 }
                 ancestry.pop();
             }
@@ -1181,6 +1236,7 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(enum_def) = find_enum_definition(ctx, type_name) {
+                let output_name = names.name(type_name).to_string();
                 // Skipped variants are already filtered out in bex_engine extraction.
                 let values: Vec<self::EnumValue> = enum_def
                     .variants
@@ -1193,9 +1249,9 @@ fn walk_ty(
                     .collect();
 
                 content.enums.insert(
-                    type_name.display_name().to_string(),
+                    output_name.clone(),
                     self::Enum {
-                        name: type_name.display_name().to_string(),
+                        name: output_name,
                         alias: enum_def.alias.clone(),
                         description: enum_def.description.clone(),
                         values,
@@ -1219,27 +1275,60 @@ fn walk_ty(
                 return Ok(());
             }
             if let Some(target_ty) = find_type_alias_definition(ctx, type_name) {
+                let output_name = names.name(type_name).to_string();
                 content
                     .recursive_type_aliases
-                    .insert(type_name.display_name().to_string(), target_ty.clone());
+                    .insert(output_name, names.rename_ty(target_ty));
                 let target_origins = LaneOrigins::opaque(ancestry.len());
-                walk_ty(target_ty, &target_origins, ctx, content, visited, ancestry)?;
+                walk_ty(
+                    target_ty,
+                    &target_origins,
+                    ctx,
+                    content,
+                    visited,
+                    ancestry,
+                    names,
+                )?;
             }
         }
         SapTy::List(inner, _) => {
             let inner_origins = origins.list_element();
-            walk_ty(inner, &inner_origins, ctx, content, visited, ancestry)?;
+            walk_ty(
+                inner,
+                &inner_origins,
+                ctx,
+                content,
+                visited,
+                ancestry,
+                names,
+            )?;
         }
         SapTy::Map { key, value, .. } => {
             let key_origins = origins.map_key();
             let value_origins = origins.map_value();
-            walk_ty(key, &key_origins, ctx, content, visited, ancestry)?;
-            walk_ty(value, &value_origins, ctx, content, visited, ancestry)?;
+            walk_ty(key, &key_origins, ctx, content, visited, ancestry, names)?;
+            walk_ty(
+                value,
+                &value_origins,
+                ctx,
+                content,
+                visited,
+                ancestry,
+                names,
+            )?;
         }
         SapTy::Union(members, _) => {
             for (index, member) in members.iter().enumerate() {
                 let member_origins = origins.union_member(index);
-                walk_ty(member, &member_origins, ctx, content, visited, ancestry)?;
+                walk_ty(
+                    member,
+                    &member_origins,
+                    ctx,
+                    content,
+                    visited,
+                    ancestry,
+                    names,
+                )?;
             }
         }
         _ => {}
@@ -1264,7 +1353,51 @@ mod tests {
         )
     }
 
+    fn dynamic_key(name: &str) -> DefKey {
+        DefKey::new(
+            baml_type::typetag::TypeTag::fresh_dynamic(),
+            DeclarationName::Anonymous(baml_type::Name::new(name)),
+        )
+    }
+
     use super::*;
+
+    #[test]
+    fn same_named_declarations_keep_distinct_output_schema_entries() {
+        let first = dynamic_key("Choice");
+        let second = dynamic_key("Choice");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::Class(first.clone(), Vec::new(), TyAttr::default()),
+                RuntimeTy::Class(second.clone(), Vec::new(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut classes = indexmap::IndexMap::new();
+        classes.insert(
+            first.clone(),
+            ctx_class_definition(&first, vec![ctx_class_field("left", ty_string(), None)]),
+        );
+        classes.insert(
+            second.clone(),
+            ctx_class_definition(&second, vec![ctx_class_field("right", ty_int(), None)]),
+        );
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.class_definitions = Arc::new(classes);
+
+        let content = build_output_format_content(&target, &ctx);
+        assert!(content.classes.contains_key("Choice"));
+        assert!(content.classes.contains_key("Choice_2"));
+        let rendered = content
+            .render(&RenderOptions {
+                hoist_classes: HoistClasses::All,
+                ..RenderOptions::default()
+            })
+            .unwrap()
+            .unwrap();
+        assert!(rendered.contains("Choice {"));
+        assert!(rendered.contains("Choice_2 {"));
+    }
 
     // -------------------------------------------------------------------------
     // Phase 3: json alias sentinel

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -30,6 +30,12 @@ pub enum RenderError {
         first: String,
         second: String,
     },
+    #[error("Enums '{first}' and '{second}' both render as '{rendered_name}' in the output schema")]
+    RenderedEnumNameCollision {
+        rendered_name: String,
+        first: String,
+        second: String,
+    },
 }
 
 /// A value within an enum definition for output format rendering.
@@ -152,6 +158,7 @@ impl OutputFormatContent {
         let hoisted_classes = self.compute_hoisted_classes(options);
         let hoisted_enums = self.compute_hoisted_enums(options);
         self.validate_hoisted_class_names(&hoisted_classes)?;
+        self.validate_hoisted_enum_names(&hoisted_enums)?;
 
         let prefix = self.get_prefix(options, &hoisted_classes);
 
@@ -380,6 +387,31 @@ impl OutputFormatContent {
             if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
                 if first != definition_key {
                     return Err(RenderError::RenderedClassNameCollision {
+                        rendered_name,
+                        first: first.clone(),
+                        second: definition_key.clone(),
+                    });
+                }
+            } else {
+                definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_hoisted_enum_names(
+        &self,
+        hoisted: &indexmap::IndexSet<String>,
+    ) -> Result<(), RenderError> {
+        let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
+        for definition_key in hoisted {
+            let Some(enm) = self.find_enum(definition_key) else {
+                continue;
+            };
+            let rendered_name = rendered_name(&enm.name, enm.alias.as_ref()).to_string();
+            if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
+                if first != definition_key {
+                    return Err(RenderError::RenderedEnumNameCollision {
                         rendered_name,
                         first: first.clone(),
                         second: definition_key.clone(),
@@ -1397,6 +1429,50 @@ mod tests {
             .unwrap();
         assert!(rendered.contains("Choice {"));
         assert!(rendered.contains("Choice_2 {"));
+    }
+
+    #[test]
+    fn duplicate_hoisted_enum_aliases_are_rejected() {
+        let first = dynamic_key("Choice");
+        let second = dynamic_key("Choice");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::Enum(first.clone(), TyAttr::default()),
+                RuntimeTy::Enum(second.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let definition = |name: &str| sys_types::EnumDefinition {
+            name: name.to_string(),
+            description: None,
+            alias: Some("SharedChoice".to_string()),
+            variants: vec![sys_types::EnumVariantDefinition {
+                name: "Value".to_string(),
+                description: None,
+                alias: None,
+            }],
+        };
+        let mut enums = indexmap::IndexMap::new();
+        enums.insert(first, definition("Choice"));
+        enums.insert(second, definition("Choice"));
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.enum_definitions = Arc::new(enums);
+
+        let content = build_output_format_content(&target, &ctx);
+        let error = content
+            .render(&RenderOptions {
+                always_hoist_enums: RenderSetting::Always(true),
+                ..RenderOptions::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedEnumNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedChoice" && first == "Choice" && second == "Choice_2"
+        ));
     }
 
     // -------------------------------------------------------------------------

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -23,7 +23,7 @@ pub enum RenderError {
         instantiation: String,
     },
     #[error(
-        "Classes '{first}' and '{second}' both render as '{rendered_name}' in the output schema"
+        "Output definitions '{first}' and '{second}' both render as '{rendered_name}' in the output schema"
     )]
     RenderedClassNameCollision {
         rendered_name: String,
@@ -380,23 +380,24 @@ impl OutputFormatContent {
         hoisted_classes: &indexmap::IndexSet<String>,
         hoisted_enums: &indexmap::IndexSet<String>,
     ) -> Result<(), RenderError> {
-        let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
+        let mut definitions_by_rendered_name = self
+            .recursive_type_aliases
+            .keys()
+            .map(|name| (name.clone(), name.clone()))
+            .collect::<IndexMap<String, String>>();
         for definition_key in hoisted_classes {
             let Some(cls) = self.find_class(definition_key) else {
                 continue;
             };
             let rendered_name = rendered_hoisted_definition_name(definition_key, cls);
             if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
-                if first != definition_key {
-                    return Err(RenderError::RenderedClassNameCollision {
-                        rendered_name,
-                        first: first.clone(),
-                        second: definition_key.clone(),
-                    });
-                }
-            } else {
-                definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
+                return Err(RenderError::RenderedClassNameCollision {
+                    rendered_name,
+                    first: first.clone(),
+                    second: definition_key.clone(),
+                });
             }
+            definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
         }
         for definition_key in hoisted_enums {
             let Some(enm) = self.find_enum(definition_key) else {
@@ -404,16 +405,13 @@ impl OutputFormatContent {
             };
             let rendered_name = rendered_name(&enm.name, enm.alias.as_ref()).to_string();
             if let Some(first) = definitions_by_rendered_name.get(&rendered_name) {
-                if first != definition_key {
-                    return Err(RenderError::RenderedEnumNameCollision {
-                        rendered_name,
-                        first: first.clone(),
-                        second: definition_key.clone(),
-                    });
-                }
-            } else {
-                definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
+                return Err(RenderError::RenderedEnumNameCollision {
+                    rendered_name,
+                    first: first.clone(),
+                    second: definition_key.clone(),
+                });
             }
+            definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
         }
         Ok(())
     }
@@ -1520,6 +1518,31 @@ mod tests {
                 first,
                 second,
             } if rendered_name == "SharedChoice" && first == "Choice" && second == "Choice_2"
+        ));
+    }
+
+    #[test]
+    fn type_alias_and_hoisted_class_alias_collision_is_rejected() {
+        let mut class = mk_class("Choice", vec![("value", ty_string())]);
+        class.alias = Some("SharedChoice".to_string());
+        let mut content = OutputFormatContent::new(ty_class("Choice")).with_class(class);
+        content
+            .recursive_type_aliases
+            .insert("SharedChoice".to_string(), ty_string());
+
+        let error = content
+            .render(&RenderOptions {
+                hoist_classes: HoistClasses::All,
+                ..RenderOptions::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedClassNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedChoice" && first == "SharedChoice" && second == "Choice"
         ));
     }
 

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -38,6 +38,14 @@ pub enum RenderError {
         first: String,
         second: String,
     },
+    #[error(
+        "Type alias definitions for '{rendered_name}' have non-equivalent targets '{first}' and '{second}'"
+    )]
+    RenderedTypeAliasNameCollision {
+        rendered_name: String,
+        first: String,
+        second: String,
+    },
 }
 
 /// A value within an enum definition for output format rendering.
@@ -1246,9 +1254,19 @@ fn walk_ty(
             }
             if let Some(target_ty) = find_type_alias_definition(ctx, type_name) {
                 let output_name = type_name.display_name().to_string();
-                content
-                    .recursive_type_aliases
-                    .insert(output_name, target_ty.clone());
+                if let Some(first) = content.recursive_type_aliases.get(&output_name) {
+                    if first != target_ty {
+                        return Err(RenderError::RenderedTypeAliasNameCollision {
+                            rendered_name: output_name,
+                            first: first.to_string(),
+                            second: target_ty.to_string(),
+                        });
+                    }
+                } else {
+                    content
+                        .recursive_type_aliases
+                        .insert(output_name, target_ty.clone());
+                }
                 let target_origins = LaneOrigins::opaque(ancestry.len());
                 walk_ty(target_ty, &target_origins, ctx, content, visited, ancestry)?;
             }
@@ -1421,6 +1439,58 @@ mod tests {
                 second,
             } if rendered_name == "SharedChoice" && first == "SharedChoice" && second == "Choice"
         ));
+    }
+
+    #[test]
+    fn same_name_type_aliases_with_different_targets_are_rejected() {
+        let first = dynamic_key("SharedAlias");
+        let second = dynamic_key("SharedAlias");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::TypeAlias(first.clone(), TyAttr::default()),
+                RuntimeTy::TypeAlias(second.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut aliases = indexmap::IndexMap::new();
+        aliases.insert(first, ty_string());
+        aliases.insert(second, ty_int());
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.type_alias_definitions = Arc::new(aliases);
+
+        let error = build_output_format_content(&target, &ctx)
+            .render(&RenderOptions::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedTypeAliasNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedAlias" && first == "string" && second == "int"
+        ));
+    }
+
+    #[test]
+    fn same_name_type_aliases_with_equivalent_targets_fold_once() {
+        let first = dynamic_key("SharedAlias");
+        let second = dynamic_key("SharedAlias");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::TypeAlias(first.clone(), TyAttr::default()),
+                RuntimeTy::TypeAlias(second.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut aliases = indexmap::IndexMap::new();
+        aliases.insert(first, ty_string());
+        aliases.insert(second, ty_string());
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.type_alias_definitions = Arc::new(aliases);
+
+        let content = build_output_format_content(&target, &ctx);
+        assert_eq!(content.recursive_type_aliases.len(), 1);
+        assert!(content.render(&RenderOptions::default()).is_ok());
     }
 
     // -------------------------------------------------------------------------

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -30,7 +30,9 @@ pub enum RenderError {
         first: String,
         second: String,
     },
-    #[error("Enums '{first}' and '{second}' both render as '{rendered_name}' in the output schema")]
+    #[error(
+        "Output definitions '{first}' and '{second}' both render as '{rendered_name}' in the output schema"
+    )]
     RenderedEnumNameCollision {
         rendered_name: String,
         first: String,
@@ -157,8 +159,7 @@ impl OutputFormatContent {
         // Compute which classes and enums to hoist
         let hoisted_classes = self.compute_hoisted_classes(options);
         let hoisted_enums = self.compute_hoisted_enums(options);
-        self.validate_hoisted_class_names(&hoisted_classes)?;
-        self.validate_hoisted_enum_names(&hoisted_enums)?;
+        self.validate_hoisted_definition_names(&hoisted_classes, &hoisted_enums)?;
 
         let prefix = self.get_prefix(options, &hoisted_classes);
 
@@ -374,12 +375,13 @@ impl OutputFormatContent {
         hoisted
     }
 
-    fn validate_hoisted_class_names(
+    fn validate_hoisted_definition_names(
         &self,
-        hoisted: &indexmap::IndexSet<String>,
+        hoisted_classes: &indexmap::IndexSet<String>,
+        hoisted_enums: &indexmap::IndexSet<String>,
     ) -> Result<(), RenderError> {
         let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
-        for definition_key in hoisted {
+        for definition_key in hoisted_classes {
             let Some(cls) = self.find_class(definition_key) else {
                 continue;
             };
@@ -396,15 +398,7 @@ impl OutputFormatContent {
                 definitions_by_rendered_name.insert(rendered_name, definition_key.clone());
             }
         }
-        Ok(())
-    }
-
-    fn validate_hoisted_enum_names(
-        &self,
-        hoisted: &indexmap::IndexSet<String>,
-    ) -> Result<(), RenderError> {
-        let mut definitions_by_rendered_name = IndexMap::<String, String>::new();
-        for definition_key in hoisted {
+        for definition_key in hoisted_enums {
             let Some(enm) = self.find_enum(definition_key) else {
                 continue;
             };
@@ -1461,6 +1455,60 @@ mod tests {
         let content = build_output_format_content(&target, &ctx);
         let error = content
             .render(&RenderOptions {
+                always_hoist_enums: RenderSetting::Always(true),
+                ..RenderOptions::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RenderError::RenderedEnumNameCollision {
+                rendered_name,
+                first,
+                second,
+            } if rendered_name == "SharedChoice" && first == "Choice" && second == "Choice_2"
+        ));
+    }
+
+    #[test]
+    fn class_and_enum_hoisted_alias_collision_is_rejected() {
+        let class_key = dynamic_key("Choice");
+        let enum_key = dynamic_key("Choice");
+        let target = RuntimeTy::Union(
+            vec![
+                RuntimeTy::Class(class_key.clone(), Vec::new(), TyAttr::default()),
+                RuntimeTy::Enum(enum_key.clone(), TyAttr::default()),
+            ],
+            TyAttr::default(),
+        );
+        let mut class = ctx_class_definition(
+            &class_key,
+            vec![ctx_class_field("value", ty_string(), None)],
+        );
+        class.alias = Some("SharedChoice".to_string());
+        let mut classes = indexmap::IndexMap::new();
+        classes.insert(class_key, class);
+        let mut enums = indexmap::IndexMap::new();
+        enums.insert(
+            enum_key,
+            sys_types::EnumDefinition {
+                name: "Choice".to_string(),
+                description: None,
+                alias: Some("SharedChoice".to_string()),
+                variants: vec![sys_types::EnumVariantDefinition {
+                    name: "Value".to_string(),
+                    description: None,
+                    alias: None,
+                }],
+            },
+        );
+        let mut ctx = sys_types::SysOpContext::empty();
+        ctx.class_definitions = Arc::new(classes);
+        ctx.enum_definitions = Arc::new(enums);
+
+        let content = build_output_format_content(&target, &ctx);
+        let error = content
+            .render(&RenderOptions {
+                hoist_classes: HoistClasses::All,
                 always_hoist_enums: RenderSetting::Always(true),
                 ..RenderOptions::default()
             })


### PR DESCRIPTION
B-1605 exposed runtime type identity being flattened back to display names across container conversion, Session mounts, and standalone type rendering.

Before:

```baml
let compiled = package.get_class("root.Choice") ?? throw "missing Choice"
let minted = reflect.class.new("Choice", { "right": reflect.Type.of<int>() })
let combined = reflect.union.new([compiled.as_type(), minted.as_type()])
let source = combined.as_type().to_baml()
// source contained two non-equivalent `class Choice` declarations
```

After:

```baml
let source = combined.as_type().to_baml()
// E0162: type `Choice` has non-equivalent definitions in the same LLM render context
```

Equivalent same-name declarations fold once, while non-equivalent declarations are rejected consistently by `type.to_baml()` and the LLM render boundary. Empty runtime containers also preserve their original `TypeTag`, and valid rendered types include the static dependencies needed to compile standalone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runtime type resolution for mounted classes, enums, aliases, arrays, maps, and nested declarations.
  * Preserved type information across package and session boundaries, including dependency exports and aliases.
  * Enhanced reflection output to include reachable declarations and correctly render package-qualified types.

* **Bug Fixes**
  * Added clearer errors for conflicting class, enum, and type-alias names.
  * Equivalent declarations are now deduplicated during reflection and output generation.
  * Session result bindings now report an error when no result type is provided.
  * Improved field access for interface-based types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->