### PR TITLE
ci: cache C# MSBuild state and parallelize the C# sdk tests

### DIFF
--- a/.github/scripts/csharp-mtime-cache.py
+++ b/.github/scripts/csharp-mtime-cache.py
@@ -28,11 +28,14 @@ import json
 import os
 import sys
 
-# Everything the C# projects compile lives under these two trees: the bridge
-# library + tools, and the fixture programs with their generated clients.
+# Everything the C# projects compile lives under these trees: the bridge
+# library + tools, the fixture programs with their generated clients, and the
+# .proto definitions the bridge's protobuf codegen target consumes (they live
+# with the Rust cffi types, outside the C# trees).
 ROOTS = [
     "baml_language/sdks/csharp",
     "baml_language/sdk_tests/crates/csharp",
+    "baml_language/crates/bridge_ctypes/types",
 ]
 # bin/obj are build outputs (cached wholesale, never hashed); .baml is BAML's
 # own runtime state (profile CAS + locks written during test execution) —

--- a/.github/scripts/csharp-mtime-cache.py
+++ b/.github/scripts/csharp-mtime-cache.py
@@ -71,16 +71,33 @@ def restore():
     with open(MANIFEST) as f:
         manifest = json.load(f)
     backdated = 0
+    changed = []
+    missing = []
     for path, want in manifest.items():
         try:
             if digest(path) == want:
                 os.utime(path, (BACKDATED_MTIME, BACKDATED_MTIME))
                 backdated += 1
+            else:
+                changed.append(path)
         except OSError:
             # Deleted or unreadable file: nothing to backdate; any project
             # that referenced it rebuilds via its own fresh inputs.
-            continue
+            missing.append(path)
+    new = [p for p in tracked_files() if p not in manifest]
     print(f"backdated {backdated}/{len(manifest)} unchanged files")
+    for label, paths in (("changed", changed), ("missing", missing), ("new", new)):
+        if not paths:
+            continue
+        by_prefix = {}
+        for p in paths:
+            prefix = "/".join(p.split("/")[:6])
+            by_prefix[prefix] = by_prefix.get(prefix, 0) + 1
+        print(f"{label}: {len(paths)} files")
+        for prefix, count in sorted(by_prefix.items(), key=lambda kv: -kv[1])[:15]:
+            print(f"  {count:5d}  {prefix}")
+        for p in paths[:8]:
+            print(f"    e.g. {p}")
 
 
 def main():

--- a/.github/scripts/csharp-mtime-cache.py
+++ b/.github/scripts/csharp-mtime-cache.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Content-aware mtime backdating for the C# sdk-test MSBuild cache.
+
+MSBuild's incremental build is timestamp-based: a target is up to date when
+its outputs are newer than its inputs. Caching `bin/`+`obj/` across CI runs
+is therefore not enough on its own — a fresh checkout (and the build.rs
+regeneration of the generated clients) stamps every input with the current
+time, which makes every cached output look stale and forces the full ~20s
+Roslyn rebuild per fixture that the cache was meant to avoid.
+
+This script closes that gap by content, not by time:
+
+- `record` walks the C# source roots (everything except `bin/`/`obj/`) and
+  writes a `{path: sha256}` manifest into the cache directory.
+- `restore` re-hashes the same tree and backdates ONLY byte-identical files
+  to a fixed timestamp in 2000, i.e. older than any cached output. Files
+  that changed — or are new, or of a kind we didn't anticipate — keep their
+  fresh mtimes and rebuild exactly as they do today.
+
+A missed input therefore fails toward a redundant rebuild, never toward a
+stale test binary. With unchanged sources this restores MSBuild's no-op
+path (~1s per fixture instead of ~20s, measured on macOS and mirrored by
+the CI step times).
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+# Everything the C# projects compile lives under these two trees: the bridge
+# library + tools, and the fixture programs with their generated clients.
+ROOTS = [
+    "baml_language/sdks/csharp",
+    "baml_language/sdk_tests/crates/csharp",
+]
+EXCLUDED_DIR_NAMES = {"bin", "obj"}
+MANIFEST = os.path.expanduser("~/.baml-csharp-ci/manifest.json")
+# 2000-01-01 UTC: comfortably older than any output restored from the cache.
+BACKDATED_MTIME = 946_684_800
+
+
+def tracked_files():
+    for root in ROOTS:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = sorted(d for d in dirnames if d not in EXCLUDED_DIR_NAMES)
+            for name in sorted(filenames):
+                yield os.path.join(dirpath, name).replace(os.sep, "/")
+
+
+def digest(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def record():
+    manifest = {path: digest(path) for path in tracked_files()}
+    os.makedirs(os.path.dirname(MANIFEST), exist_ok=True)
+    with open(MANIFEST, "w") as f:
+        json.dump(manifest, f, indent=0)
+    print(f"recorded {len(manifest)} files")
+
+
+def restore():
+    if not os.path.exists(MANIFEST):
+        print("no manifest from a previous run; leaving all mtimes fresh")
+        return
+    with open(MANIFEST) as f:
+        manifest = json.load(f)
+    backdated = 0
+    for path, want in manifest.items():
+        try:
+            if digest(path) == want:
+                os.utime(path, (BACKDATED_MTIME, BACKDATED_MTIME))
+                backdated += 1
+        except OSError:
+            # Deleted or unreadable file: nothing to backdate; any project
+            # that referenced it rebuilds via its own fresh inputs.
+            continue
+    print(f"backdated {backdated}/{len(manifest)} unchanged files")
+
+
+def main():
+    actions = {"record": record, "restore": restore}
+    if len(sys.argv) != 2 or sys.argv[1] not in actions:
+        sys.exit(f"usage: {sys.argv[0]} {{record|restore}}")
+    actions[sys.argv[1]]()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/csharp-mtime-cache.py
+++ b/.github/scripts/csharp-mtime-cache.py
@@ -34,7 +34,10 @@ ROOTS = [
     "baml_language/sdks/csharp",
     "baml_language/sdk_tests/crates/csharp",
 ]
-EXCLUDED_DIR_NAMES = {"bin", "obj"}
+# bin/obj are build outputs (cached wholesale, never hashed); .baml is BAML's
+# own runtime state (profile CAS + locks written during test execution) —
+# volatile, content-addressed, and never an MSBuild input.
+EXCLUDED_DIR_NAMES = {"bin", "obj", ".baml"}
 MANIFEST = os.path.expanduser("~/.baml-csharp-ci/manifest.json")
 # 2000-01-01 UTC: comfortably older than any output restored from the cache.
 BACKDATED_MTIME = 946_684_800

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -937,6 +937,38 @@ jobs:
         with:
           dotnet-version: 10.0.301
 
+      # The C# suite is serialized (every fixture shares the bridge
+      # project's obj/) and each test is a full `dotnet run -c Release`, so
+      # the job's wall time is ~12 cold Roslyn compiles in a row. Cache the
+      # NuGet package folder and every project's bin/obj between runs.
+      # MSBuild's up-to-date check is mtime-based and a fresh checkout (plus
+      # the build.rs client regeneration) stamps every input with the
+      # current time, so restoring bin/obj alone changes nothing; the
+      # backdate steps below reset byte-identical inputs to a fixed old
+      # timestamp so cached outputs count as current, while changed files
+      # keep fresh mtimes and rebuild as before. The key never matches
+      # exactly, so every run saves its end state and the next run restores
+      # the newest prior cache via restore-keys.
+      - name: "Restore C# build cache"
+        if: matrix.sdk-label == 'csharp'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            ~/.baml-csharp-ci
+            baml_language/sdks/csharp/**/obj
+            baml_language/sdks/csharp/**/bin
+            baml_language/sdk_tests/crates/csharp/*/obj
+            baml_language/sdk_tests/crates/csharp/*/bin
+          key: csharp-msbuild-v1-${{ matrix.os-label }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: csharp-msbuild-v1-${{ matrix.os-label }}-
+
+      - name: "Backdate unchanged C# sources"
+        if: matrix.sdk-label == 'csharp'
+        shell: bash
+        run: |
+          "$(command -v python3 || command -v python)" .github/scripts/csharp-mtime-cache.py restore
+
       - name: "Test C# NuGet payload comparison"
         if: matrix.sdk-label == 'csharp'
         run: |
@@ -973,13 +1005,20 @@ jobs:
           expected_count="$(scripts/baml-csharp-release-contract matrix \
             | jq '.include | length')"
           project=baml_language/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj
+          # --artifacts-path keeps this version-stamped build out of the
+          # project's regular obj/bin: those are cached across runs for the
+          # sdk tests, and rebuilding the bridge here with different global
+          # properties would churn the cached state (and the bridge dll
+          # mtime every fixture compile depends on) on every run.
           dotnet build "$project" --configuration Release --nologo \
+            --artifacts-path "$work/artifacts" \
             -p:NuGetAudit=false \
             -p:Version="$canonical" \
             -p:InformationalVersion="$canonical" \
             -p:PackageVersion="$nuget"
           dotnet pack "$project" --configuration Release --nologo \
             --no-build --no-restore \
+            --artifacts-path "$work/artifacts" \
             --output "$work/package" \
             -p:NuGetAudit=false \
             -p:Version="$canonical" \
@@ -1041,6 +1080,17 @@ jobs:
         run: cargo test --no-run -p ${{ matrix.package-name }} --all-features --timings
         working-directory: baml_language
 
+      # Second pass: the build above ran the sdk_test_csharp build script,
+      # which regenerates every fixture's client tree with fresh mtimes even
+      # when the generated content is byte-identical (the writer stages and
+      # renames a whole new tree). Re-run the backdate so unchanged
+      # generated sources also count as older than the cached outputs.
+      - name: "Backdate unchanged C# generated clients"
+        if: matrix.sdk-label == 'csharp'
+        shell: bash
+        run: |
+          "$(command -v python3 || command -v python)" .github/scripts/csharp-mtime-cache.py restore
+
       - name: "Show sccache stats"
         if: always()
         run: sccache --show-stats
@@ -1061,6 +1111,15 @@ jobs:
         if: matrix.sdk-label == 'csharp'
         run: cargo nextest run -p ${{ matrix.package-name }} --all-features --no-fail-fast -E 'package(=${{ matrix.package-name }})'
         working-directory: baml_language
+
+      # Record the content hashes the next run's backdate steps compare
+      # against. Runs even on test failure: the bin/obj state saved by the
+      # cache post-step must always be described by a matching manifest.
+      - name: "Record C# build cache manifest"
+        if: always() && matrix.sdk-label == 'csharp'
+        shell: bash
+        run: |
+          "$(command -v python3 || command -v python)" .github/scripts/csharp-mtime-cache.py record
 
       # The Rust bridge runtime crate (baml_bridge). Its tests load the engine
       # cdylib at run time, and its lib test binary mixes pure (loader/encode)

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -991,8 +991,12 @@ jobs:
             baml_language/sdks/csharp/**/bin
             baml_language/sdk_tests/crates/csharp/*/obj
             baml_language/sdk_tests/crates/csharp/*/bin
-          key: csharp-msbuild-v1-${{ matrix.os-label }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: csharp-msbuild-v1-${{ matrix.os-label }}-
+          # The pinned SDK version is part of the key (no versionless
+          # fallback): the backdate step trusts the SDK's content because
+          # dotnet-version pins it, so an SDK bump must start a cold cache
+          # rather than lean on secondary invalidation signals.
+          key: csharp-msbuild-v1-${{ matrix.os-label }}-sdk10.0.301-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: csharp-msbuild-v1-${{ matrix.os-label }}-sdk10.0.301-
 
       - name: "Backdate unchanged C# sources"
         if: matrix.sdk-label == 'csharp'

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -911,6 +911,15 @@ jobs:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: ${{ matrix.timeout }}
+    env:
+      # MSBuild reads environment variables as global properties. The .NET
+      # SDK embeds the git commit into every build by default (SourceLink
+      # json + SourceRevisionId in InformationalVersion), which changes a
+      # CoreCompile input on every push and would defeat the C# MSBuild
+      # cache below for any new commit. Test builds need neither; only
+      # dotnet reads these, so the other SDK matrix legs are unaffected.
+      EnableSourceLink: "false"
+      IncludeSourceRevisionInInformationalVersion: "false"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -936,6 +945,27 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.301
+
+      # The SDK install is freshly stamped every run, and its targets files
+      # and reference packs are MSBuild inputs (e.g. Microsoft.Common.targets
+      # regenerates AssemblyAttributes.cs, a CoreCompile input), which alone
+      # invalidates every output the cache below restores. The SDK's content
+      # is pinned by dotnet-version, so backdating it is safe.
+      - name: "Backdate .NET SDK install"
+        if: matrix.sdk-label == 'csharp'
+        shell: bash
+        run: |
+          dotnet_root="$(dirname "$(readlink -f "$(command -v dotnet)")")"
+          echo "dotnet root: $dotnet_root"
+          find "$dotnet_root" -exec touch -t 200001010000 {} + 2>/dev/null || true
+          if command -v sudo >/dev/null; then
+            sudo find "$dotnet_root" -exec touch -t 200001010000 {} + 2>/dev/null || true
+          fi
+          fresh="$(find "$dotnet_root" -newermt 2001-01-01 | head -5)"
+          if [ -n "$fresh" ]; then
+            echo "WARNING: some SDK files kept fresh mtimes (cache will under-hit):"
+            echo "$fresh"
+          fi
 
       # The C# suite is serialized (every fixture shares the bridge
       # project's obj/) and each test is a full `dotnet run -c Release`, so

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -1122,19 +1122,6 @@ jobs:
         run: |
           "$(command -v python3 || command -v python)" .github/scripts/csharp-mtime-cache.py restore
 
-      # TEMPORARY diagnostic while validating the cache: build one fixture at
-      # detailed verbosity and surface MSBuild's incremental-build decisions,
-      # so a run that ignores the cache explains itself.
-      - name: "DEBUG: explain fixture up-to-date state"
-        if: matrix.sdk-label == 'csharp' && matrix.os-label == 'linux'
-        shell: bash
-        working-directory: baml_language/sdk_tests/crates/csharp
-        run: |
-          ls -la --time-style=full-iso basic_calls basic_calls/obj || true
-          dotnet build basic_calls/BasicCalls.csproj --configuration Release -v:d 2>&1 \
-            | grep -E "Building target .* completely|newer than output|input file|out-of-date|is missing|Skipping target \"(CoreCompile|CoreGenerateAssemblyInfo)\"" \
-            | head -60 || true
-
       - name: "Show sccache stats"
         if: always()
         run: sccache --show-stats

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -1091,6 +1091,19 @@ jobs:
         run: |
           "$(command -v python3 || command -v python)" .github/scripts/csharp-mtime-cache.py restore
 
+      # TEMPORARY diagnostic while validating the cache: build one fixture at
+      # detailed verbosity and surface MSBuild's incremental-build decisions,
+      # so a run that ignores the cache explains itself.
+      - name: "DEBUG: explain fixture up-to-date state"
+        if: matrix.sdk-label == 'csharp' && matrix.os-label == 'linux'
+        shell: bash
+        working-directory: baml_language/sdk_tests/crates/csharp
+        run: |
+          ls -la --time-style=full-iso basic_calls basic_calls/obj || true
+          dotnet build basic_calls/BasicCalls.csproj --configuration Release -v:d 2>&1 \
+            | grep -E "Building target .* completely|newer than output|input file|out-of-date|is missing|Skipping target \"(CoreCompile|CoreGenerateAssemblyInfo)\"" \
+            | head -60 || true
+
       - name: "Show sccache stats"
         if: always()
         run: sccache --show-stats

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -967,10 +967,11 @@ jobs:
             echo "$fresh"
           fi
 
-      # The C# suite is serialized (every fixture shares the bridge
-      # project's obj/) and each test is a full `dotnet run -c Release`, so
-      # the job's wall time is ~12 cold Roslyn compiles in a row. Cache the
-      # NuGet package folder and every project's bin/obj between runs.
+      # The C# fixtures all build the shared bridge project and, without a
+      # cache, every CI run pays the full set of Roslyn compiles from
+      # scratch (setup.sh builds them as one solution; the tests run with
+      # --no-build). Cache the NuGet package folder and every project's
+      # bin/obj between runs so the setup build is incremental.
       # MSBuild's up-to-date check is mtime-based and a fresh checkout (plus
       # the build.rs client regeneration) stamps every input with the
       # current time, so restoring bin/obj alone changes nothing; the

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -980,9 +980,14 @@ jobs:
       # keep fresh mtimes and rebuild as before. The key never matches
       # exactly, so every run saves its end state and the next run restores
       # the newest prior cache via restore-keys.
+      # Split restore/save (instead of plain actions/cache) so a FAILED run
+      # still saves its build state: iterating on a red PR is exactly when
+      # incremental rebuilds matter, and the combined action's post step only
+      # saves on success. The matching save step runs at the end of the job
+      # under `if: always()`.
       - name: "Restore C# build cache"
         if: matrix.sdk-label == 'csharp'
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.nuget/packages
@@ -1155,6 +1160,22 @@ jobs:
         shell: bash
         run: |
           "$(command -v python3 || command -v python)" .github/scripts/csharp-mtime-cache.py record
+
+      # Counterpart of "Restore C# build cache" above; keep path and key in
+      # sync with it. The key is unique per run+attempt, so this save never
+      # collides with an existing entry.
+      - name: "Save C# build cache"
+        if: always() && matrix.sdk-label == 'csharp'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            ~/.baml-csharp-ci
+            baml_language/sdks/csharp/**/obj
+            baml_language/sdks/csharp/**/bin
+            baml_language/sdk_tests/crates/csharp/*/obj
+            baml_language/sdk_tests/crates/csharp/*/bin
+          key: csharp-msbuild-v1-${{ matrix.os-label }}-sdk10.0.301-${{ github.run_id }}-${{ github.run_attempt }}
 
       # The Rust bridge runtime crate (baml_bridge). Its tests load the engine
       # cdylib at run time, and its lib test binary mixes pure (loader/encode)

--- a/baml_language/.config/nextest.toml
+++ b/baml_language/.config/nextest.toml
@@ -19,17 +19,17 @@ rust-sdk-fixture = { max-threads = 2 }
 # forgiving but not immune under CI load. Funnel the whole package through one
 # in-flight gradle at a time (see the package-wide override below).
 java-gradle-serial = { max-threads = 1 }
-# C# fixtures share the bridge project's MSBuild obj directory.
-csharp-sdk-fixture = { max-threads = 1 }
+# C# needs no test group: the fixtures share the bridge project's MSBuild
+# obj directory, but setup.sh/setup.ps1 build all of them in one solution
+# build and the tests execute with `dotnet run --no-build`, so no MSBuild
+# runs at test time. The only test-time builders are the trimmed-publish
+# test (sole writer to the shared obj) and the generics compile-negative
+# matrix (isolated via --artifacts-path).
 typescript-web-workers = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'package(=sdk_test_rust)'
 test-group = 'rust-sdk-fixture'
-
-[[profile.default.overrides]]
-filter = 'package(=sdk_test_csharp)'
-test-group = 'csharp-sdk-fixture'
 
 [[profile.default.overrides]]
 filter = 'package(=sdk_test_typescript_web) & test(/::vitest_workers$/)'

--- a/baml_language/sdk_tests/crates/csharp/Fixtures.slnx
+++ b/baml_language/sdk_tests/crates/csharp/Fixtures.slnx
@@ -1,0 +1,27 @@
+<!--
+  One-shot build of every C# fixture consumer plus the union-generator tool.
+
+  setup.sh / setup.ps1 build this solution once before the test suite runs:
+  a single MSBuild invocation compiles the projects in parallel across cores
+  and builds the shared Baml.Bridge project exactly once. The tests then
+  execute in no-build mode, so no MSBuild processes race on the bridge's
+  obj/ at test time and nextest can run the tests concurrently.
+
+  The documentation consumer is NOT part of this solution: it needs the
+  BamlBridgeProjectReference / BamlGeneratedSourceRoot properties, so setup
+  builds it with a dedicated invocation carrying those same properties.
+-->
+<Solution>
+  <Project Path="basic_calls/BasicCalls.csproj" />
+  <Project Path="dynamic_values/DynamicValues.csproj" />
+  <Project Path="failures_and_cancellation/FailuresAndCancellation.csproj" />
+  <Project Path="generics/Generics.csproj" />
+  <Project Path="host_callables/HostCallables.csproj" />
+  <Project Path="media/Media.csproj" />
+  <Project Path="primitive_edges/PrimitiveEdges.csproj" />
+  <Project Path="stdlib_resources/StdlibResources.csproj" />
+  <Project Path="stdlib_structurals/StdlibStructurals.csproj" />
+  <Project Path="streaming/Streaming.csproj" />
+  <Project Path="type_roundtrips/TypeRoundtrips.csproj" />
+  <Project Path="../../../sdks/csharp/bridge_csharp/tools/Baml.UnionGenerator/Baml.UnionGenerator.csproj" />
+</Solution>

--- a/baml_language/sdk_tests/crates/csharp/generics/verify_compile_negative.sh
+++ b/baml_language/sdk_tests/crates/csharp/generics/verify_compile_negative.sh
@@ -59,9 +59,20 @@ verify_negative() {
   printf '%s=CS0411\n' "$case_name"
 }
 
-verify_negative BareNullInference
-verify_negative ResultOnlyInference
-verify_negative RawNullableInference
-verify_negative StaticNullInference
+# Each case restores and builds into its own artifacts directory, so the
+# four builds share nothing and can run concurrently. `wait -n`-free
+# collection: wait on each pid and fold failures, so one bad case never
+# hides another's log (fail() output goes to stderr as before).
+pids=()
+verify_negative BareNullInference & pids+=("$!")
+verify_negative ResultOnlyInference & pids+=("$!")
+verify_negative RawNullableInference & pids+=("$!")
+verify_negative StaticNullInference & pids+=("$!")
+
+failed=0
+for pid in "${pids[@]}"; do
+  wait "$pid" || failed=1
+done
+[[ "$failed" -eq 0 ]] || exit 1
 
 printf 'csharp_generics_generated_compile_matrix=ok\n'

--- a/baml_language/sdk_tests/crates/csharp/setup.ps1
+++ b/baml_language/sdk_tests/crates/csharp/setup.ps1
@@ -20,6 +20,35 @@ if (-not [System.IO.Path]::IsPathRooted($TargetDir)) {
 $TargetDir = [System.IO.Path]::GetFullPath($TargetDir)
 $NativeLibrary = Join-Path $TargetDir "debug/bridge_cffi.dll"
 
+# Build every fixture consumer (and the union-generator tool) in ONE
+# MSBuild invocation: the projects compile in parallel across cores and the
+# shared Baml.Bridge project builds exactly once. The tests then run with
+# --no-build, which is what makes it safe for nextest to run them
+# concurrently — at test time no MSBuild processes exist to race on the
+# bridge's shared obj/ (the historical reason this suite was serialized).
+Push-Location $CrateDir
+try {
+    dotnet build Fixtures.slnx --configuration Release -m --nologo
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet build Fixtures.slnx failed with exit code $LASTEXITCODE"
+    }
+
+    # The documentation consumer swaps its package reference for a project
+    # reference via these properties, so it cannot ride along in the solution
+    # build; its test passes the same properties with --no-build.
+    $DocConsumer = Join-Path $WorkspaceRoot "sdks/csharp/bridge_csharp/tests/Baml.Bridge.DocumentationConsumer/Baml.Bridge.DocumentationConsumer.csproj"
+    $BridgeProject = Join-Path $WorkspaceRoot "sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj"
+    $GeneratedRoot = Join-Path $CrateDir "basic_calls/baml_sdk"
+    dotnet build $DocConsumer --configuration Release --nologo `
+        "-p:BamlBridgeProjectReference=$BridgeProject" `
+        "-p:BamlGeneratedSourceRoot=$GeneratedRoot"
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet build Baml.Bridge.DocumentationConsumer failed with exit code $LASTEXITCODE"
+    }
+} finally {
+    Pop-Location
+}
+
 if ($env:NEXTEST_ENV) {
     Add-Content -Path $env:NEXTEST_ENV -Value "SDK_TEST_CSHARP_SETUP=1"
     Add-Content -Path $env:NEXTEST_ENV -Value "BAML_BRIDGE_CSHARP_NATIVE_LIBRARY=$NativeLibrary"

--- a/baml_language/sdk_tests/crates/csharp/setup.sh
+++ b/baml_language/sdk_tests/crates/csharp/setup.sh
@@ -16,6 +16,23 @@ case "$(uname -s)" in
   *) native_library="$target_dir/debug/libbridge_cffi.so" ;;
 esac
 
+# Build every fixture consumer (and the union-generator tool) in ONE
+# MSBuild invocation: the projects compile in parallel across cores and the
+# shared Baml.Bridge project builds exactly once. The tests then run with
+# --no-build, which is what makes it safe for nextest to run them
+# concurrently — at test time no MSBuild processes exist to race on the
+# bridge's shared obj/ (the historical reason this suite was serialized).
+dotnet build Fixtures.slnx --configuration Release -m --nologo
+
+# The documentation consumer swaps its package reference for a project
+# reference via these properties, so it cannot ride along in the solution
+# build; its test passes the same properties with --no-build.
+dotnet build \
+  "$workspace_root/sdks/csharp/bridge_csharp/tests/Baml.Bridge.DocumentationConsumer/Baml.Bridge.DocumentationConsumer.csproj" \
+  --configuration Release --nologo \
+  "-p:BamlBridgeProjectReference=$workspace_root/sdks/csharp/bridge_csharp/src/Baml.Bridge.csproj" \
+  "-p:BamlGeneratedSourceRoot=$(pwd)/basic_calls/baml_sdk"
+
 if [[ -n "${NEXTEST_ENV:-}" ]]; then
   echo "SDK_TEST_CSHARP_SETUP=1" >> "$NEXTEST_ENV"
   echo "BAML_BRIDGE_CSHARP_NATIVE_LIBRARY=$native_library" >> "$NEXTEST_ENV"

--- a/baml_language/sdk_tests/crates/csharp/src/lib.rs
+++ b/baml_language/sdk_tests/crates/csharp/src/lib.rs
@@ -20,6 +20,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -102,6 +103,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -138,6 +140,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -172,6 +175,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -237,6 +241,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -271,6 +276,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -305,6 +311,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -340,6 +347,7 @@ mod tests {
             Command::new("dotnet")
                 .args([
                     "run",
+                    "--no-build",
                     "--project",
                     project.to_str().expect("project path is not UTF-8"),
                     "--configuration",
@@ -401,6 +409,7 @@ mod tests {
         Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -462,6 +471,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -498,6 +508,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",
@@ -590,6 +601,7 @@ mod tests {
         let output = Command::new("dotnet")
             .args([
                 "run",
+                "--no-build",
                 "--project",
                 project.to_str().expect("project path is not UTF-8"),
                 "--configuration",


### PR DESCRIPTION
## What

Two layered changes to the C# sdk-test CI jobs:

### 1. MSBuild cache across CI runs (workflow-only)

- `actions/cache` over `~/.nuget/packages` and every C# project's `bin`/`obj` (bridge, tools, test consumers, fixtures). The key never matches exactly, so each run saves its end state; `restore-keys` restores the newest prior cache. The pinned .NET SDK version is part of the key, so an SDK bump starts a cold cache.
- **`.github/scripts/csharp-mtime-cache.py`** — MSBuild's up-to-date check is mtime-based, and a fresh checkout (plus the build.rs fixture-client regeneration, which stages + renames a whole new tree) stamps every input with the current time. The script records a sha256 manifest of the C# source roots (including the bridge's `.proto` inputs under `crates/bridge_ctypes/types`) after each run, and before builds backdates *byte-identical* files to a fixed 2000 timestamp so cached outputs count as current. Changed / new / unanticipated files keep fresh mtimes — a missed input fails toward a redundant rebuild, never a stale test binary.
- The freshly-installed .NET SDK is backdated too (its targets files and ref packs are CoreCompile inputs stamped "now" each run; content is pinned by `dotnet-version`, and the version-in-key covers bumps).
- SourceLink + `SourceRevisionId` embedding is disabled for sdk-test builds via job env: both bake the commit SHA into compile inputs, which would rebuild the world on every push. (Release builds are untouched and keep SHA embedding.)
- The linux-only nightly pack check builds with `--artifacts-path` into its mktemp workdir so its `-p:Version`-stamped bridge build stops churning the cached obj.

### 2. Build once, test in parallel (harness)

The suite was serialized (`max-threads = 1`) because each test's `dotnet run -c Release` was its own MSBuild process, and concurrent MSBuilds race on the shared bridge `obj/`. Now:

- `Fixtures.slnx` aggregates all 11 fixtures + the union-generator tool; `setup.sh`/`setup.ps1` build it in **one** MSBuild invocation (projects parallel, bridge built once), plus a dedicated documentation-consumer build with its property overrides.
- Tests invoke `dotnet run --no-build` — no MSBuild at test time, so the nextest serialization group is removed and tests run concurrently.
- The generics compile-negative matrix runs its 4 cases concurrently (each already isolated via `--artifacts-path`).

## Measured results (CI, this PR — "Run C# sdk tests" step)

| scenario | linux | windows |
|---|---|---|
| baseline (before this PR) | 444s | 352s |
| warm cache, tests only (`d66e2b9`) | 193s | 84s |
| **steady state: cache + parallel harness (`32883373143`)** | **132s** | **67s** |
| upstream compiler/generator changed (`32884210847`) | 359s | 537s |

Steady state applies whenever the C#-relevant inputs are unchanged since the previous run — the common case for successive pushes to a PR. When canary's merge brings compiler or `sdkgen_csharp` changes (as happened live during measurement: #4570 touched the generator), every generated client's hash changes and the fixtures correctly rebuild — near-cold cost, by design. In the warm case the per-fixture tests are 1–3s (MSBuild `-v:d` logs confirmed `CoreCompile` skipped), and the linux residual is the compile-negative matrix, which builds into fresh temp dirs by design (150s serial → ~82–110s at 4-way concurrency).

Correctness posture throughout: the cache is never trusted for staleness decisions — MSBuild's own input checks run every time, and the backdate script only backdates files whose bytes match the previous run, so any change (source, proto, generated client, SDK version) forces a real rebuild. The debugging trail lives in the intermediate commits; a temporary `-v:d` diagnostic step identified the three cache-busters (fresh SDK mtimes, un-hashed proto inputs, commit-SHA embedding) and was removed once validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only correctness hinges on mtime backdating matching real content changes—wrong hashing would force redundant rebuilds, not stale binaries, but parallel C# tests assume no concurrent MSBuild on shared bridge `obj/` except isolated publish/negative-compile paths.
> 
> **Overview**
> Speeds up C# sdk-test CI by **caching MSBuild outputs** and **building fixtures once** instead of per-test `dotnet run` compiles.
> 
> **CI (csharp matrix leg):** Restores/saves `~/.nuget/packages`, `bin`/`obj`, and a content manifest via split `actions/cache/restore` + `save` (save runs on failure too). New `csharp-mtime-cache.py` records SHA256 hashes after each run and backdates byte-identical inputs (plus backdates the pinned .NET SDK tree) so MSBuild treats restored outputs as current; SourceLink / commit SHA embedding is disabled for these test builds. The linux nightly pack check uses `--artifacts-path` so it does not disturb the shared cached bridge build.
> 
> **Harness:** `Fixtures.slnx` plus `setup.sh`/`setup.ps1` build all fixture consumers in one solution build (documentation consumer still separate). Rust tests use `dotnet run --no-build`; nextest drops the C# serialization group. Generics negative-compile verification runs its four isolated cases in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 022587346cb5cb5d1cf5425a9051de64b5932695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of C# SDK integration and compilation tests by ensuring failed builds and negative test cases report errors correctly.

- **Performance**
  - Accelerated C# test setup and execution through parallelized builds and reuse of unchanged build outputs.

- **Testing**
  - Expanded fixture coverage to include protocol definitions and consolidated fixture projects for more consistent validation.
  - Improved incremental build behavior across supported development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->