### PR TITLE
Add inferred throws inlay hints

### DIFF
--- a/baml_language/crates/baml_ide/src/annotations.rs
+++ b/baml_language/crates/baml_ide/src/annotations.rs
@@ -1,4 +1,5 @@
-//! Inline type / parameter-name annotations for BAML files (inlay hints).
+//! Inline type, inferred-throws, and parameter-name annotations for BAML
+//! files (inlay hints).
 //!
 //! Provides `file_annotations(db, file) -> &Vec<InlineAnnotation>` — a Salsa
 //! tracked query that walks expression-body functions in a file
@@ -19,6 +20,17 @@
 //!
 //! The hint is positioned at the end of the pattern span (just after the
 //! variable name token).
+//!
+//! ## Inferred throws hints on function declarations
+//!
+//! For each user-written function without an explicit `throws` clause, we
+//! display its inferred non-`never` throws contract after the return type:
+//!
+//! ```baml
+//! function load() -> Data  // -> function load() -> Data throws baml.errors.Io
+//! ```
+//!
+//! The hint is positioned at the end of the return-type span.
 //!
 //! ## Parameter-name hints on call expressions
 //!
@@ -73,6 +85,8 @@ type SemanticIndex<'a> = baml_compiler2_hir::semantic_index::FileSemanticIndex<'
 pub enum AnnotationKind {
     /// A type hint after a variable name: `x: int`
     Type,
+    /// An inferred throws contract after a function return type.
+    Throws,
     /// A parameter-name hint before a call argument: `name:`
     Parameter,
 }
@@ -129,7 +143,31 @@ pub fn file_annotations(
         // calls, and since we don't recurse into skipped functions, their
         // internals stay hidden.
         match func_data.metadata.origin {
-            FunctionOrigin::UserDefined | FunctionOrigin::Internal => {}
+            FunctionOrigin::UserDefined => {
+                if func_data.throws.is_none()
+                    && let Some(return_type) = func_data.return_type
+                {
+                    let throws = baml_compiler2_hir_ty::callable::callable_throws(db, func_loc).0;
+                    if !should_suppress_type(&throws) {
+                        let source_map =
+                            baml_compiler2_ppir::item_data::function_source_map(db, func_loc);
+                        let return_type_span = source_map.type_refs.span(return_type);
+                        if !return_type_span.is_empty() {
+                            out.push(InlineAnnotation {
+                                offset: return_type_span.end(),
+                                label: format!(
+                                    " throws {}",
+                                    display_ty_for_file(db, file, &throws)
+                                ),
+                                kind: AnnotationKind::Throws,
+                                padding_left: false,
+                                padding_right: true,
+                            });
+                        }
+                    }
+                }
+            }
+            FunctionOrigin::Internal => {}
             FunctionOrigin::Companion | FunctionOrigin::AutoDerive => continue,
         }
         if baml_compiler2_ppir::item_data::function_llm_meta(db, func_loc).is_some() {
@@ -594,6 +632,57 @@ class Greeter {
         assert!(
             labels.iter().any(|label| label.starts_with(": ")),
             "expected a let type hint inside the method body, got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn annotations_show_inferred_throws_on_function_declarations() {
+        let mut builder = ProjectTest::builder();
+        let source = r#"
+class Boom {}
+
+function direct() -> int {
+    throw Boom {}
+}
+
+function propagated() -> int {
+    direct()
+}
+
+function explicit() -> int throws Boom {
+    throw Boom {}
+}
+
+function safe() -> int {
+    1
+}
+"#;
+        builder.source("main.baml", source);
+        let project = builder.build();
+
+        let hints = file_annotations(&project.db, project.files[0]);
+        let throws_hints: Vec<_> = hints
+            .iter()
+            .filter(|hint| hint.kind == AnnotationKind::Throws)
+            .collect();
+
+        assert_eq!(
+            throws_hints
+                .iter()
+                .map(|hint| hint.label.as_str())
+                .collect::<Vec<_>>(),
+            vec![" throws Boom", " throws Boom"]
+        );
+        let expected_offsets =
+            ["function direct() -> int", "function propagated() -> int"].map(|signature| {
+                TextSize::try_from(source.find(signature).unwrap() + signature.len()).unwrap()
+            });
+        assert_eq!(
+            throws_hints
+                .iter()
+                .map(|hint| hint.offset)
+                .collect::<Vec<_>>(),
+            expected_offsets
         );
     }
 

--- a/baml_language/crates/baml_lsp/src/dispatch/requests.rs
+++ b/baml_language/crates/baml_lsp/src/dispatch/requests.rs
@@ -738,7 +738,9 @@ pub(super) fn inlay_hint(
             position: codec.offset_to_position(u32::from(annotation.offset)),
             label: lsp_types::InlayHintLabel::String(annotation.label.clone()),
             kind: Some(match annotation.kind {
-                baml_ide::AnnotationKind::Type => lsp_types::InlayHintKind::TYPE,
+                baml_ide::AnnotationKind::Type | baml_ide::AnnotationKind::Throws => {
+                    lsp_types::InlayHintKind::TYPE
+                }
                 baml_ide::AnnotationKind::Parameter => lsp_types::InlayHintKind::PARAMETER,
             }),
             text_edits: None,

--- a/baml_language/crates/baml_lsp/tests/protocol.rs
+++ b/baml_language/crates/baml_lsp/tests/protocol.rs
@@ -1410,6 +1410,41 @@ fn inlay_hints_appear_for_inferred_let_types() {
     );
 }
 
+#[test]
+fn inlay_hints_appear_for_inferred_throws() {
+    let mut harness = Harness::new();
+    harness.fs.add_project(&harness.ws);
+    let fixture = "class Boom {}\n\nfunction fail() -> int {\n    throw Boom {}\n}\n";
+    harness.fs.write(harness.ws.join("main.baml"), fixture);
+    harness.init_session(SessionKey(1), &[lsp_types::PositionEncodingKind::UTF16]);
+    harness.settle();
+
+    let uri = harness.uri("main.baml");
+    let response = harness
+        .request(
+            SessionKey(1),
+            "textDocument/inlayHint",
+            serde_json::json!({
+                "textDocument": { "uri": uri },
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 5, "character": 0 },
+                },
+            }),
+        )
+        .expect("inlay hints succeed");
+    let hints = response.as_array().expect("hint array");
+    let hint = hints
+        .iter()
+        .find(|hint| hint["label"] == " throws Boom")
+        .unwrap_or_else(|| panic!("inferred throws hint present, got: {hints:?}"));
+    assert_eq!(hint["kind"], 1);
+    assert_eq!(
+        hint["position"],
+        serde_json::json!({ "line": 2, "character": 22 })
+    );
+}
+
 // ── 2.3b-3 substrate: cancellation, incremental sync, diffing, rescue ────
 
 /// `$/cancelRequest` cancels the running read's Salsa token: the parked job


### PR DESCRIPTION
## Changes

- Show declaration-site inlay hints for inferred non-never `throws` clauses.
- Reuse `callable_throws` and source-aware type rendering, with no compiler changes.
- Suppress hints for explicit throws clauses and synthetic functions.

## Testing

- [x] Unit tests added/updated
- [x] `cargo test -p baml_ide -p baml_lsp`
- [x] `cargo clippy -p baml_ide -p baml_lsp --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p baml_ide -p baml_lsp --no-deps`

## Screenshots

Not applicable.

## PR Checklist

- [x] Code follows the project style.
- [x] Self-review completed.
- [x] Documentation updated.
- [x] No new warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inlay hints showing inferred `throws` clauses for functions that may raise user-defined errors.
  * Hints appear after return types and are omitted when a function already declares `throws` or cannot throw.

* **Tests**
  * Added coverage for direct and propagated throws hints.
  * Added end-to-end validation of hint content, type, and position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->