### PR TITLE
Remove green elephant markers from what-is-baml headings

### DIFF
--- a/typescript2/app-website/app/what-is-baml/page.tsx
+++ b/typescript2/app-website/app/what-is-baml/page.tsx
@@ -266,11 +266,9 @@ const SECTIONS: Section[] = [
     title: 'Better testing',
   },
   {
-    // {elephant} marks the four elephant-in-the-room sections: will I have to
-    // rewrite everything, can models write this, where are the packages, and
-    // how do these people make money. The art is a placeholder until the
-    // generated lamb/elephant images land.
-    art: '/elephants/elephant-adoption.png',
+    // The four elephant-in-the-room sections: will I have to rewrite
+    // everything, can models write this, where are the packages, and how do
+    // these people make money.
     body: 'You can if you want. But we went the extra mile in the other direction: every type, every function, every method crosses the bridge to your language. Even generics. Even lambdas. Even tracing. Sh{lamb}t just works.',
     id: 'adopting',
     matrix: {
@@ -290,29 +288,26 @@ const SECTIONS: Section[] = [
     num: 7,
     readMore: 'Incremental adoption',
     sign: 'Do not rewrite your codebase in BAML.',
-    title: '{elephant} I’m hyped. How do I port my codebase to BAML?',
+    title: 'I’m hyped. How do I port my codebase to BAML?',
   },
   {
-    art: '/elephants/elephant-models.png',
     body: 'Decide for yourself. BAML reads like TypeScript and is already an official language on GitHub, so models should know most of it. We don’t leave the rest up to vibes. We measure how agents write programs: how long it takes, what it costs, how many turns. `baml describe` wasn’t a coincidence. It’s a science.\nAnd remember, today is the worst the models will ever be at BAML.',
     id: 'models-write',
     num: 8,
     readMore: 'Agent tries BAML',
-    title: '{elephant} Can models actually write BAML?',
+    title: 'Can models actually write BAML?',
   },
   {
-    art: '/elephants/elephant-packages.png',
     body: '`npm install is-even`. It depends on `is-odd`? That depends on `is-number`?! 🤯 We’re rethinking package management from first principles. For now, we’ve shipped a thorough standard library. For anything else, ask Claude to port what you need, or pass functions over the bridge.\nBesides, no packages means no supply chain attacks. QED.',
     id: 'packages',
     num: 9,
-    title: '{elephant} Is there an ecosystem?',
+    title: 'Is there an ecosystem?',
   },
   {
-    art: '/elephants/elephant-money.png',
     body: 'No thank you.\nThe BAML language is and will always be open. Apache-2, free, works offline.\nWe make money on Boundary Web Services. Build the language, the runtime, and the tracing layer, and you can make things nobody else can. We think you’ll love paying for some of them.\nSome of you may wish to build your own cloud. Good luck and Claudespeed.\nFor the rest, we’re launching with observability, and saving you from Datadog. [Reach out](mailto:vbv@boundaryml.com?subject=I%20want%20to%20send%20BAML%20monies) if you want in early.',
     id: 'money',
     num: 10,
-    title: '{elephant} Are you trying to get bought by {acquirer}',
+    title: 'Are you trying to get bought by {acquirer}',
   },
 ];
 
@@ -589,9 +584,8 @@ a.wib-fab img { height: 1.1em; width: auto; filter: brightness(0) invert(1); }
 }
 `;
 
-// Section titles can carry two tokens: {elephant} renders the section's art
-// (placeholder until the generated lamb/elephant images land) and {acquirer}
-// renders the cycling company name.
+// Section titles can carry two tokens: {elephant} (legacy marker, rendered as
+// no-op) and {acquirer} (cycling company name).
 function renderTitle(s: Section) {
   return s.title.split(/(\{elephant\}|\{acquirer\})/).map((part, i) => {
     if (part === '{elephant}') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

- Removed the `{elephant}` prefix markers from the four "elephant in the room" section titles on `app/what-is-baml/page.tsx`.
- Removed the now-unused placeholder `art` entries tied to those markers.
- Updated nearby inline comments to reflect the new behavior.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in local dev environment

Validation run:
- `pnpm exec biome check app/what-is-baml/page.tsx` ✅
- `pnpm typecheck` ❌ (fails due to pre-existing unrelated workspace issues, e.g. missing generated `pkg-proto` modules and existing `TenetsAccordion.tsx` type errors)

## Screenshots
If applicable, add screenshots to help explain your changes

- N/A (content-only heading marker removal)

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

- This is a minimal UI cleanup to remove the green placeholder markers shown before those headings in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1787724063370409?thread_ts=1787724063.370409&cid=C09F3QMJE9G)

<div><a href="https://cursor.com/agents/bc-5f4ca684-39a1-5370-b966-31a99d3c888f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f4ca684-39a1-5370-b966-31a99d3c888f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

