### PR TITLE
Update GA onboarding banner copy

### DIFF
--- a/typescript2/app-website/components/site-banner.tsx
+++ b/typescript2/app-website/components/site-banner.tsx
@@ -16,25 +16,12 @@ const CARD_BG = '#FBF8F1';
 // the Link only on the client sidesteps the mismatch.
 const RESERVED_HEIGHT = 41;
 
-// Launch target — the banner counts down to this date, floored at 0.
-const LAUNCH = new Date('2026-08-30T00:00:00');
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
-
-// Whole days from now until launch, never below 0. Computed on the client
-// (after mount) so the number reflects the visitor's current date.
-function daysUntilLaunch(): number {
-  const diff = LAUNCH.getTime() - Date.now();
-  return Math.max(0, Math.ceil(diff / MS_PER_DAY));
-}
-
 export function SiteBanner() {
   const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
   useEffect(() => {
     setMounted(true);
   }, []);
-  const days = daysUntilLaunch();
-
   // The /learn* and /bamlcode pages are self-contained; no marketing banner.
   if (pathname?.startsWith('/learn') || pathname?.startsWith('/bamlcode')) {
     return null;
@@ -106,8 +93,7 @@ export function SiteBanner() {
           New
         </span>
         <span style={{ color: MUTED }}>
-          {days} {days === 1 ? 'day' : 'days'} to launch{'  ·  '}
-          join a live onboarding,{' '}
+          BAML 1.0 will be GA soon! in the meantime, join a live onboarding,{' '}
           <span style={{ color: INK, fontWeight: 600 }}>every Thursday</span>
         </span>
         <span


### PR DESCRIPTION
## Summary
- replace the launch countdown with BAML 1.0 GA-soon messaging
- retain the live onboarding call to action and every Thursday schedule

## Testing
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Replaced the launch countdown with a static “BAML 1.0 will be GA soon!” banner message.
  * Retained the existing onboarding link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->