### PR TITLE
Restore canary website deployments

### DIFF
--- a/typescript2/app-website/vercel.json
+++ b/typescript2/app-website/vercel.json
@@ -4,7 +4,7 @@
   "git": {
     "deploymentEnabled": {
       "**": false,
-      "dhilan/website-v1": true
+      "canary": true
     }
   },
   "installCommand": "bash scripts/vercel-install.sh"


### PR DESCRIPTION
## Summary
- re-enable automatic website deployments from canary
- stop targeting the retired dhilan/website-v1 branch

## Testing
- parsed vercel.json with JSON.parse
- repository pre-commit hooks