### PR TITLE
fix(sap): preserve optional classes with omitted fields

### DIFF
--- a/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
@@ -438,6 +438,107 @@ test "chat_generic_collapses_text" {
     )
 }
 
+// Regression for #4589. Both provider paths receive the exact same answer;
+// each result retains the reported omitted/present/explicit-null comparison.
+class Issue4589Bbox {
+    x float
+    y float
+    w float
+    h float
+}
+
+class Issue4589Source {
+    doc_id string
+    page int
+    bbox Issue4589Bbox?
+}
+
+class Issue4589Envelope {
+    value string?
+    source Issue4589Source?
+    abstained bool
+    note string?
+}
+
+class Issue4589FourCases {
+    optional_omitted Issue4589Envelope?
+    required_omitted Issue4589Envelope
+    optional_present Issue4589Envelope?
+    optional_explicit_null Issue4589Envelope?
+}
+
+function Issue4589Probe(t: string) -> Issue4589FourCases {
+    client: "openai/gpt-4o-mini"
+    prompt: `${role("user")}${t}\n${ctx.output_format()}`
+}
+
+function _issue_4589_answer() -> string {
+    `{"optional_omitted":{"value":"optional-omitted","source":{"doc_id":"d","page":0},"abstained":false},"required_omitted":{"value":"required-omitted","source":{"doc_id":"d","page":0},"abstained":false},"optional_present":{"value":"optional-present","source":{"doc_id":"d","page":0,"bbox":{"x":0.1,"y":0.1,"w":0.1,"h":0.1}},"abstained":false},"optional_explicit_null":{"value":"optional-explicit-null","source":{"doc_id":"d","page":0,"bbox":null},"abstained":false}}`
+}
+
+function _issue_4589_chat_response() -> string {
+    let answer = baml.json.stringify(baml.json.to_json(_issue_4589_answer()));
+    `{"id":"chatcmpl-4589","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":${answer}},"finish_reason":"stop"}]}`
+}
+
+function _issue_4589_responses_response() -> string {
+    let answer = baml.json.stringify(baml.json.to_json(_issue_4589_answer()));
+    `{"id":"resp-4589","model":"m","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":${answer}}]}]}`
+}
+
+function _issue_4589_result_label(path: string, value: Issue4589FourCases) -> string {
+    [
+        path,
+        value.optional_omitted?.value ?? "NULLED",
+        value.required_omitted.value ?? "NULLED",
+        value.optional_present?.value ?? "NULLED",
+        value.optional_explicit_null?.value ?? "NULLED",
+    ].join("|")
+}
+
+function issue_4589_chat_preserves_omitted_nested_optional_class() -> string {
+    root.llm_mock.mock_json_serve(
+        [root.llm_mock.MockResponse.ok(_issue_4589_chat_response())],
+        (mock: root.llm_mock.MockJsonServer) -> {
+            let cl = openai.GenericClient.new(
+                model = "m",
+                base_url = mock.base_url() + "/v1",
+            );
+            let result = ai.Agent.new(client = cl).run(Issue4589Probe@spec("probe")).value;
+            _issue_4589_result_label(mock.last_request().path(), result)
+        },
+    )
+}
+
+test "issue_4589_chat_preserves_omitted_nested_optional_class" {
+    assert.equal(
+        issue_4589_chat_preserves_omitted_nested_optional_class(),
+        "/v1/chat/completions|optional-omitted|required-omitted|optional-present|optional-explicit-null",
+    )
+}
+
+function issue_4589_responses_preserves_omitted_nested_optional_class() -> string {
+    root.llm_mock.mock_json_serve(
+        [root.llm_mock.MockResponse.ok(_issue_4589_responses_response())],
+        (mock: root.llm_mock.MockJsonServer) -> {
+            let cl = openai.ResponsesClient.new(
+                model = "m",
+                api_key = "test-key",
+                base_url = mock.base_url() + "/v1",
+            );
+            let result = ai.Agent.new(client = cl).run(Issue4589Probe@spec("probe")).value;
+            _issue_4589_result_label(mock.last_request().path(), result)
+        },
+    )
+}
+
+test "issue_4589_responses_preserves_omitted_nested_optional_class" {
+    assert.equal(
+        issue_4589_responses_preserves_omitted_nested_optional_class(),
+        "/v1/responses|optional-omitted|required-omitted|optional-present|optional-explicit-null",
+    )
+}
+
 function chat_generic_request_timeout_ms() -> string {
     root.llm_mock.mock_json_serve(
         [root.llm_mock.MockResponse.ok(_chat_ok_body())],

--- a/baml_language/crates/bex_sap/src/deserializer/coercer/coerce_class.rs
+++ b/baml_language/crates/bex_sap/src/deserializer/coercer/coerce_class.rs
@@ -384,7 +384,7 @@ where
             .db
             .resolve_with_meta(ty.as_ref())
             .map_err(|ident| ctx.error_type_resolution(ident))?;
-        // let is_optional = ty.ty.is_optional(ctx.db);
+        let is_optional = ty.ty.is_optional(ctx.db);
         let field_entry = match entries.remove(name.as_ref()) {
             // Happy path: we have this field
             Some(Ok(some)) => some,
@@ -427,8 +427,11 @@ where
             None /*if !is_incomplete */=> {
                 let field_value = ty.ty.from_literal(missing, ctx)?;
                 let field_meta = DeserializerMeta {
-                    flags: DeserializerConditions::new()
-                        .with_flag(Flag::DefaultFromNoValue),
+                    flags: DeserializerConditions::new().with_flag(if is_optional {
+                        Flag::OptionalDefaultFromNoValue
+                    } else {
+                        Flag::DefaultFromNoValue
+                    }),
                     ty,
                 };
                 ValueWithFlags::new(field_value, field_meta)

--- a/baml_language/crates/bex_sap/src/tests/test_class.rs
+++ b/baml_language/crates/bex_sap/src/tests/test_class.rs
@@ -161,6 +161,95 @@ test_deserializer!(
     { "one": "a", "two": "b" }
 );
 
+// Regression for #4589: a valid optional class must not lose to its null arm
+// merely because the class contains omitted optional fields. This keeps the
+// reported required/present/explicit-null comparison in one coercion.
+test_deserializer!(
+    test_optional_class_with_omitted_nested_optional_class,
+    r#"{
+        "optional_omitted": {
+            "value": "optional-omitted",
+            "source": {"doc_id": "d", "page": 0},
+            "abstained": false
+        },
+        "required_omitted": {
+            "value": "required-omitted",
+            "source": {"doc_id": "d", "page": 0},
+            "abstained": false
+        },
+        "optional_present": {
+            "value": "optional-present",
+            "source": {
+                "doc_id": "d",
+                "page": 0,
+                "bbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}
+            },
+            "abstained": false
+        },
+        "optional_explicit_null": {
+            "value": "optional-explicit-null",
+            "source": {"doc_id": "d", "page": 0, "bbox": null},
+            "abstained": false
+        }
+    }"#,
+    baml_tyannotated!(Issue4589Outer),
+    baml_db! {
+        class Issue4589Bbox {
+            x: float,
+            y: float,
+            w: float,
+            h: float,
+        }
+        class Issue4589Source {
+            doc_id: string,
+            page: int,
+            bbox: (Issue4589Bbox | null) @class_completed_field_missing(null),
+        }
+        class Issue4589Envelope {
+            value: (string | null) @class_completed_field_missing(null),
+            source: (Issue4589Source | null) @class_completed_field_missing(null),
+            abstained: bool,
+            note: (string | null) @class_completed_field_missing(null),
+        }
+        class Issue4589Outer {
+            optional_omitted: (Issue4589Envelope | null) @class_completed_field_missing(null),
+            required_omitted: Issue4589Envelope,
+            optional_present: (Issue4589Envelope | null) @class_completed_field_missing(null),
+            optional_explicit_null: (Issue4589Envelope | null) @class_completed_field_missing(null),
+        }
+    },
+    {
+        "optional_omitted": {
+            "value": "optional-omitted",
+            "source": {"doc_id": "d", "page": 0, "bbox": null},
+            "abstained": false,
+            "note": null
+        },
+        "required_omitted": {
+            "value": "required-omitted",
+            "source": {"doc_id": "d", "page": 0, "bbox": null},
+            "abstained": false,
+            "note": null
+        },
+        "optional_present": {
+            "value": "optional-present",
+            "source": {
+                "doc_id": "d",
+                "page": 0,
+                "bbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}
+            },
+            "abstained": false,
+            "note": null
+        },
+        "optional_explicit_null": {
+            "value": "optional-explicit-null",
+            "source": {"doc_id": "d", "page": 0, "bbox": null},
+            "abstained": false,
+            "note": null
+        }
+    }
+);
+
 test_deserializer!(
     test_multi_fielded_foo_with_optional_and_extra_text,
     r#"Here is how you can build the API call:


### PR DESCRIPTION
## Issue Reference

Fixes #4589.

## Changes

- Score an omitted optional class field with the existing `OptionalDefaultFromNoValue` condition while retaining `DefaultFromNoValue` for required fields.
- Add a SAP regression covering the optional-parent omitted-member, required-parent, member-present, and member-explicitly-null cases.
- Add deterministic local HTTP mock coverage that sends the same answer through both `/v1/chat/completions` and `/v1/responses` and verifies neither path nulls the valid class.

## Root Cause

The completed-class coercer assigned the required missing-field penalty (100) to omitted optional fields. In the reported shape, two valid omissions gave the class union arm a score of 200, so coercing the non-null object to the null arm (110) incorrectly won. Optional omissions now use the existing score of 1, matching the legacy coercer and leaving validation and unrelated union selection behavior unchanged.

## Testing

- [x] `cargo test -p bex_sap` — 595 passed.
- [x] OpenAI chat and Responses namespace suites — 77 passed.
- [x] Focused chat-versus-responses regressions — 2 passed.
- [x] Locally built current-canary CLI against a deterministic HTTP sink, before and after the fix.
- [x] `git diff --check`.
- [ ] Full `baml_tests`: 2,038 of 2,039 passed. The unrelated `claude_code_client_preserves_process_wait_timeout` assertion also fails in isolation because it receives the provider network-timeout variant at its 25 ms boundary.

## Screenshots

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of nested optional fields when values are omitted, preventing valid objects from being incorrectly interpreted as `null`.
  - Optional fields with configured defaults are now populated consistently while preserving explicit `null` values.
  - Improved consistency across OpenAI chat-completions and Responses integrations.

- **Tests**
  - Added regression coverage for omitted, present, and explicitly null nested optional fields across supported OpenAI endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->