### PR TITLE
fix: wait for current product metrics charts

### DIFF
--- a/typescript2/app-product-metrics/src/jobs/send-slack-report.ts
+++ b/typescript2/app-product-metrics/src/jobs/send-slack-report.ts
@@ -21,8 +21,11 @@ interface EmbeddedDashboardLayout {
 const primaryPanelTitles = [
   'CLI invocations — daily',
   'CLI weekly cohort retention',
-  'CLI new users — daily',
-  'CLI existing users — daily',
+  'CLI 7DAU — daily',
+  'CLI 30DAU — daily',
+  'CLI new users (7d period)',
+  'CLI retained users (7d period)',
+  'CLI resurrected users (7d period)',
 ];
 
 export async function captureDashboard(dashboardUrl: string): Promise<Buffer> {


### PR DESCRIPTION
## Summary
- update the Slack report readiness check to match the current 7DAU, 30DAU, new, retained, and resurrected chart titles

## Verification
- captured the complete live dashboard locally (252,336-byte PNG)
- `pnpm --filter app-product-metrics test`
- `pnpm --filter app-product-metrics typecheck`
- `pnpm exec biome check app-product-metrics/src/jobs/send-slack-report.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated primary dashboard validation panels to display 7-day and 30-day active users, new users, retained users, and resurrected users.
  * Replaced the previous daily new-user and existing-user panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->