### PR TITLE
chore: notify Slack on successful nightly releases

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2342,7 +2342,7 @@ jobs:
       - smoke-swift-release
     # Use the dispatch input so a failure in plan itself is still reportable.
     # This job must run after failed dependencies. Every production release result notifies Slack, including successful nightlies.
-    if: ${{ always() && inputs.dry_run == false && needs.plan.outputs.source_branch == 'canary' }}
+    if: ${{ always() && inputs.dry_run == false && (needs.plan.outputs.source_branch == 'canary' || (needs.plan.result == 'failure' && github.ref_type == 'tag' && github.ref_name == format('baml-language-source-{0}', inputs.source_sha))) }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev
     permissions:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2341,7 +2341,7 @@ jobs:
       - publish-pkg-channel
       - smoke-swift-release
     # Use the dispatch input so a failure in plan itself is still reportable.
-    # This job must run after failed dependencies. Failures and successful canary releases notify Slack; successful nightlies stay silent.
+    # This job must run after failed dependencies. Every production release result notifies Slack, including successful nightlies.
     if: ${{ always() && inputs.dry_run == false && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -654,7 +654,7 @@ def step_inputs(step: str) -> dict[str, str]:
 
 
 class WorkflowGraphTests(unittest.TestCase):
-    def test_release_slack_notifications_cover_failures_and_canary_success(self) -> None:
+    def test_release_slack_notifications_cover_failures_and_successes(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         notifier = RELEASE_NOTIFIER.read_text(encoding="utf-8")
         notify_slack = job_block(workflow, "notify-slack")
@@ -677,10 +677,7 @@ class WorkflowGraphTests(unittest.TestCase):
             "RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}",
             notify_step,
         )
-        self.assertIn(
-            'if release_succeeded and not failures and channel != "canary"',
-            notifier,
-        )
+        self.assertNotIn("skipping Slack notification", notifier)
         self.assertIn(
             'SUCCESSFUL_JOB_CONCLUSIONS = {"success", "skipped"}',
             notifier,

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -18,7 +18,6 @@ GO_RELEASE_SMOKE = ROOT / "scripts" / "smoke-go-release.py"
 GO_SDK_ASSEMBLER = ROOT / "scripts" / "assemble-go-sdk-mirror"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
-RELEASE_NOTIFIER = ROOT / "tools" / "notify-release-failure.py"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
 NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly-release.yml"
 BRIDGE_CFFI_PUBLIC_EXPORTS = (
@@ -654,38 +653,6 @@ def step_inputs(step: str) -> dict[str, str]:
 
 
 class WorkflowGraphTests(unittest.TestCase):
-    def test_release_slack_notifications_cover_failures_and_successes(self) -> None:
-        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-        notifier = RELEASE_NOTIFIER.read_text(encoding="utf-8")
-        notify_slack = job_block(workflow, "notify-slack")
-        notify_step = step_block(notify_slack, "Notify Slack of the release result")
-
-        self.assertIn("always()", notify_slack)
-        self.assertIn(
-            "run: uv run --script tools/notify-release-failure.py",
-            notify_step,
-        )
-        self.assertIn(
-            "CHANNEL: ${{ needs.plan.outputs.channel }}",
-            notify_step,
-        )
-        self.assertIn(
-            "VERSION: ${{ needs.plan.outputs.version }}",
-            notify_step,
-        )
-        self.assertIn(
-            "RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}",
-            notify_step,
-        )
-        self.assertNotIn("skipping Slack notification", notifier)
-        self.assertIn(
-            'SUCCESSFUL_JOB_CONCLUSIONS = {"success", "skipped"}',
-            notifier,
-        )
-        self.assertIn("conclusion not in SUCCESSFUL_JOB_CONCLUSIONS", notifier)
-        self.assertIn("❌ BAML {channel} release failed", notifier)
-        self.assertIn("✅ BAML {channel} release succeeded", notifier)
-
     def test_cpp_verifier_stamps_the_frozen_release_plan(self) -> None:
         workflow = CPP_VERIFIER.read_text(encoding="utf-8")
         verify = job_block(workflow, "verify")

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -146,9 +146,6 @@ def main() -> int:
         release_succeeded = os.environ.get("RELEASE_SUCCEEDED") == "true"
         started_at = get_run_started_at(repository, run_id, run_attempt, github_token)
         failures = find_failures(repository, run_id, run_attempt, github_token)
-        if release_succeeded and not failures and channel != "canary":
-            print(f"Successful {channel} release; skipping Slack notification.")
-            return 0
 
         run_url = (
             f"https://github.com/{repository}/actions/runs/{run_id}"

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -133,6 +133,7 @@ def format_failure(failure: Failure) -> str:
 
 
 def main() -> int:
+    """Notify Slack of the current release result."""
     try:
         repository = required_env("GITHUB_REPOSITORY")
         run_id = required_env("GITHUB_RUN_ID")


### PR DESCRIPTION
We've had questions about "has nightly gone out yet?" so let's just send these to Slack directly.