### PR TITLE
feat: link Slack report to product metrics dashboard

### DIFF
--- a/typescript2/app-product-metrics/src/jobs/send-slack-report.ts
+++ b/typescript2/app-product-metrics/src/jobs/send-slack-report.ts
@@ -43,6 +43,13 @@ const nativePanelTitles = [
 
 const dashboardSettleTimeMs = 20_000;
 
+export function dashboardReportText(
+  dashboardUrl: string,
+  date: string,
+): string {
+  return `<${new URL(dashboardUrl).href}|Product metrics dashboard> · ${date}`;
+}
+
 export async function captureDashboard(dashboardUrl: string): Promise<Buffer> {
   const browser = await chromium.launch({ headless: true });
   try {
@@ -210,6 +217,6 @@ export async function sendSlackDashboardReport(
       filename: `product-metrics-dashboard-${date}.png`,
       title: `Product metrics dashboard · ${date}`,
     },
-    text: `Product metrics dashboard · ${date}`,
+    text: dashboardReportText(config.dashboardUrl, date),
   });
 }

--- a/typescript2/app-product-metrics/src/slack-report.test.ts
+++ b/typescript2/app-product-metrics/src/slack-report.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { dashboardReportText } from './jobs/send-slack-report.js';
+
+test('dashboardReportText links the Slack report to the live dashboard', () => {
+  assert.equal(
+    dashboardReportText(
+      'https://boundary-product-metrics.fly.dev',
+      '2026-08-28',
+    ),
+    '<https://boundary-product-metrics.fly.dev/|Product metrics dashboard> · 2026-08-28',
+  );
+});


### PR DESCRIPTION
## Summary
- link the Slack report comment to the live Product metrics dashboard
- keep the report date alongside the link
- add unit coverage for the Slack text

## Verification
- `pnpm --filter app-product-metrics test`
- `pnpm --filter app-product-metrics typecheck`
- `pnpm exec biome check app-product-metrics/src/jobs/send-slack-report.ts app-product-metrics/src/slack-report.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Slack product metrics reports now include a clickable link to the live dashboard.
  * Reports continue to display the relevant reporting date.

* **Tests**
  * Added coverage to verify the dashboard link and date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->