### PR TITLE
test(lsp): make didOpen filesystem assertion deterministic

### DIFF
--- a/baml_language/crates/baml_lsp/tests/protocol.rs
+++ b/baml_language/crates/baml_lsp/tests/protocol.rs
@@ -379,7 +379,15 @@ fn open_bad_document_publishes_versioned_diagnostics() {
 /// neither inline nor through the discovery it triggers.
 #[test]
 fn did_open_never_reads_the_opened_file() {
-    let mut h = Harness::new();
+    let io = Arc::new(ManualExecutor::default());
+    let mut h = Harness::with_executors(
+        Executors {
+            requests: Arc::new(ThreadPool::new(2)),
+            diagnostics: Arc::new(ThreadPool::new(2)),
+            io: io.clone(),
+        },
+        None,
+    );
     h.fs.add_project(&h.ws);
     h.fs.write(h.ws.join("main.baml"), "// stale disk copy\n");
     h.fs.write(h.ws.join("other.baml"), "class Other { y int }\n");
@@ -394,6 +402,8 @@ fn did_open_never_reads_the_opened_file() {
         h.fs.reads().is_empty(),
         "didOpen is inline and read nothing"
     );
+    assert_eq!(io.parked(), 1, "didOpen queues one discovery job");
+    io.run_all();
     h.settle();
 
     assert_eq!(


### PR DESCRIPTION
## Stack context

This PR targets `canary` and is the bottom layer of the active stack. [#4593](https://github.com/BoundaryML/baml/pull/4593) is stacked on top of it. The change is independent of the compiler behavior in that PR and can land first.

## Problem

`did_open_never_reads_the_opened_file` uses a real thread pool for filesystem discovery.

After `h.open(...)` queues discovery, a worker may immediately discover the project and read `other.baml` before the test checks that the read log is empty:

```text
owner:  didOpen ── queue discovery ── return ── assert no reads
worker:                   └────────── read other.baml
```

The resulting failure does not mean that the opened `main.baml` buffer was read from disk. It only means that legitimate asynchronous sibling-file discovery won the scheduling race.

## After this PR

This test supplies a manual executor for the I/O lane while retaining real thread pools for request and diagnostic work.

The sequence is now deterministic:

1. Dispatch `didOpen`.
2. Assert that synchronous handling performed no filesystem reads.
3. Assert that exactly one discovery job was queued.
4. Explicitly run the discovery job.
5. Settle owner events and diagnostics.
6. Preserve the existing assertion that discovery walked once and read only `other.baml`.

The production LSP implementation is unchanged.

## Behavioral boundaries

| Behavior | Assertion |
| --- | --- |
| `didOpen` uses the editor buffer and performs no synchronous disk read | Read log is empty before releasing I/O |
| Opening an unserved document queues project discovery | Exactly one I/O job is parked |
| Discovery skips the opened document | `main.baml` never appears in the read log |
| Discovery loads sibling source files | Final read log is exactly `other.baml` |
| Diagnostics use the editor contents | The opened document compiles without diagnostics |

## Validation

- [ ] CI
- [x] Diff and whitespace checks
- [x] No production code changes

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated language-server protocol testing to verify that opening a document queues exactly one discovery job.
  * Added explicit execution and settling of the queued job for more reliable test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->