### PR TITLE
refactor(mir): remove dead visualization nodes from MIR

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -606,9 +606,6 @@ fn collect_def_use<'db>(body: &MirFunctionBody<'db>) -> HashMap<Local, LocalDefU
                         });
                     }
                 }
-                StatementKind::VizEnter(_) | StatementKind::VizExit(_) => {
-                    // VizEnter/VizExit don't use any locals
-                }
                 StatementKind::Nop => {}
             }
         }
@@ -1355,8 +1352,7 @@ fn call_result_carried_into(terminator: Option<&Terminator<'_>>, block: BlockId)
 /// between the assignment to `_0` and the `Return` terminator.
 fn is_stack_neutral_statement(kind: &StatementKind<'_>) -> bool {
     match kind {
-        // These don't touch the stack at all - just update external state
-        StatementKind::VizEnter(_) | StatementKind::VizExit(_) => true,
+        // Replaces a captured cell in place - doesn't touch the stack
         StatementKind::FreshCell(_) => true,
         // Intrinsics push args then SendEvent consumes them - net neutral
         StatementKind::Intrinsic { .. } => true,
@@ -1375,7 +1371,7 @@ fn is_stack_neutral_statement(kind: &StatementKind<'_>) -> bool {
 /// Check if `_0` (the return place) is a "return-phi" local.
 ///
 /// Return-phi applies when `_0` is assigned before Return in each defining block,
-/// with only stack-neutral statements (like `VizExit`) between the assignment
+/// with only stack-neutral statements (like `FreshCell`) between the assignment
 /// and Return. This allows us to:
 /// - At def sites: emit rvalue but NOT `StoreVar` (leave value on stack)
 /// - At Return: skip `LoadVar` for _0 (value already on stack)
@@ -1888,7 +1884,6 @@ fn has_side_effect(kind: &StatementKind<'_>, rvalue_reads: &HashSet<Local>) -> b
         }
         StatementKind::Drop(_) => true,
         StatementKind::FreshCell(local) => rvalue_reads.contains(local),
-        StatementKind::VizEnter(_) | StatementKind::VizExit(_) => true, // VizEnter/VizExit emit notifications
         StatementKind::Intrinsic { .. } => true, // Intrinsics emit events — observable side effect
         // A write through an interface field mutates the receiver.
         StatementKind::VirtualFieldStore { .. } => true,
@@ -2381,7 +2376,6 @@ mod tests {
             entry: BlockId(0),
             locals: vec![],
             catch_regions: vec![],
-            viz_nodes: vec![],
         };
         let du = LocalDefUse {
             def: Some(DefLocation {
@@ -2453,7 +2447,6 @@ mod tests {
             entry: BlockId(0),
             locals: vec![],
             catch_regions: vec![],
-            viz_nodes: vec![],
         };
         let du = LocalDefUse {
             def: Some(DefLocation {
@@ -2596,7 +2589,6 @@ mod tests {
             entry: BlockId(0),
             locals: vec![bool_local_decl(None), bool_local_decl(name)],
             catch_regions: vec![],
-            viz_nodes: vec![],
         }
     }
 
@@ -3052,7 +3044,6 @@ mod tests {
                 int_local_decl(Some("result")),
             ],
             catch_regions: vec![],
-            viz_nodes: vec![],
         };
 
         let analysis = AnalysisResult::analyze(&body, 0, OptLevel::One);
@@ -3105,7 +3096,6 @@ mod tests {
                 int_list_local_decl(Some("items")),
             ],
             catch_regions: vec![],
-            viz_nodes: vec![],
         };
 
         let analysis = AnalysisResult::analyze(&body, 0, OptLevel::One);
@@ -3157,7 +3147,6 @@ mod tests {
                 int_local_decl(Some("n")),
             ],
             catch_regions: vec![],
-            viz_nodes: vec![],
         };
 
         let analysis = AnalysisResult::analyze(&body, 0, OptLevel::One);

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1491,12 +1491,6 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             StatementKind::Drop(place) => {
                 unwrap_infallible(pull_semantics::walk_drop_statement(self, place));
             }
-            StatementKind::VizEnter(_node_idx) => {
-                // Viz observability is not emitted to bytecode.
-            }
-            StatementKind::VizExit(_node_idx) => {
-                // Viz observability is not emitted to bytecode.
-            }
             StatementKind::FreshCell(local) => {
                 if self.captured_locals.contains(local) {
                     if let Some(&slot) = self.local_slots.get(local) {
@@ -3952,7 +3946,6 @@ mod tests {
             entry: BlockId(0),
             locals: vec![local(RuntimeTy::int()), local(RuntimeTy::bool())],
             catch_regions: Vec::new(),
-            viz_nodes: Vec::new(),
         };
 
         let globals = HashMap::new();

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -469,11 +469,7 @@ fn simulate_statement_stack<'db>(
             };
             pull_semantics::walk_drop_statement(&mut sink, place).is_ok()
         }
-        StatementKind::FreshCell(_)
-        | StatementKind::VizEnter(_)
-        | StatementKind::VizExit(_)
-        | StatementKind::Intrinsic { .. }
-        | StatementKind::Nop => true,
+        StatementKind::FreshCell(_) | StatementKind::Intrinsic { .. } | StatementKind::Nop => true,
     }
 }
 
@@ -1593,7 +1589,6 @@ mod tests {
             entry: baml_compiler2_mir::BlockId(0),
             locals: local_tys.into_iter().map(local_decl).collect(),
             catch_regions: vec![],
-            viz_nodes: vec![],
         }
     }
 

--- a/baml_language/crates/baml_compiler2_emit/src/verifier.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/verifier.rs
@@ -147,7 +147,6 @@ mod tests {
             ],
             entry: BlockId(0),
             locals: vec![local("ret")],
-            viz_nodes: vec![],
         };
         // Ensure IDs/indexes stay coherent for this synthetic MIR.
         for (i, block) in body.blocks.iter_mut().enumerate() {
@@ -194,7 +193,6 @@ mod tests {
             ],
             entry: BlockId(0),
             locals: vec![local("ret")],
-            viz_nodes: vec![],
         };
         for (i, block) in body.blocks.iter_mut().enumerate() {
             block.id = BlockId(i);

--- a/baml_language/crates/baml_compiler2_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/builder.rs
@@ -32,7 +32,6 @@ use baml_type::{RuntimeTy, TyTemplate};
 use crate::{
     BasicBlock, BlockId, CatchRegion, Constant, ItemRef, Local, LocalDecl, MirFunction,
     MirFunctionBody, MirFunctionKind, Operand, Place, Rvalue, Statement, StatementKind, Terminator,
-    VizNode,
 };
 
 /// Builder for constructing MIR functions.
@@ -43,7 +42,6 @@ pub(crate) struct MirBuilder<'db> {
     locals: Vec<LocalDecl>,
     current_block: Option<BlockId>,
     span: Option<Span>,
-    viz_nodes: Vec<VizNode>,
     /// Current source span for tagging statements/terminators.
     pub(crate) current_source_span: Option<Span>,
     /// Catch regions recorded during lowering for exception table construction.
@@ -62,7 +60,6 @@ impl<'db> MirBuilder<'db> {
             locals: Vec::new(),
             current_block: None,
             span: None,
-            viz_nodes: Vec::new(),
             current_source_span: None,
             catch_regions: Vec::new(),
         }
@@ -712,7 +709,6 @@ impl<'db> MirBuilder<'db> {
                 entry: BlockId(0),
                 locals: self.locals,
                 catch_regions: self.catch_regions.clone(),
-                viz_nodes: self.viz_nodes,
             }),
             lambdas: vec![],
             signature: None,
@@ -733,7 +729,6 @@ impl<'db> MirBuilder<'db> {
             entry: BlockId(0),
             locals: self.locals,
             catch_regions: self.catch_regions,
-            viz_nodes: self.viz_nodes,
         }
     }
 
@@ -755,21 +750,9 @@ impl<'db> MirBuilder<'db> {
                 entry: BlockId(0),
                 locals: self.locals,
                 catch_regions: self.catch_regions.clone(),
-                viz_nodes: self.viz_nodes,
             }),
             lambdas: vec![],
             signature: None,
         }
-    }
-
-    // ========================================================================
-    // Visualization Helpers
-    // ========================================================================
-
-    /// Add a visualization node and return its index.
-    pub(crate) fn add_viz_node(&mut self, node: VizNode) -> usize {
-        let idx = self.viz_nodes.len();
-        self.viz_nodes.push(node);
-        idx
     }
 }

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -90,8 +90,6 @@ pub struct MirFunctionBody<'db> {
     /// Catch regions mapping try-body extents to handler blocks.
     /// Populated during catch lowering; used by the emitter to build exception tables.
     pub catch_regions: Vec<CatchRegion>,
-    /// Visualization nodes for control flow visualization.
-    pub viz_nodes: Vec<VizNode>,
 }
 
 impl<'db> MirFunctionBody<'db> {
@@ -359,14 +357,6 @@ pub enum StatementKind<'db> {
 
     /// Drop a value (run destructor if any).
     Drop(Place),
-
-    /// Enter a visualization node.
-    /// Emitted at the start of control flow structures (if, while, etc.).
-    VizEnter(usize),
-
-    /// Exit a visualization node.
-    /// Emitted at the end of control flow structures.
-    VizExit(usize),
 
     /// Replace a captured local's cell with a fresh one.
     /// Emitted at the top of for-loop iteration bodies so each iteration's
@@ -1304,42 +1294,4 @@ impl fmt::Display for UnaryOp {
         };
         write!(f, "{s}")
     }
-}
-
-// ============================================================================
-// Visualization Nodes
-// ============================================================================
-
-/// Type of visualization node for control flow visualization.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VizNodeType {
-    /// Root of a function's control flow.
-    FunctionRoot,
-    /// Header context from `//# header` annotation.
-    HeaderContextEnter,
-    /// Group of branches (if-else chain).
-    BranchGroup,
-    /// Single branch arm (if/else if/else).
-    BranchArm,
-    /// Loop construct (while/for).
-    Loop,
-    /// Other block scope.
-    OtherScope,
-}
-
-/// Visualization node metadata for control flow visualization.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VizNode {
-    /// Unique node ID within this function.
-    pub node_id: u32,
-    /// Encoded log filter key for this node.
-    pub log_filter_key: String,
-    /// Parent node's log filter key (None for root).
-    pub parent_log_filter_key: Option<String>,
-    /// Type of this visualization node.
-    pub node_type: VizNodeType,
-    /// Human-readable label for this node.
-    pub label: String,
-    /// Header level (only for `HeaderContextEnter`).
-    pub header_level: Option<u8>,
 }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -15942,7 +15942,6 @@ fn lower_function_impl<'db>(
                     })
                     .collect(),
                 catch_regions: vec![],
-                viz_nodes: vec![],
             }),
             lambdas: vec![],
             signature: None,

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -454,10 +454,7 @@ fn collect_place_index_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
                 // declines to write into the `Local`-typed position, while the
                 // defining assignment is dropped regardless — leaving the
                 // projection pointing at a local nothing defines.
-                crate::StatementKind::FreshCell(_)
-                | crate::StatementKind::VizEnter(_)
-                | crate::StatementKind::VizExit(_)
-                | crate::StatementKind::Nop => {}
+                crate::StatementKind::FreshCell(_) | crate::StatementKind::Nop => {}
             }
         }
         if let Some(term) = &block.terminator {
@@ -759,9 +756,7 @@ fn count_in_statement(stmt: &crate::Statement, uses: &mut [usize]) {
         crate::StatementKind::FreshCell(l) => {
             uses[l.0] += 1;
         }
-        crate::StatementKind::VizEnter(_)
-        | crate::StatementKind::VizExit(_)
-        | crate::StatementKind::Nop => {}
+        crate::StatementKind::Nop => {}
         crate::StatementKind::Intrinsic { args, .. } => {
             for arg in args {
                 count_in_operand(arg, uses);
@@ -1136,8 +1131,6 @@ fn apply_subst_to_statement<'db>(
         // propagation has already retired, and the emitter then loads a slot
         // nothing ever stored to.
         crate::StatementKind::Drop(_)
-        | crate::StatementKind::VizEnter(_)
-        | crate::StatementKind::VizExit(_)
         | crate::StatementKind::FreshCell(_)
         | crate::StatementKind::Nop => {}
     }
@@ -1442,9 +1435,7 @@ fn rewrite_locals_in_statement(stmt: &mut crate::Statement, map: &[Option<Local>
         }
         crate::StatementKind::Drop(p) => remap_place(p, map),
         crate::StatementKind::FreshCell(l) => remap_local(l, map),
-        crate::StatementKind::VizEnter(_)
-        | crate::StatementKind::VizExit(_)
-        | crate::StatementKind::Nop => {}
+        crate::StatementKind::Nop => {}
         crate::StatementKind::Intrinsic { args, .. } => {
             for arg in args {
                 remap_operand(arg, map);
@@ -1729,9 +1720,7 @@ fn verify_mir(body: &MirFunctionBody<'_>, name: &crate::ItemRef) {
                 // Exhaustive rather than wildcarded: an operand-carrying
                 // statement kind that skips this check loses the one cheap
                 // tripwire for a reference to a retired local.
-                crate::StatementKind::VizEnter(_)
-                | crate::StatementKind::VizExit(_)
-                | crate::StatementKind::Nop => {}
+                crate::StatementKind::Nop => {}
             }
         }
     }

--- a/baml_language/crates/baml_compiler2_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/pretty.rs
@@ -172,12 +172,6 @@ fn write_statement(f: &mut impl Write, stmt: &Statement<'_>) -> fmt::Result {
         StatementKind::Drop(place) => {
             write!(f, "drop({place});")
         }
-        StatementKind::VizEnter(idx) => {
-            write!(f, "viz_enter({idx});")
-        }
-        StatementKind::VizExit(idx) => {
-            write!(f, "viz_exit({idx});")
-        }
         StatementKind::FreshCell(local) => {
             write!(f, "fresh_cell({local});")
         }


### PR DESCRIPTION
## Summary

The MIR still carried the remnants of the original playground animation scheme, where viz opcodes were inserted around every control-flow statement:

- `StatementKind::VizEnter` / `StatementKind::VizExit`
- `VizNode`, `VizNodeType`
- `MirFunctionBody::viz_nodes`
- `MirBuilder::add_viz_node` (zero callers)

None of it is used anymore:

- The last producers (the `//# header` lowering in `lower.rs`) were removed in #3247.
- The VM opcode and `VizNodeMeta` were dropped in #3616; since then `emit.rs` has treated both statements as explicit no-ops.
- `bex_vm`, `bex_vm_types`, `bex_engine`, `bex_events`, `bex_project` and `bridge_wasm` have zero viz references.
- The live playground (`typescript2/pkg-playground`) builds its graph from the AST via `baml_compiler2_visualization` and derives node run-state from the `RunPatch`/`RunSnapshot` event stream, not from bytecode.

This PR deletes the types, variants, field and builder helper, plus the ~20 pass-through match arms and test struct literals that referenced them. Nothing under `engine/` or `typescript/` is touched — those trees are legacy and carry their own complete viz system.

No `.snap`, `.md` or TS file referenced `viz_enter`/`viz_exit`/`VizNode`, so output is unchanged. Net −115/+7.

## Test plan

- [x] `cargo fmt` with repo config
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test --lib` — green for `baml_tests` (954), `baml_compiler2_*`, `baml_db`, `baml_ide`, `bex_vm`, `bex_engine`, `bex_project`; only failures locally are environment-only (`baml_bridge` needs a prebuilt `libbridge_cffi.dylib`, `sdk_test_*` need external toolchains, one `bex_prof_store` `StreamInUse` flake that passes in isolation)

https://claude.ai/code/session_01Qai5VpnzsTj8SxtmDXB9Tz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed control-flow visualization data and processing from the compiler’s intermediate representation.
  * Simplified MIR generation, optimization, validation, stack handling, bytecode emission, and pretty-printing.
  * Updated compiler test fixtures to reflect the streamlined representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->