### PR TITLE
feat(atb2): handle_issue: a design pass, then a fix pass in the sandbox; PR body; outcome; agents run on Fable

### DIFF
--- a/tools/atb2/baml_src/handle_issue.baml
+++ b/tools/atb2/baml_src/handle_issue.baml
@@ -20,7 +20,114 @@
 //   ~/.atb2/worktrees/<branch>/   the agent's checkout, deleted at the end
 //   ~/.atb2/runs/<branch>/        audit trail: transcript.jsonl, pr_body.md, outcome.json
 
+enum HandleMode {
+    /// Push the branch and open a draft PR when the gate passes.
+    Live,
+    /// Everything up to (not including) the push — what the evals run.
+    DryRun,
+}
+
 // ==================== Pipeline ====================
+//#handle_issue(issue: Issue, mode: HandleMode = HandleMode.Live, update: bool = false) -> Issue
+function handle_issue(
+    issue: Issue,
+    mode: HandleMode = HandleMode.Live,
+    update: bool = false,
+) -> Issue {
+    //# skip: not ready (not gauged / not open / already handled)
+    let skip = handle_ready(issue, update);
+    if (skip != null) {
+        log.info({ "issue": issue.id, "skipped": skip });
+        return issue;
+    };
+    let difficulty = issue.difficulty ?? baml.sys.panic("handle_issue: gauge_issue first (" + issue.id + ")");
+    //# is it still broken on canary HEAD?
+    // canary is fetched and its baml-cli rebuilt (seconds when warm) so the
+    // repros are checked against what a PR would actually land on
+    ensure_cache();
+    build_canary_cli();
+    if (!still_broken(issue)) {
+        //## already fixed: nothing to do
+        log.info({ "issue": issue.id, "kind": "already_fixed", "checked_with": check_cli() });
+        return issue;
+    };
+    //# open a worktree on a fresh branch
+    let sb = open_sandbox(issue, update);
+    let keep_branch = false;
+    defer {
+        //## always: tear the sandbox down
+        close_sandbox(sb, keep_branch);
+    }
+    let started = baml.time.Instant.now();
+    //# design pass: investigate, propose the fix, write the plan (read-only)
+    let design = run_agent_design(sb, issue, design_budget_s(difficulty));
+    if (design == null) {
+        //## stop: the design agent produced nothing
+        write_outcome(sb, stopped_outcome(sb, started));
+        return issue;
+    };
+    let doc = render_design_doc(design ?? baml.sys.panic("unreachable"));
+    baml.fs.write(sb.run_dir + "/design.md", doc);
+    if (difficulty == Difficulty.Hard) {
+        //## hard: hand the design doc to the shepherd, no code change
+        write_outcome(sb, outcome(sb, "hard", null, started, null, null, doc));
+        return with_design_doc(issue, doc);
+    };
+    //# fix pass: implement the plan, encode the repros as tests
+    warm_build(sb);
+    let report = run_agent_fix(sb, issue, doc, time_budget_s(difficulty));
+    if (report == null) {
+        //## stop: the fix agent ran out of budget or reported nothing
+        keep_branch = mode == HandleMode.Live;
+        write_outcome(sb, stopped_outcome(sb, started));
+        return with_design_doc(issue, doc);
+    };
+    let fix = report ?? baml.sys.panic("unreachable");
+    //# re-run the gate ourselves (the agent's own claim is never trusted)
+    checkpoint_uncommitted(sb);
+    let gate = run_gate(sb.worktree);
+    if (!gate.ok) {
+        //## stop: gate failed — branch kept for a human in Live mode
+        keep_branch = mode == HandleMode.Live;
+        write_outcome(sb, outcome(sb, "gate_failed", null, started, gate, fix, doc));
+        return with_design_doc(issue, doc);
+    };
+    //# write the PR body
+    let draft = PrDraft {
+        title: pr_title(issue),
+        body: pr_body(issue, fix, gate, read_turns(sb), elapsed_s(started)),
+    };
+    baml.fs.write(sb.run_dir + "/pr_body.md", draft.body);
+    if (mode == HandleMode.DryRun) {
+        //## dry run: stop before the push (what the evals run)
+        write_outcome(sb, outcome(sb, "fixed", null, started, gate, fix, doc));
+        return with_design_doc(issue, doc);
+    };
+    //# push the branch and open the draft PR
+    let pr = push_and_open_pr(sb, draft);
+    write_outcome(sb, outcome(sb, "fixed", pr, started, gate, fix, doc));
+    log.info(
+        { "issue": issue.id, "pr": pr, "turns": read_turns(sb), "seconds": elapsed_s(started) },
+    );
+    with_status(with_design_doc(issue, doc), InProgress { state: "in_progress", pr: pr })
+}
+
+/// Why the stage would not run on this issue; null means go.
+function handle_ready(issue: Issue, update: bool) -> string? {
+    if (issue.difficulty == null) {
+        return "not gauged";
+    };
+    if (update) {
+        return null;
+    };
+    if (issue.design_doc != null) {
+        return "already has a design doc";
+    };
+    match (issue.status) {
+        let s: Open => null,
+        _ => "not open",
+    }
+}
 
 /// True unless EVERY repro comes back Fixed on CANARY. Inconclusive (needs
 /// a human, or a command that cannot be checked) counts as still broken —
@@ -692,9 +799,402 @@ function checkpoint_uncommitted(sb: Sandbox) -> null {
     null
 }
 
+// ==================== The agent ====================
+
+// Only so implement_fix / write_design_doc are LLM functions: their
+// $render_prompt / $parse companions render the prompt and parse the reply.
+// The CLI itself is run by run_claude, not through this client.
+client Handle = claude_code.ClaudeCodeClient.new(model = "claude-fable-5");
+
+function agent_model() -> string {
+    baml.env.get("ATB2_MODEL") ?? "claude-fable-5"
+}
+
+class AgentRun {
+    text: string,
+    num_turns: int,
+    exit_code: int,
+    timed_out: bool,
+}
+
+/// The `claude -p` argv, mirroring what claude_code.ClaudeCodeClient builds
+/// minus --json-schema (the prompt carries the schema via ctx.output_format).
+function claude_args(prompt: string, tools: string[]) -> string[] {
+    [
+        "-p",
+        prompt,
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        agent_model(),
+        // bypassPermissions: in -p mode a "requires approval" Bash call just
+        // fails, and the agent needs cargo. The worktree is disposable and the
+        // env is an allowlist, so this is the sandbox, not the prompt.
+        "--permission-mode",
+        "bypassPermissions",
+        "--no-session-persistence",
+        "--tools",
+        tools.join(","),
+    ]
+}
+
+/// Run one Claude Code session in `cwd` with Claude Code's own tools, killed
+/// at `timeout_s`. The stream-json goes to `transcript_path`; the reply text
+/// and turn count come from its `result` event.
+function run_claude(
+    cwd: string,
+    prompt: string,
+    tools: string[],
+    timeout_s: int,
+    transcript_path: string,
+) -> AgentRun {
+    //# the CLI writes its stream straight to the transcript file
+    // The CLI writes its stream straight to the transcript file, so the
+    // record survives when the process is killed at the budget (exec
+    // returns nothing on a timeout).
+    let env = sandbox_env(false);
+    env.set("ATB2_TRANSCRIPT", transcript_path);
+    let r = run_with(
+        Cmd {
+            program: "sh",
+            args: ["-c", "exec \"$@\" > \"$ATB2_TRANSCRIPT\" 2>&1", "atb2", "claude"].concat(
+                claude_args(prompt, tools),
+            ),
+            cwd: cwd,
+            timeout_ms: timeout_s * 1000,
+        },
+        env,
+    );
+    //# read the result event back: reply text + turn count
+    let transcript = if (baml.fs.exists(transcript_path)) {
+        baml.fs.read(transcript_path)
+    } else {
+        ""
+    };
+    let parsed = parse_stream(transcript);
+    AgentRun {
+        text: parsed.text,
+        num_turns: parsed.num_turns,
+        exit_code: r.exit_code,
+        timed_out: r.exit_code == 124,
+    }
+}
+
+/// stream-json -> the `result` event's text and num_turns. Without a result
+/// event (killed mid-run) the turns are the assistant messages seen and the
+/// text is empty. Non-JSON lines are skipped.
+function parse_stream(transcript: string) -> AgentRun {
+    let text = "";
+    let turns = 0;
+    let assistants = 0;
+    let saw_result = false;
+    for (let line in transcript.lines()) {
+        if (line.trim().length() == 0) {
+            continue;
+        };
+        let j = baml.json.parse(line) catch (_) {
+            _ => null,
+        };
+        if (j == null) {
+            continue;
+        };
+        let ev = j ?? baml.sys.panic("unreachable");
+        let kind = baml.json.path_or<string>(ev, ".type", "");
+        if (kind == "assistant") {
+            assistants += 1;
+        } else if (kind == "result") {
+            saw_result = true;
+            turns += baml.json.path_or<int>(ev, ".num_turns", 0);
+            text = baml.json.path_or<string>(ev, ".result", text);
+        };
+    }
+    AgentRun {
+        text: text,
+        num_turns: if (saw_result) {
+            turns
+        } else {
+            assistants
+        },
+        exit_code: 0,
+        timed_out: false,
+    }
+}
+
+/// Turns across both passes (design.jsonl + fix.jsonl).
+function read_turns(sb: Sandbox) -> int {
+    let total = 0;
+    for (let name in ["design.jsonl", "fix.jsonl"]) {
+        let path = sb.run_dir + "/" + name;
+        if (baml.fs.exists(path)) {
+            total += parse_stream(baml.fs.read(path)).num_turns;
+        };
+    }
+    total
+}
+
 function elapsed_s(started: baml.time.Instant) -> int {
     started.elapsed().to_seconds().to_int() catch (_) {
         _ => 0,
+    }
+}
+
+// The tools the CLI is given: Claude Code's own. The fix run may edit; the
+// design run is told not to (and its branch is discarded regardless).
+function fix_tools() -> string[] {
+    ["Read", "Edit", "Write", "Glob", "Grep", "Bash"]
+}
+
+function design_tools() -> string[] {
+    ["Read", "Glob", "Grep", "Bash"]
+}
+
+/// What the agent must know about where it is and what it may not do. The
+/// guarantees that matter (no push, no secrets, cleanup) are enforced
+/// outside the prompt too.
+function sandbox_rules(branch: string) -> string {
+    "You are working in a git worktree of BoundaryML/baml on branch `"
+        + branch
+        + "`, checked out from `canary`. "
+        + "The Rust workspace is `baml_language/` (run cargo from there); `CARGO_TARGET_DIR` is shared and already warm, so "
+        + "the built CLI is at `$CARGO_TARGET_DIR/debug/baml-cli`, not `target/`.\n"
+        + "Rules:\n"
+        + "- Stay on this branch. Never `git push`, never checkout or create another branch, never touch `.git` directly.\n"
+        + "- Never create or modify files outside this worktree.\n"
+        + "- Commit as you go with conventional-commit messages (`fix(scope): ...`, `test(scope): ...`). Leave the tree clean.\n"
+        + "- Never edit `.snap` files by hand; regenerate with `cargo insta test --test-runner=nextest --accept -p baml_tests`.\n"
+        + "- Do not change CI, `mise.toml`, or `Cargo.lock` unless the fix genuinely requires it.\n"
+        + "- If the gate cannot be made to pass honestly, stop and say so in `blockers`. Never weaken or delete tests to pass.\n"
+        + "- Your final message must be exactly the JSON the output format below asks for, nothing else."
+}
+
+/// One row of the PR's "Behavioral boundaries" table.
+class Boundary {
+    scenario: string,
+    result: string,
+    why: string,
+}
+
+/// The agent's account of the fix, in the shape of the team's PRs
+/// (see BoundaryML/baml#4621): Problem / After this PR / Behavioral
+/// boundaries / where the tests live / what was validated.
+class FixReport {
+    /// 2-4 sentences: the root cause and the change made.
+    summary: string,
+    /// Markdown for "## Problem": what BAML did wrong, with the minimal
+    /// program that shows it in a fenced ```baml block, and why it was wrong.
+    problem: string,
+    /// Markdown for "## After this PR": the new behavior, quoting the exact
+    /// diagnostic or value the same program now produces, and the fix in
+    /// one or two paragraphs citing the files touched.
+    after: string,
+    /// The "Behavioral boundaries" table: what compiles / is rejected /
+    /// evaluates to what, and why, for the cases around the fix. 3-8 rows.
+    boundaries: Boundary[],
+    /// Markdown for the tests section: where the new tests live (paths),
+    /// what each asserts, and any snapshots refreshed.
+    tests: string,
+    /// Paths of the tests that encode the issue's repro(s).
+    tests_added: string[],
+    files_changed: string[],
+    /// What the agent believes about the gate; BAML re-runs it regardless.
+    gate_passed: bool,
+    /// Why it stopped short, if it did.
+    blockers: string?,
+}
+
+function implement_fix(
+    issue: Issue,
+    branch: string,
+    test_route: string,
+    plan: string,
+) -> FixReport {
+    client: Handle
+    prompt: `
+        ${sandbox_rules(branch)}
+
+        Fix this issue in the BAML toolchain. A read-only design pass has already investigated
+        it and written the plan below; follow the plan unless the code proves it wrong, and if
+        you deviate, say so in \`summary\`.
+
+        Title: ${issue.title}
+        Subsystem: ${issue.subsystem.to_string()}
+
+        ${issue.description}
+
+        Resolution plan from triage (a starting point, not gospel):
+        ${issue.resolution_plan ?? "(none)"}
+
+        Repros (${issue.repros.length().to_string()}):
+        ${issue.repros.map((r: Repro) -> string { format_repro(r) }).join("\n\n")}
+
+        The plan from the design pass:
+        ${plan}
+
+        How to work:
+        1. Reproduce FIRST. Turn every repro above into a test before touching the fix, placed
+           per baml_language/TEST_INSTRUCTIONS.md. For this issue: ${test_route}
+           Confirm the new test fails before the fix and passes after it.
+        2. Make the smallest correct fix. Cite the files you changed.
+        3. Verify with FAST, targeted checks only — your time budget is short and the full gate
+           (clippy, nextest, insta, the baml-cli corpus) is run by the pipeline after you finish:
+             cargo fmt --all -- --config imports_granularity=Crate --config group_imports=StdExternalCrate
+             cargo test -p <each crate you changed> <your new test name>      (the repro test: fails before, passes after)
+             cargo test --lib -p <each crate you changed>
+           If you added a diagnostic fixture or changed diagnostics, also: cargo insta test --test-runner=nextest --accept -p baml_tests
+           and commit the .snap changes. Do not run the whole workspace's clippy or nextest.
+        4. Commit everything. \`git status --porcelain\` must be empty. Do not push.
+        5. Report in the shape of this team's PRs: \`problem\` (with the repro in a fenced baml code block),
+           \`after\` (quote the exact diagnostic/value the repro now produces; cite files), a
+           \`boundaries\` table of the cases around the fix (compiles / rejected / value, and why),
+           and \`tests\` (paths, what each asserts, snapshots refreshed). Declarative, no hedging.
+
+        ${ctx.output_format()}
+    `
+}
+
+/// Where the repro's test belongs, per TEST_INSTRUCTIONS.md, from the
+/// repros' expectations.
+function test_route(issue: Issue) -> string {
+    let compile_error = false;
+    let behavior = false;
+    let inspection = false;
+    for (let r in issue.repros) {
+        match (r.expectation) {
+            let e: ShouldNotCompile => {
+                compile_error = true;
+            },
+            let e: ShouldCompile => {
+                behavior = true;
+            },
+            let e: ShouldEvaluateTo => {
+                behavior = true;
+            },
+            let e: RequiresInspection => {
+                inspection = true;
+            },
+        }
+    }
+    let routes: string[] = [];
+    if (compile_error) {
+        routes.push(
+            "a compile-error fixture: one .baml file under crates/baml_tests/projects/diagnostic_errors/<name>/ (snapshots are generated; commit them)",
+        );
+    };
+    if (behavior) {
+        routes.push(
+            "a BAML `test` block under crates/baml_tests/baml_src/ns_<topic>/ that runs the code and asserts the correct value or a catchable throw",
+        );
+    };
+    if (inspection || routes.length() == 0) {
+        routes.push(
+            "a Rust test in the owning crate (use baml_tests::stdlib_prefix::{check_user_files, setup_test_db}, not baml_project::testing) — with a comment on why a BAML test cannot observe it",
+        );
+    };
+    routes.join("; and ")
+}
+
+function run_agent_fix(sb: Sandbox, issue: Issue, plan: string, timeout_s: int) -> FixReport? {
+    //# render the prompt: rules + ticket + repros + the design pass's plan
+    let prompt = implement_fix@render_prompt(issue, sb.branch, test_route(issue), plan).text();
+    //# one Claude Code session with its own tools, killed at the budget
+    let session = run_claude(sb.worktree, prompt, fix_tools(), timeout_s, sb.run_dir + "/fix.jsonl");
+    if (session.timed_out || session.exit_code != 0 || session.text.length() == 0) {
+        log.warn(
+            {
+                "issue": issue.id,
+                "agent": "stopped",
+                "exit_code": session.exit_code,
+                "timed_out": session.timed_out,
+                "turns": session.num_turns,
+            },
+        );
+        return null;
+    };
+    implement_fix@parse(session.text) catch (_) {
+        _ => {
+            log.warn(
+                { "issue": issue.id, "agent": "unparseable report", "tail": tail(session.text, 5) },
+            );
+            null
+        },
+    }
+}
+
+// ---------- Hard path ----------
+
+class DesignDoc {
+    /// Concrete enough to hand to an agent as its task.
+    suggested_fix: string,
+    /// Markdown with: Problem, Root-cause hypothesis (with evidence),
+    /// Proposed design, Alternatives considered, Test plan, Risks and
+    /// rollout, Open questions for the shepherd.
+    doc: string,
+}
+
+function write_design_doc(issue: Issue, branch: string) -> DesignDoc {
+    client: Handle
+    prompt: `
+        ${sandbox_rules(branch)}
+        This is a READ-ONLY investigation: do not change any file.
+
+        Investigate the repository and write the suggested fix and the plan a maintainer would
+        hand to an engineer (or their agent): where the defect lives, what to change, which tests
+        to add and where. Cite file paths and line ranges you actually read. If the issue turns
+        out to be already fixed on this branch, say so plainly and make the plan "add the missing
+        regression test".
+
+        Title: ${issue.title}
+        Subsystem: ${issue.subsystem.to_string()}
+
+        ${issue.description}
+
+        Resolution plan from triage:
+        ${issue.resolution_plan ?? "(none)"}
+
+        Repros:
+        ${issue.repros.map((r: Repro) -> string { format_repro(r) }).join("\n\n")}
+
+        The doc must have these sections: Problem; Root-cause hypothesis (with the evidence);
+        Proposed design; Alternatives considered; Test plan (which route per
+        baml_language/TEST_INSTRUCTIONS.md, which repros); Risks and rollout; Open questions for the shepherd.
+
+        ${ctx.output_format()}
+    `
+}
+
+function render_design_doc(d: DesignDoc) -> string {
+    "## Suggested fix\n\n" + d.suggested_fix + "\n\n" + d.doc
+}
+
+function run_agent_design(sb: Sandbox, issue: Issue, timeout_s: int) -> DesignDoc? {
+    //# render the prompt: rules + ticket + repros, read-only
+    let prompt = write_design_doc@render_prompt(issue, sb.branch).text();
+    //# one Claude Code session, read-only tools, killed at the budget
+    let session = run_claude(sb.worktree, prompt, design_tools(), timeout_s, sb.run_dir + "/design.jsonl");
+    if (session.timed_out || session.exit_code != 0 || session.text.length() == 0) {
+        log.warn(
+            {
+                "issue": issue.id,
+                "agent": "stopped",
+                "exit_code": session.exit_code,
+                "timed_out": session.timed_out,
+                "turns": session.num_turns,
+            },
+        );
+        return null;
+    };
+    write_design_doc@parse(session.text) catch (_) {
+        _ => {
+            log.warn(
+                {
+                    "issue": issue.id,
+                    "agent": "unparseable design doc",
+                    "tail": tail(session.text, 5),
+                },
+            );
+            null
+        },
     }
 }
 
@@ -948,7 +1448,337 @@ function gate_summary(g: GateResult) -> string {
         .join(" · ")
 }
 
+// ==================== The PR ====================
+
+class PrDraft {
+    title: string,
+    body: string,
+}
+
+function pr_title(issue: Issue) -> string {
+    let scope = issue.subsystem.to_string().to_lower_case();
+    let t = "fix(" + scope + "): " + issue.title;
+    if (t.length() > 72) {
+        t.slice(0, 72)
+    } else {
+        t
+    }
+}
+
+function pr_body(issue: Issue, r: FixReport, g: GateResult, turns: int, seconds: int) -> string {
+    let n = github_number(issue);
+    let fixes = if (n != null) {
+        "Fixes #" + (n ?? 0).to_string() + "\n\n"
+    } else {
+        ""
+    };
+    let rows = r.boundaries
+        .map((b: Boundary) -> string {
+            "| "
+                + b.scenario.replace("|", "\\|")
+                + " | "
+                + b.result.replace("|", "\\|")
+                + " | "
+                + b.why.replace("|", "\\|")
+                + " |"
+        })
+        .join("\n");
+    let boundaries = if (r.boundaries.length() == 0) {
+        ""
+    } else {
+        "## Behavioral boundaries\n\n| Scenario | Result | Why |\n| --- | --- | --- |\n"
+            + rows
+            + "\n\n"
+    };
+    fixes
+        + "## Problem\n\n"
+        + r.problem.trim()
+        + "\n\n"
+        + "## After this PR\n\n"
+        + r.after.trim()
+        + "\n\n"
+        + boundaries
+        + "## Tests\n\n"
+        + r.tests.trim()
+        + "\n\n"
+        + "## Validation\n\n"
+        + validation_checklist(g)
+        + "\n_Opened by atb2 `handle_issue` ("
+        + (issue.difficulty ?? Difficulty.Medium).to_string().to_lower_case()
+        + ", "
+        + turns.to_string()
+        + " agent turns, "
+        + (seconds / 60).to_string()
+        + " min); the checklist above was run by the pipeline after the agent finished._\n"
+}
+
+/// The gate as a checklist: one line per step, with the pass count when
+/// the tool printed one.
+function validation_checklist(g: GateResult) -> string {
+    g.steps
+        .map((s: GateStep) -> string {
+            let count = passed_count(s.tail);
+            "- ["
+                + (
+                    if (s.ok) {
+                        "x"
+                    } else {
+                        " "
+                    }
+                )
+                + "] `"
+                + s.name
+                + "`"
+                + (
+                    if (count != null) {
+                        ": " + (count ?? "")
+                    } else {
+                        ""
+                    }
+                )
+                + (
+                    if (s.ok) {
+                        ""
+                    } else {
+                        " — FAILED"
+                    }
+                )
+        })
+        .join("\n")
+        + "\n"
+}
+
+/// "N passed" from cargo test / nextest summaries, if present.
+function passed_count(output: string) -> string? {
+    let found: string? = null;
+    for (let line in output.lines()) {
+        let l = line.trim();
+        let i = l.index_of(" passed");
+        if (
+            i != null
+                && (
+                    l.starts_with("test result:")
+                        || l.includes("tests run:")
+                        || l.starts_with("Summary")
+                )
+        ) {
+            let head = l.slice(0, i ?? 0);
+            let words = head.split(" ");
+            let num = words.at(words.length() - 1) ?? "";
+            if (num.length() > 0) {
+                found = num + " passed";
+            };
+        };
+    }
+    found
+}
+
+/// Live only. Lifts the worktree's push guard, pushes, and opens a draft
+/// PR — or updates the existing PR for the branch.
+function push_and_open_pr(sb: Sandbox, draft: PrDraft) -> string {
+    //# lift the push guard and push the branch
+    let env = sandbox_env(true);
+    // pushurl is multi-valued, so it cannot be overridden with -c; the
+    // no_push guard is removed here, and only here, for this one push
+    git(sb.worktree, ["config", "--worktree", "--unset-all", "remote.origin.pushurl"]);
+    let push = run_with(
+        Cmd {
+            program: "git",
+            args: [
+                "-c",
+                "core.hooksPath=/dev/null",
+                "push",
+                "--force-with-lease",
+                "-u",
+                "origin",
+                sb.branch,
+            ],
+            cwd: sb.worktree,
+            timeout_ms: 600000,
+        },
+        env,
+    );
+    if (!push.ok) {
+        baml.sys.panic("push failed: " + tail(push.stderr, 5));
+    };
+    //# update the existing PR for this branch, if there is one
+    let body_path = sb.run_dir + "/pr_body.md";
+    let existing = run_with(
+        Cmd {
+            program: "gh",
+            args: ["pr", "view", sb.branch, "--repo", repo_slug(), "--json", "url", "--jq", ".url"],
+            cwd: sb.worktree,
+            timeout_ms: 120000,
+        },
+        env,
+    );
+    if (existing.ok && existing.stdout.trim().length() > 0) {
+        run_with(
+            Cmd {
+                program: "gh",
+                args: [
+                    "pr",
+                    "edit",
+                    sb.branch,
+                    "--repo",
+                    repo_slug(),
+                    "--title",
+                    draft.title,
+                    "--body-file",
+                    body_path,
+                ],
+                cwd: sb.worktree,
+                timeout_ms: 120000,
+            },
+            env,
+        );
+        return existing.stdout.trim();
+    };
+    //# otherwise open a draft PR
+    let created = run_with(
+        Cmd {
+            program: "gh",
+            args: [
+                "pr",
+                "create",
+                "--repo",
+                repo_slug(),
+                "--draft",
+                "--base",
+                "canary",
+                "--head",
+                sb.branch,
+                "--title",
+                draft.title,
+                "--body-file",
+                body_path,
+            ],
+            cwd: sb.worktree,
+            timeout_ms: 120000,
+        },
+        env,
+    );
+    if (!created.ok) {
+        baml.sys.panic("gh pr create failed: " + tail(created.stderr, 5));
+    };
+    created.stdout.trim()
+}
+
+// ==================== Outcome (audit trail + what the evals read) ====================
+
+class HandleOutcome {
+    kind: "fixed" | "hard" | "gate_failed" | "agent_stopped",
+    branch: string?,
+    pr: string?,
+    turns: int,
+    seconds: int,
+    timed_out: bool,
+    gate: GateResult?,
+    report: FixReport?,
+    design_doc: string?,
+    /// Why the agent stopped (agent_stopped only): the CLI's error text,
+    /// "killed at the time budget", or "reply did not parse".
+    reason: string?,
+}
+
+/// Reads the last agent transcript for the reason the run stopped.
+function stop_reason(path: string) -> string? {
+    if (!baml.fs.exists(path)) {
+        return "no transcript was written";
+    };
+    let lines = baml.fs.read(path).split("\n").filter((l: string) -> bool {
+        l.includes("\"type\":\"result\"")
+    });
+    if (lines.length() == 0) {
+        return "killed at the time budget";
+    };
+    let ev = baml.json.parse(lines[lines.length() - 1]) catch (_) {
+        _ => baml.json.parse("{}"),
+    };
+    if (baml.json.path_or<bool>(ev, ".is_error", false)) {
+        return "cli error: " + baml.json.path_or<string>(ev, ".result", "").slice(0, 300);
+    };
+    "reply did not parse"
+}
+
+function outcome(
+    sb: Sandbox,
+    kind: "fixed" | "hard" | "gate_failed" | "agent_stopped",
+    pr: string?,
+    started: baml.time.Instant,
+    gate: GateResult?,
+    report: FixReport?,
+    doc: string?,
+) -> HandleOutcome {
+    HandleOutcome {
+        kind: kind,
+        branch: sb.branch,
+        pr: pr,
+        turns: read_turns(sb),
+        seconds: elapsed_s(started),
+        timed_out: false,
+        gate: gate,
+        report: report,
+        design_doc: doc,
+        reason: null,
+    }
+}
+
+/// An agent pass ended without a result: budget exhausted (no `result`
+/// event in its transcript) or an unparseable reply.
+function stopped_outcome(sb: Sandbox, started: baml.time.Instant) -> HandleOutcome {
+    let last = if (baml.fs.exists(sb.run_dir + "/fix.jsonl")) {
+        sb.run_dir + "/fix.jsonl"
+    } else {
+        sb.run_dir + "/design.jsonl"
+    };
+    HandleOutcome {
+        kind: "agent_stopped",
+        branch: sb.branch,
+        pr: null,
+        turns: read_turns(sb),
+        seconds: elapsed_s(started),
+        timed_out: baml.fs.exists(last) && !baml.fs.read(last).includes("\"type\":\"result\""),
+        gate: null,
+        report: null,
+        design_doc: null,
+        reason: stop_reason(last),
+    }
+}
+
+function write_outcome(sb: Sandbox, o: HandleOutcome) -> null {
+    baml.fs.write(sb.run_dir + "/outcome.json", baml.json.stringify_pretty(o.to_json()));
+    log.info(
+        {
+            "issue_branch": sb.branch,
+            "kind": o.kind,
+            "reason": o.reason,
+            "turns": o.turns,
+            "seconds": o.seconds,
+            "timed_out": o.timed_out,
+        },
+    );
+    null
+}
+
+function read_outcome(issue: Issue) -> HandleOutcome? {
+    let path = run_dir_for(branch_for(issue)) + "/outcome.json";
+    if (!baml.fs.exists(path)) {
+        return null;
+    };
+    baml.json.from_string<HandleOutcome>(baml.fs.read(path))
+}
+
 // ==================== Unit tests (token-free) ====================
+
+function sample_stream() -> string {
+    "{\"type\":\"system\",\"subtype\":\"init\"}\n"
+        + "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"looking\"}]}}\n"
+        + "not json at all\n"
+        + "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\"}]}}\n"
+        + "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\"}]}}\n"
+        + "{\"type\":\"result\",\"subtype\":\"success\",\"num_turns\":7,\"result\":\"{\\\"summary\\\":\\\"done\\\"}\"}\n"
+}
 
 function gh_issue(number: int, difficulty: Difficulty?) -> Issue {
     Issue {
@@ -976,6 +1806,26 @@ function sample_gate() -> GateResult {
         ],
         ok: true,
         changed_crates: ["baml_compiler2_hir"],
+    }
+}
+
+function sample_report() -> FixReport {
+    FixReport {
+        summary: "Guarded the type-ref lookup.",
+        problem: "A `throws` clause naming an unresolved type panics the compiler:\n\n```baml\nfunction f() -> int throws Nope { 1 }\n```",
+        after: "The same program reports `E0002: unresolved type Nope`. Bounds check in `type_ref.rs:346`.",
+        boundaries: [
+            Boundary {
+                scenario: "`throws Nope`",
+                result: "`E0002`",
+                why: "the type is looked up before lowering",
+            },
+        ],
+        tests: "`crates/baml_tests/projects/diagnostic_errors/unresolved_throws/main.baml` asserts the exact diagnostic.",
+        tests_added: ["crates/baml_tests/projects/diagnostic_errors/unresolved_throws/main.baml"],
+        files_changed: ["crates/baml_compiler2_hir/src/type_ref.rs"],
+        gate_passed: true,
+        blockers: null,
     }
 }
 
@@ -1020,6 +1870,20 @@ testset "handle_issue" {
         assert.is_true(run_dir_for("agent/gh-1-x").ends_with("/runs/agent__gh-1-x"));
     }
 
+    test "parse_stream reads the result event" {
+        let r = parse_stream(sample_stream());
+        assert.equal(r.num_turns, 7);
+        assert.equal(r.text, "{\"summary\":\"done\"}");
+    }
+
+    test "parse_stream without a result event counts assistant messages" {
+        let cut = sample_stream().lines().slice(0, 5).join("\n");
+        let r = parse_stream(cut);
+        assert.equal(r.num_turns, 2);
+        assert.equal(r.text, "");
+        assert.equal(parse_stream("").num_turns, 0);
+    }
+
     test "the agent env is an allowlist" {
         let env = sandbox_env(false);
         assert.is_true(env.has("PATH") && env.has("HOME"));
@@ -1042,6 +1906,43 @@ testset "handle_issue" {
         assert.equal(sanitize_rel_path("../../x"), "x");
         assert.is_true(!repro_file_path("baml_src/../../x", false).includes(".."));
         assert.is_true(!repro_file_path("../../../etc/passwd", true).includes(".."));
+    }
+
+    test "claude argv mirrors the client's flags plus --tools" {
+        let a = claude_args("hi", fix_tools());
+        assert.equal(a.at(0) ?? "", "-p");
+        assert.equal(a.at(1) ?? "", "hi");
+        assert.is_true(
+            a.includes("--no-session-persistence")
+                && a.includes("stream-json")
+                && a.includes("--tools"),
+        );
+        assert.equal(a.at(a.length() - 1) ?? "", "Read,Edit,Write,Glob,Grep,Bash");
+    }
+
+    test "the claude process writes its own transcript" {
+        let out = baml.sys.exec(
+            "sh",
+            [
+                "-c",
+                "exec \"$@\" > \"$ATB2_TRANSCRIPT\" 2>&1",
+                "atb2",
+                "echo",
+                "{\"type\":\"result\",\"num_turns\":3,\"result\":\"ok\"}",
+            ],
+            baml.sys.ProcessOptions {
+                cwd: null,
+                env: {
+                    "PATH": baml.env.get("PATH") ?? "/bin:/usr/bin",
+                    "ATB2_TRANSCRIPT": "/tmp/atb2-transcript-test.jsonl",
+                },
+                timeout_ms: 10000,
+                stdin: null,
+            },
+        );
+        assert.equal(out.exit_code, 0);
+        assert.equal(parse_stream(baml.fs.read("/tmp/atb2-transcript-test.jsonl")).num_turns, 3);
+        baml.fs.remove("/tmp/atb2-transcript-test.jsonl");
     }
 
     test "repro files land in baml_src/ whether or not the repro says so" {
@@ -1104,6 +2005,7 @@ testset "handle_issue" {
                 .length(),
             0,
         );
+        assert.is_true(claude_args("x", fix_tools()).includes("bypassPermissions"));
     }
 
     test "time budgets" {
@@ -1118,6 +2020,76 @@ testset "handle_issue" {
         assert.equal(changed_crates_from(names), ["baml_compiler2_hir", "baml_tests"]);
     }
 
+    test "test_route follows the repro expectations" {
+        let base = gh_issue(1, Difficulty.Easy);
+        let with_repro = Issue {
+            id: base.id,
+            title: base.title,
+            description: base.description,
+            shepherd: null,
+            subsystem: base.subsystem,
+            repros: [
+                Repro {
+                    files: { "main.baml": "function f() -> int { \"x\" }" },
+                    command: "baml check",
+                    setup: null,
+                    expectation: ShouldNotCompile { check: "should_not_compile", diagnostic_contains: null },
+                },
+            ],
+            version: base.version,
+            feedback_ids: [],
+            status: Open { state: "open" },
+            comments: [],
+            resolution_plan: null,
+            difficulty: Difficulty.Easy,
+            design_doc: null,
+        };
+        assert.contains(test_route(with_repro), "diagnostic_errors");
+        assert.contains(test_route(base), "Rust test");
+    }
+
+    test "pr title and body" {
+        let issue = gh_issue(4587, Difficulty.Easy);
+        assert.is_true(pr_title(issue).starts_with("fix(compiler): "));
+        assert.is_true(pr_title(issue).length() <= 72);
+        let body = pr_body(issue, sample_report(), sample_gate(), 12, 640);
+        assert.is_true(body.starts_with("Fixes #4587"));
+        assert.contains(body, "## Problem");
+        assert.contains(body, "## After this PR");
+        assert.contains(body, "| `throws Nope` | `E0002` | the type is looked up before lowering |");
+        assert.contains(body, "## Tests");
+        assert.contains(body, "## Validation");
+        assert.contains(body, "- [x] `clippy`");
+        assert.contains(body, "12 agent turns, 10 min");
+    }
+
+    test "validation counts come from the tool summaries" {
+        assert.equal(
+            passed_count("running 3 tests\ntest result: ok. 46 passed; 0 failed") ?? "",
+            "46 passed",
+        );
+        assert.equal(
+            passed_count(
+                "     Summary [ 183.785s] 1925/2039 tests run: 1924 passed (2 slow), 1 failed, 23 skipped",
+            )
+                ?? "",
+            "1924 passed",
+        );
+        assert.equal(passed_count("nothing here") == null, true);
+    }
+
+    test "handle_ready reasons" {
+        assert.equal(handle_ready(gh_issue(1, null), false) ?? "go", "not gauged");
+        assert.equal(handle_ready(gh_issue(1, Difficulty.Easy), false) ?? "go", "go");
+        let taken = with_status(gh_issue(1, Difficulty.Easy), InProgress { state: "in_progress", pr: null });
+        assert.equal(handle_ready(taken, false) ?? "go", "not open");
+        assert.equal(handle_ready(taken, true) ?? "go", "go");
+        assert.equal(
+            handle_ready(with_design_doc(gh_issue(1, Difficulty.Hard), "doc"), false) ?? "go",
+            "already has a design doc",
+        );
+    }
+
     test "with_status / with_design_doc change nothing else" {
         let i = gh_issue(7, Difficulty.Medium);
         let s = with_status(i, InProgress { state: "in_progress", pr: "https://x/pr/1" });
@@ -1126,5 +2098,15 @@ testset "handle_issue" {
         let d = with_design_doc(i, "doc");
         assert.equal(d.design_doc ?? "", "doc");
         assert.equal(d.title, i.title);
+    }
+
+    test "llm replies parse" {
+        let r = implement_fix@parse(
+            `{ "summary": "s", "problem": "p", "after": "a", "boundaries": [{ "scenario": "x", "result": "compiles", "why": "y" }], "tests": "t", "tests_added": ["a.baml"], "files_changed": ["x.rs"], "gate_passed": true, "blockers": null }`,
+        );
+        assert.equal(r.boundaries.length(), 1);
+        assert.equal(r.tests_added.length(), 1);
+        let d = write_design_doc@parse(`{ "suggested_fix": "f", "doc": "## Problem\\nx" }`);
+        assert.contains(render_design_doc(d), "## Suggested fix");
     }
 }


### PR DESCRIPTION
The stage itself. For an Easy/Medium issue: a read-only design pass
investigates and writes the plan; a fix pass implements it, encodes the
repros as tests (routed per TEST_INSTRUCTIONS.md from the repros'
expectations) and runs targeted checks; the pipeline re-runs the gate,
writes the PR body in the team's shape (Problem / After this PR /
Behavioral boundaries / Tests / Validation) and, in Live mode, lifts the
worktree's push guard for the one push and opens (or updates) a draft
PR. DryRun stops before the push: what the evals run. For a Hard
issue the design pass's output becomes `Issue.design_doc` for the
shepherd; no code change.

The Claude Code CLI is run directly (`claude -p ... --output-format
stream-json`), writing its own transcript so the record survives a kill
at the budget; implement_fix / write_design_doc are LLM functions only so
their $render_prompt / $parse companions render and parse. Both passes
run on claude-fable-5 (ATB2_MODEL overrides); time budgets were
recalibrated from the first eval (Easy 3600s, Medium 7200s).

Every run leaves ~/.atb2/runs/<branch>/outcome.json: kind (fixed / hard
/ gate_failed / agent_stopped), why the agent stopped, turns, seconds,
the gate and the report.

## Stack (bottom to top)
1. #4634 sandbox: worktree lifecycle, allowlisted env, repro pre-check
2. #4635 the gate: re-run by the pipeline, judged by exit code
3. #4636 handle_issue: design pass, fix pass, PR body, outcome
4. #4637 evals, run_tests.sh, `//#` headers

Each PR passes `baml check` / `baml fmt` / `baml test` on its own; the top of the stack reproduces the reviewed `baml/feedback-part-3` `tools/atb2` exactly. Supersedes `baml/feedback-part-3`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated issue-handling workflow that assesses readiness, develops a proposed solution, applies fixes, and validates the results.
  * Added Live and Dry Run modes, allowing changes to be reviewed without publishing them.
  * Live runs can push changes and open a pull request with generated summaries and validation details.
  * Added per-run outcome records, including status, validation results, timing, and any blockers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->