### PR TITLE
ci: decouple engine and baml_language Rust setup

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -56,16 +56,29 @@ Sets up Node.js with pnpm package manager.
 ```
 
 ### setup-rust
-Sets up Rust toolchain with caching and optional WASM support.
+Sets up the baml_language Rust toolchain with caching and optional WASM support.
 
 ```yaml
 - name: Setup Rust
   uses: ./.github/actions/setup-rust
   with:
-    toolchain: 'stable'                           # Optional, default: 'stable'
+    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
     enable-wasm: 'false'                         # Optional, default: 'false'
     targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
-    workspace: 'engine'                          # Optional, default: 'engine'
+    workspace: 'baml_language'                   # Optional, default: 'baml_language'
+```
+
+### engine-setup-rust
+Sets up the engine Rust toolchain with caching and optional WASM support.
+
+```yaml
+- name: Setup Engine Rust
+  uses: ./.github/actions/engine-setup-rust
+  with:
+    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
+    enable-wasm: 'false'                         # Optional, default: 'false'
+    targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
+    workspace: 'engine'                         # Optional, default: 'engine'
 ```
 
 ### setup-python
@@ -146,7 +159,7 @@ Only needs Node.js and pnpm:
 Only needs Rust toolchain:
 ```yaml
 - name: Setup Rust
-  uses: ./.github/actions/setup-rust
+  uses: ./.github/actions/engine-setup-rust
   with:
     toolchain: ${{ env.RUST_TOOLCHAIN }}
     targets: ${{ matrix.target }}
@@ -156,7 +169,7 @@ Only needs Rust toolchain:
 Needs Rust with WASM support:
 ```yaml
 - name: Setup Rust
-  uses: ./.github/actions/setup-rust
+  uses: ./.github/actions/engine-setup-rust
   with:
     toolchain: ${{ env.RUST_TOOLCHAIN }}
     enable-wasm: 'true'
@@ -166,7 +179,7 @@ Needs Rust with WASM support:
 Needs multiple technologies:
 ```yaml
 - name: Setup Rust
-  uses: ./.github/actions/setup-rust
+  uses: ./.github/actions/engine-setup-rust
   with:
     toolchain: ${{ env.RUST_TOOLCHAIN }}
 

--- a/.github/actions/engine-setup-rust/action.yml
+++ b/.github/actions/engine-setup-rust/action.yml
@@ -1,5 +1,5 @@
-name: "Setup baml_language Rust"
-description: "Setup the baml_language Rust toolchain with caching and optional WASM support"
+name: "Setup Engine Rust"
+description: "Setup the engine Rust toolchain with caching and optional WASM support"
 
 inputs:
   toolchain:
@@ -25,7 +25,7 @@ inputs:
   workspace:
     description: "Workspace path for Rust cache"
     required: false
-    default: "baml_language"
+    default: "engine"
   prefix-key:
     description: "Cache key prefix for Rust cache"
     required: false

--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -112,7 +112,7 @@ runs:
 
     - name: Setup Rust
       if: inputs.setup-rust == 'true'
-      uses: ./.github/actions/setup-rust
+      uses: ./.github/actions/engine-setup-rust
       with:
         toolchain: ${{ inputs.rust-toolchain }}
         enable-wasm: ${{ inputs.rust-enable-wasm }}

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: ${{ matrix._.target }}
           enable-cache: false

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -112,7 +112,7 @@ jobs:
           node-action-version: v6
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: ${{ matrix._.target }}
           prefix-key: v5-rust-${{ matrix._.target }}

--- a/.github/workflows/build-vscode-release.reusable.yaml
+++ b/.github/workflows/build-vscode-release.reusable.yaml
@@ -60,7 +60,7 @@ jobs:
           node-action-version: 'v6'
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: true
 

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -83,7 +83,7 @@ jobs:
           node-action-version: 'v6'
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
 
       - name: Setup Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -177,7 +177,7 @@ jobs:
       # Setup Rust for Rust checks
       - name: Setup Rust
         if: contains(matrix.check, 'rust')
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: ${{ matrix.check == 'rust-lint-wasm' && 'true' || 'false' }}
 
@@ -234,7 +234,7 @@ jobs:
 
       # Setup Rust for Rust checks
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: true
 
@@ -257,7 +257,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: wasm32-unknown-unknown
           enable-wasm: true
@@ -284,7 +284,7 @@ jobs:
           node-action-version: "v6"
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: false
           enable-cross: false
@@ -339,7 +339,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -422,7 +422,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
 
       - name: Setup Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -11,7 +11,7 @@ on:
       - "engine/**/*.rs"
       - "engine/**/*.proto"
       - ".github/actions/setup-protoc/**"
-      - ".github/actions/setup-rust/**"
+      - ".github/actions/engine-setup-rust/**"
       - ".github/workflows/test-rust-sdk.yml"
   push:
     branches: [canary]
@@ -20,7 +20,7 @@ on:
       - "engine/**/*.rs"
       - "engine/**/*.proto"
       - ".github/actions/setup-protoc/**"
-      - ".github/actions/setup-rust/**"
+      - ".github/actions/engine-setup-rust/**"
       - ".github/workflows/test-rust-sdk.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Changes

- Add `.github/actions/engine-setup-rust` for engine and legacy runtime workflows.
- Keep `.github/actions/setup-rust` dedicated to baml_language workflows.
- Give each action the correct default Cargo cache workspace.
- Update engine workflow callers, path filters, and action documentation.
- Keep both toolchains at Rust 1.93.0; version bumps are in the next two stacked PRs.

## Validation

- [x] Both composite action YAML files parse successfully.
- [x] `git diff --check`
- [x] `actionlint` on every changed workflow; it reports only the pre-existing `install-protoc-gen-go` input mismatch in `primary.yml`.

## Stack

1. This PR: decouple engine and baml_language Rust setup.
2. #4681: bump baml_language to Rust 1.98.
3. #4682: move the root pin into engine and bump engine to Rust 1.98.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Rust build and release workflows with dedicated setup configurations for language and engine components.
  * Enhanced support for caching, WebAssembly builds, cross-compilation, and platform-specific toolchain setup.
  * Updated automated tests, coverage checks, and SDK release processes to use the appropriate build configuration.

* **Documentation**
  * Updated setup guidance and examples to reflect the separated Rust workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->