### PR TITLE
Add approval-gated BAML book imports

### DIFF
--- a/.github/workflows/developer-docs.yml
+++ b/.github/workflows/developer-docs.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Verify generated CLI reference
         run: pnpm --filter @baml/developer-docs check:cli-reference
 
+      - name: Verify approved book imports
+        run: pnpm --filter @baml/developer-docs check:book
+
       - name: Verify checked-in browser runtime
         run: pnpm --filter @baml/developer-docs check:runner-artifact
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,28 @@ BAML_BIN="$PWD/baml_language/target/debug/baml-cli" pnpm --filter @baml/develope
 
 The generated Markdown and source snapshots are committed. CI rebuilds the repository CLI and runs both corresponding `check:*` commands, so language or command-tree drift fails with a regeneration instruction.
 
+## BAML book imports
+
+The book remains at `/baml/book`, but publication is approval-gated. Add only
+human-audited chapters to `book-import.json` with `status: "approved"`, the
+source path, route output, and SHA-256 of the exact reviewed Markdown. Drafts
+that merely exist in the `baml-book` working tree are not publishable input.
+The source checkout must be clean and at the revision pinned by the manifest,
+which also pins every included listing and quiz.
+
+Import approved chapters from a local checkout:
+
+```sh
+pnpm --filter @baml/developer-docs generate:book -- --source /path/to/baml-book
+pnpm --filter @baml/developer-docs check:book
+```
+
+The importer converts anchored mdBook includes, semantic notes, numbered code
+listings, opt-in runnable projects, and TOML quizzes into native Fumadocs MDX.
+Generated pages and provenance are committed so previews do not depend on a
+second repository. CI verifies their hashes, navigation, and that no unmanaged
+book chapter slipped around the approval manifest.
+
 ## Runnable examples
 
 Runnable examples execute in one isolated Web Worker per page. The worker and

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -110,6 +110,147 @@ html > body[data-scroll-locked] {
   font-size: 0.75rem;
 }
 
+.book-listing {
+  margin-block: 1.5rem;
+  overflow: hidden;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.8rem;
+  background: var(--color-fd-card);
+}
+
+.book-listing-file {
+  border-bottom: 1px solid var(--color-fd-border);
+  padding: 0.55rem 1rem;
+  color: var(--color-fd-muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
+.book-listing-body > pre,
+.book-listing-body > .baml-runner {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+}
+
+.book-listing-body > .baml-runner {
+  border-top: 1px solid var(--color-fd-border);
+}
+
+.book-listing figcaption {
+  border-top: 1px solid var(--color-fd-border);
+  padding: 0.7rem 1rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.8rem;
+}
+
+.book-listing figcaption a {
+  color: var(--color-fd-foreground);
+  font-weight: 600;
+}
+
+.book-quiz {
+  margin-block: 2rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.8rem;
+  padding: 1.25rem;
+  background: color-mix(in oklab, var(--color-fd-card) 88%, transparent);
+}
+
+.book-quiz > h2,
+.book-quiz-question > h3 {
+  margin: 0;
+  font-weight: 650;
+}
+
+.book-quiz > h2 {
+  font-size: 1.05rem;
+}
+
+.book-quiz-question {
+  margin-top: 1rem;
+  border-top: 1px solid var(--color-fd-border);
+  padding-top: 1rem;
+}
+
+.book-quiz-question > h3 {
+  font-size: 0.9rem;
+}
+
+.book-quiz-question p {
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.86rem;
+}
+
+.book-quiz-question pre {
+  overflow-x: auto;
+  border-radius: 0.6rem;
+  padding: 0.9rem;
+  background: var(--color-fd-secondary);
+  font-size: 0.8rem;
+}
+
+.book-quiz-choices {
+  display: grid;
+  gap: 0.5rem;
+  margin-block: 0.85rem;
+}
+
+.book-quiz-choices label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.55rem;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.84rem;
+}
+
+.book-quiz-question > label {
+  display: grid;
+  gap: 0.35rem;
+  margin-block: 0.85rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.78rem;
+}
+
+.book-quiz-question input[type='text'],
+.book-quiz-question > label input {
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.7rem;
+  color: var(--color-fd-foreground);
+  background: var(--color-fd-background);
+}
+
+.book-quiz-question > button {
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-fd-primary);
+  color: var(--color-fd-primary-foreground);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.book-quiz-question > button:disabled {
+  opacity: 0.5;
+}
+
+.book-quiz-feedback {
+  margin-top: 0.75rem;
+  border-left: 3px solid var(--color-fd-border);
+  padding: 0.65rem 0.8rem;
+  font-size: 0.82rem;
+}
+
+.book-quiz-feedback--correct {
+  border-left-color: var(--color-green-500);
+}
+
+.book-quiz-feedback--incorrect {
+  border-left-color: var(--color-red-500);
+}
+
 @media (max-width: 640px) {
   .baml-runner-toolbar,
   .baml-runner-result {

--- a/docs/book-import.json
+++ b/docs/book-import.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "repository": "https://github.com/BoundaryML/baml-book",
+    "revision": "55de1c917db5a84b92fd10a381fb493d4e2675f2"
+  },
+  "chapters": []
+}

--- a/docs/components/baml-runner.tsx
+++ b/docs/components/baml-runner.tsx
@@ -13,6 +13,7 @@ type Props = {
   expected?: string;
   files: Record<string, string>;
   functionName?: string;
+  showSource?: boolean;
 };
 
 function milliseconds(value?: number) {
@@ -20,7 +21,7 @@ function milliseconds(value?: number) {
   return value >= 1000 ? `${(value / 1000).toFixed(2)} s` : `${value.toFixed(0)} ms`;
 }
 
-export function BamlRunner({ expected, files, functionName = 'main' }: Props) {
+export function BamlRunner({ expected, files, functionName = 'main', showSource = true }: Props) {
   const root = useRef<HTMLDivElement>(null);
   const [state, setState] = useState<'idle' | 'running' | 'success' | 'error'>('idle');
   const [result, setResult] = useState<RunnerResponse>();
@@ -58,9 +59,11 @@ export function BamlRunner({ expected, files, functionName = 'main' }: Props) {
 
   return (
     <div ref={root} className="baml-runner not-prose">
-      <pre className="baml-runner-source" aria-label="Runnable BAML source">
-        <code>{source}</code>
-      </pre>
+      {showSource && (
+        <pre className="baml-runner-source" aria-label="Runnable BAML source">
+          <code>{source}</code>
+        </pre>
+      )}
       <div className="baml-runner-toolbar">
         <button type="button" onClick={run} disabled={state === 'running'}>
           {state === 'success' || state === 'error' ? <RotateCcw /> : <Play />}
@@ -78,7 +81,7 @@ export function BamlRunner({ expected, files, functionName = 'main' }: Props) {
           ) : result?.ok ? (
             <>
               <code>{result.output}</code>
-              <span>{matched ? 'Output verified' : `Expected ${expected}`}</span>
+              <span>{expected === undefined ? 'Run completed' : matched ? 'Output verified' : `Expected ${expected}`}</span>
             </>
           ) : (
             <span>{result?.error ?? 'The run failed.'}</span>

--- a/docs/components/book-listing.tsx
+++ b/docs/components/book-listing.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  caption?: ReactNode;
+  children: ReactNode;
+  fileName?: string;
+  number?: string;
+};
+
+export function BookListing({ caption, children, fileName, number }: Props) {
+  const id = number ? `listing-${number}` : undefined;
+
+  return (
+    <figure className="book-listing not-prose" id={id}>
+      {fileName && <div className="book-listing-file">Filename: {fileName}</div>}
+      <div className="book-listing-body prose dark:prose-invert">{children}</div>
+      {(number || caption) && (
+        <figcaption>
+          {number && <a href={`#${id}`}>Listing {number}</a>}
+          {number && caption ? ': ' : null}
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/docs/components/book-quiz.tsx
+++ b/docs/components/book-quiz.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useId, useState } from 'react';
+
+export type BookQuestion = {
+  answer: {
+    answer?: string;
+    doesCompile?: boolean;
+    lineNumber?: number;
+  };
+  context?: string;
+  id: string;
+  prompt: {
+    distractors?: string[];
+    program?: string;
+    prompt?: string;
+  };
+  type: 'MultipleChoice' | 'ShortAnswer' | 'Tracing';
+};
+
+function answerFor(question: BookQuestion) {
+  if (question.type === 'Tracing') {
+    return question.answer.doesCompile ? 'Compiles' : 'Does not compile';
+  }
+  return question.answer.answer ?? '';
+}
+
+function choicesFor(question: BookQuestion) {
+  if (question.type === 'Tracing') return ['Compiles', 'Does not compile'];
+  const answer = answerFor(question);
+  return [answer, ...(question.prompt.distractors ?? [])].sort((a, b) =>
+    `${question.id}:${a}`.localeCompare(`${question.id}:${b}`),
+  );
+}
+
+function QuizQuestion({ question, index }: { question: BookQuestion; index: number }) {
+  const group = useId();
+  const [selected, setSelected] = useState('');
+  const [checked, setChecked] = useState(false);
+  const expected = answerFor(question);
+  const correct = selected.trim() === expected.trim();
+  const isShortAnswer = question.type === 'ShortAnswer';
+
+  return (
+    <section className="book-quiz-question">
+      <h3>Question {index + 1}</h3>
+      {question.prompt.prompt && <p>{question.prompt.prompt}</p>}
+      {question.prompt.program && (
+        <pre aria-label="BAML program for this question"><code>{question.prompt.program.trim()}</code></pre>
+      )}
+      {isShortAnswer ? (
+        <label>
+          <span>Your answer</span>
+          <input value={selected} onChange={(event) => setSelected(event.target.value)} />
+        </label>
+      ) : (
+        <div className="book-quiz-choices">
+          {choicesFor(question).map((choice) => (
+            <label key={choice}>
+              <input
+                type="radio"
+                name={group}
+                value={choice}
+                checked={selected === choice}
+                onChange={(event) => setSelected(event.target.value)}
+              />
+              <span>{choice}</span>
+            </label>
+          ))}
+        </div>
+      )}
+      <button type="button" disabled={!selected} onClick={() => setChecked(true)}>
+        Check answer
+      </button>
+      {checked && (
+        <div className={`book-quiz-feedback book-quiz-feedback--${correct ? 'correct' : 'incorrect'}`} aria-live="polite">
+          <strong>{correct ? 'Correct.' : `The answer is ${expected}.`}</strong>
+          {question.type === 'Tracing' && !question.answer.doesCompile && question.answer.lineNumber && (
+            <span> The compiler reports the error on line {question.answer.lineNumber}.</span>
+          )}
+          {question.context && <p>{question.context}</p>}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function BookQuiz({ questions }: { questions: BookQuestion[] }) {
+  return (
+    <section className="book-quiz not-prose" aria-label="Chapter quiz">
+      <h2>Check your understanding</h2>
+      {questions.map((question, index) => (
+        <QuizQuestion key={question.id} question={question} index={index} />
+      ))}
+    </section>
+  );
+}

--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -1,11 +1,15 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 import { BamlRunner } from './baml-runner';
+import { BookListing } from './book-listing';
+import { BookQuiz } from './book-quiz';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
     BamlRunner,
+    BookListing,
+    BookQuiz,
     ...components,
   } satisfies MDXComponents;
 }

--- a/docs/content/baml/book/index.mdx
+++ b/docs/content/baml/book/index.mdx
@@ -5,4 +5,6 @@ description: Learn BAML from first principles through verified, runnable program
 
 The BAML book teaches the language through human-written, compiler-verified chapters.
 
-The first audited chapter will land in the next layer of this stack.
+Chapters are published here only after human review. The importer is ready for
+the first approved chapter; the current `baml-book` checkout contains drafts
+and an infrastructure smoke test, but no chapter marked ready to publish.

--- a/docs/content/baml/book/meta.json
+++ b/docs/content/baml/book/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "The BAML Programming Language",
+  "pages": [
+    "index"
+  ]
+}

--- a/docs/generated/book/manifest.json
+++ b/docs/generated/book/manifest.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "repository": "https://github.com/BoundaryML/baml-book",
+    "revision": "55de1c917db5a84b92fd10a381fb493d4e2675f2"
+  },
+  "approvalManifestSha256": "217a1411384b0cf2b84b4c42aa201aa3aa44eb7f4facb2ed51acb2cb01399c19",
+  "files": []
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "scripts": {
     "build": "next build",
+    "check:book": "node scripts/import-baml-book.mjs --check",
     "check:cli-reference": "node scripts/generate-cli-reference.mjs --check",
     "check:reference": "node scripts/generate-baml-reference.mjs --check",
     "check:runner-artifact": "node scripts/check-runner-artifact.mjs && node scripts/build-runner-bundle.mjs --check",
     "dev": "next dev",
+    "generate:book": "node scripts/import-baml-book.mjs",
     "generate:cli-reference": "node scripts/generate-cli-reference.mjs",
     "generate:reference": "node scripts/generate-baml-reference.mjs",
     "runner:artifact": "node scripts/build-runner-artifact.mjs",
@@ -30,6 +32,7 @@
     "react-dom": "19.2.8"
   },
   "devDependencies": {
+    "@mdx-js/mdx": "3.1.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/mdx": "^2.0.13",
     "@types/node": "^24.0.3",
@@ -37,6 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "esbuild": "0.25.2",
     "postcss": "^8.5.14",
+    "smol-toml": "1.5.2",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.8.3"
   }

--- a/docs/scripts/import-baml-book.mjs
+++ b/docs/scripts/import-baml-book.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { access, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { parse as parseToml } from 'smol-toml';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const defaultManifestPath = path.join(packageRoot, 'book-import.json');
+const outputRoot = path.join(packageRoot, 'content', 'baml', 'book');
+const generatedManifestPath = path.join(packageRoot, 'generated', 'book', 'manifest.json');
+const execFileAsync = promisify(execFile);
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function json(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function within(root, target, label) {
+  const resolved = path.resolve(root, target);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`${label} escapes the book repository: ${target}`);
+  }
+  return resolved;
+}
+
+async function exists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseAttributes(raw) {
+  const attributes = {};
+  for (const match of raw.matchAll(/([a-z][a-z-]*)\s*=\s*"([^"]*)"/gi)) {
+    attributes[match[1]] = match[2];
+  }
+  return attributes;
+}
+
+function inlineMarkdownToJsx(value) {
+  const escaped = value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+  return escaped
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>');
+}
+
+function extractAnchor(source, anchor, sourcePath) {
+  if (!anchor) {
+    return source
+      .split('\n')
+      .filter((line) => !/^\s*\/\/\s*ANCHOR(?:_END)?:\s*/.test(line))
+      .join('\n');
+  }
+
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) =>
+    new RegExp(`^\\s*//\\s*ANCHOR:\\s*${anchor.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`).test(line),
+  );
+  const end = lines.findIndex((line, index) =>
+    index > start && new RegExp(`^\\s*//\\s*ANCHOR_END:\\s*${anchor.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`).test(line),
+  );
+  if (start === -1 || end === -1) {
+    throw new Error(`Missing anchor '${anchor}' in ${sourcePath}`);
+  }
+  return lines
+    .slice(start + 1, end)
+    .filter((line) => !/^\s*\/\/\s*ANCHOR(?:_END)?:\s*/.test(line))
+    .join('\n');
+}
+
+async function expandIncludes(markdown, chapterPath, sourceRoot) {
+  const includes = [...markdown.matchAll(/\{\{#include\s+([^}\s]+)\s*\}\}/g)];
+  let output = markdown;
+  for (const match of includes) {
+    const specifier = match[1];
+    const anchorMatch = specifier.match(/^(.*):([A-Za-z0-9_-]+)$/);
+    const relativePath = anchorMatch ? anchorMatch[1] : specifier;
+    const anchor = anchorMatch?.[2];
+    const includePath = within(
+      sourceRoot,
+      path.relative(sourceRoot, path.resolve(path.dirname(chapterPath), relativePath)),
+      'Include path',
+    );
+    const included = await readFile(includePath, 'utf8');
+    output = output.replace(match[0], extractAnchor(included, anchor, includePath));
+  }
+  return output;
+}
+
+async function readRunnableProject(sourceRoot, projectName) {
+  if (!projectName || path.isAbsolute(projectName) || projectName.split('/').includes('..')) {
+    throw new Error(`Invalid runnable listing path: ${projectName}`);
+  }
+  const projectRoot = within(sourceRoot, path.join('listings', projectName), 'Runnable listing path');
+  const files = {
+    'baml.toml': await readFile(path.join(projectRoot, 'baml.toml'), 'utf8'),
+  };
+  const sourceDir = path.join(projectRoot, 'baml_src');
+  for (const entry of (await readdir(sourceDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.baml'))
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    files[`baml_src/${entry.name}`] = await readFile(path.join(sourceDir, entry.name), 'utf8');
+  }
+  if (Object.keys(files).length === 1) {
+    throw new Error(`Runnable listing '${projectName}' has no baml_src/*.baml files`);
+  }
+  return files;
+}
+
+async function convertListings(markdown, sourceRoot) {
+  const pattern = /<Listing\b([^>]*)>([\s\S]*?)<\/Listing>/g;
+  const matches = [...markdown.matchAll(pattern)];
+  let output = markdown;
+  for (const match of matches) {
+    const attributes = parseAttributes(match[1]);
+    const props = [];
+    if (attributes.number) props.push(`number=${JSON.stringify(attributes.number)}`);
+    if (attributes['file-name']) props.push(`fileName=${JSON.stringify(attributes['file-name'])}`);
+    if (attributes.caption) props.push(`caption={<>${inlineMarkdownToJsx(attributes.caption)}</>}`);
+    let body = match[2].trim();
+    if (attributes.runnable) {
+      const files = await readRunnableProject(sourceRoot, attributes.runnable);
+      body += `\n\n<BamlRunner files={${JSON.stringify(files)}} showSource={false} />`;
+    }
+    output = output.replace(match[0], `<BookListing ${props.join(' ')}>\n\n${body}\n\n</BookListing>`);
+  }
+  return output;
+}
+
+async function convertQuizzes(markdown, chapterPath, sourceRoot) {
+  const includes = [...markdown.matchAll(/\{\{#quiz\s+([^}\s]+)\s*\}\}/g)];
+  let output = markdown;
+  for (const match of includes) {
+    const quizPath = within(
+      sourceRoot,
+      path.relative(sourceRoot, path.resolve(path.dirname(chapterPath), match[1])),
+      'Quiz path',
+    );
+    const parsed = parseToml(await readFile(quizPath, 'utf8'));
+    if (!Array.isArray(parsed.questions) || parsed.questions.length === 0) {
+      throw new Error(`Quiz has no questions: ${quizPath}`);
+    }
+    output = output.replace(match[0], `<BookQuiz questions={${JSON.stringify(parsed.questions)}} />`);
+  }
+  return output;
+}
+
+function convertNotes(markdown) {
+  return markdown.replace(/^> Note:\s*(.*(?:\n>.*)*)/gm, (_match, quoted) => {
+    const body = quoted.replace(/^>\s?/gm, '');
+    return `<Callout title="Note">\n\n${body}\n\n</Callout>`;
+  });
+}
+
+export async function convertChapter({ chapter, sourceRoot }) {
+  const chapterPath = within(sourceRoot, chapter.source, 'Chapter source');
+  const raw = await readFile(chapterPath, 'utf8');
+  const actualSourceSha256 = sha256(raw);
+  if (actualSourceSha256 !== chapter.sourceSha256) {
+    throw new Error(
+      `Approval hash mismatch for ${chapter.source}: expected ${chapter.sourceSha256}, got ${actualSourceSha256}`,
+    );
+  }
+
+  const heading = raw.match(/^#\s+(.+)$/m)?.[1];
+  const title = chapter.title ?? heading;
+  if (!title) throw new Error(`Chapter needs a title: ${chapter.source}`);
+
+  let body = raw.replace(/^#\s+.+\n+/, '');
+  body = await expandIncludes(body, chapterPath, sourceRoot);
+  body = await convertListings(body, sourceRoot);
+  body = await convertQuizzes(body, chapterPath, sourceRoot);
+  body = convertNotes(body).trim();
+
+  const description = chapter.description ?? `Read ${title} in The BAML Programming Language.`;
+  const content = [
+    '---',
+    `title: ${JSON.stringify(title)}`,
+    `description: ${JSON.stringify(description)}`,
+    '---',
+    '',
+    body,
+    '',
+  ].join('\n');
+  return { content, sourceSha256: actualSourceSha256 };
+}
+
+function validateManifest(manifest) {
+  if (manifest.schemaVersion !== 1) throw new Error('book-import.json schemaVersion must be 1');
+  if (!manifest.source?.repository || !manifest.source?.revision) {
+    throw new Error('book-import.json must pin a source repository and revision');
+  }
+  if (!Array.isArray(manifest.chapters)) throw new Error('book-import.json chapters must be an array');
+  const outputs = new Set();
+  for (const chapter of manifest.chapters) {
+    if (chapter.status !== 'approved') {
+      throw new Error(`${chapter.source}: only explicitly approved chapters may enter the import manifest`);
+    }
+    if (!chapter.source || !chapter.output || !/^[0-9a-f]{64}$/.test(chapter.sourceSha256 ?? '')) {
+      throw new Error('Every approved chapter needs source, output, and sourceSha256');
+    }
+    if (!/^[a-z0-9][a-z0-9/_-]*\.mdx$/.test(chapter.output) || chapter.output === 'index.mdx') {
+      throw new Error(`Invalid managed chapter output: ${chapter.output}`);
+    }
+    if (outputs.has(chapter.output)) throw new Error(`Duplicate chapter output: ${chapter.output}`);
+    outputs.add(chapter.output);
+  }
+}
+
+async function readApprovalManifest(manifestPath) {
+  const raw = await readFile(manifestPath, 'utf8');
+  const manifest = JSON.parse(raw);
+  validateManifest(manifest);
+  return { manifest, sha256: sha256(raw) };
+}
+
+function navigationFor(chapters) {
+  return {
+    title: 'The BAML Programming Language',
+    pages: ['index', ...chapters.map((chapter) => chapter.output.replace(/\.mdx$/, ''))],
+  };
+}
+
+async function verifySourceCheckout(sourceRoot, revision) {
+  const [{ stdout: head }, { stdout: status }] = await Promise.all([
+    execFileAsync('git', ['-C', sourceRoot, 'rev-parse', 'HEAD']),
+    execFileAsync('git', ['-C', sourceRoot, 'status', '--porcelain', '--untracked-files=all']),
+  ]);
+  if (head.trim() !== revision) {
+    throw new Error(`baml-book checkout is at ${head.trim()}, but book-import.json pins ${revision}`);
+  }
+  if (status.trim()) {
+    throw new Error('baml-book checkout has uncommitted files; import from a clean checkout of the pinned revision');
+  }
+}
+
+async function buildDesired(manifest, sourceRoot) {
+  if (manifest.chapters.length > 0 && !sourceRoot) {
+    throw new Error('Pass --source <baml-book checkout> to import approved chapters');
+  }
+  if (manifest.chapters.length > 0) {
+    await verifySourceCheckout(sourceRoot, manifest.source.revision);
+  }
+  const files = [];
+  for (const chapter of manifest.chapters) {
+    const converted = await convertChapter({ chapter, sourceRoot });
+    files.push({
+      output: chapter.output,
+      outputSha256: sha256(converted.content),
+      source: chapter.source,
+      sourceSha256: converted.sourceSha256,
+      content: converted.content,
+    });
+  }
+  return files;
+}
+
+async function listManagedPages(directory, prefix = '') {
+  if (!(await exists(directory))) return [];
+  const pages = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const relative = path.posix.join(prefix, entry.name);
+    if (entry.isDirectory()) pages.push(...await listManagedPages(path.join(directory, entry.name), relative));
+    else if (entry.isFile() && entry.name.endsWith('.mdx') && relative !== 'index.mdx') pages.push(relative);
+  }
+  return pages.sort();
+}
+
+async function verifyCurrent({ approvalSha256, manifest }) {
+  const generated = JSON.parse(await readFile(generatedManifestPath, 'utf8'));
+  if (generated.approvalManifestSha256 !== approvalSha256) {
+    throw new Error('Book approval manifest changed; run pnpm generate:book with the approved baml-book checkout');
+  }
+  const expectedOutputs = manifest.chapters.map((chapter) => chapter.output).sort();
+  const generatedOutputs = generated.files.map((file) => file.output).sort();
+  if (JSON.stringify(expectedOutputs) !== JSON.stringify(generatedOutputs)) {
+    throw new Error('Generated book manifest does not match approved chapter outputs');
+  }
+  for (const file of generated.files) {
+    const content = await readFile(within(outputRoot, file.output, 'Generated output'), 'utf8');
+    if (sha256(content) !== file.outputSha256) throw new Error(`Generated book page drifted: ${file.output}`);
+  }
+  const currentPages = await listManagedPages(outputRoot);
+  if (JSON.stringify(currentPages) !== JSON.stringify(expectedOutputs)) {
+    throw new Error(`Unmanaged book pages found; expected ${expectedOutputs.join(', ') || 'none'}, got ${currentPages.join(', ') || 'none'}`);
+  }
+  const meta = JSON.parse(await readFile(path.join(outputRoot, 'meta.json'), 'utf8'));
+  if (JSON.stringify(meta) !== JSON.stringify(navigationFor(manifest.chapters))) {
+    throw new Error('Book navigation drifted from the approval manifest');
+  }
+  console.log(`Book import is current (${generated.files.length} approved chapters).`);
+}
+
+async function writeGenerated({ approvalSha256, files, manifest }) {
+  let previous = { files: [] };
+  if (await exists(generatedManifestPath)) {
+    previous = JSON.parse(await readFile(generatedManifestPath, 'utf8'));
+  }
+  const desired = new Set(files.map((file) => file.output));
+  for (const file of previous.files ?? []) {
+    if (!desired.has(file.output)) await rm(within(outputRoot, file.output, 'Stale generated output'));
+  }
+  for (const file of files) {
+    const target = within(outputRoot, file.output, 'Generated output');
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, file.content);
+  }
+  await mkdir(path.dirname(generatedManifestPath), { recursive: true });
+  await writeFile(path.join(outputRoot, 'meta.json'), json(navigationFor(manifest.chapters)));
+  await writeFile(generatedManifestPath, json({
+    schemaVersion: 1,
+    source: manifest.source,
+    approvalManifestSha256: approvalSha256,
+    files: files.map(({ content: _content, ...file }) => file),
+  }));
+  console.log(`Imported ${files.length} approved book chapters.`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const check = args.includes('--check');
+  const sourceIndex = args.indexOf('--source');
+  const manifestIndex = args.indexOf('--manifest');
+  const sourceRoot = sourceIndex === -1 ? undefined : path.resolve(args[sourceIndex + 1]);
+  const manifestPath = manifestIndex === -1 ? defaultManifestPath : path.resolve(args[manifestIndex + 1]);
+  const approval = await readApprovalManifest(manifestPath);
+
+  if (check && !sourceRoot) {
+    await verifyCurrent({ approvalSha256: approval.sha256, manifest: approval.manifest });
+    return;
+  }
+  const files = await buildDesired(approval.manifest, sourceRoot);
+  if (check) {
+    await verifyCurrent({ approvalSha256: approval.sha256, manifest: approval.manifest });
+    for (const desired of files) {
+      const current = await readFile(within(outputRoot, desired.output, 'Generated output'), 'utf8');
+      if (current !== desired.content) throw new Error(`Generated book page is stale: ${desired.output}`);
+    }
+    return;
+  }
+  await writeGenerated({ approvalSha256: approval.sha256, files, manifest: approval.manifest });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/docs/tests/book-import.test.mjs
+++ b/docs/tests/book-import.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { compile } from '@mdx-js/mdx';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { convertChapter } from '../scripts/import-baml-book.mjs';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const sourceRoot = path.join(packageRoot, 'tests', 'fixtures', 'book');
+const source = 'src/chapter.md';
+
+async function approvedChapter(overrides = {}) {
+  const raw = await readFile(path.join(sourceRoot, source), 'utf8');
+  return {
+    source,
+    output: 'getting-started.mdx',
+    status: 'approved',
+    sourceSha256: createHash('sha256').update(raw).digest('hex'),
+    ...overrides,
+  };
+}
+
+test('converts mdBook semantics into native Fumadocs MDX', async () => {
+  const result = await convertChapter({ chapter: await approvedChapter(), sourceRoot });
+
+  assert.match(result.content, /title: "Getting Started"/);
+  assert.match(result.content, /<Callout title="Note">/);
+  assert.match(result.content, /<BookListing number="1-1" fileName="baml_src\/main\.baml"/);
+  assert.match(result.content, /caption=\{<>A function that returns <em>its argument<\/em><\/>\}/);
+  assert.match(result.content, /<BamlRunner files=\{/);
+  assert.match(result.content, /showSource=\{false\}/);
+  assert.match(result.content, /<BookQuiz questions=\{/);
+  assert.match(result.content, /"type":"Tracing"/);
+  const renderedListing = result.content.match(/```baml\n([\s\S]*?)```/)?.[1] ?? '';
+  assert.doesNotMatch(renderedListing, /ANCHOR/);
+  assert.match(result.content, /"baml_src\/main\.baml":"\/\/ ANCHOR: all/);
+  assert.doesNotMatch(result.content, /\{\{#(?:include|quiz)/);
+  await assert.doesNotReject(
+    compile(result.content.replace(/^---[\s\S]*?---\n/, '')),
+    'the converted chapter must parse as MDX',
+  );
+});
+
+test('refuses source that changed after editorial approval', async () => {
+  await assert.rejects(
+    convertChapter({
+      chapter: await approvedChapter({ sourceSha256: '0'.repeat(64) }),
+      sourceRoot,
+    }),
+    /Approval hash mismatch/,
+  );
+});

--- a/docs/tests/fixtures/book/listings/ch01/listing-01-01/baml.toml
+++ b/docs/tests/fixtures/book/listings/ch01/listing-01-01/baml.toml
@@ -1,0 +1,2 @@
+[package]
+name = "listing-01-01"

--- a/docs/tests/fixtures/book/listings/ch01/listing-01-01/baml_src/main.baml
+++ b/docs/tests/fixtures/book/listings/ch01/listing-01-01/baml_src/main.baml
@@ -1,0 +1,11 @@
+// ANCHOR: all
+// ANCHOR: greet
+function greet(name: string) -> string {
+  name
+}
+// ANCHOR_END: greet
+
+function main() -> string {
+  greet("world")
+}
+// ANCHOR_END: all

--- a/docs/tests/fixtures/book/quizzes/chapter.toml
+++ b/docs/tests/fixtures/book/quizzes/chapter.toml
@@ -1,0 +1,19 @@
+[[questions]]
+id = "question-one"
+type = "MultipleChoice"
+prompt.prompt = "Which command checks a BAML project?"
+prompt.distractors = ["`baml run`", "`baml test`"]
+answer.answer = "`baml check`"
+context = "The check command reports compiler diagnostics."
+
+[[questions]]
+id = "question-two"
+type = "Tracing"
+prompt.program = """
+function main() -> string {
+  42
+}
+"""
+answer.doesCompile = false
+answer.lineNumber = 2
+context = "The return value has the wrong type."

--- a/docs/tests/fixtures/book/src/chapter.md
+++ b/docs/tests/fixtures/book/src/chapter.md
@@ -1,0 +1,19 @@
+# Getting Started
+
+> Note: This note has publication semantics.
+
+<Listing number="1-1" file-name="baml_src/main.baml" caption="A function that returns *its argument*" runnable="ch01/listing-01-01">
+
+```baml
+{{#include ../listings/ch01/listing-01-01/baml_src/main.baml:all}}
+```
+
+</Listing>
+
+Just the function:
+
+```baml
+{{#include ../listings/ch01/listing-01-01/baml_src/main.baml:greet}}
+```
+
+{{#quiz ../quizzes/chapter.toml}}

--- a/docs/tests/routes.test.mjs
+++ b/docs/tests/routes.test.mjs
@@ -16,7 +16,12 @@ test('the public route contract has a landing page for every section', async () 
 });
 
 test('the BAML book remains under /baml/book', async () => {
-  await access(path.join(packageRoot, 'content', 'baml', 'book', 'index.mdx'));
+  await Promise.all([
+    access(path.join(packageRoot, 'content', 'baml', 'book', 'index.mdx')),
+    access(path.join(packageRoot, 'content', 'baml', 'book', 'meta.json')),
+    access(path.join(packageRoot, 'book-import.json')),
+    access(path.join(packageRoot, 'generated', 'book', 'manifest.json')),
+  ]);
 });
 
 test('content is served from the domain root', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@mdx-js/mdx':
+        specifier: 3.1.1
+        version: 3.1.1
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -107,6 +110,9 @@ importers:
       postcss:
         specifier: ^8.5.14
         version: 8.5.26
+      smol-toml:
+        specifier: 1.5.2
+        version: 1.5.2
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3


### PR DESCRIPTION
## Outcome

Adds the publication boundary for The BAML Programming Language at `/baml/book` without publishing unapproved drafts.

Before this PR, the book route was a placeholder and moving an mdBook chapter required manual rewriting. After this PR, an editor can approve an exact committed chapter in `docs/book-import.json` and run one command to produce native Fumadocs MDX with pinned provenance.

## What readers get

- Numbered, captioned book listings with stable anchors
- Opt-in runnable listings backed by the existing version-pinned Web Worker runtime
- Interactive multiple-choice, short-answer, and tracing quizzes
- Semantic notes rendered as native callouts
- Correct runner language when no expected output exists (`Run completed`, not `Output verified`)

## Automation and safety

- Converts mdBook include anchors, listing metadata, runnable projects, and TOML quizzes
- Requires an explicit `status: approved`, exact source SHA-256, a clean source checkout, and the pinned `baml-book` revision
- Commits generated MDX and provenance so Vercel previews do not depend on a second repository
- CI rejects generated drift, unmanaged book pages, and navigation that bypasses the manifest
- The current manifest has zero chapters because the source repository contains only an infrastructure smoke test and explicitly unapproved drafts

## Verification

- `pnpm --filter @baml/developer-docs check:book`
- `pnpm --filter @baml/developer-docs test` (13 tests)
- `pnpm --filter @baml/developer-docs typecheck`
- `pnpm --filter @baml/developer-docs build` (500 static pages)
- `pnpm --filter @baml/developer-docs check:runner-artifact`
- pre-commit YAML/TOML and repository hooks