### PR TITLE
engine: trigger releases from versioned source tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -61,6 +62,47 @@ jobs:
             echo "- Commit: \`$GITHUB_SHA\`"
             echo "- Production release: \`true\`"
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: Verify source is the current green canary commit
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sourceSha = context.sha;
+            const canary = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: "heads/canary",
+            });
+            const canarySha = canary.data.object.sha;
+            if (sourceSha !== canarySha) {
+              throw new Error(`Trigger tag commit ${sourceSha} is not current canary ${canarySha}`);
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              {
+                owner,
+                repo,
+                head_sha: sourceSha,
+                status: "success",
+                per_page: 100,
+              },
+              (response) => response.data.workflow_runs,
+            );
+            const sourceCi = runs.find((run) => {
+              if (run.name !== "BAML Runtime" || run.path !== ".github/workflows/primary.yml") {
+                return false;
+              }
+              if (run.event === "push" && run.head_branch === "canary") {
+                return true;
+              }
+              return run.event === "merge_group" && run.head_branch.startsWith("gh-readonly-queue/canary/");
+            });
+            if (sourceCi === undefined) {
+              throw new Error(`Current canary ${sourceSha} has no successful BAML Runtime push or merge-queue run`);
+            }
+
+            core.info(`Verified current canary ${sourceSha} with successful CI run ${sourceCi.html_url}`);
       - name: Verify source versions
         env:
           VERSION: ${{ steps.set-version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,14 @@
 name: BAML Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Build and verify without creating tags or publishing"
-        type: boolean
-        required: false
-        default: false
+  push:
+    tags:
+      - "*.*.*-engine"
 
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock
-  group: ${{ github.workflow }}-${{ inputs.dry_run && format('dry-run-{0}', github.sha) || 'release' }}
+  group: ${{ github.workflow }}-release
   cancel-in-progress: false
 
 permissions:
@@ -36,15 +32,9 @@ jobs:
       - name: Set Version Info
         id: set-version
         env:
-          DRY_RUN: ${{ inputs.dry_run }}
           REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-
-          if [[ "$REF" != "refs/heads/canary" ]]; then
-            echo "Engine releases must be dispatched from the canary branch, not $REF" >&2
-            exit 1
-          fi
 
           VERSION="$(awk '/^current_version =/ { print $3; exit }' tools/versions/engine.cfg)"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -52,21 +42,24 @@ jobs:
             exit 1
           fi
 
-          IS_RELEASE="true"
-          if [[ "$DRY_RUN" == "true" ]]; then
-            IS_RELEASE="false"
+          EXPECTED_REF="refs/tags/$VERSION-engine"
+          if [[ "$REF" != "$EXPECTED_REF" ]]; then
+            echo "Engine release tag $REF does not match tools/versions/engine.cfg; expected $EXPECTED_REF" >&2
+            exit 1
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "is_release=true" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
-          echo "Production release: $IS_RELEASE"
+          echo "Trigger tag: $REF"
+          echo "Production release: true"
           {
             echo "### Engine release plan"
             echo
             echo "- Version: \`$VERSION\`"
+            echo "- Trigger tag: \`$REF\`"
             echo "- Commit: \`$GITHUB_SHA\`"
-            echo "- Production release: \`$IS_RELEASE\`"
+            echo "- Production release: \`true\`"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Verify source versions
         env:

--- a/engine/RELEASING.md
+++ b/engine/RELEASING.md
@@ -8,7 +8,7 @@ Engine releases are triggered by pushing a versioned `<version>-engine` source t
 2. Wait for the `canary` CI run for the exact commit intended for release to pass.
 3. Confirm that neither the trigger tag nor either release tag exists: `git ls-remote --tags origin refs/tags/0.226.2-engine refs/tags/0.226.2 refs/tags/v0.226.2` should print nothing (replace `0.226.2` with the intended version).
 
-The workflow derives the release version from `current_version` in `tools/versions/engine.cfg`. It requires the triggering ref to be exactly `refs/tags/<version>-engine`, then verifies that every other `tools/versions/*.cfg` file and the changelog agree with that version.
+The workflow derives the release version from `current_version` in `tools/versions/engine.cfg`. It requires the triggering ref to be exactly `refs/tags/<version>-engine`, verifies that its commit is the current `canary` head with a successful `BAML Runtime` push or merge-queue run, then verifies that every other `tools/versions/*.cfg` file and the changelog agree with that version.
 
 The release workflow runs `integ-tests` for informational signal, but its failures are tolerated and it is deliberately excluded from the release gate because it is currently too flaky. The green `canary` CI run is the operator's test prerequisite.
 

--- a/engine/RELEASING.md
+++ b/engine/RELEASING.md
@@ -1,31 +1,31 @@
 # Releasing the engine
 
-Engine releases are started manually from `canary`. The workflow is not triggered by tag pushes or path-filtered pushes because the set of files that affects an engine release is too broad to maintain safely.
+Engine releases are triggered by pushing a versioned `<version>-engine` source tag. The trigger tag must point to the exact tested `canary` commit intended for release.
 
 ## Prepare the release
 
 1. Set the intended version and run the bump script from a clean checkout: `VERSION=0.226.2; ./tools/bump-version.py --all --new-version "$VERSION"`. Follow its prompts, review the generated version and changelog changes, then merge the resulting PR into `canary`.
-2. Wait for the `canary` CI run for the merged commit to pass.
-3. Confirm that neither release tag exists: `git ls-remote --tags origin refs/tags/0.226.2 refs/tags/v0.226.2` should print nothing (replace `0.226.2` with the intended version).
+2. Wait for the `canary` CI run for the exact commit intended for release to pass.
+3. Confirm that neither the trigger tag nor either release tag exists: `git ls-remote --tags origin refs/tags/0.226.2-engine refs/tags/0.226.2 refs/tags/v0.226.2` should print nothing (replace `0.226.2` with the intended version).
 
-The workflow derives the release version from `current_version` in `tools/versions/engine.cfg`. It verifies that every other `tools/versions/*.cfg` file and the changelog agree with that version.
+The workflow derives the release version from `current_version` in `tools/versions/engine.cfg`. It requires the triggering ref to be exactly `refs/tags/<version>-engine`, then verifies that every other `tools/versions/*.cfg` file and the changelog agree with that version.
 
 The release workflow runs `integ-tests` for informational signal, but its failures are tolerated and it is deliberately excluded from the release gate because it is currently too flaky. The green `canary` CI run is the operator's test prerequisite.
 
 ## Run the release
 
-1. Open **Actions → BAML Release → Run workflow**.
-2. Select the `canary` branch.
-3. Leave `dry_run` unchecked for a real release. Check it only to build and verify artifacts without creating tags or publishing.
-4. Start the workflow, confirm the derived version and commit in the workflow summary, and approve the `release` environment when requested.
+1. Fetch `canary`, record its commit, and confirm that it is the exact green commit intended for release: `git fetch origin canary && git rev-parse origin/canary`.
+2. Create the trigger tag at that commit: `VERSION=0.226.2; git tag "$VERSION-engine" origin/canary`.
+3. Push only the trigger tag: `git push origin "refs/tags/$VERSION-engine"`.
+4. Open **Actions → BAML Release**, confirm the trigger tag, derived version, and commit in the workflow summary, and approve the `release` environment when requested.
 
-The workflow builds all release artifacts from the selected `canary` commit before making external changes. The `create-release-tag` job then creates annotated `<version>` and `v<version>` tags through the GitHub API, verifying each tag before proceeding. Publishing jobs, including the GitHub Release, run only after both tags exist; this prevents the GitHub Release API from implicitly creating a lightweight tag.
+The workflow builds all release artifacts from the trigger tag's commit before making external changes. The `create-release-tag` job then creates annotated `<version>` and `v<version>` tags through the GitHub API, verifying each tag before proceeding. Publishing jobs, including the GitHub Release, run only after both tags exist; this prevents the GitHub Release API from implicitly creating a lightweight tag.
 
 ## Recover from a transient failure
 
-Use **Re-run failed jobs** on the same workflow run. Do not start a new workflow run for the same version; the workflow rejects a new dispatch when either release tag already exists. Tag creation is idempotent only within the original run: a retry verifies that both tags are annotated, point to the original workflow commit, and contain the original run URL.
+Use **Re-run failed jobs** on the same workflow run. Do not move, recreate, or push another trigger tag for the same version. The workflow rejects a new run when either release tag already exists. Release-tag creation is idempotent only within the original run: a retry verifies that both release tags are annotated, point to the original workflow commit, and contain the original run URL.
 
-Never delete, move, force-push, or recreate a published release tag. If product or workflow source must change after the tags were created, fix the problem and release a new patch version.
+Never delete, move, force-push, or recreate a trigger or published release tag. If product or workflow source must change after the trigger tag was pushed, fix the problem and release a new patch version.
 
 After the run succeeds, verify both tags and the GitHub Release:
 


### PR DESCRIPTION
## Summary

- trigger engine releases only from versioned `*.*.*-engine` tags
- verify the trigger tag exactly matches `tools/versions/engine.cfg` before building
- update the engine release and recovery runbook for immutable trigger tags

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Engine releases now run automatically when a versioned `<version>-engine` tag is pushed.
  * Releases require the tag to reference the tested `canary` commit with successful runtime checks.
  * Release runs require an exact version tag and are consistently treated as production releases.
  * Workflow summaries now display the triggering release tag.

* **Documentation**
  * Updated engine release and recovery instructions for tag-based workflows and rerunning failed releases without moving tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->