### PR TITLE
Mark Boundary Web Services as coming soon

### DIFF
--- a/docs/content/bws/api/index.mdx
+++ b/docs/content/bws/api/index.mdx
@@ -1,6 +1,0 @@
----
-title: API Reference
-description: BWS API endpoints, requests, and responses.
----
-
-This section will be generated from the canonical BWS API schema.

--- a/docs/content/bws/debugging/index.mdx
+++ b/docs/content/bws/debugging/index.mdx
@@ -1,6 +1,0 @@
----
-title: Debugging
-description: Diagnose and resolve production failures.
----
-
-Production debugging workflows will live here.

--- a/docs/content/bws/deployment/index.mdx
+++ b/docs/content/bws/deployment/index.mdx
@@ -1,6 +1,0 @@
----
-title: Deployment
-description: Deploy BAML workloads to BWS.
----
-
-Deployment concepts and procedures will live here.

--- a/docs/content/bws/get-started/index.mdx
+++ b/docs/content/bws/get-started/index.mdx
@@ -1,6 +1,0 @@
----
-title: Get Started
-description: Connect a BAML project to BWS.
----
-
-The first production workflow will be documented here.

--- a/docs/content/bws/index.mdx
+++ b/docs/content/bws/index.mdx
@@ -1,6 +1,13 @@
 ---
-title: Boundary Workflow Service
-description: Deploy, observe, and debug BAML workloads.
+title: Boundary Web Services
+description: Boundary's upcoming web services for BAML.
 ---
 
-BWS provides the managed services used to run BAML systems in production.
+Boundary Web Services (BWS) is not yet available.
+
+This section is reserved for BWS documentation once the product and its public
+interfaces are ready. There is no onboarding, API reference, deployment guide,
+or published service-limit contract to follow today.
+
+For currently available tooling, start with the [BAML language](/baml) and the
+[BAML CLI](/cli).

--- a/docs/content/bws/limits/index.mdx
+++ b/docs/content/bws/limits/index.mdx
@@ -1,6 +1,0 @@
----
-title: Limits
-description: Service limits, quotas, and availability.
----
-
-Published BWS limits and quotas will live here.

--- a/docs/content/bws/meta.json
+++ b/docs/content/bws/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "BWS",
-  "pages": ["index", "get-started", "deployment", "observability", "debugging", "api", "limits"]
+  "title": "Boundary Web Services",
+  "pages": ["index"]
 }

--- a/docs/content/bws/observability/index.mdx
+++ b/docs/content/bws/observability/index.mdx
@@ -1,6 +1,0 @@
----
-title: Observability
-description: Understand production behavior with logs, traces, and metrics.
----
-
-Observability concepts and workflows will live here.

--- a/docs/tests/bws.test.mjs
+++ b/docs/tests/bws.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const bwsRoot = path.join(packageRoot, 'content', 'bws');
+
+test('BWS expands to Boundary Web Services on its pre-release surface', async () => {
+  const [landing, meta] = await Promise.all([
+    readFile(path.join(bwsRoot, 'index.mdx'), 'utf8'),
+    readFile(path.join(bwsRoot, 'meta.json'), 'utf8'),
+  ]);
+
+  assert.match(landing, /title: Boundary Web Services/);
+  assert.match(landing, /Boundary Web Services \(BWS\)/);
+  assert.match(landing, /BWS\) is not yet available/);
+  assert.match(meta, /"title": "Boundary Web Services"/);
+  assert.doesNotMatch(landing, /Boundary Workflow Service/);
+});
+
+test('the BWS navigation exposes only the truthful landing page', async () => {
+  const meta = JSON.parse(await readFile(path.join(bwsRoot, 'meta.json'), 'utf8'));
+  assert.deepEqual(meta.pages, ['index']);
+  await access(path.join(bwsRoot, 'index.mdx'));
+});
+
+test('the pre-release page does not imply a usable BWS workflow', async () => {
+  const content = await readFile(path.join(bwsRoot, 'index.mdx'), 'utf8');
+  assert.match(content, /There is no onboarding, API reference, deployment guide/);
+  assert.doesNotMatch(content, /baml-cli deploy|BOUNDARY_API_KEY|api2\.boundaryml\.com/);
+});


### PR DESCRIPTION
## Outcome

BWS now expands to **Boundary Web Services** and is presented truthfully as not yet available.

Before this PR, placeholder pages implied that onboarding, deployment, observability, debugging, APIs, and service limits existed. After it, `/bws` is a single coming-soon surface that points readers to currently available BAML and CLI documentation without inventing product behavior.

A focused test prevents future placeholder copy from implying credentials, endpoints, or a usable deployment workflow before those interfaces exist.

## Validation

- BWS naming, navigation, and pre-release contract tests pass
- MDX compiles as part of the complete docs build

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>