### PR TITLE
Polish the developer docs experience

### DIFF
--- a/docs/app/(docs)/[...slug]/page.tsx
+++ b/docs/app/(docs)/[...slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function Page(props: PageProps<'/[...slug]'>) {
   const MDX = page.data.body;
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage toc={page.data.toc} full={page.data.full} className="shadcn-docs-page">
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/docs/app/(docs)/layout.tsx
+++ b/docs/app/(docs)/layout.tsx
@@ -1,10 +1,16 @@
 import { source } from '@/lib/source';
 import { baseOptions } from '@/lib/layout.shared';
+import { DocsSiteHeader } from '@/components/site-header';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 
 export default function Layout({ children }: LayoutProps<'/'>) {
   return (
-    <DocsLayout tree={source.getPageTree()} {...baseOptions()}>
+    <DocsLayout
+      tree={source.getPageTree()}
+      {...baseOptions()}
+      containerProps={{ className: 'shadcn-docs-layout' }}
+      slots={{ header: DocsSiteHeader }}
+    >
       {children}
     </DocsLayout>
   );

--- a/docs/app/(home)/layout.tsx
+++ b/docs/app/(home)/layout.tsx
@@ -1,6 +1,10 @@
-import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { baseOptions } from '@/lib/layout.shared';
+import { SiteHeader } from '@/components/site-header';
 
 export default function Layout({ children }: LayoutProps<'/'>) {
-  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      {children}
+    </div>
+  );
 }

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -1,63 +1,53 @@
+import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 
 const sections = [
   {
     href: '/baml',
     title: 'BAML',
-    description: 'The language, book, standard library, and language bridges.',
+    description: 'Language concepts, the book, and generated standard library reference.',
   },
   {
     href: '/cli',
     title: 'CLI',
-    description: 'Installation, commands, configuration, and releases.',
+    description: 'Installation, workflows, and the complete generated command reference.',
   },
   {
     href: '/bws',
-    title: 'BWS',
-    description: 'Deploy, observe, and debug BAML workloads.',
+    title: 'Boundary Web Services',
+    description: 'Documentation is coming soon.',
   },
-  {
-    href: '/tutorials',
-    title: 'Tutorials',
-    description: 'Learn complete workflows across BAML, the CLI, and BWS.',
-  },
-  {
-    href: '/examples',
-    title: 'Examples',
-    description: 'Start from complete, runnable projects.',
-  },
-];
+] as const;
 
 export default function HomePage() {
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-20">
-      <div className="max-w-3xl">
-        <p className="mb-4 text-sm font-medium uppercase tracking-[0.2em] text-fd-muted-foreground">
-          Boundary Developer
-        </p>
-        <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">
-          Build reliable AI systems with BAML.
-        </h1>
-        <p className="mt-6 text-lg leading-8 text-fd-muted-foreground">
-          Learn the language, use the CLI, ship with BWS, and run examples in
-          the browser.
-        </p>
+    <main className="shadcn-home">
+      <div className="shadcn-home__intro">
+        <h1>Boundary Developer</h1>
+        <p>Documentation for building reliable AI software with BAML.</p>
+        <div className="shadcn-home__actions">
+          <Link href="/baml">
+            Get started <ArrowRight aria-hidden="true" />
+          </Link>
+          <Link href="/baml/book">Read the book</Link>
+        </div>
       </div>
 
-      <div className="mt-14 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="shadcn-home__grid">
         {sections.map((section) => (
-          <Link
-            key={section.href}
-            href={section.href}
-            className="rounded-xl border bg-fd-card p-6 transition-colors hover:bg-fd-accent"
-          >
-            <h2 className="text-xl font-semibold">{section.title}</h2>
-            <p className="mt-2 leading-7 text-fd-muted-foreground">
-              {section.description}
-            </p>
+          <Link key={section.href} href={section.href}>
+            <h2>{section.title}</h2>
+            <p>{section.description}</p>
+            <span>Open documentation <ArrowRight aria-hidden="true" /></span>
           </Link>
         ))}
       </div>
+
+      <nav className="shadcn-home__more" aria-label="More documentation">
+        <Link href="/tutorials">Tutorials</Link>
+        <Link href="/examples">Examples</Link>
+        <a href="https://github.com/BoundaryML/baml">GitHub</a>
+      </nav>
     </main>
   );
 }

--- a/docs/app/api/github-stars/route.ts
+++ b/docs/app/api/github-stars/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+export const revalidate = 86_400;
+
+export async function GET() {
+  const response = await fetch('https://api.github.com/repos/BoundaryML/baml', {
+    headers: { Accept: 'application/vnd.github+json' },
+    next: { revalidate },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json({ error: 'GitHub stars are unavailable.' }, { status: 502 });
+  }
+
+  const data = await response.json() as { stargazers_count?: unknown };
+  if (typeof data.stargazers_count !== 'number') {
+    return NextResponse.json({ error: 'GitHub returned an invalid star count.' }, { status: 502 });
+  }
+
+  return NextResponse.json({ stars: data.stargazers_count });
+}

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -2,8 +2,85 @@
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
 
+/* Ported from shadcn/ui apps/v4/app/globals.css. Keep these neutral tokens in
+   sync with the reference instead of introducing a docs-specific palette. */
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0% 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0% 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0% 0 0);
+  --primary: oklch(0% 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --surface: oklch(0.98 0 0);
+  --surface-foreground: var(--foreground);
+  --code: var(--surface);
+  --code-foreground: var(--surface-foreground);
+  --code-highlight: oklch(0.96 0 0);
+  --code-number: oklch(0.56 0 0);
+  --selection: oklch(0% 0 0);
+  --selection-foreground: oklch(1 0 0);
+
+  --color-fd-background: var(--background);
+  --color-fd-foreground: var(--foreground);
+  --color-fd-card: var(--card);
+  --color-fd-card-foreground: var(--card-foreground);
+  --color-fd-popover: var(--popover);
+  --color-fd-popover-foreground: var(--popover-foreground);
+  --color-fd-primary: var(--primary);
+  --color-fd-primary-foreground: var(--primary-foreground);
+  --color-fd-secondary: var(--secondary);
+  --color-fd-secondary-foreground: var(--secondary-foreground);
+  --color-fd-muted: var(--muted);
+  --color-fd-muted-foreground: var(--muted-foreground);
+  --color-fd-accent: var(--accent);
+  --color-fd-accent-foreground: var(--accent-foreground);
+  --color-fd-border: var(--border);
+  --color-fd-ring: var(--ring);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.371 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --surface: oklch(0.2 0 0);
+  --surface-foreground: oklch(0.708 0 0);
+  --code: var(--surface);
+  --code-foreground: var(--surface-foreground);
+  --code-highlight: oklch(0.27 0 0);
+  --code-number: oklch(0.72 0 0);
+  --selection: oklch(0.922 0 0);
+  --selection-foreground: oklch(0.205 0 0);
+}
+
 html {
   scrollbar-gutter: stable;
+  scroll-padding-top: 4rem;
 }
 
 html > body[data-scroll-locked] {
@@ -11,12 +88,477 @@ html > body[data-scroll-locked] {
   --removed-body-scroll-bar-size: 0px !important;
 }
 
-.baml-runner {
+body {
+  position: relative;
+  color: var(--foreground);
+  background: var(--background);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis-weight: none;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  color: var(--selection-foreground);
+  background: var(--selection);
+}
+
+/* shadcn site header */
+.shadcn-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  width: 100%;
+  height: 4rem;
+  grid-column: 1 / -1;
+  grid-row: 1;
+  align-items: center;
+  gap: 1.5rem;
+  border-bottom: 1px solid transparent;
+  padding-inline: 1.5rem;
+  color: var(--foreground);
+  background: var(--background);
+}
+
+.shadcn-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+}
+
+.shadcn-header__nav a {
+  color: color-mix(in oklab, var(--foreground) 84%, transparent);
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.shadcn-header__nav a:hover {
+  color: var(--foreground);
+}
+
+.shadcn-header__actions {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.shadcn-header__search {
+  display: inline-flex;
+  width: min(21rem, 30vw);
+  height: 2.25rem;
+  align-items: center;
+  gap: 0.5rem;
+  border: 0;
+  border-radius: calc(var(--radius) * 0.8);
+  padding-inline: 0.75rem;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  font-size: 0.8125rem;
+  text-align: left;
+}
+
+.shadcn-header__search svg,
+.shadcn-header__icon svg,
+.shadcn-header__book svg,
+.shadcn-header__menu svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.shadcn-header__search span {
+  flex: 1;
+}
+
+.shadcn-header__search kbd {
+  font-family: inherit;
+  font-size: 0.7rem;
+}
+
+.shadcn-header__separator {
+  width: 1px;
+  height: 1rem;
+  background: var(--border);
+}
+
+.shadcn-header__icon,
+.shadcn-header__menu {
+  display: inline-flex;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: calc(var(--radius) * 0.8);
+  color: var(--muted-foreground);
+  background: transparent;
+}
+
+.shadcn-header__icon {
+  gap: 0.35rem;
+  min-width: 2rem;
+  padding-inline: 0.5rem;
+}
+
+.shadcn-header__menu {
+  width: 2rem;
+}
+
+.shadcn-header__stars {
+  min-width: 1.75rem;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.shadcn-header__stars--loading {
+  height: 0.75rem;
+  border-radius: calc(var(--radius) * 0.6);
+  background: var(--muted);
+}
+
+.shadcn-header__theme {
+  width: 2rem;
+  height: 2rem;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+}
+
+.shadcn-header__theme svg {
+  display: none;
+}
+
+.shadcn-header__theme svg.bg-fd-accent {
+  display: block;
+  width: 1.625rem;
+  height: 1.625rem;
+  background: transparent;
+}
+
+.shadcn-header__icon:hover,
+.shadcn-header__menu:hover {
+  color: var(--foreground);
+  background: var(--accent);
+}
+
+.shadcn-header__book {
+  display: inline-flex;
+  height: 1.9375rem;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: calc(var(--radius) * 0.8);
+  padding-inline: 0.75rem;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.shadcn-header__mobile {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+/* shadcn docs proportions: 18rem sidebar, 40rem reading column, 18rem TOC. */
+.shadcn-docs-layout {
+  --fd-header-height: 4rem !important;
+  --fd-layout-width: 88rem;
+  --fd-sidebar-width: 18rem !important;
+  --fd-toc-width: 18rem !important;
+  grid-template:
+    'header header header'
+    'sidebar toc-popover toc'
+    'sidebar main toc' 1fr / 18rem minmax(0, 1fr) 18rem !important;
+}
+
+.shadcn-docs-layout [data-sidebar-placeholder] {
+  top: var(--fd-docs-row-2);
+  height: calc(var(--fd-docs-height) - var(--fd-docs-row-2));
+}
+
+.shadcn-docs-layout #nd-sidebar {
+  border: 0;
+  color: var(--foreground);
+  background: var(--background);
+}
+
+.shadcn-docs-layout #nd-sidebar::after {
+  position: absolute;
+  top: 3rem;
+  right: 0.5rem;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(to bottom, transparent, var(--border) 10%, var(--border) 90%, transparent);
+  content: '';
+}
+
+.shadcn-docs-layout #nd-sidebar .site-brand,
+.shadcn-docs-layout #nd-sidebar [data-search-full],
+.shadcn-docs-layout #nd-sidebar [data-theme-toggle] {
+  display: none;
+}
+
+.shadcn-docs-layout #nd-sidebar > div:first-child {
+  display: none;
+}
+
+.shadcn-docs-layout #nd-sidebar [data-radix-scroll-area-viewport] {
+  padding-top: 4rem;
+}
+
+.shadcn-docs-layout #nd-sidebar [data-radix-scroll-area-viewport] > div::before {
+  display: block;
+  margin-bottom: 0.5rem;
+  padding-inline: 0.5rem;
+  color: var(--muted-foreground);
+  content: 'Sections';
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.shadcn-docs-layout #nd-sidebar a,
+.shadcn-docs-layout #nd-sidebar button {
+  min-height: 1.875rem;
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius) * 0.8);
+  padding-block: 0.25rem;
+  color: var(--foreground);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.shadcn-docs-layout #nd-sidebar [data-active='true'] {
+  border-color: var(--accent);
+  color: var(--foreground);
+  background: var(--accent);
+}
+
+.shadcn-docs-layout #nd-sidebar [role='separator'] {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.shadcn-docs-layout #nd-toc {
+  padding-top: 3rem;
+  padding-inline: 2rem;
+}
+
+.shadcn-docs-layout #toc-title {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.shadcn-docs-layout #nd-toc a {
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+}
+
+.shadcn-docs-layout #nd-toc a[data-active='true'],
+.shadcn-docs-layout #nd-toc a:hover {
+  color: var(--foreground);
+  font-weight: 500;
+}
+
+.shadcn-docs-page {
+  width: 100% !important;
+  max-width: 40rem !important;
+  gap: 1.5rem !important;
+  padding-top: 2rem !important;
+  padding-bottom: 4rem !important;
+}
+
+.shadcn-docs-page h1 {
+  font-size: 1.875rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.shadcn-docs-page > p {
+  max-width: 32rem;
+  color: var(--muted-foreground);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.shadcn-docs-page .prose {
+  color: var(--foreground);
+  font-size: 0.9375rem;
+  line-height: 1.75;
+}
+
+.shadcn-docs-page .prose h2 {
+  margin-top: 2rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+
+.shadcn-docs-page .prose h3 {
+  margin-top: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.shadcn-docs-page [data-rehype-pretty-code-figure],
+.shadcn-docs-page .prose > pre {
+  overflow: hidden;
+  border: 0;
+  border-radius: calc(var(--radius) * 1.8);
+  color: var(--code-foreground);
+  background: var(--code);
+  box-shadow: none;
+}
+
+.shadcn-docs-page .prose :not(pre) > code {
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 0.6);
+  padding: 0.1rem 0.3rem;
+  color: var(--foreground);
+  background: var(--muted);
+  font-size: 0.875em;
+  font-weight: 500;
+}
+
+@media (min-width: 768px) {
+  .shadcn-docs-layout {
+    --fd-toc-popover-height: 0px !important;
+  }
+
+  .shadcn-docs-layout [data-toc-popover] {
+    display: none;
+  }
+}
+
+/* Home uses the same shadcn docs typography and controls—no separate theme. */
+.shadcn-home {
+  width: min(calc(100% - 2rem), 64rem);
+  margin-inline: auto;
+  padding: 7rem 1rem 5rem;
+}
+
+.shadcn-home__intro {
+  max-width: 40rem;
+}
+
+.shadcn-home__intro h1 {
+  font-size: 2.25rem;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.15;
+}
+
+.shadcn-home__intro > p {
+  max-width: 34rem;
+  margin-top: 0.75rem;
+  color: var(--muted-foreground);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.shadcn-home__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.shadcn-home__actions a {
+  display: inline-flex;
+  height: 2.25rem;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 0.8);
+  padding-inline: 0.875rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.shadcn-home__actions a:first-child {
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  background: var(--primary);
+}
+
+.shadcn-home__actions svg,
+.shadcn-home__grid svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.shadcn-home__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 4rem;
+}
+
+.shadcn-home__grid > a {
+  min-height: 12rem;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 1.4);
+  padding: 1.25rem;
+  background: var(--card);
+}
+
+.shadcn-home__grid > a:hover {
+  background: var(--accent);
+}
+
+.shadcn-home__grid h2 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.shadcn-home__grid p {
+  margin-top: 0.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  line-height: 1.55;
+}
+
+.shadcn-home__grid span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 2rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.shadcn-home__more {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 2rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+}
+
+.shadcn-home__more a {
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+}
+
+.shadcn-home__more a:hover {
+  color: var(--foreground);
+}
+
+/* Existing docs-native interactive content, using the same neutral tokens. */
+.baml-runner,
+.book-listing {
   margin-block: 1.5rem;
   overflow: hidden;
-  border: 1px solid color-mix(in oklab, var(--color-fd-border) 88%, transparent);
-  border-radius: 0.8rem;
-  background: var(--color-fd-card);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 1.4);
+  background: var(--card);
 }
 
 .baml-runner-source {
@@ -25,7 +567,7 @@ html > body[data-scroll-locked] {
   border: 0;
   border-radius: 0;
   padding: 1.1rem 1.25rem;
-  background: color-mix(in oklab, var(--color-fd-secondary) 55%, transparent);
+  background: var(--surface);
   font-size: 0.875rem;
   line-height: 1.65;
 }
@@ -34,24 +576,25 @@ html > body[data-scroll-locked] {
   display: flex;
   align-items: center;
   gap: 0.85rem;
-  border-top: 1px solid var(--color-fd-border);
+  border-top: 1px solid var(--border);
   padding: 0.75rem 0.9rem;
 }
 
-.baml-runner-toolbar button {
+.baml-runner-toolbar button,
+.book-quiz-question > button {
   display: inline-flex;
-  flex: none;
   align-items: center;
   gap: 0.45rem;
-  border-radius: 0.5rem;
-  background: var(--color-fd-primary);
-  color: var(--color-fd-primary-foreground);
+  border-radius: calc(var(--radius) * 0.8);
   padding: 0.5rem 0.75rem;
-  font-size: 0.82rem;
-  font-weight: 600;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  font-size: 0.8125rem;
+  font-weight: 500;
 }
 
-.baml-runner-toolbar button:disabled {
+.baml-runner-toolbar button:disabled,
+.book-quiz-question > button:disabled {
   cursor: wait;
   opacity: 0.7;
 }
@@ -63,7 +606,7 @@ html > body[data-scroll-locked] {
 
 .baml-runner-toolbar span,
 .baml-runner-result span {
-  color: var(--color-fd-muted-foreground);
+  color: var(--muted-foreground);
   font-size: 0.78rem;
 }
 
@@ -72,12 +615,12 @@ html > body[data-scroll-locked] {
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
-  border-top: 1px solid var(--color-fd-border);
+  border-top: 1px solid var(--border);
   padding: 0.85rem 1rem;
 }
 
 .baml-runner-result code {
-  color: var(--color-fd-foreground);
+  color: var(--foreground);
   font-size: 0.9rem;
   font-weight: 600;
 }
@@ -89,7 +632,7 @@ html > body[data-scroll-locked] {
 .baml-runner-timings {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  border-top: 1px solid var(--color-fd-border);
+  border-top: 1px solid var(--border);
   margin: 0;
 }
 
@@ -98,7 +641,7 @@ html > body[data-scroll-locked] {
 }
 
 .baml-runner-timings dt {
-  color: var(--color-fd-muted-foreground);
+  color: var(--muted-foreground);
   font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -110,20 +653,16 @@ html > body[data-scroll-locked] {
   font-size: 0.75rem;
 }
 
-.book-listing {
-  margin-block: 1.5rem;
-  overflow: hidden;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 0.8rem;
-  background: var(--color-fd-card);
+.book-listing-file,
+.book-listing figcaption {
+  border-bottom: 1px solid var(--border);
+  padding: 0.55rem 1rem;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
 }
 
 .book-listing-file {
-  border-bottom: 1px solid var(--color-fd-border);
-  padding: 0.55rem 1rem;
-  color: var(--color-fd-muted-foreground);
   font-family: var(--font-mono);
-  font-size: 0.75rem;
 }
 
 .book-listing-body > pre,
@@ -133,61 +672,30 @@ html > body[data-scroll-locked] {
   border-radius: 0;
 }
 
-.book-listing-body > .baml-runner {
-  border-top: 1px solid var(--color-fd-border);
-}
-
 .book-listing figcaption {
-  border-top: 1px solid var(--color-fd-border);
-  padding: 0.7rem 1rem;
-  color: var(--color-fd-muted-foreground);
+  border-top: 1px solid var(--border);
+  border-bottom: 0;
   font-size: 0.8rem;
-}
-
-.book-listing figcaption a {
-  color: var(--color-fd-foreground);
-  font-weight: 600;
 }
 
 .book-quiz {
   margin-block: 2rem;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 1.4);
   padding: 1.25rem;
-  background: color-mix(in oklab, var(--color-fd-card) 88%, transparent);
+  background: var(--card);
 }
 
 .book-quiz > h2,
 .book-quiz-question > h3 {
   margin: 0;
-  font-weight: 650;
-}
-
-.book-quiz > h2 {
-  font-size: 1.05rem;
+  font-weight: 600;
 }
 
 .book-quiz-question {
   margin-top: 1rem;
-  border-top: 1px solid var(--color-fd-border);
+  border-top: 1px solid var(--border);
   padding-top: 1rem;
-}
-
-.book-quiz-question > h3 {
-  font-size: 0.9rem;
-}
-
-.book-quiz-question p {
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.86rem;
-}
-
-.book-quiz-question pre {
-  overflow-x: auto;
-  border-radius: 0.6rem;
-  padding: 0.9rem;
-  background: var(--color-fd-secondary);
-  font-size: 0.8rem;
 }
 
 .book-quiz-choices {
@@ -198,60 +706,91 @@ html > body[data-scroll-locked] {
 
 .book-quiz-choices label {
   display: flex;
-  align-items: flex-start;
   gap: 0.55rem;
-  border: 1px solid var(--color-fd-border);
-  border-radius: 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 0.8);
   padding: 0.65rem 0.75rem;
   font-size: 0.84rem;
 }
 
-.book-quiz-question > label {
-  display: grid;
-  gap: 0.35rem;
-  margin-block: 0.85rem;
-  color: var(--color-fd-muted-foreground);
-  font-size: 0.78rem;
+@media (max-width: 1100px) {
+  .shadcn-docs-layout {
+    --fd-toc-width: 0px !important;
+    grid-template:
+      'header header'
+      'sidebar toc-popover'
+      'sidebar main' 1fr / 18rem minmax(0, 1fr) !important;
+  }
+
+  .shadcn-docs-layout #nd-toc,
+  .shadcn-docs-layout #nd-toc-placeholder {
+    display: none;
+  }
+
+  .shadcn-header__nav {
+    gap: 1rem;
+  }
+
+  .shadcn-header__nav a:nth-last-child(-n + 2) {
+    display: none;
+  }
 }
 
-.book-quiz-question input[type='text'],
-.book-quiz-question > label input {
-  border: 1px solid var(--color-fd-border);
-  border-radius: 0.5rem;
-  padding: 0.6rem 0.7rem;
-  color: var(--color-fd-foreground);
-  background: var(--color-fd-background);
-}
+@media (max-width: 768px) {
+  .shadcn-header {
+    height: 3.5rem;
+    gap: 0.75rem;
+    padding-inline: 0.75rem;
+  }
 
-.book-quiz-question > button {
-  border-radius: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: var(--color-fd-primary);
-  color: var(--color-fd-primary-foreground);
-  font-size: 0.8rem;
-  font-weight: 600;
-}
+  .shadcn-header__mobile {
+    display: flex;
+  }
 
-.book-quiz-question > button:disabled {
-  opacity: 0.5;
-}
+  .shadcn-header__nav,
+  .shadcn-header__search span,
+  .shadcn-header__search kbd,
+  .shadcn-header__separator,
+  .shadcn-header__book {
+    display: none;
+  }
 
-.book-quiz-feedback {
-  margin-top: 0.75rem;
-  border-left: 3px solid var(--color-fd-border);
-  padding: 0.65rem 0.8rem;
-  font-size: 0.82rem;
-}
+  .shadcn-header__actions {
+    gap: 0.25rem;
+  }
 
-.book-quiz-feedback--correct {
-  border-left-color: var(--color-green-500);
-}
+  .shadcn-header__search {
+    width: 2rem;
+    height: 2rem;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+  }
 
-.book-quiz-feedback--incorrect {
-  border-left-color: var(--color-red-500);
-}
+  .shadcn-docs-layout {
+    --fd-header-height: 3.5rem !important;
+    grid-template:
+      'header'
+      'toc-popover'
+      'main' 1fr / minmax(0, 1fr) !important;
+  }
 
-@media (max-width: 640px) {
+  .shadcn-docs-layout [data-sidebar-placeholder] {
+    top: var(--fd-docs-row-1);
+  }
+
+  .shadcn-docs-page {
+    padding-inline: 1rem !important;
+  }
+
+  .shadcn-home {
+    padding-top: 4rem;
+  }
+
+  .shadcn-home__grid {
+    grid-template-columns: 1fr;
+  }
+
   .baml-runner-toolbar,
   .baml-runner-result {
     align-items: flex-start;

--- a/docs/components/site-brand.tsx
+++ b/docs/components/site-brand.tsx
@@ -1,0 +1,3 @@
+export function SiteBrand({ className = '' }: { className?: string }) {
+  return <span className={`site-brand ${className}`}>Boundary Developer</span>;
+}

--- a/docs/components/site-header.tsx
+++ b/docs/components/site-header.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useSearchContext } from 'fumadocs-ui/contexts/search';
+import { useDocsLayout } from 'fumadocs-ui/layouts/docs';
+import { ThemeSwitch } from 'fumadocs-ui/layouts/shared/slots/theme-switch';
+import { BookOpen, Menu, Search } from 'lucide-react';
+import Link from 'next/link';
+import { type ComponentProps, type ReactNode, useEffect, useState } from 'react';
+
+const navigation = [
+  ['Home', '/'],
+  ['BAML', '/baml'],
+  ['CLI', '/cli'],
+  ['BWS', '/bws'],
+  ['Tutorials', '/tutorials'],
+  ['Examples', '/examples'],
+] as const;
+
+function GitHubIcon() {
+  return (
+    <svg viewBox="0 0 438.549 438.549" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M409.132 114.573c-19.608-33.596-46.205-60.194-79.798-79.8-33.598-19.607-70.277-29.408-110.063-29.408-39.781 0-76.472 9.804-110.063 29.408-33.596 19.605-60.192 46.204-79.8 79.8C9.803 148.168 0 184.854 0 224.63c0 47.78 13.94 90.745 41.827 128.906 27.884 38.164 63.906 64.572 108.063 79.227 5.14.954 8.945.283 11.419-1.996 2.475-2.282 3.711-5.14 3.711-8.562 0-.571-.049-5.708-.144-15.417a2549.81 2549.81 0 01-.144-25.406l-6.567 1.136c-4.187.767-9.469 1.092-15.846 1-6.374-.089-12.991-.757-19.842-1.999-6.854-1.231-13.229-4.086-19.13-8.559-5.898-4.473-10.085-10.328-12.56-17.556l-2.855-6.57c-1.903-4.374-4.899-9.233-8.992-14.559-4.093-5.331-8.232-8.945-12.419-10.848l-1.999-1.431c-1.332-.951-2.568-2.098-3.711-3.429-1.142-1.331-1.997-2.663-2.568-3.997-.572-1.335-.098-2.43 1.427-3.289 1.525-.859 4.281-1.276 8.28-1.276l5.708.853c3.807.763 8.516 3.042 14.133 6.851 5.614 3.806 10.229 8.754 13.846 14.842 4.38 7.806 9.657 13.754 15.846 17.847 6.184 4.093 12.419 6.136 18.699 6.136 6.28 0 11.704-.476 16.274-1.423 4.565-.952 8.848-2.383 12.847-4.285 1.713-12.758 6.377-22.559 13.988-29.41-10.848-1.14-20.601-2.857-29.264-5.14-8.658-2.286-17.605-5.996-26.835-11.14-9.235-5.137-16.896-11.516-22.985-19.126-6.09-7.614-11.088-17.61-14.987-29.979-3.901-12.374-5.852-26.648-5.852-42.826 0-23.035 7.52-42.637 22.557-58.817-7.044-17.318-6.379-36.732 1.997-58.24 5.52-1.715 13.706-.428 24.554 3.853 10.85 4.283 18.794 7.952 23.84 10.994 5.046 3.041 9.089 5.618 12.135 7.708 17.705-4.947 35.976-7.421 54.818-7.421s37.117 2.474 54.823 7.421l10.849-6.849c7.419-4.57 16.18-8.758 26.262-12.565 10.088-3.805 17.802-4.853 23.134-3.138 8.562 21.509 9.325 40.922 2.279 58.24 15.036 16.18 22.559 35.787 22.559 58.817 0 16.178-1.958 30.497-5.853 42.966-3.9 12.471-8.941 22.457-15.125 29.979-6.191 7.521-13.901 13.85-23.131 18.986-9.232 5.14-18.182 8.85-26.84 11.136-8.662 2.286-18.415 4.004-29.263 5.146 9.894 8.562 14.842 22.077 14.842 40.539v60.237c0 3.422 1.19 6.279 3.572 8.562 2.379 2.279 6.136 2.95 11.276 1.995 44.163-14.653 80.185-41.062 108.068-79.226 27.88-38.161 41.825-81.126 41.825-128.906-.01-39.771-9.818-76.454-29.414-110.049z"
+      />
+    </svg>
+  );
+}
+
+function StarsCount() {
+  const [stars, setStars] = useState<number | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    fetch('/api/github-stars')
+      .then((response) => response.ok ? response.json() : null)
+      .then((data: { stars?: unknown } | null) => {
+        if (active && typeof data?.stars === 'number') setStars(data.stars);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (stars === null) return <span className="shadcn-header__stars shadcn-header__stars--loading" />;
+
+  const formatted = stars >= 1_000 ? `${Math.round(stars / 1_000)}k` : stars.toLocaleString();
+  return <span className="shadcn-header__stars">{formatted}</span>;
+}
+
+function HeaderContents({ sidebarTrigger }: { sidebarTrigger?: ReactNode }) {
+  const { setOpenSearch } = useSearchContext();
+
+  return (
+    <>
+      <div className="shadcn-header__mobile">
+        {sidebarTrigger}
+        <Link href="/">Boundary Developer</Link>
+      </div>
+
+      <nav className="shadcn-header__nav" aria-label="Primary navigation">
+        {navigation.map(([label, href]) => (
+          <Link key={href} href={href}>{label}</Link>
+        ))}
+      </nav>
+
+      <div className="shadcn-header__actions">
+        <button
+          className="shadcn-header__search"
+          type="button"
+          onClick={() => setOpenSearch(true)}
+        >
+          <Search aria-hidden="true" />
+          <span>Search documentation...</span>
+          <kbd>⌘ K</kbd>
+        </button>
+        <span className="shadcn-header__separator" aria-hidden="true" />
+        <a
+          className="shadcn-header__icon"
+          href="https://github.com/BoundaryML/baml"
+          aria-label="BAML on GitHub"
+        >
+          <GitHubIcon />
+          <StarsCount />
+        </a>
+        <span className="shadcn-header__separator" aria-hidden="true" />
+        <ThemeSwitch className="shadcn-header__theme" />
+        <span className="shadcn-header__separator shadcn-header__book-separator" aria-hidden="true" />
+        <Link className="shadcn-header__book" href="/baml/book">
+          <BookOpen aria-hidden="true" /> Book
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export function SiteHeader(props: ComponentProps<'header'>) {
+  return (
+    <header {...props} className={`shadcn-header ${props.className ?? ''}`}>
+      <HeaderContents />
+    </header>
+  );
+}
+
+export function DocsSiteHeader(props: ComponentProps<'header'>) {
+  const { slots } = useDocsLayout();
+  const SidebarTrigger = slots.sidebar.trigger;
+
+  return (
+    <header id="nd-subnav" {...props} className={`shadcn-header ${props.className ?? ''}`}>
+      <HeaderContents
+        sidebarTrigger={
+          <SidebarTrigger className="shadcn-header__menu" aria-label="Open navigation">
+            <Menu aria-hidden="true" />
+          </SidebarTrigger>
+        }
+      />
+    </header>
+  );
+}

--- a/docs/lib/constants.ts
+++ b/docs/lib/constants.ts
@@ -1,5 +1,5 @@
 export const siteName = 'Boundary Developer';
 export const siteDescription =
-  'Build with BAML, the BAML CLI, and Boundary Workflow Service.';
+  'Documentation for BAML, the BAML CLI, and upcoming Boundary Web Services.';
 export const siteUrl =
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://developer.boundaryml.com';

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -1,16 +1,16 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import { siteName } from './constants';
+import { SiteBrand } from '@/components/site-brand';
 
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: siteName,
+      title: <SiteBrand />,
     },
     githubUrl: 'https://github.com/BoundaryML/baml',
     links: [
       { text: 'BAML', url: '/baml' },
       { text: 'CLI', url: '/cli' },
-      { text: 'BWS', url: '/bws' },
+      { text: 'BWS', url: '/bws', description: 'Boundary Web Services' },
       { text: 'Tutorials', url: '/tutorials' },
       { text: 'Examples', url: '/examples' },
     ],


### PR DESCRIPTION
## Outcome

The developer portal now uses the shadcn docs shell directly: the same neutral palette, full-width header composition, search/action cluster, sidebar proportions, active-row treatment, reading width, code surfaces, and plain right-hand table of contents.

Before this PR, the branch had a custom Boundary visual direction. After it, the UI follows the checked-out shadcn `apps/v4` implementation and changes only the product labels, routes, and content. The header also fetches and displays the live `BoundaryML/baml` GitHub star count using shadcn-style compact formatting.

BWS remains a truthful **Boundary Web Services — coming soon** placeholder.

## Review map

- Copied shadcn shell and responsive behavior: `docs/components/site-header.tsx`, `docs/app/global.css`
- Docs layout integration: `docs/app/(docs)`
- Restrained portal entry page: `docs/app/(home)`
- Cached GitHub star endpoint: `docs/app/api/github-stars/route.ts`

## Validation

- 28 docs tests pass
- TypeScript passes
- Production build passes
- Local desktop and mobile visual comparison against `ui.shadcn.com/docs/cli`
- No browser console warnings or errors

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
