### PR TITLE
engine: fix release CI attestation pagination

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
                 status: "success",
                 per_page: 100,
               },
-              (response) => response.data.workflow_runs,
             );
             const sourceCi = runs.find((run) => {
               if (run.name !== "BAML Runtime" || run.path !== ".github/workflows/primary.yml") {


### PR DESCRIPTION
## Summary

- let Octokit return the normalized workflow-run array from `github.paginate`
- prevent the release source attestation from dereferencing an undefined mapped entry

## Failure context

[BAML Release run 33463902889](https://github.com/BoundaryML/baml/actions/runs/33463902889) failed before any build, tag creation, or publishing because the pagination mapper accessed `response.data.workflow_runs` after Octokit had normalized `response.data` to the runs array.

This PR does not move, delete, or recreate `0.226.2-engine`, and does not rerun the failed release. Under the release runbook, a workflow-source fix after trigger creation requires a new patch version.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canary CI verification pagination to reliably process workflow run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->