### PR TITLE
Render multiple toolchain documentation versions

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2060,12 +2060,54 @@ jobs:
       - name: Promote mutable channel manifest
         env:
           CHANNEL: ${{ needs.plan.outputs.channel }}
+          VERSION: ${{ needs.plan.outputs.version }}
         run: |
           set -euo pipefail
           aws s3 cp "manifests/$CHANNEL.json" \
             "s3://$PKG_BUCKET/manifest/v1/$CHANNEL.json" \
             --content-type application/json \
             --cache-control "public, max-age=60, must-revalidate"
+
+          current_index="$(mktemp)"
+          next_index="$(mktemp)"
+          if ! aws s3 cp \
+            "s3://$PKG_BUCKET/manifest/v1/docs/versions.json" \
+            "$current_index" >/dev/null 2>&1; then
+            printf '%s\n' '{"schema":1,"defaultVersion":null,"aliases":{},"versions":[]}' > "$current_index"
+          fi
+          jq \
+            --arg channel "$CHANNEL" \
+            --arg version "$VERSION" \
+            --slurpfile release "manifests/docs/v$VERSION/stdlib.json" '
+              .schema = 1
+              | .aliases = ((.aliases // {}) + {($channel): $version})
+              | .defaultVersion = if $channel == "nightly" then (.defaultVersion // $version) else $version end
+              | .versions = ([{
+                  version: $version,
+                  channel: $channel,
+                  releasedAt: $release[0].releasedAt,
+                  sourceRevision: $release[0].sourceRevision,
+                  artifacts: {
+                    stdlib: {
+                      path: ("v" + $version + "/stdlib.json"),
+                      payloadSha256: $release[0].payloadSha256
+                    }
+                  }
+                }] + [(.versions // [])[] | select(.version != $version)])
+              | (.aliases | [.[]]) as $alias_versions
+              | .versions = (
+                  (.versions | sort_by(.releasedAt) | reverse) as $ordered
+                  | ($ordered[0:5] + [$ordered[] | select(.version as $candidate | $alias_versions | index($candidate))])
+                  | unique_by(.version)
+                  | sort_by(.releasedAt)
+                  | reverse
+                )
+            ' "$current_index" > "$next_index"
+          aws s3 cp "$next_index" \
+            "s3://$PKG_BUCKET/manifest/v1/docs/versions.json" \
+            --content-type application/json \
+            --cache-control "public, max-age=60, must-revalidate"
+          rm -f "$current_index" "$next_index"
       - name: Rebuild developer docs from the promoted release
         env:
           DEPLOY_HOOK: ${{ secrets.DEVELOPER_DOCS_VERCEL_DEPLOY_HOOK }}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -12,6 +12,8 @@
 /generated/cli/
 /generated/book/
 /generated/docs-metadata.json
+/generated/docs-versions.json
+/generated/metadata/
 
 # build and typecheck output
 /.next

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,11 +24,18 @@ https://pkg.boundaryml.com/manifest/v1/docs/v<version>/stdlib.json
 ```
 
 The Fumadocs build is a TypeScript-only consumer. By default it resolves the
-current canary channel to an exact version and renders that immutable artifact.
-Use `BAML_DOCS_VERSION`, `BAML_DOCS_METADATA_URL`, or
-`BAML_DOCS_METADATA_FILE` to select another version or a local artifact. The
-release JSON contains all toolchain-discovered packages—not a docs-maintained
-list—and generated symbols use fully qualified names such as
+curated release index at
+`https://pkg.boundaryml.com/manifest/v1/docs/versions.json`, fetches every
+listed immutable artifact, and renders the versions side by side. Unversioned
+reference routes remain aliases for the index's default version; exact routes
+include `v<version>` after `/baml/language/reference` or `/cli/commands`.
+
+Use `BAML_DOCS_VERSIONS` (comma-separated), `BAML_DOCS_METADATA_URLS`, or
+`BAML_DOCS_METADATA_FILES` to build an explicit set. Their singular forms stay
+supported for deterministic one-version and pull-request builds.
+`BAML_DOCS_DEFAULT_VERSION` selects the unversioned alias and must be present
+in the set. Each release JSON contains all toolchain-discovered packages—not a
+docs-maintained list—and generated symbols use fully qualified names such as
 `baml.http.Request`.
 
 To exercise the complete producer/consumer path locally:

--- a/docs/app/(docs)/[...slug]/page.tsx
+++ b/docs/app/(docs)/[...slug]/page.tsx
@@ -1,4 +1,6 @@
 import { getMDXComponents } from '@/components/mdx';
+import { VersionSwitcher } from '@/components/version-switcher';
+import docsVersions from '@/generated/docs-versions.json';
 import { source } from '@/lib/source';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
@@ -10,6 +12,41 @@ import {
 } from 'fumadocs-ui/layouts/docs/page';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 
+const versionCatalog = docsVersions as {
+  defaultVersion: string | null;
+  versions: Array<{ version: string; channel: string }>;
+};
+
+const versionedRoots = [
+  ['baml', 'language', 'reference'],
+  ['cli', 'commands'],
+] as const;
+
+function versionSwitcher(slug: string[]) {
+  const root = versionedRoots.find((candidate) => candidate.every((segment, index) => slug[index] === segment));
+  if (!root || !versionCatalog.defaultVersion || versionCatalog.versions.length === 0) return null;
+
+  const tail = slug.slice(root.length);
+  const explicitVersion = tail[0]?.match(/^v(.+)$/)?.[1];
+  const currentVersion = versionCatalog.versions.some((entry) => entry.version === explicitVersion)
+    ? explicitVersion as string
+    : versionCatalog.defaultVersion;
+  const relativePath = explicitVersion ? tail.slice(1) : tail;
+  const routes = Object.fromEntries(versionCatalog.versions.map((entry) => {
+    const exactSlug = [...root, `v${entry.version}`, ...relativePath];
+    const target = source.getPage(exactSlug) ? exactSlug : [...root, `v${entry.version}`];
+    return [entry.version, `/${target.join('/')}`];
+  }));
+
+  return (
+    <VersionSwitcher
+      currentVersion={currentVersion}
+      routes={routes}
+      versions={versionCatalog.versions}
+    />
+  );
+}
+
 export default async function Page(props: PageProps<'/[...slug]'>) {
   const params = await props.params;
   const page = source.getPage(params.slug);
@@ -19,6 +56,7 @@ export default async function Page(props: PageProps<'/[...slug]'>) {
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full} className="shadcn-docs-page">
+      {versionSwitcher(params.slug)}
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -374,6 +374,27 @@ body {
   padding-bottom: 4rem !important;
 }
 
+.shadcn-version-switcher {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.shadcn-version-switcher select {
+  height: 2rem;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 0.8);
+  padding-inline: 0.625rem 1.75rem;
+  color: var(--foreground);
+  background: var(--background);
+  font: inherit;
+}
+
 .shadcn-docs-page h1 {
   font-size: 1.875rem;
   font-weight: 600;

--- a/docs/components/version-switcher.tsx
+++ b/docs/components/version-switcher.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+type DocsVersion = {
+  version: string;
+  channel: string;
+};
+
+export function VersionSwitcher({
+  currentVersion,
+  routes,
+  versions,
+}: {
+  currentVersion: string;
+  routes: Record<string, string>;
+  versions: DocsVersion[];
+}) {
+  return (
+    <label className="shadcn-version-switcher">
+      <span>Version</span>
+      <select
+        aria-label="BAML documentation version"
+        value={currentVersion}
+        onChange={(event) => {
+          window.location.assign(routes[event.target.value] ?? routes[currentVersion]);
+        }}
+      >
+        {versions.map((entry) => (
+          <option key={entry.version} value={entry.version}>
+            v{entry.version} ({entry.channel})
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/docs/scripts/check-derived-content-policy.mjs
+++ b/docs/scripts/check-derived-content-policy.mjs
@@ -12,6 +12,8 @@ const generatedPaths = [
   'docs/generated/baml',
   'docs/generated/cli',
   'docs/generated/book',
+  'docs/generated/docs-versions.json',
+  'docs/generated/metadata',
   'docs/content/baml/book/meta.json',
 ];
 

--- a/docs/scripts/docs-metadata-source.mjs
+++ b/docs/scripts/docs-metadata-source.mjs
@@ -23,6 +23,51 @@ export function versionMetadataUrl(baseUrl, version) {
   return `${baseUrl.replace(/\/$/, '')}/docs/v${encodeURIComponent(version)}/stdlib.json`;
 }
 
+export function docsVersionsIndexUrl(baseUrl) {
+  return `${baseUrl.replace(/\/$/, '')}/docs/versions.json`;
+}
+
+export function validateDocsVersionsIndex(index) {
+  if (!index || typeof index !== 'object') throw new Error('Docs versions index must be an object');
+  if (index.schema !== 1) throw new Error(`Unsupported docs versions index schema: ${index.schema}`);
+  if (!Array.isArray(index.versions) || index.versions.length === 0) {
+    throw new Error('Docs versions index must contain at least one version');
+  }
+  const versionPattern = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+  const names = new Set();
+  for (const [position, entry] of index.versions.entries()) {
+    if (!entry || !versionPattern.test(entry.version)) throw new Error(`Docs versions index entry ${position} has an invalid version`);
+    if (names.has(entry.version)) throw new Error(`Docs versions index contains duplicate version ${entry.version}`);
+    names.add(entry.version);
+    if (!['stable', 'canary', 'nightly'].includes(entry.channel)) {
+      throw new Error(`Docs versions index entry ${entry.version} has an invalid channel`);
+    }
+    if (typeof entry.releasedAt !== 'string' || Number.isNaN(Date.parse(entry.releasedAt))) {
+      throw new Error(`Docs versions index entry ${entry.version} has an invalid release date`);
+    }
+    if (!/^[0-9a-f]{40}$/.test(entry.sourceRevision)) {
+      throw new Error(`Docs versions index entry ${entry.version} has an invalid source revision`);
+    }
+    if (entry.artifacts?.stdlib?.path !== `v${entry.version}/stdlib.json`) {
+      throw new Error(`Docs versions index entry ${entry.version} has an invalid stdlib artifact path`);
+    }
+    if (!/^[0-9a-f]{64}$/.test(entry.artifacts.stdlib.payloadSha256)) {
+      throw new Error(`Docs versions index entry ${entry.version} has an invalid stdlib payload checksum`);
+    }
+  }
+  if (!names.has(index.defaultVersion)) {
+    throw new Error(`Docs versions index default ${index.defaultVersion} is not present`);
+  }
+  if (!index.aliases || typeof index.aliases !== 'object' || Array.isArray(index.aliases)) {
+    throw new Error('Docs versions index aliases must be an object');
+  }
+  for (const [alias, version] of Object.entries(index.aliases)) {
+    if (!['stable', 'canary', 'nightly'].includes(alias)) throw new Error(`Docs versions index alias ${alias} is invalid`);
+    if (!names.has(version)) throw new Error(`Docs versions index alias ${alias} points to unknown version ${version}`);
+  }
+  return index;
+}
+
 export function previewFallbackAllowed({ args = [], environment = process.env, explicitSelection = false } = {}) {
   if (explicitSelection) return false;
   if (args.includes('--allow-unavailable') || environment.BAML_DOCS_ALLOW_UNAVAILABLE === '1') return true;

--- a/docs/scripts/generate-cli-reference.mjs
+++ b/docs/scripts/generate-cli-reference.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { readDocsMetadata } from './docs-metadata.mjs';
 import {
   checkGeneratedTree,
@@ -48,7 +48,8 @@ function pagePath(commandPath, hasChildren) {
   return `${path.posix.join(...commandPath)}.md`;
 }
 
-function buildFiles(entries, metadata) {
+export function buildCliReferenceFiles(metadata) {
+  const entries = metadata.cli.commands;
   const content = new Map();
   for (const entry of entries) {
     content.set(
@@ -84,31 +85,33 @@ function buildFiles(entries, metadata) {
   };
 }
 
-if (!process.env.BAML_DOCS_METADATA_FILE || !process.env.BAML_DOCS_VERSION) {
-  throw new Error('BAML_DOCS_METADATA_FILE and BAML_DOCS_VERSION are required; run pnpm generate:derived');
-}
-const metadata = await readDocsMetadata(
-  path.resolve(process.env.BAML_DOCS_METADATA_FILE),
-  process.env.BAML_DOCS_VERSION,
-);
-const entries = metadata.cli.commands;
-const expected = buildFiles(entries, metadata);
-
-if (check) {
-  const changed = [
-    ...await checkGeneratedTree(contentRoot, expected.content, 'content'),
-    ...await checkGeneratedTree(dataRoot, expected.data, 'generated'),
-  ];
-  if (changed.length > 0) {
-    console.error('Generated CLI reference is stale. Run pnpm generate:cli-reference.');
-    for (const name of changed.slice(0, 30)) console.error(`- ${name}`);
-    if (changed.length > 30) console.error(`- …and ${changed.length - 30} more`);
-    process.exitCode = 1;
-  } else {
-    console.log(`CLI reference is current (${entries.length - 1} commands).`);
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  if (!process.env.BAML_DOCS_METADATA_FILE || !process.env.BAML_DOCS_VERSION) {
+    throw new Error('BAML_DOCS_METADATA_FILE and BAML_DOCS_VERSION are required; run pnpm generate:derived');
   }
-} else {
-  await writeGeneratedTree(contentRoot, expected.content);
-  await writeGeneratedTree(dataRoot, expected.data);
-  console.log(`Generated ${entries.length - 1} CLI command pages for BAML ${metadata.version}.`);
+  const metadata = await readDocsMetadata(
+    path.resolve(process.env.BAML_DOCS_METADATA_FILE),
+    process.env.BAML_DOCS_VERSION,
+  );
+  const entries = metadata.cli.commands;
+  const expected = buildCliReferenceFiles(metadata);
+
+  if (check) {
+    const changed = [
+      ...await checkGeneratedTree(contentRoot, expected.content, 'content'),
+      ...await checkGeneratedTree(dataRoot, expected.data, 'generated'),
+    ];
+    if (changed.length > 0) {
+      console.error('Generated CLI reference is stale. Run pnpm generate:cli-reference.');
+      for (const name of changed.slice(0, 30)) console.error(`- ${name}`);
+      if (changed.length > 30) console.error(`- …and ${changed.length - 30} more`);
+      process.exitCode = 1;
+    } else {
+      console.log(`CLI reference is current (${entries.length - 1} commands).`);
+    }
+  } else {
+    await writeGeneratedTree(contentRoot, expected.content);
+    await writeGeneratedTree(dataRoot, expected.data);
+    console.log(`Generated ${entries.length - 1} CLI command pages for BAML ${metadata.version}.`);
+  }
 }

--- a/docs/scripts/prepare-generated-docs.mjs
+++ b/docs/scripts/prepare-generated-docs.mjs
@@ -7,16 +7,18 @@ import { readDocsMetadata, validateDocsMetadata } from './docs-metadata.mjs';
 import {
   DEFAULT_MANIFEST_BASE_URL,
   channelManifestUrl,
+  docsVersionsIndexUrl,
   previewFallbackAllowed,
   unavailableReferencePage,
   validateChannelManifest,
+  validateDocsVersionsIndex,
   versionMetadataUrl,
 } from './docs-metadata-source.mjs';
-import { run, writeGeneratedTree } from './generated-content.mjs';
+import { writeGeneratedTree } from './generated-content.mjs';
+import { buildVersionedReferences, versionDirectory } from './versioned-reference.mjs';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const repositoryRoot = path.resolve(packageRoot, '..');
-const metadataCache = path.join(packageRoot, 'generated', 'docs-metadata.json');
+const generatedRoot = path.join(packageRoot, 'generated');
 
 class HttpStatusError extends Error {
   constructor(url, status, statusText) {
@@ -45,10 +47,93 @@ function metadataUnavailable(error) {
   return error instanceof HttpStatusError || error?.name === 'TypeError' || error?.name === 'TimeoutError';
 }
 
+function list(value) {
+  return (value ?? '').split(',').map((entry) => entry.trim()).filter(Boolean);
+}
+
+function selections(environment) {
+  const selected = [];
+  const singleFile = environment.BAML_DOCS_METADATA_FILE;
+  const singleUrl = environment.BAML_DOCS_METADATA_URL;
+  const singleVersion = environment.BAML_DOCS_VERSION;
+  const files = [...(singleFile ? [singleFile] : []), ...list(environment.BAML_DOCS_METADATA_FILES)];
+  const urls = [...(singleUrl ? [singleUrl] : []), ...list(environment.BAML_DOCS_METADATA_URLS)];
+  const versions = list(environment.BAML_DOCS_VERSIONS);
+  const channels = list(environment.BAML_DOCS_CHANNELS);
+
+  if (files.length > 0) {
+    files.forEach((file, index) => selected.push({
+      type: 'file',
+      value: file,
+      expectedVersion: files.length === 1 && index === 0 ? singleVersion : undefined,
+      explicit: true,
+    }));
+  } else if (urls.length > 0) {
+    urls.forEach((url, index) => selected.push({
+      type: 'url',
+      value: url,
+      expectedVersion: urls.length === 1 && index === 0 ? singleVersion : undefined,
+      explicit: true,
+    }));
+  }
+
+  const requestedVersions = versions.length > 0
+    ? versions
+    : files.length === 0 && urls.length === 0 && singleVersion ? [singleVersion] : [];
+  requestedVersions.forEach((version) => selected.push({ type: 'version', value: version, explicit: true }));
+  channels.forEach((channel) => selected.push({ type: 'channel', value: channel, explicit: true }));
+
+  if (selected.length === 0) {
+    selected.push({ type: 'index', value: docsVersionsIndexUrl(environment.BAML_DOCS_MANIFEST_BASE_URL ?? DEFAULT_MANIFEST_BASE_URL), explicit: false });
+  }
+  return selected;
+}
+
 async function cacheMetadata(metadata) {
-  await mkdir(path.dirname(metadataCache), { recursive: true });
-  await writeFile(metadataCache, `${JSON.stringify(metadata, null, 2)}\n`);
-  return metadataCache;
+  const file = path.join(generatedRoot, 'metadata', versionDirectory(metadata.version), 'stdlib.json');
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
+async function loadSelection(selection, manifestBaseUrl, environment) {
+  if (selection.type === 'file') {
+    const metadata = await readDocsMetadata(
+      path.resolve(selection.value),
+      selection.expectedVersion,
+      environment.BAML_DOCS_CHANNEL,
+    );
+    return { metadata, url: path.resolve(selection.value) };
+  }
+
+  if (selection.type === 'url') {
+    const metadata = validateDocsMetadata(
+      await fetchJson(selection.value),
+      selection.expectedVersion,
+      environment.BAML_DOCS_CHANNEL,
+    );
+    return { metadata, url: selection.value };
+  }
+
+  if (selection.type === 'version') {
+    const url = versionMetadataUrl(manifestBaseUrl, selection.value);
+    const metadata = validateDocsMetadata(await fetchJson(url), selection.value);
+    return { metadata, url };
+  }
+
+  if (selection.type === 'indexed') {
+    const url = `${manifestBaseUrl}/docs/${selection.path}`;
+    const metadata = validateDocsMetadata(await fetchJson(url), selection.value, selection.channel);
+    if (metadata.payloadSha256 !== selection.payloadSha256) {
+      throw new Error(`Docs versions index checksum for BAML ${selection.value} does not match its immutable artifact`);
+    }
+    return { metadata, url };
+  }
+
+  const manifestUrl = channelManifestUrl(manifestBaseUrl, selection.value);
+  const version = validateChannelManifest(await fetchJson(manifestUrl), selection.value);
+  const url = versionMetadataUrl(manifestBaseUrl, version);
+  const metadata = validateDocsMetadata(await fetchJson(url), version, selection.value);
+  return { metadata, url };
 }
 
 async function writeUnavailableReferences({ channel, url, version }) {
@@ -74,70 +159,94 @@ async function writeUnavailableReferences({ channel, url, version }) {
         ['meta.json', `${JSON.stringify({ title: 'Commands', pages: ['index'] }, null, 2)}\n`],
       ]),
     ),
-    writeGeneratedTree(
-      path.join(packageRoot, 'generated', 'baml'),
-      new Map([['manifest.json', `${JSON.stringify(provenance, null, 2)}\n`]]),
-    ),
-    writeGeneratedTree(
-      path.join(packageRoot, 'generated', 'cli'),
-      new Map([['manifest.json', `${JSON.stringify(provenance, null, 2)}\n`]]),
-    ),
+    writeGeneratedTree(path.join(generatedRoot, 'baml'), new Map([['manifest.json', `${JSON.stringify(provenance, null, 2)}\n`]])),
+    writeGeneratedTree(path.join(generatedRoot, 'cli'), new Map([['manifest.json', `${JSON.stringify(provenance, null, 2)}\n`]])),
+    writeFile(path.join(generatedRoot, 'docs-versions.json'), `${JSON.stringify({ schemaVersion: 1, defaultVersion: null, versions: [] }, null, 2)}\n`),
   ]);
   console.warn(`Rendered preview placeholders because ${url} could not be loaded.`);
 }
 
-const explicitFile = process.env.BAML_DOCS_METADATA_FILE;
-const explicitUrl = process.env.BAML_DOCS_METADATA_URL;
-const explicitVersion = process.env.BAML_DOCS_VERSION;
-const explicitSelection = Boolean(explicitFile || explicitUrl || explicitVersion);
-const manifestBaseUrl = (process.env.BAML_DOCS_MANIFEST_BASE_URL ?? DEFAULT_MANIFEST_BASE_URL).replace(/\/$/, '');
-const channel = process.env.BAML_DOCS_CHANNEL ?? 'canary';
-const expectedChannel = process.env.BAML_DOCS_CHANNEL ?? (explicitSelection ? undefined : channel);
+const environment = process.env;
+const manifestBaseUrl = (environment.BAML_DOCS_MANIFEST_BASE_URL ?? DEFAULT_MANIFEST_BASE_URL).replace(/\/$/, '');
+let requested = selections(environment);
+const loaded = [];
 
-let version = explicitVersion;
-let metadataFile;
-let metadataUrl = explicitUrl;
-
-if (explicitFile) {
-  metadataFile = path.resolve(explicitFile);
-  const metadata = await readDocsMetadata(metadataFile, version, expectedChannel);
-  version = metadata.version;
-} else {
+let indexedDefaultVersion;
+if (requested.length === 1 && requested[0].type === 'index') {
   try {
-    if (!version && !metadataUrl) {
-      metadataUrl = channelManifestUrl(manifestBaseUrl, channel);
-      const releaseManifest = await fetchJson(metadataUrl);
-      version = validateChannelManifest(releaseManifest, channel);
-      metadataUrl = versionMetadataUrl(manifestBaseUrl, version);
-    } else {
-      metadataUrl ??= versionMetadataUrl(manifestBaseUrl, version);
-    }
-    const metadata = validateDocsMetadata(await fetchJson(metadataUrl), version, expectedChannel);
-    version = metadata.version;
-    metadataFile = await cacheMetadata(metadata);
+    const index = validateDocsVersionsIndex(await fetchJson(requested[0].value));
+    indexedDefaultVersion = index.defaultVersion;
+    requested = index.versions.map((entry) => ({
+      type: 'indexed',
+      value: entry.version,
+      channel: entry.channel,
+      path: entry.artifacts.stdlib.path,
+      payloadSha256: entry.artifacts.stdlib.payloadSha256,
+      explicit: false,
+    }));
   } catch (error) {
-    if (!metadataUnavailable(error) || !previewFallbackAllowed({
+    const fallback = metadataUnavailable(error) && previewFallbackAllowed({
       args: process.argv.slice(2),
-      environment: process.env,
-      explicitSelection,
-    })) {
-      throw error;
-    }
-    await writeUnavailableReferences({ channel, url: metadataUrl, version });
+      environment,
+      explicitSelection: false,
+    });
+    if (!fallback) throw error;
+    await mkdir(generatedRoot, { recursive: true });
+    await writeUnavailableReferences({
+      channel: environment.BAML_DOCS_CHANNEL ?? 'canary',
+      url: requested[0].value,
+      version: undefined,
+    });
     process.exit(0);
   }
 }
 
-const environment = {
-  ...process.env,
-  BAML_DOCS_METADATA_FILE: metadataFile,
-  BAML_DOCS_VERSION: version,
-};
-for (const generator of ['generate-baml-reference.mjs', 'generate-cli-reference.mjs']) {
-  run(process.execPath, [path.join(packageRoot, 'scripts', generator)], {
-    cwd: repositoryRoot,
-    env: environment,
-    stdio: 'inherit',
-  });
+for (const selection of requested) {
+  try {
+    loaded.push(await loadSelection(selection, manifestBaseUrl, environment));
+  } catch (error) {
+    const fallback = !selection.explicit && metadataUnavailable(error) && previewFallbackAllowed({
+      args: process.argv.slice(2),
+      environment,
+      explicitSelection: false,
+    });
+    if (!fallback) throw error;
+    const channel = selection.type === 'channel'
+      ? selection.value
+      : selection.channel ?? environment.BAML_DOCS_CHANNEL ?? 'canary';
+    const version = ['version', 'indexed'].includes(selection.type) ? selection.value : undefined;
+    const url = selection.type === 'indexed'
+      ? `${manifestBaseUrl}/docs/${selection.path}`
+      : version ? versionMetadataUrl(manifestBaseUrl, version) : channelManifestUrl(manifestBaseUrl, channel);
+    await mkdir(generatedRoot, { recursive: true });
+    await writeUnavailableReferences({ channel, url, version });
+    process.exit(0);
+  }
 }
-console.log(`Rendered all derived references from immutable metadata for BAML ${version}.`);
+
+const byVersion = new Map();
+for (const entry of loaded) {
+  const previous = byVersion.get(entry.metadata.version);
+  if (previous && previous.payloadSha256 !== entry.metadata.payloadSha256) {
+    throw new Error(`BAML ${entry.metadata.version} was selected with conflicting metadata payloads`);
+  }
+  byVersion.set(entry.metadata.version, entry.metadata);
+}
+const metadataEntries = [...byVersion.values()];
+const defaultVersion = environment.BAML_DOCS_DEFAULT_VERSION
+  ?? environment.BAML_DOCS_VERSION
+  ?? indexedDefaultVersion
+  ?? metadataEntries[0]?.version;
+if (!defaultVersion) throw new Error('No BAML docs metadata versions were loaded');
+
+for (const metadata of metadataEntries) await cacheMetadata(metadata);
+const generated = buildVersionedReferences(metadataEntries, defaultVersion);
+await Promise.all([
+  writeGeneratedTree(path.join(packageRoot, 'content', 'baml', 'language', 'reference'), generated.bamlContent),
+  writeGeneratedTree(path.join(packageRoot, 'content', 'cli', 'commands'), generated.cliContent),
+  writeGeneratedTree(path.join(generatedRoot, 'baml'), generated.bamlData),
+  writeGeneratedTree(path.join(generatedRoot, 'cli'), generated.cliData),
+  writeFile(path.join(generatedRoot, 'docs-versions.json'), `${JSON.stringify(generated.catalog, null, 2)}\n`),
+]);
+
+console.log(`Rendered ${metadataEntries.length} immutable BAML docs version${metadataEntries.length === 1 ? '' : 's'} (${metadataEntries.map((entry) => entry.version).join(', ')}); default is ${defaultVersion}.`);

--- a/docs/scripts/versioned-reference.mjs
+++ b/docs/scripts/versioned-reference.mjs
@@ -1,0 +1,69 @@
+import path from 'node:path';
+import { buildBamlReferenceFiles } from './generate-baml-reference.mjs';
+import { buildCliReferenceFiles } from './generate-cli-reference.mjs';
+
+export function versionDirectory(version) {
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Cannot generate routes for invalid BAML version ${JSON.stringify(version)}`);
+  }
+  return `v${version}`;
+}
+
+function addFiles(target, files, prefix = '') {
+  for (const [name, contents] of files) {
+    const output = prefix ? path.posix.join(prefix, name) : name;
+    if (target.has(output)) throw new Error(`Duplicate generated file: ${output}`);
+    target.set(output, contents);
+  }
+}
+
+export function buildVersionedReferences(metadataEntries, defaultVersion) {
+  const ordered = [...metadataEntries].sort((left, right) => (
+    left.version === defaultVersion ? -1 : right.version === defaultVersion ? 1 : right.version.localeCompare(left.version)
+  ));
+  if (!ordered.some((entry) => entry.version === defaultVersion)) {
+    throw new Error(`Default BAML docs version ${defaultVersion} was not loaded`);
+  }
+
+  const bamlContent = new Map();
+  const bamlData = new Map();
+  const cliContent = new Map();
+  const cliData = new Map();
+  const catalog = [];
+
+  for (const metadata of ordered) {
+    const directory = versionDirectory(metadata.version);
+    const baml = buildBamlReferenceFiles(metadata);
+    const cli = buildCliReferenceFiles(metadata);
+    addFiles(bamlContent, baml.content, directory);
+    addFiles(bamlData, baml.data, path.posix.join('versions', directory));
+    addFiles(cliContent, cli.content, directory);
+    addFiles(cliData, cli.data, path.posix.join('versions', directory));
+
+    if (metadata.version === defaultVersion) {
+      addFiles(bamlContent, baml.content);
+      addFiles(bamlData, baml.data);
+      addFiles(cliContent, cli.content);
+      addFiles(cliData, cli.data);
+    }
+
+    catalog.push({
+      version: metadata.version,
+      channel: metadata.channel,
+      releasedAt: metadata.releasedAt,
+      sourceRevision: metadata.sourceRevision,
+    });
+  }
+
+  return {
+    bamlContent,
+    bamlData,
+    cliContent,
+    cliData,
+    catalog: {
+      schemaVersion: 1,
+      defaultVersion,
+      versions: catalog,
+    },
+  };
+}

--- a/docs/tests/docs-metadata.test.mjs
+++ b/docs/tests/docs-metadata.test.mjs
@@ -9,12 +9,15 @@ import {
 } from '../scripts/docs-metadata.mjs';
 import {
   channelManifestUrl,
+  docsVersionsIndexUrl,
   previewFallbackAllowed,
   unavailableReferencePage,
   validateChannelManifest,
+  validateDocsVersionsIndex,
   versionMetadataUrl,
 } from '../scripts/docs-metadata-source.mjs';
 import { buildBamlReferenceFiles } from '../scripts/generate-baml-reference.mjs';
+import { buildVersionedReferences, versionDirectory } from '../scripts/versioned-reference.mjs';
 
 function metadata() {
   const emptySignature = () => ({
@@ -192,11 +195,69 @@ test('renders every package with fully qualified symbol UI', () => {
   );
 });
 
+test('renders multiple immutable toolchains alongside a default-version alias', () => {
+  const current = metadata();
+  const previous = metadata();
+  previous.version = '1.2.2';
+  previous.channel = 'stable';
+  previous.sourceRevision = 'b'.repeat(40);
+  previous.releasedAt = '2026-08-01T00:00:00.000Z';
+  previous.toolchain = 'baml-cli 1.2.2';
+  previous.payloadSha256 = sha256Json(docsMetadataChecksumPayload(previous));
+
+  const rendered = buildVersionedReferences([previous, current], current.version);
+  assert.equal(versionDirectory(current.version), `v${current.version}`);
+  assert.equal(rendered.catalog.defaultVersion, current.version);
+  assert.deepEqual(rendered.catalog.versions.map((entry) => entry.version), [current.version, previous.version]);
+  assert.equal(
+    rendered.bamlContent.get('baml/classes/http/Request.md'),
+    rendered.bamlContent.get(`v${current.version}/baml/classes/http/Request.md`),
+  );
+  assert.match(rendered.bamlContent.get(`v${previous.version}/index.md`), /BAML 1\.2\.2/);
+  assert.match(rendered.cliContent.get(`v${previous.version}/check.md`), /BAML version: `1\.2\.2`/);
+  assert.ok(rendered.bamlData.has(`versions/v${previous.version}/manifest.json`));
+  assert.ok(rendered.cliData.has(`versions/v${current.version}/manifest.json`));
+});
+
 test('resolves a mutable channel only to its exact immutable metadata URL', () => {
   const base = 'https://pkg.boundaryml.com/manifest/v1/';
   const version = validateChannelManifest({ schema: 1, channel: 'canary', version: '1.2.3' }, 'canary');
   assert.equal(channelManifestUrl(base, 'canary'), `${base}canary.json`);
   assert.equal(versionMetadataUrl(base, version), `${base}docs/v1.2.3/stdlib.json`);
+});
+
+test('validates the curated multi-version discovery index', () => {
+  const indexEntry = (version, channel, source = 'a') => ({
+    version,
+    channel,
+    releasedAt: '2026-08-31T00:00:00.000Z',
+    sourceRevision: source.repeat(40),
+    artifacts: { stdlib: { path: `v${version}/stdlib.json`, payloadSha256: source.repeat(64) } },
+  });
+  const index = {
+    schema: 1,
+    defaultVersion: '1.2.3',
+    aliases: { canary: '1.2.3', stable: '1.2.2' },
+    versions: [
+      indexEntry('1.2.3', 'canary'),
+      indexEntry('1.2.2', 'stable', 'b'),
+    ],
+  };
+  assert.equal(validateDocsVersionsIndex(index), index);
+  assert.equal(docsVersionsIndexUrl('https://pkg.boundaryml.com/manifest/v1/'), 'https://pkg.boundaryml.com/manifest/v1/docs/versions.json');
+
+  const duplicate = structuredClone(index);
+  duplicate.versions[1].version = '1.2.3';
+  duplicate.versions[1].artifacts.stdlib.path = 'v1.2.3/stdlib.json';
+  assert.throws(() => validateDocsVersionsIndex(duplicate), /duplicate version 1\.2\.3/);
+
+  const unsafe = structuredClone(index);
+  unsafe.versions[0].artifacts.stdlib.path = '../stdlib.json';
+  assert.throws(() => validateDocsVersionsIndex(unsafe), /invalid stdlib artifact path/);
+
+  const unknownAlias = structuredClone(index);
+  unknownAlias.aliases.nightly = '1.2.1';
+  assert.throws(() => validateDocsVersionsIndex(unknownAlias), /points to unknown version 1\.2\.1/);
 });
 
 test('unavailable references are allowed only for implicit previews or explicit local development', () => {


### PR DESCRIPTION
## Outcome

The docs build can now consume several immutable BAML toolchain artifacts at once instead of selecting exactly one version.

For readers, generated references have exact versioned routes such as:

- `/baml/language/reference/v0.18.0/baml/classes/http/Request`
- `/cli/commands/v0.18.0/check`

Existing unversioned routes remain default-version aliases, and generated pages expose a version selector that preserves the current symbol or command when it exists in the selected toolchain.

For releases, channel promotion updates a bounded discovery index at `pkg.boundaryml.com/manifest/v1/docs/versions.json`. The index points at immutable `docs/v<version>/stdlib.json` artifacts, integrity-binds their payload checksums, keeps five recent versions plus live channel aliases, and triggers the docs rebuild only after release verification succeeds. Vercel remains a TypeScript-only consumer.

## Inputs

- Default: every version in the curated discovery index
- Explicit versions: `BAML_DOCS_VERSIONS`
- Explicit URLs: `BAML_DOCS_METADATA_URLS`
- Local/CI artifacts: `BAML_DOCS_METADATA_FILES`
- Default alias: `BAML_DOCS_DEFAULT_VERSION`
- Singular environment variables remain backward compatible

## Review map

- Multi-version orchestration: `docs/scripts/prepare-generated-docs.mjs`
- Pure combined renderer: `docs/scripts/versioned-reference.mjs`
- Discovery contract: `docs/scripts/docs-metadata-source.mjs`
- Release index publication: `.github/workflows/release-baml-language.yml`
- Reader selector: `docs/components/version-switcher.tsx`

## Validation

- 30 docs tests pass, including two simultaneous toolchains and discovery-index rejection cases
- TypeScript and actionlint pass
- Production build passes with 2,974 generated routes
- Exact-version route verified in the browser

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
