### PR TITLE
Scale versioned docs builds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,11 @@ in the set. Each release JSON contains all toolchain-discovered packages—not a
 docs-maintained list—and generated symbols use fully qualified names such as
 `baml.http.Request`.
 
+The build eagerly renders authored pages, the default-version aliases, and each
+version landing page. Versioned symbol and command pages remain normal public
+routes, but render on their first request instead of multiplying release build
+work by the number of retained toolchains.
+
 To exercise the complete producer/consumer path locally:
 
 ```sh

--- a/docs/app/(docs)/[...slug]/page.tsx
+++ b/docs/app/(docs)/[...slug]/page.tsx
@@ -2,6 +2,7 @@ import { getMDXComponents } from '@/components/mdx';
 import { VersionSwitcher } from '@/components/version-switcher';
 import docsVersions from '@/generated/docs-versions.json';
 import { source } from '@/lib/source';
+import { createDocsPrerenderPredicate } from '@/lib/static-generation.mjs';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import {
@@ -21,6 +22,10 @@ const versionedRoots = [
   ['baml', 'language', 'reference'],
   ['cli', 'commands'],
 ] as const;
+
+const shouldPreRenderDocsSlug = createDocsPrerenderPredicate(
+  versionCatalog.versions.map(({ version }) => version),
+);
 
 function versionSwitcher(slug: string[]) {
   const root = versionedRoots.find((candidate) => candidate.every((segment, index) => slug[index] === segment));
@@ -71,8 +76,10 @@ export default async function Page(props: PageProps<'/[...slug]'>) {
 }
 
 export function generateStaticParams() {
-  return source.generateParams();
+  return source.generateParams().filter(({ slug }) => shouldPreRenderDocsSlug(slug));
 }
+
+export const dynamicParams = true;
 
 export async function generateMetadata(
   props: PageProps<'/[...slug]'>,

--- a/docs/lib/static-generation.mjs
+++ b/docs/lib/static-generation.mjs
@@ -1,0 +1,31 @@
+const versionedReferenceRoots = [
+  ['baml', 'language', 'reference'],
+  ['cli', 'commands'],
+];
+
+function matchesRoot(slug, root) {
+  return root.every((segment, index) => slug[index] === segment);
+}
+
+/**
+ * Version landing pages are cheap and useful to pre-render, but eagerly rendering
+ * every symbol and command once per toolchain makes release builds grow linearly.
+ * Omitted paths remain available through Next.js dynamic params and are cached
+ * after their first request.
+ *
+ * @param {string[]} versions
+ */
+export function createDocsPrerenderPredicate(versions) {
+  const versionSegments = new Set(versions.map((version) => `v${version}`));
+
+  /** @param {string[]} slug */
+  return function shouldPreRenderDocsSlug(slug) {
+    const root = versionedReferenceRoots.find((candidate) => matchesRoot(slug, candidate));
+    if (!root) return true;
+
+    const versionSegment = slug[root.length];
+    if (!versionSegments.has(versionSegment)) return true;
+
+    return slug.length === root.length + 1;
+  };
+}

--- a/docs/tests/static-generation.test.mjs
+++ b/docs/tests/static-generation.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createDocsPrerenderPredicate } from '../lib/static-generation.mjs';
+
+const shouldPreRenderDocsSlug = createDocsPrerenderPredicate(['0.18.0', '0.17.2']);
+
+test('pre-renders authored and default-version reference pages', () => {
+  assert.equal(shouldPreRenderDocsSlug(['baml', 'book', 'prompt-engineering']), true);
+  assert.equal(
+    shouldPreRenderDocsSlug(['baml', 'language', 'reference', 'baml', 'classes', 'http', 'Request']),
+    true,
+  );
+  assert.equal(shouldPreRenderDocsSlug(['cli', 'commands', 'auth', 'login']), true);
+});
+
+test('pre-renders each version landing without multiplying symbol pages', () => {
+  assert.equal(shouldPreRenderDocsSlug(['baml', 'language', 'reference', 'v0.18.0']), true);
+  assert.equal(shouldPreRenderDocsSlug(['cli', 'commands', 'v0.18.0']), true);
+
+  assert.equal(
+    shouldPreRenderDocsSlug([
+      'baml',
+      'language',
+      'reference',
+      'v0.18.0',
+      'baml',
+      'classes',
+      'http',
+      'Request',
+    ]),
+    false,
+  );
+  assert.equal(shouldPreRenderDocsSlug(['cli', 'commands', 'v0.18.0', 'auth', 'login']), false);
+});
+
+test('only treats versions from the release catalog as versioned routes', () => {
+  assert.equal(
+    shouldPreRenderDocsSlug(['baml', 'language', 'reference', 'vercel', 'classes', 'AiGatewayClient']),
+    true,
+  );
+  assert.equal(
+    shouldPreRenderDocsSlug(['baml', 'language', 'reference', 'v0.19.0', 'baml', 'classes', 'Array']),
+    true,
+  );
+});


### PR DESCRIPTION
## Why

The multi-version layer makes every retained toolchain available at a stable URL, but eagerly pre-rendering every versioned symbol and command makes deployment work grow linearly with the catalog. With one toolchain selected, the portal emitted 2,972 HTML pages because the default alias and `v0.18.0` tree were both rendered in full.

## Reader-visible behavior

All routes remain available. For example:

```text
/baml/language/reference/v0.18.0/baml/classes/http/Request
/cli/commands/v0.18.0/auth/login
```

Authored pages, default-version aliases, and each version landing page are still generated during deployment. Versioned symbol and command pages are rendered on their first request and then retained in the shared cache. The version selector and fully qualified symbol names are unchanged.

## Build impact

For the same one-version source tree in CI:

- Before: 2,974 generated routes; static generation took 100 seconds.
- After: 1,499 generated routes; static generation took 59 seconds.
- Complete source-build/metadata/runtime/docs job: 7m02s before, 6m14s after.
- Local production build: 45.57 seconds.
- A non-prerendered `baml.http.Request` page returned `200`, then reported `x-nextjs-cache: HIT` and `Cache-Control: s-maxage=31536000`.

The pre-render classifier uses versions from the validated release catalog, so an ordinary package path such as `vercel/classes/...` is never mistaken for a toolchain version.

## Verification

- `pnpm --filter @baml/developer-docs test` — 33 tests passed.
- Fumadocs generation, Next route type generation, and `tsc --noEmit` passed.
- `pnpm --filter @baml/developer-docs exec next build` passed.
- Production-server requests passed for non-prerendered BAML and CLI version routes.

This PR is stacked on #4664.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
