### PR TITLE
Enforce WASM runner delivery budgets

### DIFF
--- a/docs/architecture/wasm-runner.md
+++ b/docs/architecture/wasm-runner.md
@@ -44,6 +44,11 @@ The provisional regression budgets are 5 MB gzip, 250 ms initialization, 5 s
 first project readiness, and 100 ms for a repeat zero-network run. Browser p50
 and p95 gates must replace the local numbers before launch.
 
+CI recomputes the gzip size of the exact checked-in artifact and enforces the
+5 MB download budget. The deployment explicitly serves content-addressed
+runtime files with a one-year immutable cache lifetime, while the mutable
+manifest and worker entrypoint revalidate on every navigation.
+
 ## Protocol finding
 
 The book's BAML 0.17 driver expected a successful result to contain a

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -6,6 +6,37 @@ const withMDX = createMDX();
 const config = {
   agentRules: false,
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: '/baml-runtime/artifacts/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/baml-runtime/manifest.json',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
+          },
+        ],
+      },
+      {
+        source: '/baml-runtime/runner-worker.mjs',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, must-revalidate',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default withMDX(config);

--- a/docs/scripts/check-runner-artifact.mjs
+++ b/docs/scripts/check-runner-artifact.mjs
@@ -2,9 +2,11 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const publicRoot = path.join(packageRoot, 'public');
+const maxGzipBytes = 5_000_000;
 const manifest = JSON.parse(
   await readFile(path.join(publicRoot, 'baml-runtime/manifest.json'), 'utf8'),
 );
@@ -22,6 +24,9 @@ function digest(bytes) {
 
 const wasm = await readFile(filePath(manifest.wasm));
 const module = await readFile(filePath(manifest.module));
+if (manifest.schemaVersion !== 1) {
+  throw new Error(`unsupported runtime manifest schema: ${manifest.schemaVersion}`);
+}
 if (wasm.length !== manifest.rawBytes) {
   throw new Error(`runtime has ${wasm.length} bytes; manifest records ${manifest.rawBytes}`);
 }
@@ -31,13 +36,42 @@ if (digest(wasm) !== manifest.sha256) {
 if (digest(module) !== manifest.moduleSha256) {
   throw new Error('runtime JavaScript digest does not match the manifest');
 }
+const gzipBytes = gzipSync(wasm, { level: 9 }).length;
+if (gzipBytes !== manifest.gzipBytes) {
+  throw new Error(`runtime gzip size is ${gzipBytes} bytes; manifest records ${manifest.gzipBytes}`);
+}
+if (gzipBytes > maxGzipBytes) {
+  throw new Error(`runtime gzip size is ${gzipBytes} bytes; budget is ${maxGzipBytes}`);
+}
+if (!Number.isSafeInteger(manifest.brotliBytes) || manifest.brotliBytes <= 0) {
+  throw new Error(`invalid runtime Brotli size: ${manifest.brotliBytes}`);
+}
 if (!/^\d+\.\d+\.\d+/.test(manifest.runtimeVersion)) {
   throw new Error(`invalid runtime version: ${manifest.runtimeVersion}`);
 }
 if (!/^[0-9a-f]{40}$/.test(manifest.sourceCommit)) {
   throw new Error(`invalid source commit: ${manifest.sourceCommit}`);
 }
+if (!/^[0-9a-f]{7,40}$/.test(manifest.runtimeCommit)) {
+  throw new Error(`invalid runtime commit: ${manifest.runtimeCommit}`);
+}
+if (!manifest.sourceCommit.startsWith(manifest.runtimeCommit)) {
+  throw new Error('runtime commit does not match the source commit');
+}
+if (manifest.toolchain !== `baml-cli ${manifest.runtimeVersion}`) {
+  throw new Error(
+    `runtime ${manifest.runtimeVersion} does not match toolchain ${manifest.toolchain}`,
+  );
+}
+
+const artifactRoot = `/baml-runtime/artifacts/${manifest.sha256.slice(0, 16)}`;
+if (manifest.module !== `${artifactRoot}/bridge_wasm.js`) {
+  throw new Error(`runtime module is not stored under its content digest: ${manifest.module}`);
+}
+if (manifest.wasm !== `${artifactRoot}/bridge_wasm_bg.wasm`) {
+  throw new Error(`runtime WASM is not stored under its content digest: ${manifest.wasm}`);
+}
 
 console.log(
-  `ok — runtime ${manifest.runtimeVersion} @ ${manifest.runtimeCommit} (${manifest.rawBytes} bytes)`,
+  `ok — runtime ${manifest.runtimeVersion} @ ${manifest.runtimeCommit} (${manifest.rawBytes} raw, ${gzipBytes} gzip)`,
 );

--- a/docs/tests/runner-delivery.test.mjs
+++ b/docs/tests/runner-delivery.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import nextConfig from '../next.config.mjs';
+
+async function cacheHeaders() {
+  assert.equal(typeof nextConfig.headers, 'function');
+  const rules = await nextConfig.headers();
+  return Object.fromEntries(
+    rules.map((rule) => [
+      rule.source,
+      Object.fromEntries(rule.headers.map(({ key, value }) => [key.toLowerCase(), value])),
+    ]),
+  );
+}
+
+test('serves content-addressed runtime artifacts with immutable caching', async () => {
+  const headers = await cacheHeaders();
+  assert.equal(
+    headers['/baml-runtime/artifacts/:path*']['cache-control'],
+    'public, max-age=31536000, immutable',
+  );
+});
+
+test('revalidates mutable runtime entrypoints', async () => {
+  const headers = await cacheHeaders();
+  assert.equal(
+    headers['/baml-runtime/manifest.json']['cache-control'],
+    'public, max-age=0, must-revalidate',
+  );
+  assert.equal(
+    headers['/baml-runtime/runner-worker.mjs']['cache-control'],
+    'public, max-age=0, must-revalidate',
+  );
+});


### PR DESCRIPTION
## Why

The runner architecture promised lazy loading, worker isolation, content-addressed delivery, and a provisional 5 MB gzip budget. The runtime already met the first three code-level requirements, but the deployment served its 17.9 MB content-addressed WASM with `max-age=0`, and CI did not enforce the documented compressed-size or version-synchronization contracts.

## Reader-visible behavior

The first nearby runnable example still initializes the version-pinned runtime in an isolated Web Worker. After that first download, the browser can retain the immutable runtime module and WASM for one year instead of revalidating them on every visit.

The mutable entrypoints remain safe to update:

```text
/baml-runtime/manifest.json       revalidate
/baml-runtime/runner-worker.mjs   revalidate
/baml-runtime/artifacts/<sha>/…   cache for one year, immutable
```

## Release protection

The existing runner artifact check now fails when:

- the exact WASM exceeds 5,000,000 gzip bytes;
- its recorded raw/gzip size or SHA-256 no longer matches;
- the module and WASM are not stored under the WASM digest;
- the runtime commit does not match the source commit; or
- the runtime version does not match the source-built `baml-cli` toolchain.

Current measured payload:

- Raw WASM: 17,856,276 bytes.
- gzip level 9: 4,606,951 bytes.
- Brotli quality 11: 2,954,759 bytes.

## Verification

- `pnpm --filter @baml/developer-docs check:runner-artifact` passed against the checked-in runtime and generated worker.
- `pnpm --filter @baml/developer-docs test` — 35 tests passed.
- Fumadocs generation, Next route types, and `tsc --noEmit` passed.
- The production Next build passed.
- A production server returned `must-revalidate` for the manifest/worker, `max-age=31536000, immutable` for both content-addressed artifacts, and `application/wasm` for the WASM response.

Browser p50/p95 gates remain separate launch work; this PR enforces the existing artifact and delivery budgets without pretending local timings are browser benchmarks.

This PR is stacked on #4665.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
