### PR TITLE
Automate BAML book review bundles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,21 @@ that merely exist in the `baml-book` working tree are not publishable input.
 The source checkout must be clean and at the revision pinned by the manifest,
 which also pins every included listing and quiz.
 
+Prepare a deterministic editorial bundle from a clean checkout at that pinned
+revision before approving anything:
+
+```sh
+pnpm --filter @baml/developer-docs review:book -- \
+  --source /path/to/clean/baml-book \
+  --output /tmp/baml-book-review
+```
+
+The bundle discovers the ordered chapters from `src/SUMMARY.md`, verifies that
+every include, listing, runnable project, and quiz converts to valid MDX, and
+records exact source and converted hashes. Its Markdown summary and converted
+pages are review aids only: every candidate is explicitly unapproved until a
+human copies its approval entry into `book-import.json` after auditing it.
+
 Import approved chapters from a local checkout:
 
 ```sh

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "generate:reference": "node scripts/generate-baml-reference.mjs",
     "prepare:content": "pnpm run generate:derived && pnpm run generate:book",
     "produce:docs-metadata": "node scripts/produce-docs-metadata.mjs",
+    "review:book": "node scripts/review-baml-book.mjs",
     "runner:artifact": "node scripts/build-runner-artifact.mjs",
     "runner:bundle": "node scripts/build-runner-bundle.mjs",
     "runner:browser": "node scripts/verify-runner-browser.mjs",

--- a/docs/scripts/import-baml-book.mjs
+++ b/docs/scripts/import-baml-book.mjs
@@ -234,7 +234,7 @@ function navigationFor(chapters) {
   };
 }
 
-async function verifySourceCheckout(sourceRoot, revision) {
+export async function verifySourceCheckout(sourceRoot, revision) {
   const [{ stdout: head }, { stdout: status }] = await Promise.all([
     execFileAsync('git', ['-C', sourceRoot, 'rev-parse', 'HEAD']),
     execFileAsync('git', ['-C', sourceRoot, 'status', '--porcelain', '--untracked-files=all']),

--- a/docs/scripts/review-baml-book.mjs
+++ b/docs/scripts/review-baml-book.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { convertChapter, verifySourceCheckout } from './import-baml-book.mjs';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const defaultManifestPath = path.join(packageRoot, 'book-import.json');
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function json(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/^ch\d+(?:-\d+)?-/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function parseSummary(summary) {
+  const entries = [];
+  for (const line of summary.split('\n')) {
+    const match = line.match(/^\s*(?:[-*+]\s+)?\[([^\]]+)]\(([^)]+\.md)(?:#[^)]+)?\)\s*$/);
+    if (!match) continue;
+    const [, title, source] = match;
+    if (path.posix.isAbsolute(source) || source.split('/').includes('..')) {
+      throw new Error(`Book summary entry escapes src/: ${source}`);
+    }
+    const basename = path.posix.basename(source, '.md');
+    const slug = slugify(basename) || slugify(title);
+    if (!slug) throw new Error(`Cannot derive an output route for ${source}`);
+    entries.push({ title, source: path.posix.join('src', source), output: `${slug}.mdx` });
+  }
+  if (entries.length === 0) throw new Error('src/SUMMARY.md contains no Markdown chapters');
+  const duplicate = entries.find((entry, index) => entries.findIndex((candidate) => candidate.output === entry.output) !== index);
+  if (duplicate) throw new Error(`Book summary produces duplicate output: ${duplicate.output}`);
+  return entries;
+}
+
+function sourceStats(raw) {
+  return {
+    lines: raw === '' ? 0 : raw.split('\n').length,
+    words: raw.trim() === '' ? 0 : raw.trim().split(/\s+/).length,
+    includes: [...raw.matchAll(/\{\{#include\s+/g)].length,
+    listings: [...raw.matchAll(/<Listing\b/g)].length,
+    runnableListings: [...raw.matchAll(/<Listing\b[^>]*\brunnable=/g)].length,
+    quizzes: [...raw.matchAll(/\{\{#quiz\s+/g)].length,
+  };
+}
+
+export async function buildReviewBundle({ manifestPath = defaultManifestPath, sourceRoot }) {
+  if (!sourceRoot) throw new Error('Pass --source <clean baml-book checkout>');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  if (manifest.schemaVersion !== 1 || !manifest.source?.repository || !manifest.source?.revision) {
+    throw new Error('book-import.json must contain a versioned source repository and revision');
+  }
+  await verifySourceCheckout(sourceRoot, manifest.source.revision);
+  const summary = await readFile(path.join(sourceRoot, 'src', 'SUMMARY.md'), 'utf8');
+  const chapters = parseSummary(summary);
+  const candidates = [];
+  for (const chapter of chapters) {
+    const raw = await readFile(path.join(sourceRoot, chapter.source), 'utf8');
+    const sourceSha256 = sha256(raw);
+    const approvalEntry = {
+      source: chapter.source,
+      output: chapter.output,
+      status: 'approved',
+      sourceSha256,
+    };
+    const converted = await convertChapter({ chapter: { ...approvalEntry, title: chapter.title }, sourceRoot });
+    candidates.push({
+      title: chapter.title,
+      source: chapter.source,
+      proposedOutput: chapter.output,
+      sourceSha256,
+      convertedSha256: sha256(converted.content),
+      stats: sourceStats(raw),
+      approvalEntry,
+      convertedContent: converted.content,
+    });
+  }
+  return {
+    schemaVersion: 1,
+    disposition: 'candidate-only',
+    source: manifest.source,
+    candidates,
+  };
+}
+
+function reviewMarkdown(bundle) {
+  const lines = [
+    '# BAML book editorial review bundle',
+    '',
+    '> None of these chapters is approved or published. Audit the source and converted MDX before copying an approval entry into `docs/book-import.json`.',
+    '',
+    `Source revision: \`${bundle.source.revision}\``,
+    '',
+  ];
+  for (const candidate of bundle.candidates) {
+    lines.push(
+      `## ${candidate.title}`,
+      '',
+      `- Source: \`${candidate.source}\``,
+      `- Proposed route: \`/baml/book/${candidate.proposedOutput.replace(/\.mdx$/, '')}\``,
+      `- Source SHA-256: \`${candidate.sourceSha256}\``,
+      `- Converted SHA-256: \`${candidate.convertedSha256}\``,
+      `- Scope: ${candidate.stats.words} words, ${candidate.stats.listings} listings (${candidate.stats.runnableListings} runnable), ${candidate.stats.quizzes} quizzes, ${candidate.stats.includes} includes`,
+      '',
+      'Approval entry to use only after editorial sign-off:',
+      '',
+      '```json',
+      JSON.stringify(candidate.approvalEntry, null, 2),
+      '```',
+      '',
+      `Converted preview: [${candidate.proposedOutput}](./converted/${candidate.proposedOutput})`,
+      '',
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export async function writeReviewBundle({ bundle, outputRoot }) {
+  await rm(outputRoot, { recursive: true, force: true });
+  await mkdir(path.join(outputRoot, 'converted'), { recursive: true });
+  for (const candidate of bundle.candidates) {
+    await writeFile(path.join(outputRoot, 'converted', candidate.proposedOutput), candidate.convertedContent);
+  }
+  const serializable = {
+    ...bundle,
+    candidates: bundle.candidates.map(({ convertedContent: _convertedContent, ...candidate }) => candidate),
+  };
+  await writeFile(path.join(outputRoot, 'review.json'), json(serializable));
+  await writeFile(path.join(outputRoot, 'README.md'), reviewMarkdown(bundle));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const sourceIndex = args.indexOf('--source');
+  const outputIndex = args.indexOf('--output');
+  const manifestIndex = args.indexOf('--manifest');
+  if (sourceIndex === -1 || !args[sourceIndex + 1]) throw new Error('Pass --source <clean baml-book checkout>');
+  if (outputIndex === -1 || !args[outputIndex + 1]) throw new Error('Pass --output <review bundle directory>');
+  const bundle = await buildReviewBundle({
+    sourceRoot: path.resolve(args[sourceIndex + 1]),
+    manifestPath: manifestIndex === -1 ? defaultManifestPath : path.resolve(args[manifestIndex + 1]),
+  });
+  const outputRoot = path.resolve(args[outputIndex + 1]);
+  await writeReviewBundle({ bundle, outputRoot });
+  console.log(`Prepared ${bundle.candidates.length} unapproved chapter candidates at ${outputRoot}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/docs/tests/book-review.test.mjs
+++ b/docs/tests/book-review.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { cp, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { buildReviewBundle, parseSummary, writeReviewBundle } from '../scripts/review-baml-book.mjs';
+
+const execFileAsync = promisify(execFile);
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const fixtureRoot = path.join(packageRoot, 'tests', 'fixtures', 'book');
+
+test('parses ordered mdBook chapters and assigns stable routes', () => {
+  assert.deepEqual(parseSummary(`# Book\n\n[Title](title-page.md)\n- [Getting Started](ch01-00-getting-started.md)\n`), [
+    { title: 'Title', source: 'src/title-page.md', output: 'title-page.mdx' },
+    { title: 'Getting Started', source: 'src/ch01-00-getting-started.md', output: 'getting-started.mdx' },
+  ]);
+  assert.throws(() => parseSummary('[Escape](../private.md)'), /escapes src/);
+});
+
+test('produces an unapproved, reproducible review bundle from a clean pinned checkout', async () => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'baml-book-review-'));
+  const sourceRoot = path.join(temporaryRoot, 'book');
+  const outputRoot = path.join(temporaryRoot, 'review');
+  await cp(fixtureRoot, sourceRoot, { recursive: true });
+  await writeFile(path.join(sourceRoot, 'src', 'SUMMARY.md'), '# Book\n\n- [Getting Started](chapter.md)\n');
+  await execFileAsync('git', ['init', '-q'], { cwd: sourceRoot });
+  await execFileAsync('git', ['add', '.'], { cwd: sourceRoot });
+  await execFileAsync('git', ['-c', 'user.name=Docs Test', '-c', 'user.email=docs@example.com', 'commit', '-qm', 'fixture'], { cwd: sourceRoot });
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: sourceRoot });
+  const manifestPath = path.join(temporaryRoot, 'book-import.json');
+  await writeFile(manifestPath, JSON.stringify({
+    schemaVersion: 1,
+    source: { repository: 'https://example.com/baml-book', revision: stdout.trim() },
+    chapters: [],
+  }));
+
+  const bundle = await buildReviewBundle({ manifestPath, sourceRoot });
+  assert.equal(bundle.disposition, 'candidate-only');
+  assert.equal(bundle.candidates.length, 1);
+  assert.equal(bundle.candidates[0].approvalEntry.status, 'approved');
+  assert.equal(bundle.candidates[0].stats.runnableListings, 1);
+  assert.match(bundle.candidates[0].convertedContent, /<BamlRunner files=/);
+  await writeReviewBundle({ bundle, outputRoot });
+
+  const review = await readFile(path.join(outputRoot, 'README.md'), 'utf8');
+  const serialized = JSON.parse(await readFile(path.join(outputRoot, 'review.json'), 'utf8'));
+  assert.match(review, /None of these chapters is approved or published/);
+  assert.match(review, /Approval entry to use only after editorial sign-off/);
+  assert.equal(serialized.candidates[0].convertedContent, undefined);
+  assert.equal(serialized.candidates[0].sourceSha256.length, 64);
+  assert.equal(serialized.candidates[0].convertedSha256.length, 64);
+});
+
+test('refuses a dirty source checkout before preparing candidates', async () => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'baml-book-review-dirty-'));
+  const sourceRoot = path.join(temporaryRoot, 'book');
+  await cp(fixtureRoot, sourceRoot, { recursive: true });
+  await writeFile(path.join(sourceRoot, 'src', 'SUMMARY.md'), '- [Getting Started](chapter.md)\n');
+  await execFileAsync('git', ['init', '-q'], { cwd: sourceRoot });
+  await execFileAsync('git', ['add', '.'], { cwd: sourceRoot });
+  await execFileAsync('git', ['-c', 'user.name=Docs Test', '-c', 'user.email=docs@example.com', 'commit', '-qm', 'fixture'], { cwd: sourceRoot });
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: sourceRoot });
+  const manifestPath = path.join(temporaryRoot, 'book-import.json');
+  await writeFile(manifestPath, JSON.stringify({ schemaVersion: 1, source: { repository: 'x', revision: stdout.trim() }, chapters: [] }));
+  await writeFile(path.join(sourceRoot, 'src', 'chapter.md'), '# Changed after review\n');
+
+  await assert.rejects(buildReviewBundle({ manifestPath, sourceRoot }), /uncommitted files/);
+});


### PR DESCRIPTION
## Outcome

Editors can now turn the pinned `baml-book` revision into a deterministic review bundle without publishing any prose or checking generated pages into the repository.

The bundle:

- discovers chapters in `src/SUMMARY.md` order;
- refuses dirty or incorrectly-versioned source checkouts;
- expands and validates includes, listings, runnable projects, and quizzes;
- emits converted MDX previews plus exact source and output SHA-256 hashes;
- provides manifest snippets that are explicitly labeled for use only after human approval.

## End-user impact

Before, preparing a book chapter for `/baml/book` required manually finding the source, deriving its route and hash, and testing its conversion. Now an editor can run:

```sh
pnpm --filter @baml/developer-docs review:book -- \
  --source /path/to/clean/baml-book \
  --output /tmp/baml-book-review
```

No chapter becomes public until its reviewed entry is deliberately copied into `docs/book-import.json`.

## Verification

- 38 docs tests pass.
- Docs typecheck passes against two local immutable toolchain metadata artifacts.
- The real pinned `baml-book` commit produced four candidates and validated the runnable Getting Started listing and quiz.
