### PR TITLE
Publish versioned docs runtimes

### DIFF
--- a/.github/workflows/build2-web-sdk.reusable.yaml
+++ b/.github/workflows/build2-web-sdk.reusable.yaml
@@ -99,6 +99,25 @@ jobs:
           test "$(jq -r '.[0].name' package-dry-run.json)" = "@boundaryml/baml-bridge-web"
           test "$(jq -r '.[0].version' package-dry-run.json)" = "$plan_version"
 
+      - name: Build frozen developer-docs runtime
+        run: |
+          set -euo pipefail
+          CARGO_PROFILE_RELEASE_OPT_LEVEL=z wasm-pack build \
+            baml_language/crates/bridge_wasm \
+            --target web \
+            --release \
+            --out-dir "$RUNNER_TEMP/docs-runner-dist" \
+            --out-name bridge_wasm
+
+      - name: Upload developer-docs runtime
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-runner-dist
+          path: |
+            ${{ runner.temp }}/docs-runner-dist/bridge_wasm.js
+            ${{ runner.temp }}/docs-runner-dist/bridge_wasm_bg.wasm
+          if-no-files-found: error
+
       - name: Upload Web SDK dist
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1800,6 +1800,10 @@ jobs:
         with:
           name: swift-xcframework
           path: dist/swift
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-runner-dist
+          path: dist/docs-runner
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -1872,6 +1876,15 @@ jobs:
               --source-revision "$SOURCE_REVISION" \
               --released-at "$RELEASED_AT" \
               --output "manifests/docs/v$VERSION/stdlib.json"
+          BAML_BIN="$docs_work/bin/baml-cli" \
+            node docs/scripts/package-runner-artifact.mjs \
+              --input dist/docs-runner \
+              --version "$VERSION" \
+              --source-revision "$SOURCE_REVISION" \
+              --output "manifests/docs/v$VERSION"
+          BAML_BIN="$docs_work/bin/baml-cli" \
+            node docs/scripts/verify-runnable-examples.mjs \
+              --manifest "manifests/docs/v$VERSION/runtime.json"
       - uses: actions/upload-artifact@v4
         with:
           name: release-manifests
@@ -1883,6 +1896,7 @@ jobs:
           upload_immutable() {
             local source="$1"
             local dest="$2"
+            local content_type="${3:-application/json}"
             local tmp
             local err
             tmp="$(mktemp)"
@@ -1903,7 +1917,7 @@ jobs:
               fi
             elif grep -Eq '(\(404\)|Not Found|NoSuchKey)' "$err"; then
               aws s3 cp "$source" "s3://$PKG_BUCKET/$dest" \
-                --content-type application/json \
+                --content-type "$content_type" \
                 --cache-control "public, max-age=86400, immutable"
             else
               echo "::error::failed to inspect immutable object before upload: $dest"
@@ -1917,6 +1931,18 @@ jobs:
           version="${{ needs.plan.outputs.version }}"
           upload_immutable "manifests/version/$version.json" "manifest/v1/version/$version.json"
           upload_immutable "manifests/docs/v$version/stdlib.json" "manifest/v1/docs/v$version/stdlib.json"
+          runtime_manifest="manifests/docs/v$version/runtime.json"
+          runtime_module="$(jq -r .module.path "$runtime_manifest")"
+          runtime_wasm="$(jq -r .wasm.path "$runtime_manifest")"
+          upload_immutable "$runtime_manifest" "manifest/v1/docs/v$version/runtime.json"
+          upload_immutable \
+            "manifests/docs/v$version/$runtime_module" \
+            "manifest/v1/docs/v$version/$runtime_module" \
+            application/javascript
+          upload_immutable \
+            "manifests/docs/v$version/$runtime_wasm" \
+            "manifest/v1/docs/v$version/$runtime_wasm" \
+            application/wasm
           if [[ -f manifests/wrapper.json ]]; then
             aws s3 cp manifests/wrapper.json "s3://$PKG_BUCKET/manifest/v1/wrapper.json" \
               --content-type application/json \
@@ -2078,7 +2104,8 @@ jobs:
           jq \
             --arg channel "$CHANNEL" \
             --arg version "$VERSION" \
-            --slurpfile release "manifests/docs/v$VERSION/stdlib.json" '
+            --slurpfile release "manifests/docs/v$VERSION/stdlib.json" \
+            --slurpfile runtime "manifests/docs/v$VERSION/runtime.json" '
               .schema = 1
               | .aliases = ((.aliases // {}) + {($channel): $version})
               | .defaultVersion = if $channel == "nightly" then (.defaultVersion // $version) else $version end
@@ -2091,6 +2118,10 @@ jobs:
                     stdlib: {
                       path: ("v" + $version + "/stdlib.json"),
                       payloadSha256: $release[0].payloadSha256
+                    },
+                    runtime: {
+                      path: ("v" + $version + "/runtime.json"),
+                      payloadSha256: $runtime[0].payloadSha256
                     }
                   }
                 }] + [(.versions // [])[] | select(.version != $version)])
@@ -2269,6 +2300,10 @@ jobs:
         with:
           name: swift-xcframework
           path: dist/swift
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-runner-dist
+          path: dist/docs-runner
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -2342,6 +2377,15 @@ jobs:
               --source-revision "$SOURCE_REVISION" \
               --released-at "$RELEASED_AT" \
               --output "dry-run/manifest/v1/docs/v$VERSION/stdlib.json"
+          BAML_BIN="$docs_work/bin/baml-cli" \
+            node docs/scripts/package-runner-artifact.mjs \
+              --input dist/docs-runner \
+              --version "$VERSION" \
+              --source-revision "$SOURCE_REVISION" \
+              --output "dry-run/manifest/v1/docs/v$VERSION"
+          BAML_BIN="$docs_work/bin/baml-cli" \
+            node docs/scripts/verify-runnable-examples.mjs \
+              --manifest "dry-run/manifest/v1/docs/v$VERSION/runtime.json"
       - uses: actions/upload-artifact@v4
         with:
           name: dry-run-release-files

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,13 @@ in the set. Each release JSON contains all toolchain-discovered packages—not a
 docs-maintained list—and generated symbols use fully qualified names such as
 `baml.http.Request`.
 
+The same release freezes the matching browser runtime at
+`/manifest/v1/docs/v<version>/runtime.json`, with its JavaScript and WASM files
+under content-addressed paths beside that manifest. The version index binds both
+`stdlib.json` and `runtime.json` by payload checksum. Release CI runs every
+registered example through the exact native CLI and exact packaged WASM before
+advertising either artifact.
+
 Pull-request verification and its exact-metadata Vercel preview pass the
 source-built JSON together with a captured copy of the curated version index.
 The source-built toolchain becomes the default while the other immutable

--- a/docs/architecture/wasm-runner.md
+++ b/docs/architecture/wasm-runner.md
@@ -1,6 +1,7 @@
 # BAML/WASM runner spike
 
-Status: browser component and a source-pinned preview artifact are implemented.
+Status: browser component, source-pinned preview artifact, and versioned release
+producer are implemented.
 
 ## Decision
 
@@ -95,7 +96,10 @@ exact checked-in WASM artifact. The outputs must agree.
 
 ## Remaining implementation work
 
-1. Publish the runtime artifact for every stable/canary language release.
+1. Make the TypeScript-only docs build materialize the indexed release runtime
+   and remove the transitional checked-in browser snapshot. Release CI now
+   publishes `v<version>/runtime.json` plus content-addressed JS/WASM and verifies
+   it against the exact native CLI before promoting the version index.
 2. Extract the docs-owned RunStore client, VFS, and result decoder into a small
    published browser-runtime package shared with the book.
 3. Run browser benchmarks in the preview environment and replace the

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "generate:reference": "node scripts/generate-baml-reference.mjs",
     "prepare:content": "pnpm run generate:derived && pnpm run generate:book",
     "produce:docs-metadata": "node scripts/produce-docs-metadata.mjs",
+    "produce:runner-artifact": "node scripts/package-runner-artifact.mjs",
     "review:book": "node scripts/review-baml-book.mjs",
     "runner:artifact": "node scripts/build-runner-artifact.mjs",
     "runner:bundle": "node scripts/build-runner-bundle.mjs",

--- a/docs/scripts/docs-metadata-source.mjs
+++ b/docs/scripts/docs-metadata-source.mjs
@@ -23,6 +23,10 @@ export function versionMetadataUrl(baseUrl, version) {
   return `${baseUrl.replace(/\/$/, '')}/docs/v${encodeURIComponent(version)}/stdlib.json`;
 }
 
+export function versionRuntimeUrl(baseUrl, version) {
+  return `${baseUrl.replace(/\/$/, '')}/docs/v${encodeURIComponent(version)}/runtime.json`;
+}
+
 export function docsVersionsIndexUrl(baseUrl) {
   return `${baseUrl.replace(/\/$/, '')}/docs/versions.json`;
 }
@@ -53,6 +57,17 @@ export function validateDocsVersionsIndex(index) {
     }
     if (!/^[0-9a-f]{64}$/.test(entry.artifacts.stdlib.payloadSha256)) {
       throw new Error(`Docs versions index entry ${entry.version} has an invalid stdlib payload checksum`);
+    }
+    // Runtime publishing starts after stdlib publishing, so retained historical
+    // versions may legitimately predate this artifact. Every newly promoted
+    // release includes it; if present, it must be immutable and integrity-bound.
+    if (entry.artifacts.runtime !== undefined) {
+      if (entry.artifacts.runtime?.path !== `v${entry.version}/runtime.json`) {
+        throw new Error(`Docs versions index entry ${entry.version} has an invalid runtime artifact path`);
+      }
+      if (!/^[0-9a-f]{64}$/.test(entry.artifacts.runtime.payloadSha256)) {
+        throw new Error(`Docs versions index entry ${entry.version} has an invalid runtime payload checksum`);
+      }
     }
   }
   if (!names.has(index.defaultVersion)) {

--- a/docs/scripts/package-runner-artifact.mjs
+++ b/docs/scripts/package-runner-artifact.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { packageRuntimeArtifact } from './runtime-artifact.mjs';
+
+function required(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1 || !args[index + 1]) throw new Error(`Pass ${name} <value>`);
+  return args[index + 1];
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed:\n${result.stderr ?? ''}`);
+  return result.stdout.trim();
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const inputRoot = path.resolve(required(args, '--input'));
+  const outputRoot = path.resolve(required(args, '--output'));
+  const sourceRevision = required(args, '--source-revision');
+  const version = required(args, '--version');
+  const bamlBinary = process.env.BAML_BIN ?? 'baml';
+  const toolchain = capture(bamlBinary, ['--version']);
+  const manifest = await packageRuntimeArtifact({ inputRoot, outputRoot, sourceRevision, toolchain, version });
+  console.log(`Packaged docs runtime ${manifest.version} at ${outputRoot}/runtime.json`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/docs/scripts/runtime-artifact.mjs
+++ b/docs/scripts/runtime-artifact.mjs
@@ -1,0 +1,145 @@
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { brotliCompressSync, constants, gzipSync } from 'node:zlib';
+
+export const DOCS_RUNTIME_KIND = 'baml.docs-runtime';
+export const DOCS_RUNTIME_SCHEMA_VERSION = 1;
+export const MAX_RUNTIME_GZIP_BYTES = 5_000_000;
+
+export function sha256Bytes(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function runtimeChecksumPayload(manifest) {
+  return {
+    kind: manifest.kind,
+    schemaVersion: manifest.schemaVersion,
+    version: manifest.version,
+    sourceRevision: manifest.sourceRevision,
+    runtimeVersion: manifest.runtimeVersion,
+    runtimeCommit: manifest.runtimeCommit,
+    runtimeBuildTimeUnix: manifest.runtimeBuildTimeUnix,
+    toolchain: manifest.toolchain,
+    module: manifest.module,
+    wasm: manifest.wasm,
+  };
+}
+
+export function runtimePayloadSha256(manifest) {
+  return sha256Bytes(JSON.stringify(runtimeChecksumPayload(manifest)));
+}
+
+function validateFile(file, label, suffix) {
+  if (!file || typeof file !== 'object') throw new Error(`Runtime ${label} metadata must be an object`);
+  if (!/^runtime\/[0-9a-f]{16}\/[a-zA-Z0-9._-]+$/.test(file.path) || !file.path.endsWith(suffix)) {
+    throw new Error(`Runtime ${label} path is not a safe content-addressed path: ${file.path}`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(file.sha256)) throw new Error(`Runtime ${label} checksum is invalid`);
+  if (!Number.isSafeInteger(file.rawBytes) || file.rawBytes <= 0) throw new Error(`Runtime ${label} size is invalid`);
+}
+
+export function validateRuntimeManifest(manifest, expected = {}) {
+  if (!manifest || typeof manifest !== 'object') throw new Error('Runtime manifest must be an object');
+  if (manifest.kind !== DOCS_RUNTIME_KIND || manifest.schemaVersion !== DOCS_RUNTIME_SCHEMA_VERSION) {
+    throw new Error('Unsupported docs runtime manifest');
+  }
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(manifest.version)) {
+    throw new Error(`Runtime manifest version is invalid: ${manifest.version}`);
+  }
+  if (expected.version && manifest.version !== expected.version) {
+    throw new Error(`Runtime manifest has version ${manifest.version}, expected ${expected.version}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(manifest.sourceRevision)) throw new Error('Runtime source revision is invalid');
+  if (expected.sourceRevision && manifest.sourceRevision !== expected.sourceRevision) {
+    throw new Error(`Runtime source revision ${manifest.sourceRevision} does not match docs metadata ${expected.sourceRevision}`);
+  }
+  if (manifest.runtimeVersion !== manifest.version) throw new Error('Runtime version does not match its release version');
+  if (!/^[0-9a-f]{7,40}$/.test(manifest.runtimeCommit) || !manifest.sourceRevision.startsWith(manifest.runtimeCommit)) {
+    throw new Error('Runtime commit does not match its source revision');
+  }
+  if (!/^\d+$/.test(String(manifest.runtimeBuildTimeUnix))) throw new Error('Runtime build time is invalid');
+  if (manifest.toolchain !== `baml-cli ${manifest.version}`) throw new Error('Runtime toolchain does not match its release version');
+  validateFile(manifest.module, 'module', '/bridge_wasm.js');
+  validateFile(manifest.wasm, 'WASM', '/bridge_wasm_bg.wasm');
+  const artifactRoot = `runtime/${manifest.wasm.sha256.slice(0, 16)}`;
+  if (manifest.module.path !== `${artifactRoot}/bridge_wasm.js` || manifest.wasm.path !== `${artifactRoot}/bridge_wasm_bg.wasm`) {
+    throw new Error('Runtime files do not share the WASM content-addressed directory');
+  }
+  if (!Number.isSafeInteger(manifest.wasm.gzipBytes) || manifest.wasm.gzipBytes <= 0) throw new Error('Runtime gzip size is invalid');
+  if (!Number.isSafeInteger(manifest.wasm.brotliBytes) || manifest.wasm.brotliBytes <= 0) throw new Error('Runtime Brotli size is invalid');
+  if (manifest.wasm.gzipBytes > MAX_RUNTIME_GZIP_BYTES) {
+    throw new Error(`Runtime gzip size is ${manifest.wasm.gzipBytes} bytes; budget is ${MAX_RUNTIME_GZIP_BYTES}`);
+  }
+  if (manifest.payloadSha256 !== runtimePayloadSha256(manifest)) throw new Error('Runtime manifest payload checksum does not match');
+  return manifest;
+}
+
+export function resolveRuntimePath(root, relativePath) {
+  const resolved = path.resolve(root, relativePath);
+  if (resolved !== root && !resolved.startsWith(`${path.resolve(root)}${path.sep}`)) {
+    throw new Error(`Runtime artifact escapes its root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+export async function verifyRuntimeFiles(manifest, root) {
+  validateRuntimeManifest(manifest);
+  for (const [label, file] of [['module', manifest.module], ['WASM', manifest.wasm]]) {
+    const bytes = await readFile(resolveRuntimePath(root, file.path));
+    if (bytes.length !== file.rawBytes) throw new Error(`Runtime ${label} size does not match its manifest`);
+    if (sha256Bytes(bytes) !== file.sha256) throw new Error(`Runtime ${label} checksum does not match its manifest`);
+  }
+  const wasmBytes = await readFile(resolveRuntimePath(root, manifest.wasm.path));
+  if (gzipSync(wasmBytes, { level: 9 }).length !== manifest.wasm.gzipBytes) throw new Error('Runtime gzip size does not match its manifest');
+  if (brotliCompressSync(wasmBytes, { params: { [constants.BROTLI_PARAM_QUALITY]: 11 } }).length !== manifest.wasm.brotliBytes) {
+    throw new Error('Runtime Brotli size does not match its manifest');
+  }
+  return manifest;
+}
+
+export async function packageRuntimeArtifact({ inputRoot, outputRoot, sourceRevision, toolchain, version }) {
+  if (!/^[0-9a-f]{40}$/.test(sourceRevision)) throw new Error(`Invalid source revision: ${sourceRevision}`);
+  const moduleInput = path.join(inputRoot, 'bridge_wasm.js');
+  const wasmInput = path.join(inputRoot, 'bridge_wasm_bg.wasm');
+  const moduleBytes = await readFile(moduleInput);
+  const wasmBytes = await readFile(wasmInput);
+  const wasmSha256 = sha256Bytes(wasmBytes);
+  const artifactRoot = path.posix.join('runtime', wasmSha256.slice(0, 16));
+
+  const runtime = await import(`${pathToFileURL(moduleInput).href}?artifact=${wasmSha256}`);
+  await runtime.default({ module_or_path: wasmBytes });
+  const manifest = {
+    kind: DOCS_RUNTIME_KIND,
+    schemaVersion: DOCS_RUNTIME_SCHEMA_VERSION,
+    version,
+    sourceRevision,
+    runtimeVersion: runtime.version(),
+    runtimeCommit: runtime.commitHash(),
+    runtimeBuildTimeUnix: runtime.getBuildTime(),
+    toolchain,
+    module: {
+      path: path.posix.join(artifactRoot, 'bridge_wasm.js'),
+      sha256: sha256Bytes(moduleBytes),
+      rawBytes: moduleBytes.length,
+    },
+    wasm: {
+      path: path.posix.join(artifactRoot, 'bridge_wasm_bg.wasm'),
+      sha256: wasmSha256,
+      rawBytes: wasmBytes.length,
+      gzipBytes: gzipSync(wasmBytes, { level: 9 }).length,
+      brotliBytes: brotliCompressSync(wasmBytes, { params: { [constants.BROTLI_PARAM_QUALITY]: 11 } }).length,
+    },
+  };
+  manifest.payloadSha256 = runtimePayloadSha256(manifest);
+  validateRuntimeManifest(manifest, { version, sourceRevision });
+
+  const artifactOutput = path.join(outputRoot, artifactRoot);
+  await mkdir(artifactOutput, { recursive: true });
+  await copyFile(moduleInput, path.join(artifactOutput, 'bridge_wasm.js'));
+  await copyFile(wasmInput, path.join(artifactOutput, 'bridge_wasm_bg.wasm'));
+  await writeFile(path.join(outputRoot, 'runtime.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  await verifyRuntimeFiles(manifest, outputRoot);
+  return manifest;
+}

--- a/docs/scripts/verify-runnable-examples.mjs
+++ b/docs/scripts/verify-runnable-examples.mjs
@@ -7,15 +7,27 @@ import { createSession } from '../lib/baml-runner/driver.mjs';
 import { runnableExamples } from '../lib/baml-runner/examples.mjs';
 import { formatValue } from '../lib/baml-runner/outbound.mjs';
 import { BamlVfs } from '../lib/baml-runner/vfs.mjs';
+import { resolveRuntimePath, verifyRuntimeFiles } from './runtime-artifact.mjs';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repositoryRoot = path.resolve(packageRoot, '..');
 const publicRoot = path.join(packageRoot, 'public');
+const args = process.argv.slice(2);
+const manifestIndex = args.indexOf('--manifest');
+const manifestPath = manifestIndex === -1
+  ? path.join(publicRoot, 'baml-runtime/manifest.json')
+  : path.resolve(args[manifestIndex + 1]);
 const manifest = JSON.parse(
-  await readFile(path.join(publicRoot, 'baml-runtime/manifest.json'), 'utf8'),
+  await readFile(manifestPath, 'utf8'),
 );
-const runtimeModule = path.join(publicRoot, manifest.module.slice(1));
-const runtimeWasm = path.join(publicRoot, manifest.wasm.slice(1));
+const releaseArtifact = manifest.kind === 'baml.docs-runtime';
+if (releaseArtifact) await verifyRuntimeFiles(manifest, path.dirname(manifestPath));
+const runtimeModule = releaseArtifact
+  ? resolveRuntimePath(path.dirname(manifestPath), manifest.module.path)
+  : path.join(publicRoot, manifest.module.slice(1));
+const runtimeWasm = releaseArtifact
+  ? resolveRuntimePath(path.dirname(manifestPath), manifest.wasm.path)
+  : path.join(publicRoot, manifest.wasm.slice(1));
 const wasm = await import(pathToFileURL(runtimeModule).href);
 await wasm.default({ module_or_path: await readFile(runtimeWasm) });
 

--- a/docs/tests/docs-metadata.test.mjs
+++ b/docs/tests/docs-metadata.test.mjs
@@ -16,6 +16,7 @@ import {
   validateChannelManifest,
   validateDocsVersionsIndex,
   versionMetadataUrl,
+  versionRuntimeUrl,
 } from '../scripts/docs-metadata-source.mjs';
 import { buildBamlReferenceFiles } from '../scripts/generate-baml-reference.mjs';
 import { buildVersionedReferences, versionDirectory } from '../scripts/versioned-reference.mjs';
@@ -225,6 +226,7 @@ test('resolves a mutable channel only to its exact immutable metadata URL', () =
   const version = validateChannelManifest({ schema: 1, channel: 'canary', version: '1.2.3' }, 'canary');
   assert.equal(channelManifestUrl(base, 'canary'), `${base}canary.json`);
   assert.equal(versionMetadataUrl(base, version), `${base}docs/v1.2.3/stdlib.json`);
+  assert.equal(versionRuntimeUrl(base, version), `${base}docs/v1.2.3/runtime.json`);
 });
 
 test('validates the curated multi-version discovery index', () => {
@@ -233,7 +235,10 @@ test('validates the curated multi-version discovery index', () => {
     channel,
     releasedAt: '2026-08-31T00:00:00.000Z',
     sourceRevision: source.repeat(40),
-    artifacts: { stdlib: { path: `v${version}/stdlib.json`, payloadSha256: source.repeat(64) } },
+    artifacts: {
+      stdlib: { path: `v${version}/stdlib.json`, payloadSha256: source.repeat(64) },
+      runtime: { path: `v${version}/runtime.json`, payloadSha256: source.repeat(64) },
+    },
   });
   const index = {
     schema: 1,
@@ -254,11 +259,20 @@ test('validates the curated multi-version discovery index', () => {
   const duplicate = structuredClone(index);
   duplicate.versions[1].version = '1.2.3';
   duplicate.versions[1].artifacts.stdlib.path = 'v1.2.3/stdlib.json';
+  duplicate.versions[1].artifacts.runtime.path = 'v1.2.3/runtime.json';
   assert.throws(() => validateDocsVersionsIndex(duplicate), /duplicate version 1\.2\.3/);
 
   const unsafe = structuredClone(index);
   unsafe.versions[0].artifacts.stdlib.path = '../stdlib.json';
   assert.throws(() => validateDocsVersionsIndex(unsafe), /invalid stdlib artifact path/);
+
+  const historicalWithoutRuntime = structuredClone(index);
+  delete historicalWithoutRuntime.versions[1].artifacts.runtime;
+  assert.equal(validateDocsVersionsIndex(historicalWithoutRuntime), historicalWithoutRuntime);
+
+  const unsafeRuntime = structuredClone(index);
+  unsafeRuntime.versions[0].artifacts.runtime.path = '../runtime.json';
+  assert.throws(() => validateDocsVersionsIndex(unsafeRuntime), /invalid runtime artifact path/);
 
   const unknownAlias = structuredClone(index);
   unknownAlias.aliases.nightly = '1.2.1';

--- a/docs/tests/runtime-artifact.test.mjs
+++ b/docs/tests/runtime-artifact.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  packageRuntimeArtifact,
+  validateRuntimeManifest,
+  verifyRuntimeFiles,
+} from '../scripts/runtime-artifact.mjs';
+
+async function fixture(version = '1.2.3') {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), 'baml-runtime-artifact-'));
+  const inputRoot = path.join(temporaryRoot, 'input');
+  const outputRoot = path.join(temporaryRoot, 'output');
+  await mkdir(inputRoot, { recursive: true });
+  await writeFile(path.join(inputRoot, 'package.json'), '{"type":"module"}\n');
+  await writeFile(path.join(inputRoot, 'bridge_wasm.js'), [
+    'export default async () => {};',
+    `export const version = () => ${JSON.stringify(version)};`,
+    `export const commitHash = () => ${JSON.stringify('a'.repeat(7))};`,
+    'export const getBuildTime = () => "1788224998";',
+    '',
+  ].join('\n'));
+  await writeFile(path.join(inputRoot, 'bridge_wasm_bg.wasm'), Buffer.from('deterministic wasm fixture'));
+  return { inputRoot, outputRoot };
+}
+
+test('packages a release runtime under its content digest', async () => {
+  const { inputRoot, outputRoot } = await fixture();
+  const manifest = await packageRuntimeArtifact({
+    inputRoot,
+    outputRoot,
+    sourceRevision: 'a'.repeat(40),
+    toolchain: 'baml-cli 1.2.3',
+    version: '1.2.3',
+  });
+  assert.equal(validateRuntimeManifest(manifest, { version: '1.2.3', sourceRevision: 'a'.repeat(40) }), manifest);
+  assert.match(manifest.module.path, /^runtime\/[0-9a-f]{16}\/bridge_wasm\.js$/);
+  assert.equal(path.dirname(manifest.module.path), path.dirname(manifest.wasm.path));
+  await assert.doesNotReject(verifyRuntimeFiles(manifest, outputRoot));
+  assert.deepEqual(JSON.parse(await readFile(path.join(outputRoot, 'runtime.json'), 'utf8')), manifest);
+});
+
+test('rejects provenance mismatches and tampered release files', async () => {
+  const { inputRoot, outputRoot } = await fixture('1.2.2');
+  await assert.rejects(
+    packageRuntimeArtifact({
+      inputRoot,
+      outputRoot,
+      sourceRevision: 'a'.repeat(40),
+      toolchain: 'baml-cli 1.2.3',
+      version: '1.2.3',
+    }),
+    /Runtime version does not match/,
+  );
+
+  const valid = await fixture();
+  const manifest = await packageRuntimeArtifact({
+    ...valid,
+    sourceRevision: 'a'.repeat(40),
+    toolchain: 'baml-cli 1.2.3',
+    version: '1.2.3',
+  });
+  await writeFile(path.join(valid.outputRoot, manifest.wasm.path), Buffer.from('tampered'));
+  await assert.rejects(verifyRuntimeFiles(manifest, valid.outputRoot), /WASM size does not match/);
+
+  const unsafe = structuredClone(manifest);
+  unsafe.module.path = '../bridge_wasm.js';
+  assert.throws(() => validateRuntimeManifest(unsafe), /safe content-addressed path/);
+});

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -33,6 +33,7 @@ NODE_BUILDER = (
     ROOT / ".github" / "workflows" / "build2-nodejs-sdk.reusable.yaml"
 )
 WEB_NPM_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-web-sdk.yaml"
+WEB_BUILDER = ROOT / ".github" / "workflows" / "build2-web-sdk.reusable.yaml"
 CSHARP_PREPARER = (
     ROOT / ".github" / "workflows" / "prepare-csharp-sdk.reusable.yaml"
 )
@@ -801,6 +802,27 @@ class WorkflowGraphTests(unittest.TestCase):
             ci_dispatch,
         )
         self.assertNotIn("--ref canary", ci_dispatch)
+
+    def test_docs_runtime_is_frozen_verified_and_indexed_with_each_release(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        web_builder = WEB_BUILDER.read_text(encoding="utf-8")
+        manifest = job_block(workflow, "publish-pkg-boundaryml-com")
+        channel = job_block(workflow, "publish-pkg-channel")
+        dry_run = job_block(workflow, "dry-run-artifacts")
+
+        self.assertIn("baml_language/crates/bridge_wasm", web_builder)
+        self.assertIn("name: docs-runner-dist", web_builder)
+        for block in (manifest, dry_run):
+            self.assertIn("name: docs-runner-dist", block)
+            self.assertIn("docs/scripts/package-runner-artifact.mjs", block)
+            self.assertIn("docs/scripts/verify-runnable-examples.mjs", block)
+            self.assertIn("runtime.json", block)
+        self.assertIn("application/javascript", manifest)
+        self.assertIn("application/wasm", manifest)
+        self.assertIn('--slurpfile runtime "manifests/docs/v$VERSION/runtime.json"', channel)
+        self.assertIn('path: ("v" + $version + "/runtime.json")', channel)
+        self.assertIn('payloadSha256: $runtime[0].payloadSha256', channel)
+        self.assertIn("publish-pkg-boundaryml-com", channel)
 
     def test_production_release_is_ci_attested_and_least_privilege(self) -> None:
         release = RELEASE_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Outcome

Every nightly, canary, and stable BAML release now produces an immutable browser runtime beside its generated standard-library metadata.

The exact stamped release:

- builds `bridge_wasm` once in the Web SDK build job;
- packages `v<version>/runtime.json` plus content-addressed JavaScript and WASM;
- integrity-binds version, source revision, runtime commit, toolchain, sizes, and hashes;
- runs every registered example through both the exact native CLI and exact packaged WASM;
- uploads immutable files before promoting `docs/versions.json`;
- records the runtime path and payload checksum next to `stdlib.json` in the version index;
- produces the same runtime tree in release dry runs.

Historical index entries without a runtime remain readable for migration, but every newly promoted entry is statically required by the release contract to include one.

## End-user impact

This closes the producer half of version-correct runnable docs. A follow-up stack layer will make the TypeScript-only Fumadocs build consume the selected runtime and remove the transitional checked-in snapshot.

## Verification

- 40 docs tests pass.
- All 14 release workflow graph tests pass.
- Workflow YAML validation passes.
- Docs typecheck passes against two immutable toolchain versions.
- The real 18 MB `0.18.0` runtime packaged successfully and matched the native CLI output for the registered runnable example.
