### PR TITLE
fix(typescript): escape reserved words in generated declaration names

### DIFF
--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/emit/mod.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/emit/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         method::{MethodKind, OptionalArg, RequiredArg, TypeScriptMethodBinding},
         type_alias::TypeScriptTypeAlias,
     },
+    leaf::safe_decl_name,
     routing::{LeafPath, route},
 };
 
@@ -55,6 +56,12 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
         // identifier char, so a `$stream` companion class is emitted as
         // e.g. `Resume$stream` (not stripped to `Resume`). Non-stream
         // symbols are unaffected (their name carries no `$stream`).
+        //
+        // `bare` stays raw. The class / enum / type-alias arms below wrap it in
+        // `safe_decl_name` because those three names bind a module-scope
+        // identifier, where a reserved word is a parse error. Every wire-facing
+        // field on the emitted symbol (`source`, `baml_fqn`, enum member
+        // `value`) keeps the raw spelling.
         let bare = key.name().as_str().to_string();
 
         match symbol {
@@ -82,7 +89,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::Class(TypeScriptClass {
-                        name: bare,
+                        name: safe_decl_name(&bare),
                         source: key.clone(),
                         generic_params,
                         docstring: c.docstring.clone(),
@@ -107,7 +114,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::Enum(TypeScriptEnum {
-                        name: bare,
+                        name: safe_decl_name(&bare),
                         source: key.clone(),
                         variants,
                         docstring: e.docstring.clone(),
@@ -120,7 +127,7 @@ pub(crate) fn build_emitted(pool: &SymbolPool) -> Vec<(LeafPath, EmittedSymbol, 
                 out.push((
                     leaf,
                     EmittedSymbol::TypeAlias(TypeScriptTypeAlias {
-                        name: bare,
+                        name: safe_decl_name(&bare),
                         source: key.clone(),
                         resolves_to: t.resolves_to.clone(),
                         recursive: t.recursive,

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/leaf.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/leaf.rs
@@ -309,12 +309,17 @@ fn write_enum_doc(out: &mut String, e: &TypeScriptEnum) {
     out.push_str(" */\n");
 }
 
-/// `<T, U>` generic-parameter list, or empty.
+/// `<T, U>` generic-parameter list, or empty. A type-parameter name is a
+/// binding identifier, so it takes the same declaration escape as a class or
+/// enum name; `translate_ty` re-applies that escape at every `Ty::TypeVar` use
+/// site. The raw spellings still reach the runtime through the `$generic`
+/// array and the `typeParams` factory argument, which are string literals.
 fn generic_decl(params: &[String]) -> String {
     if params.is_empty() {
         String::new()
     } else {
-        format!("<{}>", params.join(", "))
+        let escaped: Vec<String> = params.iter().map(|p| safe_decl_name(p.as_str())).collect();
+        format!("<{}>", escaped.join(", "))
     }
 }
 
@@ -323,6 +328,31 @@ fn generic_decl(params: &[String]) -> String {
 /// `(default: V)` becomes `(default_: V)`. The real BAML name still travels in
 /// the `defineFunction` `paramNames` array for marshalling.
 pub(crate) fn safe_param_name(name: &str) -> String {
+    if is_js_reserved(name) {
+        format!("{name}_")
+    } else {
+        name.to_string()
+    }
+}
+
+/// A DECLARATION name binds an identifier in module scope, so unlike an enum
+/// member or a class property (both `IdentifierName`, where reserved words are
+/// legal) it cannot be a reserved word. `export enum import {}` is TS1359, and
+/// because it is a parse error it kills the whole generated file rather than
+/// just that one symbol. Append `_`, the same rule [`safe_param_name`] uses and
+/// the same rule the Python SDK's `escape_python_keyword` uses, so a BAML
+/// `enum import` renders as `export enum import_ {}`.
+///
+/// The escape is deliberately STATELESS. A class / enum / type-alias name has
+/// to be reproducible from the bare BAML `Name` alone at a distance, because
+/// `translate_ty::render_name_ref` re-derives the reference from the IR at
+/// every cross-reference rather than reading the emitted declaration back.
+///
+/// Only the TypeScript identifier moves. Wire identity travels on separate
+/// channels and is untouched: `defineFunction` is handed `baml_fqn`,
+/// `_typemap.ts` is keyed on `TypeScriptClass::source`, and enum member values
+/// are emitted verbatim, so dispatch and marshalling still target `import`.
+pub(crate) fn safe_decl_name(name: &str) -> String {
     if is_js_reserved(name) {
         format!("{name}_")
     } else {
@@ -1130,6 +1160,32 @@ mod tests {
             docstring: None,
             raises_names: Vec::new(),
         })
+    }
+
+    #[test]
+    fn safe_decl_name_escapes_only_reserved_words() {
+        assert_eq!(safe_decl_name("import"), "import_");
+        assert_eq!(safe_decl_name("class"), "class_");
+        assert_eq!(safe_decl_name("interface"), "interface_");
+        assert_eq!(safe_decl_name("Resume"), "Resume");
+        // Companion suffixes survive: `$` is a legal TS identifier character.
+        assert_eq!(safe_decl_name("Resume$stream"), "Resume$stream");
+        // Python keywords that are not reserved in TypeScript stay put, so the
+        // shared `reserved_keywords` fixture keeps per-language spellings
+        // rather than converging on one escaped set.
+        assert_eq!(safe_decl_name("None"), "None");
+        assert_eq!(safe_decl_name("pass"), "pass");
+        assert_eq!(safe_decl_name("lambda"), "lambda");
+    }
+
+    #[test]
+    fn generic_decl_escapes_reserved_type_parameters() {
+        assert_eq!(generic_decl(&[]), "");
+        assert_eq!(generic_decl(&["T".to_string()]), "<T>");
+        assert_eq!(
+            generic_decl(&["package".to_string(), "T".to_string()]),
+            "<package_, T>"
+        );
     }
 
     #[test]

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/lib.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/lib.rs
@@ -505,6 +505,54 @@ mod tests {
     }
 
     #[test]
+    fn reserved_declaration_name_is_escaped_and_wire_identity_is_preserved() {
+        let mut pool = SymbolPool::new();
+        let enum_name = name("user", &["lorem"], "import");
+        pool.insert(enum_name.clone(), enum_sym(&enum_name, 0));
+        let fn_name = name("user", &["lorem"], "pick");
+        pool.insert(
+            fn_name,
+            Symbol::Function(Function {
+                name: BaseName::new("pick"),
+                generic_params: Vec::new(),
+                docstring: None,
+                arguments: Vec::new(),
+                return_type: Ty::Enum(enum_name, baml_base::TyAttr::EMPTY),
+                throws: None,
+                watchers: Vec::new(),
+                origin: origin(1),
+            }),
+        );
+
+        let out = emit_sdk(&pool);
+        let leaf = &out[&PathBuf::from("lorem/index.ts")];
+        // `export enum import {` is TS1359, so the declaration takes the
+        // trailing-underscore escape ...
+        assert!(leaf.contains("export enum import_ {"), "{leaf}");
+        assert!(!leaf.contains("export enum import {"), "{leaf}");
+        // ... the member name is an `IdentifierName` and keeps its source
+        // spelling, as does its wire value ...
+        assert!(leaf.contains("POSITIVE = \"POSITIVE\","), "{leaf}");
+        // ... and the reference re-derives the same escaped spelling from the
+        // IR rather than dangling on the raw name.
+        assert!(leaf.contains("=> import_;"), "{leaf}");
+
+        // Wire identity is untouched: dispatch still names the raw BAML FQN.
+        assert!(
+            leaf.contains("defineFunction(\"user.lorem.pick\", \"sync\", [])"),
+            "{leaf}"
+        );
+        // The type map is still keyed on the raw FQN; only the module-scope
+        // attribute it resolves through moved.
+        let typemap = &out[&PathBuf::from("_typemap.ts")];
+        let entry = typemap
+            .lines()
+            .find(|line| line.contains("\"user.lorem.import\":"))
+            .expect("type map keys the enum on its raw BAML FQN");
+        assert!(entry.ends_with("[\"import_\"],"), "{entry}");
+    }
+
+    #[test]
     fn function_fans_out_sync_and_async() {
         let mut pool = SymbolPool::new();
         let n = name("user", &["lorem"], "extract_resume");

--- a/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
+++ b/baml_language/sdks/typescript/sdkgen_typescript_shared/src/translate_ty.rs
@@ -22,6 +22,7 @@ use baml_base::{Literal, MediaKind};
 use baml_codegen_types::{CodegenFunctionParamMode, Name, Ty};
 
 use crate::{
+    leaf::safe_decl_name,
     routing::{LeafPath, route_class_ref},
     ts_string,
 };
@@ -160,11 +161,17 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> TranslatedType {
         Ty::EnumVariant(name, variant, _) => {
             let mut result = render_name_ref(name, ctx);
             result.expr.push('.');
+            // The MEMBER stays raw. An enum member name is an `IdentifierName`,
+            // so a reserved word is legal both in the declaration
+            // (`{ import = "import" }`) and in this member access
+            // (`Kw.import`); escaping it here would dangle.
             result.expr.push_str(variant.as_str());
             result
         }
         Ty::TypeAlias(name, _) => render_name_ref(name, ctx),
-        Ty::TypeVar(name, _) => TranslatedType::bare(name.as_str().to_string()),
+        // A type parameter is a binding identifier at its declaration site
+        // (`leaf::generic_decl`), so the use site takes the same escape.
+        Ty::TypeVar(name, _) => TranslatedType::bare(safe_decl_name(name.as_str())),
 
         Ty::Function { params, ret, .. } => {
             let ret_t = translate_ty(ret, ctx);
@@ -266,7 +273,8 @@ pub(crate) const ROOT_ALIAS: &str = "_bamlRoot";
 /// The emitted identifier is the BAML name verbatim — including any
 /// `$stream` suffix (spec2: `$` is a valid TS identifier char, and stream
 /// companions live beside their base type rather than in a `stream_types/`
-/// namespace).
+/// namespace), except that a reserved word takes the same trailing-underscore
+/// escape [`crate::leaf::safe_decl_name`] applies to the declaration.
 ///
 /// - Same leaf → bare name, no import.
 /// - Root-namespace symbol referenced from a non-root leaf → `_bamlRoot.Name`
@@ -276,9 +284,13 @@ pub(crate) const ROOT_ALIAS: &str = "_bamlRoot";
 ///   `LeafPath` in `imports`.
 fn render_name_ref(name: &Name, ctx: &TranslateCtx) -> TranslatedType {
     let routed = route_class_ref(name);
-    let ident = name.name().as_str();
+    // Re-derived from the IR `Name`, never read back off the emitted
+    // declaration, so it has to apply the identical stateless escape that
+    // `emit::build_emitted` applied when it named the declaration. Escaping one
+    // side alone produces a dangling reference instead of a fixed file.
+    let ident = safe_decl_name(name.name().as_str());
     if routed == ctx.current_leaf {
-        return TranslatedType::bare(ident.to_string());
+        return TranslatedType::bare(ident);
     }
     let mut imports = BTreeSet::new();
     if routed.segments.is_empty() {
@@ -1034,5 +1046,59 @@ mod tests {
         for case in &cases {
             assert_ty(case);
         }
+    }
+
+    #[test]
+    fn reserved_declaration_names_are_re_escaped_at_reference_sites() {
+        // Same leaf: the bare identifier, escaped exactly as the declaration
+        // was escaped in `emit::build_emitted`.
+        assert_eq!(
+            translate_ty(
+                &enum_ty(name("user", &["lorem"], "import")),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "import_"
+        );
+        // Cross leaf: only the identifier moves; the routed namespace path is
+        // untouched, because a module path segment is not a binding site.
+        assert_eq!(
+            translate_ty(&enum_ty(name("user", &["lorem"], "import")), &ctx(&[])).expr,
+            "lorem.import_"
+        );
+        // Root-namespace symbol reached from a nested leaf.
+        assert_eq!(
+            translate_ty(
+                &class_ty(name("user", &[], "class"), vec![]),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "_bamlRoot.class_"
+        );
+        // The enum MEMBER keeps its source spelling: it is an `IdentifierName`
+        // in both the declaration and the member access.
+        assert_eq!(
+            translate_ty(
+                &enum_variant_ty(name("user", &["lorem"], "import"), "default"),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "import_.default"
+        );
+        // Type parameters are binding identifiers too.
+        assert_eq!(
+            translate_ty(&type_var(BaseName::new("package")), &ctx(&[])).expr,
+            "package_"
+        );
+        // Non-reserved names are untouched, so keyword-free schemas emit
+        // byte-identical output to before this change.
+        assert_eq!(
+            translate_ty(
+                &alias_ty(name("user", &["lorem"], "Json")),
+                &ctx(&["lorem"])
+            )
+            .expr,
+            "Json"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`sdkgen_typescript_shared` writes class, enum and type-alias names into the generated
TypeScript raw. A BAML `enum import` emits

```ts
export enum import {
  A = "A",
}
```

which is `TS1359: Identifier expected. 'import' is a reserved word that cannot be used here.`
The whole generated file fails to parse, so nothing in the SDK is usable.

`is_js_reserved` and `JS_RESERVED` already exist in `leaf.rs`, but they are applied only to
parameters, free functions and child-namespace re-exports. Nothing escapes a declaration name.

### Repro

```bash
baml new repro && cd repro
printf 'enum import { A B }\n' > baml_src/main.baml
baml generate add typescript/node && baml generate
grep -n 'export enum' baml_sdk/index.ts
```

Reproduced on `0.17.0` and on `0.18.1-nightly.20260828.a`.

## Fix

Add `safe_decl_name` beside the existing `safe_param_name` and apply it at the two places that
name a binding:

- `emit::build_emitted`, where an IR name becomes an emitted symbol (the class, enum and
  type-alias arms).
- `translate_ty::render_name_ref`, which re-derives every cross-reference from the IR rather
  than reading the declaration back.

Escaping one side alone would turn a parse error into a dangling reference, so both move
together. Type parameters take the same escape in `generic_decl`.

Escaping at `build_emitted` also covers `_typemap.ts`, which indexes the module namespace
through a `Record<string, unknown>` cast and so would have resolved to `undefined` at runtime
with no compile-time signal.

## Wire identity is unchanged

Only the TypeScript identifier moves. Dispatch still uses `baml_fqn`, the type map is still
keyed on the raw BAML FQN, and enum member values, marshalling parameter names and the
`$generic` / `typeParams` arrays all keep their source spelling.

## Testing

`reserved_declaration_name_is_escaped_and_wire_identity_is_preserved` in
`sdkgen_typescript_shared/src/lib.rs` covers an `enum import` through the full emit path and
asserts both halves: the declaration is escaped, and every wire-facing field keeps the raw
name.

## Relationship to my earlier PRs

This is the TypeScript half of #4070, split out so it can be reviewed on its own. The Python
and C++ halves of that PR look superseded to me: `sdkgen_python_pydantic2/src/names.rs` (#4623)
now does the Python identifier projection, and `CPP_KEYWORDS` (#4430) covers the C++ alternative
operator tokens. The TypeScript declaration names are the part neither of those reached, so it
seemed more useful to you as a small separate PR than buried in a large stale one.

It is also the change #4445 was carrying. That one was closed as a duplicate of #4070, which was
correct in scope, and this is the piece that is still outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated TypeScript SDKs failing when BAML declarations or generic parameters use reserved TypeScript words.
  - Ensured escaped names remain consistent across declarations and type references.
  - Preserved original names for wire-level fields, enum values, and function metadata.
  - Added coverage for reserved words, legal identifiers, cross-module references, aliases, and type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->