### PR TITLE
docs: make BAML examples fixture-backed and runnable

### DIFF
--- a/.github/workflows/developer-docs.yml
+++ b/.github/workflows/developer-docs.yml
@@ -1,0 +1,73 @@
+name: Developer Docs
+
+on:
+  pull_request:
+    paths:
+      - "typescript/apps/developer-docs/**"
+      - "typescript2/pkg-grammar/**"
+      - "baml_language/**"
+      - "pnpm-lock.yaml"
+      - ".github/actions/setup-node/**"
+      - ".github/actions/setup-rust/**"
+      - ".github/workflows/developer-docs.yml"
+  push:
+    branches: [main, canary]
+    paths:
+      - "typescript/apps/developer-docs/**"
+      - "typescript2/pkg-grammar/**"
+      - "baml_language/**"
+      - "pnpm-lock.yaml"
+      - ".github/actions/setup-node/**"
+      - ".github/actions/setup-rust/**"
+      - ".github/workflows/developer-docs.yml"
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  application:
+    name: Application
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@v1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: "20"
+
+      - name: Test
+        run: pnpm --filter @baml/developer-docs test
+
+      - name: Typecheck
+        run: pnpm --filter @baml/developer-docs typecheck
+
+      - name: Build
+        run: pnpm --filter @baml/developer-docs build
+
+  fixtures:
+    name: Native fixtures
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@v1
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Validate examples
+        run: node typescript/apps/developer-docs/scripts/validate-examples.mjs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
 
   typescript/apps/developer-docs:
     dependencies:
+      '@boundaryml/baml-bridge-web':
+        specifier: 0.18.1-nightly.20260828.a
+        version: 0.18.1-nightly.20260828.a
       '@radix-ui/react-dialog':
         specifier: 1.1.14
         version: 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -501,6 +504,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      shiki:
+        specifier: 4.4.3
+        version: 4.4.3
       tailwind-merge:
         specifier: 3.3.1
         version: 3.3.1
@@ -526,6 +532,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: 4.0.16
+        version: 4.0.16(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@24.0.3)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0)
 
   typescript/apps/fiddle-web-app:
     dependencies:
@@ -2052,6 +2061,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@boundaryml/baml-bridge-web@0.18.1-nightly.20260828.a':
+    resolution: {integrity: sha512-Dez9R4s8TZbzC8iFFA0IQotQqE30TOsjaMC+xNwofQY3pIOzK8wkcrtvDr79BtFbNZiIGjy/fL/ZyFH1gN9tdg==}
 
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
@@ -8142,6 +8154,9 @@ packages:
   '@vitest/expect@4.0.15':
     resolution: {integrity: sha512-Gfyva9/GxPAWXIWjyGDli9O+waHDC0Q0jaLdFP1qPAUUfo1FEXPXUfUkp3eZA0sSq340vPycSyOlYUeM15Ft1w==}
 
+  '@vitest/expect@4.0.16':
+    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+
   '@vitest/mocker@3.2.3':
     resolution: {integrity: sha512-cP6fIun+Zx8he4rbWvi+Oya6goKQDZK+Yq4hhlggwQBbrlOQ4qtZ+G4nxB6ZnzI9lyIb+JnvyiJnPC2AGbKSPA==}
     peerDependencies:
@@ -8175,6 +8190,17 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.0.16':
+    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
@@ -8190,6 +8216,9 @@ packages:
   '@vitest/pretty-format@4.0.15':
     resolution: {integrity: sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A==}
 
+  '@vitest/pretty-format@4.0.16':
+    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+
   '@vitest/runner@3.2.3':
     resolution: {integrity: sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==}
 
@@ -8199,6 +8228,9 @@ packages:
   '@vitest/runner@4.0.15':
     resolution: {integrity: sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw==}
 
+  '@vitest/runner@4.0.16':
+    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+
   '@vitest/snapshot@3.2.3':
     resolution: {integrity: sha512-9gIVWx2+tysDqUmmM1L0hwadyumqssOL1r8KJipwLx5JVYyxvVRfxvMq7DaWbZZsCqZnu/dZedaZQh4iYTtneA==}
 
@@ -8207,6 +8239,9 @@ packages:
 
   '@vitest/snapshot@4.0.15':
     resolution: {integrity: sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g==}
+
+  '@vitest/snapshot@4.0.16':
+    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
 
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
@@ -8219,6 +8254,9 @@ packages:
 
   '@vitest/spy@4.0.15':
     resolution: {integrity: sha512-+EIjOJmnY6mIfdXtE/bnozKEvTC4Uczg19yeZ2vtCz5Yyb0QQ31QWVQ8hswJ3Ysx/K2EqaNsVanjr//2+P3FHw==}
+
+  '@vitest/spy@4.0.16':
+    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
 
   '@vitest/ui@4.0.15':
     resolution: {integrity: sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==}
@@ -8239,6 +8277,9 @@ packages:
 
   '@vitest/utils@4.0.15':
     resolution: {integrity: sha512-HXjPW2w5dxhTD0dLwtYHDnelK3j8sR8cWIaLxr22evTyY6q8pRCjZSmhRWVjBaOVXChQd6AwMzi9pucorXCPZA==}
+
+  '@vitest/utils@4.0.16':
+    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
 
   '@vscode/test-electron@2.5.2':
     resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
@@ -15184,6 +15225,40 @@ packages:
       jsdom:
         optional: true
 
+  vitest@4.0.16:
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -15629,7 +15704,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.3.0
-      tinyexec: 1.0.2
+      tinyexec: 1.3.0
 
   '@antfu/utils@8.1.1': {}
 
@@ -17065,6 +17140,10 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@boundaryml/baml-bridge-web@0.18.1-nightly.20260828.a':
+    dependencies:
+      protobufjs: 7.6.2
 
   '@braidai/lang@1.1.2': {}
 
@@ -21229,7 +21308,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.7
     optionalDependencies:
       rollup: 4.43.0
 
@@ -23458,7 +23537,7 @@ snapshots:
       glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.3
+      picomatch: 4.0.7
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -23627,6 +23706,15 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
+  '@vitest/expect@4.0.16':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.2
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      chai: 6.2.1
+      tinyrainbow: 3.0.3
+
   '@vitest/mocker@3.2.3(vite@7.2.2(@types/node@24.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.3
@@ -23659,6 +23747,14 @@ snapshots:
     optionalDependencies:
       vite: 7.2.2(@types/node@24.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0)
 
+  '@vitest/mocker@4.0.16(vite@7.2.2(@types/node@24.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.2(@types/node@24.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0)
+
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -23679,6 +23775,10 @@ snapshots:
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/pretty-format@4.0.16':
+    dependencies:
+      tinyrainbow: 3.0.3
+
   '@vitest/runner@3.2.3':
     dependencies:
       '@vitest/utils': 3.2.3
@@ -23694,6 +23794,11 @@ snapshots:
   '@vitest/runner@4.0.15':
     dependencies:
       '@vitest/utils': 4.0.15
+      pathe: 2.0.3
+
+  '@vitest/runner@4.0.16':
+    dependencies:
+      '@vitest/utils': 4.0.16
       pathe: 2.0.3
 
   '@vitest/snapshot@3.2.3':
@@ -23714,6 +23819,12 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@2.0.5':
     dependencies:
       tinyspy: 3.0.2
@@ -23727,6 +23838,8 @@ snapshots:
       tinyspy: 4.0.3
 
   '@vitest/spy@4.0.15': {}
+
+  '@vitest/spy@4.0.16': {}
 
   '@vitest/ui@4.0.15(vitest@4.0.15)':
     dependencies:
@@ -23767,6 +23880,11 @@ snapshots:
   '@vitest/utils@4.0.15':
     dependencies:
       '@vitest/pretty-format': 4.0.15
+      tinyrainbow: 3.0.3
+
+  '@vitest/utils@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
       tinyrainbow: 3.0.3
 
   '@vscode/test-electron@2.5.2':
@@ -27360,7 +27478,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.2.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.7
 
   jest-util@30.2.0:
     dependencies:
@@ -27369,7 +27487,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.2.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.7
 
   jest-validate@29.7.0:
     dependencies:
@@ -32460,6 +32578,46 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.0.3
       '@vitest/ui': 4.0.15(vitest@4.0.15)
+      jsdom: 20.0.3(canvas@2.11.2)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.16(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@24.0.3)(jiti@2.6.1)(jsdom@20.0.3(canvas@2.11.2))(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.2.2(@types/node@24.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.0.3
+      vite: 7.2.2(@types/node@24.0.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.0.3
       jsdom: 20.0.3(canvas@2.11.2)
     transitivePeerDependencies:
       - jiti

--- a/typescript/apps/developer-docs/app/globals.css
+++ b/typescript/apps/developer-docs/app/globals.css
@@ -180,6 +180,30 @@
 }
 
 @layer components {
+  .baml-example-button {
+    @apply inline-flex h-8 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 text-xs font-medium transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50;
+  }
+
+  .baml-example-button svg {
+    @apply size-3.5;
+  }
+
+  .baml-example-highlight .shiki {
+    margin: 0;
+    overflow-x: auto;
+    background-color: transparent !important;
+    padding: calc(var(--spacing) * 4);
+    font-size: 13px;
+    line-height: calc(var(--spacing) * 6);
+  }
+
+  .dark .baml-example-highlight .shiki span {
+    color: var(--shiki-dark) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
+  }
+
   [data-rehype-pretty-code-figure] {
     position: relative;
     margin-top: calc(var(--spacing) * 6);

--- a/typescript/apps/developer-docs/components/baml-example-client.tsx
+++ b/typescript/apps/developer-docs/components/baml-example-client.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Check, Clipboard, Code2, Pencil, Play, RotateCcw, X } from "lucide-react"
+
+import type { LoadedBamlExample } from "@/lib/examples/types"
+import { cn } from "@/lib/utils"
+
+type ExampleProps = Pick<
+  LoadedBamlExample,
+  | "id"
+  | "title"
+  | "listing"
+  | "caption"
+  | "file"
+  | "mode"
+  | "functionName"
+  | "args"
+  | "declaredTrack"
+  | "excludedTrack"
+  | "exclusionReason"
+  | "files"
+  | "code"
+  | "sourceBefore"
+  | "sourceAfter"
+  | "runtimeVersion"
+  | "highlightedHtml"
+>
+
+interface RuntimeResponse {
+  requestId: number
+  ok: boolean
+  output?: string
+  diagnostics?: Array<{ name: string; message: string; className?: string; trace?: string[] }>
+}
+
+type RunState =
+  | { status: "idle" }
+  | { status: "running" }
+  | { status: "success"; output: string }
+  | { status: "error"; message: string }
+
+export function BamlExampleClient(example: ExampleProps) {
+  const [code, setCode] = useState(example.code)
+  const [argsText, setArgsText] = useState(JSON.stringify(example.args ?? {}, null, 2))
+  const [editing, setEditing] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [runState, setRunState] = useState<RunState>({ status: "idle" })
+  const workerRef = useRef<Worker | null>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const requestId = useRef(0)
+  const dirty = code !== example.code || argsText !== JSON.stringify(example.args ?? {}, null, 2)
+
+  useEffect(() => () => {
+    workerRef.current?.terminate()
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+  }, [])
+
+  function finishWorker() {
+    workerRef.current?.terminate()
+    workerRef.current = null
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = null
+  }
+
+  async function copyCode() {
+    await navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1200)
+  }
+
+  function reset() {
+    setCode(example.code)
+    setArgsText(JSON.stringify(example.args ?? {}, null, 2))
+    setRunState({ status: "idle" })
+  }
+
+  function execute() {
+    let args: Record<string, unknown> = {}
+    try {
+      const parsed = JSON.parse(argsText) as unknown
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Arguments must be a JSON object.")
+      args = parsed as Record<string, unknown>
+    } catch (error) {
+      setRunState({ status: "error", message: error instanceof Error ? error.message : String(error) })
+      return
+    }
+
+    finishWorker()
+    setRunState({ status: "running" })
+    const worker = new Worker(new URL("./baml-runtime.worker.ts", import.meta.url), { type: "module" })
+    workerRef.current = worker
+    const currentRequest = ++requestId.current
+
+    worker.onmessage = ({ data }: MessageEvent<RuntimeResponse>) => {
+      if (data.requestId !== currentRequest) return
+      finishWorker()
+      if (data.ok) setRunState({ status: "success", output: data.output ?? "Completed." })
+      else {
+        const message = data.diagnostics?.map((item) => [item.message, ...(item.trace ?? [])].join("\n")).join("\n\n") || "BAML could not run this example."
+        setRunState({ status: "error", message })
+      }
+    }
+    worker.onerror = (event) => {
+      finishWorker()
+      setRunState({ status: "error", message: event.message || "The BAML runtime worker failed to load." })
+    }
+    timeoutRef.current = setTimeout(() => {
+      finishWorker()
+      setRunState({ status: "error", message: "The example exceeded its 30 second execution limit." })
+    }, 30_000)
+
+    worker.postMessage({
+      requestId: currentRequest,
+      action: example.mode === "run" ? "run" : "check",
+      files: { ...example.files, [example.file]: `${example.sourceBefore}${code}${example.sourceAfter}` },
+      functionName: example.functionName,
+      args,
+    })
+  }
+
+  const actionLabel = example.mode === "run" ? "Run" : "Check"
+
+  return (
+    <figure className="baml-example not-prose my-7 overflow-hidden rounded-xl border bg-code shadow-sm" data-example-id={example.id}>
+      <figcaption className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b bg-background/70 px-3 py-2.5 text-sm">
+        <div className="min-w-0">
+          <div className="truncate font-medium">Listing {example.listing}. {example.title}</div>
+          <div className="mt-1 flex min-w-0 items-center gap-2">
+            <code className="truncate text-xs text-muted-foreground">{example.file}</code>
+            <span className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{example.declaredTrack}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button aria-label={editing ? "Finish editing" : "Edit code"} className="baml-example-button" onClick={() => setEditing((value) => !value)} title={editing ? "Finish editing" : "Edit code"} type="button">
+            {editing ? <X /> : <Pencil />}<span className="sr-only">{editing ? "Done" : "Edit"}</span>
+          </button>
+          <button aria-label="Copy code" className="baml-example-button" onClick={copyCode} title="Copy code" type="button">
+            {copied ? <Check /> : <Clipboard />}<span className="sr-only">{copied ? "Copied" : "Copy"}</span>
+          </button>
+          {dirty ? (
+            <button aria-label="Reset example" className="baml-example-button" onClick={reset} title="Reset example" type="button">
+              <RotateCcw /><span className="sr-only">Reset</span>
+            </button>
+          ) : null}
+          <button className="baml-example-button bg-foreground text-background hover:bg-foreground/85" disabled={runState.status === "running"} onClick={execute} type="button">
+            {example.mode === "run" ? <Play /> : <Code2 />}<span>{runState.status === "running" ? `${actionLabel}ning…` : actionLabel}</span>
+          </button>
+        </div>
+      </figcaption>
+
+      {editing ? (
+        <textarea
+          aria-label={`${example.title} source`}
+          className="min-h-44 w-full resize-y bg-transparent p-4 font-mono text-[13px] leading-6 outline-none"
+          onChange={(event) => setCode(event.target.value)}
+          spellCheck={false}
+          value={code}
+        />
+      ) : dirty ? (
+        <pre className="m-0 overflow-x-auto bg-transparent p-4 text-[13px] leading-6"><code>{code}</code></pre>
+      ) : (
+        <div className="baml-example-highlight" dangerouslySetInnerHTML={{ __html: example.highlightedHtml }} />
+      )}
+
+      {example.mode === "run" ? (
+        <label className="grid gap-1.5 border-t bg-background/45 px-3 py-2.5 text-xs font-medium text-muted-foreground">
+          Arguments
+          <textarea
+            aria-label={`${example.functionName} arguments`}
+            className="min-h-14 resize-y rounded-md border bg-background px-3 py-2 font-mono text-xs leading-5 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onChange={(event) => setArgsText(event.target.value)}
+            spellCheck={false}
+            value={argsText}
+          />
+        </label>
+      ) : null}
+
+      {runState.status !== "idle" ? (
+        <div className={cn("border-t px-4 py-3 font-mono text-xs leading-5", runState.status === "error" ? "bg-destructive/8 text-destructive" : "bg-background/65")} role="status">
+          {runState.status === "running" ? "Loading the compiler and running this fixture…" : null}
+          {runState.status === "success" ? <pre className="m-0 whitespace-pre-wrap bg-transparent p-0 text-inherit">{runState.output}</pre> : null}
+          {runState.status === "error" ? <pre className="m-0 whitespace-pre-wrap bg-transparent p-0 text-inherit">{runState.message}</pre> : null}
+        </div>
+      ) : null}
+
+      {example.excludedTrack && example.exclusionReason ? (
+        <div className="border-t bg-amber-500/10 px-4 py-3 text-xs text-amber-900 dark:text-amber-200">
+          <strong>Changing soon:</strong> incompatible with {example.excludedTrack} — {example.exclusionReason}
+        </div>
+      ) : null}
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t bg-background/70 px-3 py-2 text-xs text-muted-foreground">
+        <span>{example.caption}</span>
+        <span className="font-mono">BAML {example.runtimeVersion} · {example.declaredTrack}</span>
+      </div>
+    </figure>
+  )
+}

--- a/typescript/apps/developer-docs/components/baml-example.tsx
+++ b/typescript/apps/developer-docs/components/baml-example.tsx
@@ -1,0 +1,7 @@
+import { BamlExampleClient } from "@/components/baml-example-client"
+import { loadBamlExample } from "@/lib/examples/load-example"
+
+export async function BamlExample({ id }: { id: string }) {
+  const example = await loadBamlExample(id)
+  return <BamlExampleClient {...example} />
+}

--- a/typescript/apps/developer-docs/components/baml-runtime.worker.ts
+++ b/typescript/apps/developer-docs/components/baml-runtime.worker.ts
@@ -1,0 +1,54 @@
+/// <reference lib="WebWorker" />
+
+interface RuntimeRequest {
+  requestId: number
+  action: "check" | "run"
+  files: Record<string, string>
+  functionName?: string
+  args: Record<string, unknown>
+}
+
+interface Diagnostic {
+  severity: "error"
+  name: string
+  message: string
+  className?: string
+  trace?: string[]
+}
+
+function diagnostic(error: unknown): Diagnostic {
+  const value = error as Error & { className?: string; bamlTrace?: string[] }
+  return {
+    severity: "error",
+    name: value?.name || "Error",
+    message: value?.message || String(error),
+    className: value?.className,
+    trace: value?.bamlTrace,
+  }
+}
+
+function displayResult(value: unknown) {
+  if (typeof value === "string") return value
+  return JSON.stringify(value, (_key, nested) => typeof nested === "bigint" ? nested.toString() : nested, 2)
+}
+
+const scope = self as DedicatedWorkerGlobalScope
+
+scope.onmessage = async ({ data }: MessageEvent<RuntimeRequest>) => {
+  try {
+    const { BamlRuntime, callFunction } = await import("@boundaryml/baml-bridge-web")
+    const runtimeSources = Object.fromEntries(Object.entries(data.files).filter(([file]) => file.endsWith(".baml")))
+    const runtime = BamlRuntime.initializeRuntime("/workspace", runtimeSources)
+    if (data.action === "check") {
+      scope.postMessage({ requestId: data.requestId, ok: true, output: "Compiled successfully." })
+      return
+    }
+    if (!data.functionName) throw new Error("This fixture does not declare a runnable function.")
+    const result = await callFunction(runtime, data.functionName, data.args)
+    scope.postMessage({ requestId: data.requestId, ok: true, output: displayResult(result.result()) })
+  } catch (error) {
+    scope.postMessage({ requestId: data.requestId, ok: false, diagnostics: [diagnostic(error)] })
+  }
+}
+
+export {}

--- a/typescript/apps/developer-docs/components/quiz.tsx
+++ b/typescript/apps/developer-docs/components/quiz.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle2, CircleHelp, XCircle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+export interface QuizProps {
+  question: string
+  options: string[]
+  answer: string
+  explanation: string
+}
+
+export function Quiz({ question, options, answer, explanation }: QuizProps) {
+  const [selected, setSelected] = useState<string>()
+  const [checked, setChecked] = useState(false)
+  const correct = selected === answer
+
+  return (
+    <section className="not-prose my-7 rounded-xl border bg-card p-4 shadow-sm" aria-label="Knowledge check">
+      <div className="mb-3 flex items-start gap-2">
+        <CircleHelp className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Knowledge check</div>
+          <h3 className="mt-1 text-sm font-semibold">{question}</h3>
+        </div>
+      </div>
+      <div className="grid gap-2">
+        {options.map((option) => (
+          <label className={cn("flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors hover:bg-accent", selected === option && "border-foreground bg-accent")} key={option}>
+            <input checked={selected === option} name={question} onChange={() => { setSelected(option); setChecked(false) }} type="radio" value={option} />
+            {option}
+          </label>
+        ))}
+      </div>
+      <button className="mt-3 inline-flex h-8 items-center rounded-md bg-foreground px-3 text-xs font-medium text-background disabled:opacity-50" disabled={!selected} onClick={() => setChecked(true)} type="button">
+        Check answer
+      </button>
+      {checked ? (
+        <div className={cn("mt-3 flex gap-2 rounded-lg px-3 py-2.5 text-sm", correct ? "bg-emerald-500/10 text-emerald-900 dark:text-emerald-200" : "bg-destructive/10 text-destructive")} role="status">
+          {correct ? <CheckCircle2 className="mt-0.5 size-4 shrink-0" /> : <XCircle className="mt-0.5 size-4 shrink-0" />}
+          <span><strong>{correct ? "Correct." : "Not quite."}</strong> {explanation}</span>
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/typescript/apps/developer-docs/content/docs/baml/book/index.mdx
+++ b/typescript/apps/developer-docs/content/docs/baml/book/index.mdx
@@ -3,4 +3,21 @@ title: The BAML Book
 description: A deliberate path from your first BAML program to production use.
 ---
 
-The first chapters will arrive with compiler-verified, runnable examples. This publication will grow incrementally without depending on the former `baml-book` application.
+The book teaches BAML as a language: start with a small typed function, run it, then grow the same ideas into model-backed programs.
+
+## A function is just a function
+
+BAML functions have named, typed parameters and a typed return value. This first example is deliberately local, so you can edit and run it without configuring a model provider.
+
+<BamlExample id="book/first-function" />
+
+Try changing the greeting or the `name` argument. The same fixture supplies the listing, the editable source, compiler diagnostics, and the browser run—there is no second copy of the example hiding behind the page.
+
+## Check your understanding
+
+<Quiz
+  question="What does BAML verify before this function runs?"
+  options={["Only the function name", "The parameter and return types", "A model provider API key"]}
+  answer="The parameter and return types"
+  explanation="The compiler checks the function signature and body. This local function does not need a model provider."
+/>

--- a/typescript/apps/developer-docs/examples/book/first-function/baml.toml
+++ b/typescript/apps/developer-docs/examples/book/first-function/baml.toml
@@ -1,0 +1,2 @@
+[package]
+name = "docs-first-function"

--- a/typescript/apps/developer-docs/examples/book/first-function/baml_src/main.baml
+++ b/typescript/apps/developer-docs/examples/book/first-function/baml_src/main.baml
@@ -1,0 +1,7 @@
+// TRACK: nightly
+
+// ANCHOR: welcome
+function Welcome(name: string) -> string {
+  "Hello, " + name + "!"
+}
+// ANCHOR_END: welcome

--- a/typescript/apps/developer-docs/examples/book/first-function/example.json
+++ b/typescript/apps/developer-docs/examples/book/first-function/example.json
@@ -1,0 +1,11 @@
+{
+  "id": "book/first-function",
+  "title": "Your first BAML function",
+  "listing": 1,
+  "caption": "A typed function that runs locally in the browser—no model key required.",
+  "file": "baml_src/main.baml",
+  "anchor": "welcome",
+  "mode": "run",
+  "functionName": "Welcome",
+  "args": { "name": "Ada" }
+}

--- a/typescript/apps/developer-docs/lib/examples/fixture-contract.test.ts
+++ b/typescript/apps/developer-docs/lib/examples/fixture-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { extractAnchor, parseTrackMetadata } from "./markers"
+
+const fixtureRoot = path.join(process.cwd(), "examples/book/first-function")
+const manifest = JSON.parse(readFileSync(path.join(fixtureRoot, "example.json"), "utf8"))
+const source = readFileSync(path.join(fixtureRoot, manifest.file), "utf8")
+
+describe("published fixture contract", () => {
+  it("derives the listing and track from the real project", () => {
+    expect(extractAnchor(source, manifest.anchor).code).toContain("function Welcome")
+    expect(parseTrackMetadata(source).declaredTrack).toBe("nightly")
+  })
+
+  it("does not allow a hand-authored BAML fence beside fixture-backed listings", () => {
+    const chapter = readFileSync(path.join(process.cwd(), "content/docs/baml/book/index.mdx"), "utf8")
+    expect(chapter).not.toMatch(/```baml\b/)
+    expect(chapter).toContain('<BamlExample id="book/first-function" />')
+  })
+})

--- a/typescript/apps/developer-docs/lib/examples/load-example.ts
+++ b/typescript/apps/developer-docs/lib/examples/load-example.ts
@@ -1,0 +1,85 @@
+import "server-only"
+
+import { readFile, readdir } from "node:fs/promises"
+import path from "node:path"
+
+import type { LanguageRegistration } from "shiki"
+import { createHighlighter } from "shiki"
+
+import { extractAnchor, parseTrackMetadata } from "./markers"
+import { verificationModes, type ExampleManifest, type LoadedBamlExample } from "./types"
+
+const examplesRoot = path.join(process.cwd(), "examples")
+const grammarPath = path.resolve(process.cwd(), "../../../typescript2/pkg-grammar/baml.tmLanguage.json")
+const runtimeVersion = "0.18.1-nightly.20260828.a"
+
+function assertManifest(value: unknown, requestedId: string): asserts value is ExampleManifest {
+  if (!value || typeof value !== "object") throw new Error(`Example '${requestedId}' has invalid metadata`)
+  const manifest = value as Record<string, unknown>
+  for (const key of ["id", "title", "caption", "file", "anchor", "mode"] as const) {
+    if (typeof manifest[key] !== "string" || !manifest[key]) throw new Error(`Example '${requestedId}' is missing '${key}'`)
+  }
+  if (manifest.id !== requestedId) throw new Error(`Example metadata ID '${manifest.id}' does not match '${requestedId}'`)
+  if (!Number.isInteger(manifest.listing) || Number(manifest.listing) < 1) throw new Error(`Example '${requestedId}' needs a positive listing number`)
+  if (!verificationModes.includes(manifest.mode as ExampleManifest["mode"])) throw new Error(`Example '${requestedId}' has an unknown verification mode`)
+  if (manifest.mode === "run" && typeof manifest.functionName !== "string") throw new Error(`Runnable example '${requestedId}' needs a functionName`)
+  if (manifest.args !== undefined && (!manifest.args || typeof manifest.args !== "object" || Array.isArray(manifest.args))) {
+    throw new Error(`Example '${requestedId}' args must be an object`)
+  }
+}
+
+function safeExampleDirectory(id: string) {
+  if (!/^[a-z0-9]+(?:[a-z0-9-]*\/[a-z0-9][a-z0-9-]*)$/.test(id)) throw new Error(`Invalid example ID '${id}'`)
+  const directory = path.resolve(examplesRoot, id)
+  if (!directory.startsWith(`${examplesRoot}${path.sep}`)) throw new Error(`Example ID '${id}' escapes the fixture root`)
+  return directory
+}
+
+async function readFixtureFiles(directory: string) {
+  const files: Record<string, string> = {}
+  async function visit(current: string) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const absolute = path.join(current, entry.name)
+      if (entry.isDirectory()) await visit(absolute)
+      else if (entry.name !== "example.json") files[path.relative(directory, absolute)] = await readFile(absolute, "utf8")
+    }
+  }
+  await visit(directory)
+  return files
+}
+
+let highlighterPromise: ReturnType<typeof createHighlighter> | undefined
+async function highlight(code: string) {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const grammar = JSON.parse(await readFile(grammarPath, "utf8")) as LanguageRegistration
+      return createHighlighter({ langs: [grammar], themes: ["github-light", "github-dark"] })
+    })()
+  }
+  const highlighter = await highlighterPromise
+  return highlighter.codeToHtml(code, {
+    lang: "baml",
+    themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: false,
+  })
+}
+
+export async function loadBamlExample(id: string): Promise<LoadedBamlExample> {
+  const directory = safeExampleDirectory(id)
+  const manifest = JSON.parse(await readFile(path.join(directory, "example.json"), "utf8")) as unknown
+  assertManifest(manifest, id)
+  const files = await readFixtureFiles(directory)
+  const primarySource = files[manifest.file]
+  if (primarySource === undefined) throw new Error(`Example '${id}' cannot find '${manifest.file}'`)
+
+  const anchor = extractAnchor(primarySource, manifest.anchor)
+  const track = parseTrackMetadata(primarySource)
+  return {
+    ...manifest,
+    ...track,
+    ...anchor,
+    files,
+    runtimeVersion,
+    highlightedHtml: await highlight(anchor.code),
+  }
+}

--- a/typescript/apps/developer-docs/lib/examples/markers.test.ts
+++ b/typescript/apps/developer-docs/lib/examples/markers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import { extractAnchor, parseTrackMetadata } from "./markers"
+
+describe("extractAnchor", () => {
+  it("extracts source while preserving a replacement seam", () => {
+    const source = "// TRACK: nightly\n// ANCHOR: add\nfunction Add() -> int { 2 + 2 }\n// ANCHOR_END: add\n"
+    const result = extractAnchor(source, "add")
+    expect(result.code).toBe("function Add() -> int { 2 + 2 }")
+    expect(`${result.sourceBefore}${result.code}${result.sourceAfter}`).toBe(source)
+  })
+
+  it.each([
+    ["missing", "// ANCHOR: other\nx\n// ANCHOR_END: other", "Missing anchor"],
+    ["empty", "// ANCHOR: empty\n\n// ANCHOR_END: empty", "is empty"],
+    ["nested", "// ANCHOR: a\n// ANCHOR: b\nx\n// ANCHOR_END: b\n// ANCHOR_END: a", "Nested anchor"],
+    ["mismatched", "// ANCHOR: a\nx\n// ANCHOR_END: b", "is closed by"],
+    ["duplicate", "// ANCHOR: a\nx\n// ANCHOR_END: a\n// ANCHOR: a\ny\n// ANCHOR_END: a", "Duplicate anchor"],
+  ])("rejects %s anchors", (_name, source, message) => {
+    expect(() => extractAnchor(source, _name === "missing" ? "wanted" : _name === "empty" ? "empty" : "a")).toThrow(message)
+  })
+})
+
+describe("parseTrackMetadata", () => {
+  it("defaults to canary", () => {
+    expect(parseTrackMetadata("function A() -> int { 1 }")).toEqual({ declaredTrack: "canary" })
+  })
+
+  it("normalizes leading track controls", () => {
+    expect(parseTrackMetadata("// TRACK: NIGHTLY\n// NO_TRACK: HEAD\n// NO_TRACK_REASON: Not ready yet.\nfunction A() -> int { 1 }")).toEqual({
+      declaredTrack: "nightly",
+      excludedTrack: "head",
+      exclusionReason: "Not ready yet.",
+    })
+  })
+
+  it("ignores controls after the first declaration", () => {
+    expect(parseTrackMetadata("function A() -> int { 1 }\n// TRACK: head")).toEqual({ declaredTrack: "canary" })
+  })
+
+  it.each([
+    ["duplicate keys", "// TRACK: canary\n// TRACK: head\nfunction A() -> int { 1 }", "Duplicate TRACK"],
+    ["unknown tracks", "// TRACK: stable\nfunction A() -> int { 1 }", "must be one of"],
+    ["orphan reasons", "// NO_TRACK_REASON: soon\nfunction A() -> int { 1 }", "requires NO_TRACK"],
+    ["missing reasons", "// NO_TRACK: head\nfunction A() -> int { 1 }", "requires a non-empty"],
+    ["own-track exclusions", "// TRACK: head\n// NO_TRACK: head\n// NO_TRACK_REASON: no\nfunction A() -> int { 1 }", "cannot exclude"],
+  ])("rejects %s", (_name, source, message) => {
+    expect(() => parseTrackMetadata(source)).toThrow(message)
+  })
+})

--- a/typescript/apps/developer-docs/lib/examples/markers.ts
+++ b/typescript/apps/developer-docs/lib/examples/markers.ts
@@ -1,0 +1,94 @@
+import type { ReleaseTrack, TrackMetadata } from "./types"
+
+const anchorMarker = /^\s*\/\/\s*ANCHOR(_END)?:\s*(\S(?:.*\S)?)\s*$/
+const controlMarker = /^\s*\/\/\s*(TRACK|NO_TRACK|NO_TRACK_REASON):\s*(.*?)\s*$/i
+const tracks = new Set<ReleaseTrack>(["canary", "nightly", "head"])
+
+export interface ExtractedAnchor {
+  code: string
+  sourceBefore: string
+  sourceAfter: string
+}
+
+export function extractAnchor(source: string, requestedAnchor: string): ExtractedAnchor {
+  const lines = source.replace(/\r\n/g, "\n").split("\n")
+  const regions = new Map<string, { start: number; end: number }>()
+  let open: { name: string; line: number } | undefined
+
+  for (const [index, line] of lines.entries()) {
+    const marker = line.match(anchorMarker)
+    if (!marker) continue
+
+    const isEnd = Boolean(marker[1])
+    const name = marker[2]
+    if (!name) continue
+    if (!isEnd) {
+      if (open) {
+        throw new Error(`Nested anchor '${name}' inside '${open.name}' at line ${index + 1}`)
+      }
+      if (regions.has(name)) throw new Error(`Duplicate anchor '${name}'`)
+      open = { name, line: index }
+      continue
+    }
+
+    if (!open) throw new Error(`Anchor '${name}' ends without a matching start at line ${index + 1}`)
+    if (open.name !== name) {
+      throw new Error(`Anchor '${open.name}' is closed by '${name}' at line ${index + 1}`)
+    }
+    regions.set(name, { start: open.line, end: index })
+    open = undefined
+  }
+
+  if (open) throw new Error(`Anchor '${open.name}' has no matching end`)
+  const region = regions.get(requestedAnchor)
+  if (!region) throw new Error(`Missing anchor '${requestedAnchor}'`)
+
+  const visibleLines = lines
+    .slice(region.start + 1, region.end)
+    .filter((line) => !controlMarker.test(line) && !anchorMarker.test(line))
+  const code = visibleLines.join("\n").trimEnd()
+  if (!code.trim()) throw new Error(`Anchor '${requestedAnchor}' is empty`)
+
+  return {
+    code,
+    sourceBefore: `${lines.slice(0, region.start + 1).join("\n")}\n`,
+    sourceAfter: `\n${lines.slice(region.end).join("\n")}`,
+  }
+}
+
+function releaseTrack(value: string, key: string): ReleaseTrack {
+  const normalized = value.trim().toLowerCase() as ReleaseTrack
+  if (!tracks.has(normalized)) {
+    throw new Error(`${key} must be one of: canary, nightly, head`)
+  }
+  return normalized
+}
+
+export function parseTrackMetadata(source: string): TrackMetadata {
+  const values = new Map<string, string>()
+
+  for (const line of source.replace(/\r\n/g, "\n").split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith("//")) {
+      const marker = line.match(controlMarker)
+      if (!marker) continue
+      const key = marker[1]?.toUpperCase()
+      const value = marker[2]
+      if (!key || value === undefined) continue
+      if (values.has(key)) throw new Error(`Duplicate ${key} declaration`)
+      values.set(key, value.trim())
+      continue
+    }
+    break
+  }
+
+  const declaredTrack = values.has("TRACK") ? releaseTrack(values.get("TRACK")!, "TRACK") : "canary"
+  const excludedTrack = values.has("NO_TRACK") ? releaseTrack(values.get("NO_TRACK")!, "NO_TRACK") : undefined
+  const exclusionReason = values.get("NO_TRACK_REASON")?.trim()
+
+  if (exclusionReason && !excludedTrack) throw new Error("NO_TRACK_REASON requires NO_TRACK")
+  if (excludedTrack && !exclusionReason) throw new Error("NO_TRACK requires a non-empty NO_TRACK_REASON")
+  if (excludedTrack === declaredTrack) throw new Error("A fixture cannot exclude its declared TRACK")
+
+  return { declaredTrack, excludedTrack, exclusionReason }
+}

--- a/typescript/apps/developer-docs/lib/examples/types.ts
+++ b/typescript/apps/developer-docs/lib/examples/types.ts
@@ -1,0 +1,31 @@
+export const verificationModes = ["check", "test", "run", "expect-fail", "fragment"] as const
+
+export type VerificationMode = (typeof verificationModes)[number]
+export type ReleaseTrack = "canary" | "nightly" | "head"
+
+export interface ExampleManifest {
+  id: string
+  title: string
+  listing: number
+  caption: string
+  file: string
+  anchor: string
+  mode: VerificationMode
+  functionName?: string
+  args?: Record<string, unknown>
+}
+
+export interface TrackMetadata {
+  declaredTrack: ReleaseTrack
+  excludedTrack?: ReleaseTrack
+  exclusionReason?: string
+}
+
+export interface LoadedBamlExample extends ExampleManifest, TrackMetadata {
+  files: Record<string, string>
+  code: string
+  sourceBefore: string
+  sourceAfter: string
+  runtimeVersion: string
+  highlightedHtml: string
+}

--- a/typescript/apps/developer-docs/mdx-components.tsx
+++ b/typescript/apps/developer-docs/mdx-components.tsx
@@ -1,6 +1,8 @@
 import type { MDXComponents } from "mdx/types"
 import defaultMdxComponents from "fumadocs-ui/mdx"
 
+import { BamlExample } from "@/components/baml-example"
+import { Quiz } from "@/components/quiz"
 import { cn } from "@/lib/utils"
 
 function getText(node: React.ReactNode): string {
@@ -36,6 +38,8 @@ function heading(Tag: "h2" | "h3" | "h4") {
 
 export const mdxComponents: MDXComponents = {
   ...defaultMdxComponents,
+  BamlExample,
+  Quiz,
   h2: heading("h2"),
   h3: heading("h3"),
   h4: heading("h4"),

--- a/typescript/apps/developer-docs/package.json
+++ b/typescript/apps/developer-docs/package.json
@@ -7,10 +7,13 @@
     "dev": "next dev --turbopack --port 4000",
     "build": "next build",
     "start": "next start --port 4000",
+    "test": "vitest run",
+    "validate:fixtures": "node scripts/validate-examples.mjs",
     "typecheck": "tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@boundaryml/baml-bridge-web": "0.18.1-nightly.20260828.a",
     "@tabler/icons-react": "3.31.0",
     "@tailwindcss/postcss": "4.3.0",
     "@radix-ui/react-dialog": "1.1.14",
@@ -28,6 +31,7 @@
     "next-themes": "0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "shiki": "4.4.3",
     "tailwind-merge": "3.3.1",
     "tailwindcss": "4.3.0",
     "tw-animate-css": "1.4.0"
@@ -37,6 +41,7 @@
     "@types/node": "24.0.3",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "4.0.16"
   }
 }

--- a/typescript/apps/developer-docs/scripts/validate-examples.mjs
+++ b/typescript/apps/developer-docs/scripts/validate-examples.mjs
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process"
+import { readdirSync, readFileSync, existsSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const repoRoot = path.resolve(appRoot, "../../..")
+const examplesRoot = path.join(appRoot, "examples")
+const cargoManifest = path.join(repoRoot, "baml_language/Cargo.toml")
+const binary = path.join(repoRoot, "baml_language/target/debug/baml-cli")
+
+function manifests(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolute = path.join(directory, entry.name)
+    if (entry.isDirectory()) return manifests(absolute)
+    return entry.name === "example.json" ? [absolute] : []
+  })
+}
+
+function run(command, args, cwd = repoRoot) {
+  const result = spawnSync(command, args, { cwd, encoding: "utf8", stdio: "pipe" })
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+  if (result.status !== 0) process.exit(result.status ?? 1)
+}
+
+if (!existsSync(binary)) {
+  run("cargo", ["build", "--manifest-path", cargoManifest, "-p", "baml_cli"])
+}
+
+const fixtures = manifests(examplesRoot)
+if (fixtures.length === 0) throw new Error("No documentation example fixtures were found")
+
+for (const manifestPath of fixtures) {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  if (!["check", "run"].includes(manifest.mode)) {
+    throw new Error(`Native validation for mode '${manifest.mode}' is not implemented (${manifest.id})`)
+  }
+  const fixtureRoot = path.dirname(manifestPath)
+  process.stdout.write(`\nValidating ${manifest.id} (${manifest.mode})\n`)
+  run(binary, ["check", "--project", fixtureRoot])
+}
+
+process.stdout.write(`\nValidated ${fixtures.length} documentation fixture(s) with the native compiler.\n`)


### PR DESCRIPTION
Readers now see one BamlExample surface for highlighted source, editing, arguments, compiler diagnostics, and execution. The first book lesson runs a keyless BAML function in a lazy Web Worker and includes a typed knowledge check.\n\nAuthors reference complete fixture projects through anchors and release-track metadata instead of copying fences into MDX. Unit tests enforce marker rules, the docs build consumes the canonical BAML TextMate grammar, and a path-filtered CI workflow checks the application plus every published fixture with the native compiler.\n\nVerified with pnpm --filter @baml/developer-docs validate:fixtures, test, typecheck, and build, plus browser checks for successful execution and edited-source diagnostics.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>