### PR TITLE
chore: bump baml_language Rust toolchain to 1.98.0

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -62,7 +62,7 @@ Sets up the baml_language Rust toolchain with caching and optional WASM support.
 - name: Setup Rust
   uses: ./.github/actions/setup-rust
   with:
-    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
+    toolchain: '1.98.0'                          # Optional, default: '1.98.0'
     enable-wasm: 'false'                         # Optional, default: 'false'
     targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
     workspace: 'baml_language'                   # Optional, default: 'baml_language'

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -5,7 +5,7 @@ inputs:
   toolchain:
     description: "Rust toolchain version"
     required: false
-    default: "1.93.0"
+    default: "1.98.0"
   enable-wasm:
     description: "Enable WASM support (adds wasm32-unknown-unknown target and wasm-pack)"
     required: false
@@ -78,6 +78,10 @@ runs:
         toolchain: ${{ inputs.toolchain }}
         targets: ${{ inputs.targets }}
         components: rustfmt
+
+    - name: Export BAML build fingerprint
+      run: echo "BAML_GIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+      shell: bash
 
     - name: Add additional targets
       if: inputs.targets != ''

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -119,6 +119,7 @@ jobs:
     # Experimental targets are built when possible but never block the release.
     continue-on-error: ${{ matrix._.experimental || false }}
     env:
+      BAML_GIT_SHA: ${{ inputs.source_sha || github.sha }}
       CARGO: cargo
       # Let aws-lc-sys use its prebuilt NASM objects on Windows x86-64 if the
       # runner has no NASM installed (consulted only there; harmless elsewhere).

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -89,7 +89,7 @@ jobs:
           # CROSS_CONFIG makes the plan's image control linking; the image's
           # host ldd does not determine the wrapper's compatibility floor.
           cross_config="$RUNNER_TEMP/baml-wrapper-cross.toml"
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_WORKOS_CLIENT_ID"]\n' \
+          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -357,28 +357,34 @@ jobs:
           workspace: baml_language
           prefix-key: v5-rust-baml-language-toolchain-${{ matrix.target }}
           cache-on-failure: true
-          enable-cross: false
+          enable-cross: ${{ matrix.libc == 'gnu' && 'true' || 'false' }}
           skip-protoc: true
       - name: Setup musl cross toolchain
         if: ${{ matrix.libc == 'musl' }}
         uses: ./.github/actions/setup-musl-cross
         with:
           target: ${{ matrix.target }}
-      - name: Setup cross for backward-compatible GNU toolchain
+      - name: Setup sccache for backward-compatible GNU toolchain
         if: ${{ matrix.libc == 'gnu' }}
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache cargo:cross"
+          install_args: "sccache"
       - name: Configure cross for GNU toolchain
         if: ${{ matrix.libc == 'gnu' }}
         env:
           CROSS_IMAGE: ${{ matrix.cross_image }}
           TARGET: ${{ matrix.target }}
+          MANYLINUX2014_PRE_BUILD: 'for tool in gcc g++ ar ranlib strip; do ln -sf "$(command -v "$tool")" "/usr/local/bin/x86_64-unknown-linux-gnu-$tool"; done'
         run: |
           set -euo pipefail
           cross_config="$RUNNER_TEMP/baml-toolchain-cross.toml"
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_WORKOS_CLIENT_ID"]\n' \
-            "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
+          {
+            printf '[target.%s]\nimage = "%s"\n' "$TARGET" "$CROSS_IMAGE"
+            if [[ "$TARGET" == 'x86_64-unknown-linux-gnu' ]]; then
+              printf "pre-build = ['%s']\n" "$MANYLINUX2014_PRE_BUILD"
+            fi
+            printf '[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' "$TARGET"
+          } > "$cross_config"
           {
             echo 'CARGO=cross'
             echo "CROSS_CONFIG=$cross_config"

--- a/.github/workflows/verify-rust-sdk.reusable.yaml
+++ b/.github/workflows/verify-rust-sdk.reusable.yaml
@@ -70,7 +70,7 @@ jobs:
                      and .libc != "musl"
                      and .artifacts.toolchain != null
                      and .artifacts.cffi != null)
-            | {target: .triple, os: .artifacts.toolchain.runner}]
+            | {target: .triple, os: (.artifacts.toolchain.verify_runner // .artifacts.toolchain.runner)}]
             + [{target: "x86_64-unknown-linux-gnu",
                 os: (.targets[]
                      | select(.triple == "x86_64-unknown-linux-gnu")
@@ -120,7 +120,7 @@ jobs:
         with:
           # Default mirrors the setup-rust action default; the MSRV leg pins the
           # crate's minimum supported Rust instead.
-          toolchain: ${{ matrix.toolchain || '1.93.0' }}
+          toolchain: ${{ matrix.toolchain || '1.98.0' }}
           enable-cache: false
 
       - name: Download release artifacts

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -7,16 +7,16 @@
 # rustc silently drops the `cdylib` crate type and only the `.rlib` is built.
 #
 # `cross` runs the build inside a container and forwards only a curated set of
-# environment variables, so the Rust and native C/C++ remapping flags must be
-# listed here explicitly or they never reach the compilers.
+# environment variables, so the source fingerprint and Rust/native remapping
+# flags must be listed here explicitly or they never reach the compilers.
 [target.x86_64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.x86_64-unknown-linux-musl.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-musl.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]

--- a/baml_language/crates/baml_ide/src/export.rs
+++ b/baml_language/crates/baml_ide/src/export.rs
@@ -902,13 +902,13 @@ pub fn export_package<'db>(db: &'db Db, package: PackageId<'db>) -> PackageExpor
             .iter()
             .map(|(name, def)| (name, *def))
             .collect();
-        named.sort_by(|(a, _), (b, _)| a.cmp(b));
+        named.sort_by_key(|(name, _)| *name);
         let mut values: Vec<(&Name, Definition<'db>)> = ns_items
             .values
             .iter()
             .map(|(name, def)| (name, *def))
             .collect();
-        values.sort_by(|(a, _), (b, _)| a.cmp(b));
+        values.sort_by_key(|(name, _)| *name);
         named.extend(values);
         for (_, def) in named {
             if let Some(item) = export_item(db, def, &impl_index) {

--- a/baml_language/crates/baml_ide/src/resolve.rs
+++ b/baml_language/crates/baml_ide/src/resolve.rs
@@ -1172,10 +1172,8 @@ fn operator_target_at(
                     narrower(span, dispatch, *operand, None);
                 }
             }
-            Expr::Index { base, index } => {
-                if !inside(*base) && !inside(*index) {
-                    narrower(span, ops::INDEX_DISPATCH, *base, Some(*index));
-                }
+            Expr::Index { base, index } if !inside(*base) && !inside(*index) => {
+                narrower(span, ops::INDEX_DISPATCH, *base, Some(*index));
             }
             _ => {}
         }

--- a/baml_language/crates/baml_query/src/session.rs
+++ b/baml_language/crates/baml_query/src/session.rs
@@ -368,6 +368,7 @@ impl QuerySession {
     ///
     /// A planning failure still produces a terminal outcome — take it
     /// from the returned error via the second tuple element.
+    #[allow(clippy::result_large_err)] // Preserve the public result shape without adding boxing.
     pub async fn execute(&self, sql: &str) -> Result<QueryExecution, (QueryError, QueryOutcome)> {
         match self.plan_and_run(sql).await {
             Ok(stream) => Ok(QueryExecution {

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -58,8 +58,11 @@ pub struct Artifacts {
 /// The CLI toolchain artifact (baml-cli + pack host, archived per target).
 #[derive(Debug, Clone, Deserialize)]
 pub struct ToolchainArtifact {
-    /// GitHub Actions runner label (distinct from the target's `os` family).
+    /// GitHub Actions runner label used to build the artifact (distinct from the target's `os` family).
     pub runner: String,
+    /// Native GitHub Actions runner used to execute the artifact when the build runner cross-compiles it.
+    #[serde(default)]
+    pub verify_runner: Option<String>,
     /// Built best-effort: a build failure must not block the release.
     #[serde(default)]
     pub experimental: bool,

--- a/baml_language/crates/baml_tests/src/corpus.rs
+++ b/baml_language/crates/baml_tests/src/corpus.rs
@@ -399,7 +399,7 @@ fn corpus_snapshots() {
             crate::engine::named_and_interface_body_functions(&program)
                 .filter(|(name, _)| name.starts_with(&prefix))
                 .collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        entries.sort_by_key(|(name, _)| *name);
 
         let functions: Vec<(String, &Function)> = entries
             .iter()

--- a/baml_language/crates/bex_cache/src/lib.rs
+++ b/baml_language/crates/bex_cache/src/lib.rs
@@ -1280,7 +1280,7 @@ impl BytecodeCache {
 mod remote_tests {
     use std::{
         collections::HashMap,
-        io::{BufRead, BufReader, Read as _, Write as _},
+        io::{BufRead, BufReader},
         net::TcpListener,
         sync::{Arc, Mutex},
     };

--- a/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
+++ b/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
@@ -34,8 +34,8 @@ fn rec(seq: u64) -> [u8; 8] {
 
 fn collect_seqs(bytes: &[u8], out: &mut Vec<u64>) {
     assert_eq!(bytes.len() % 8, 0, "drained range split a record");
-    for chunk in bytes.chunks_exact(8) {
-        out.push(u64::from_le_bytes(chunk.try_into().unwrap()));
+    for chunk in bytes.as_chunks::<8>().0 {
+        out.push(u64::from_le_bytes(*chunk));
     }
 }
 

--- a/baml_language/crates/bex_prof_store/src/prof/backend/decoder.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/decoder.rs
@@ -93,10 +93,10 @@ impl ExecutionHealthSnapshot {
         if bytes.len() != Self::ENCODED_LEN {
             return None;
         }
-        let mut chunks = bytes.chunks_exact(8);
+        let mut chunks = bytes.as_chunks::<8>().0.iter();
         let mut next = || {
-            let chunk: [u8; 8] = chunks.next()?.try_into().ok()?;
-            Some(u64::from_be_bytes(chunk))
+            let chunk = chunks.next()?;
+            Some(u64::from_be_bytes(*chunk))
         };
         Some(Self {
             corrupt_records: next()?,
@@ -1753,15 +1753,12 @@ impl DirectDecoder {
         // consuming a parked end never can, so opening every ready start
         // before any parked end runs resolves the same set.
         let mut opened = Vec::new();
-        loop {
+        while let Some(parked) = self.pending_starts.get(&thread_ref) {
             // A consumer can observe a spawned child's descendants before the
             // spawning thread's ring publishes the child's entry call. Only
             // remove a fact whose parent is already resolvable; removing and
             // immediately reinserting an unready fact can otherwise select the
             // same map entry forever and livelock the sole consumer.
-            let Some(parked) = self.pending_starts.get(&thread_ref) else {
-                break;
-            };
             let next = parked
                 .iter()
                 .find(|(_, pending)| self.call_start_dependency_ready(&pending.fact))

--- a/baml_language/rust-toolchain.toml
+++ b/baml_language/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.98.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["clippy", "rust-analyzer", "rustfmt"]

--- a/baml_language/sdk_tests/crates/java/setup.ps1
+++ b/baml_language/sdk_tests/crates/java/setup.ps1
@@ -34,9 +34,6 @@ if (Get-Command gradle -ErrorAction SilentlyContinue) {
 Write-Host "==> cargo build -p bridge_java (native bridge library)"
 Push-Location $WorkspaceRoot
 try {
-    # Toolchain pinning comes from the workspace rust-toolchain.toml (1.93.0);
-    # keep in sync with setup.sh, which cannot use `rustup run` (the nix CI
-    # arm's rustup owns no toolchains).
     cargo build -p bridge_java
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 } finally {

--- a/baml_language/sdk_tests/crates/java/setup.sh
+++ b/baml_language/sdk_tests/crates/java/setup.sh
@@ -47,12 +47,7 @@ else
 fi
 
 # 1. Native bridge library the fixtures load at runtime (the JVM analog of
-#    typescript_node's `.node` addon build). Toolchain pinning comes from the
-#    workspace rust-toolchain.toml (1.93.0), which whichever cargo is on PATH
-#    honors - the rustup shim resolves it on the mise arm, and the nix CI
-#    shell ships that exact toolchain directly. An explicit `rustup run` here
-#    breaks the nix arm outright (its rustup owns no toolchains) and is
-#    redundant on the mise arm. Produces target/debug/libbridge_java.so.
+#    typescript_node's `.node` addon build). Produces target/debug/libbridge_java.so.
 echo "==> cargo build -p bridge_java (native bridge library)"
 (cd "$WORKSPACE_ROOT" && cargo build -p bridge_java)
 

--- a/baml_language/sdks/java/baml_bridge/PUBLISHING.md
+++ b/baml_language/sdks/java/baml_bridge/PUBLISHING.md
@@ -60,7 +60,7 @@ working against a locally built cdylib uses step 1 or 2.
 Build the release cdylib first (from the repo root):
 
 ```
-rustup run 1.93.0 cargo build -p bridge_java --release
+cargo build -p bridge_java --release
 # → target/release/libbridge_java.so
 ```
 

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -587,7 +587,7 @@ fn render_function_registry(pool: &SymbolPool, names: &PythonNames) -> String {
                     suffix.to_string()
                 };
                 let binding = names.callable(&companion_fqn, role);
-                let _ = writeln!(out, "        {}: {},", py_string(&key), py_string(&binding),);
+                let _ = writeln!(out, "        {}: {},", py_string(&key), py_string(&binding));
             }
         }
         out.push_str("    },\n");

--- a/baml_language/sdks/swift/rust/sdkgen_swift/src/translate_ty.rs
+++ b/baml_language/sdks/swift/rust/sdkgen_swift/src/translate_ty.rs
@@ -136,7 +136,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> Option<String> {
                     return None;
                 }
                 let final_ty = translate_ty(&args[0], ctx)?;
-                return Some(format!("BamlFunctionSpec<{final_ty}>",));
+                return Some(format!("BamlFunctionSpec<{final_ty}>"));
             }
             // `ai.Prompt` is the nominal stdlib facade around PromptAst. The
             // generated SDK aliases it to the same portable bridge wrapper.

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -41,7 +41,7 @@
       "libc": "gnu",
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "ubuntu-24.04-arm", "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
+        "toolchain": { "runner": "ubuntu-latest", "verify_runner": "ubuntu-24.04-arm", "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
         "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"], "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
@@ -73,7 +73,7 @@
       "libc": "gnu",
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "ubuntu-latest", "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64" },
+        "toolchain": { "runner": "ubuntu-latest", "cross_image": "quay.io/pypa/manylinux2014_x86_64:latest" },
         "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"], "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64" },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},


### PR DESCRIPTION
## Changes

- Bump `baml_language/rust-toolchain.toml` and the dedicated baml_language setup action from Rust 1.93.0 to 1.98.0.
- Keep the Rust SDK release verification fallback synchronized.
- Apply only the compiler and Clippy compatibility changes required by Rust 1.98.
- Remove duplicated Rust-version comments from the Java SDK test setup scripts.
- Use plain `cargo build -p bridge_java --release` in the Java publishing guide.
- Use `cross` from upstream main for GNU release targets so Rust 1.98 cross-compilation works on ARM64 runners.
- Leave Salsa unchanged at 0.26.2.

## Validation

- [x] `cargo fmt --all -- --check --config imports_granularity=Crate --config group_imports=StdExternalCrate`
- [x] `cargo check --workspace --all-targets --all-features --locked`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `actionlint .github/workflows/release-baml-language.yml`
- [ ] Release workflow dry run from the top of the stack.

## Stack

1. #4648: decouple engine and baml_language Rust setup.
2. This PR: bump baml_language to Rust 1.98.
3. #4682: move the root pin into engine and bump engine to Rust 1.98.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
