### PR TITLE
chore: move engine Rust toolchain pin and bump to 1.98.0

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -75,7 +75,7 @@ Sets up the engine Rust toolchain with caching and optional WASM support.
 - name: Setup Engine Rust
   uses: ./.github/actions/engine-setup-rust
   with:
-    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
+    toolchain: '1.98.0'                          # Optional, default: '1.98.0'
     enable-wasm: 'false'                         # Optional, default: 'false'
     targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
     workspace: 'engine'                         # Optional, default: 'engine'

--- a/.github/actions/engine-setup-rust/action.yml
+++ b/.github/actions/engine-setup-rust/action.yml
@@ -5,7 +5,7 @@ inputs:
   toolchain:
     description: "Rust toolchain version"
     required: false
-    default: "1.93.0"
+    default: "1.98.0"
   enable-wasm:
     description: "Enable WASM support (adds wasm32-unknown-unknown target and wasm-pack)"
     required: false

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -33,10 +33,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Rust (MSRV 1.70)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Engine Rust
+        uses: ./.github/actions/engine-setup-rust
         with:
-          toolchain: "1.70"
+          enable-cache: false
+          enable-cross: false
+          skip-protoc: true
 
       - name: Cache Rust dependencies (engine)
         uses: Swatinem/rust-cache@v2
@@ -108,10 +110,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Rust (MSRV 1.70)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Engine Rust
+        uses: ./.github/actions/engine-setup-rust
         with:
-          toolchain: "1.70"
+          enable-cache: false
+          enable-cross: false
+          skip-protoc: true
 
       - name: Cache Rust dependencies (engine)
         uses: Swatinem/rust-cache@v2

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -349,9 +349,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4295,9 +4295,9 @@ checksum = "8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4487,6 +4487,12 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -4979,6 +4985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -8033,9 +8040,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8046,9 +8053,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8059,9 +8066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8069,9 +8076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8082,21 +8089,29 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term 0.50.1",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
@@ -8104,9 +8119,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8153,9 +8168,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -170,8 +170,8 @@ tokio = { version = "1", default-features = false, features = [
   "time",
 ] }
 
-js-sys = "=0.3.82"
-wasm-bindgen = "=0.2.105"
+js-sys = "=0.3.83"
+wasm-bindgen = "=0.2.106"
 wasm-bindgen-futures = "0.4.42"
 wasm-bindgen-test = "0.3.45"
 web-sys = { version = "0.3.78", features = [

--- a/engine/baml-lib/ast/src/parser/helpers.rs
+++ b/engine/baml-lib/ast/src/parser/helpers.rs
@@ -17,7 +17,7 @@ pub fn parsing_catch_all(token: Pair<'_>, kind: &str, diagnostics: &mut Diagnost
             let message = format!(
                 "Encountered impossible {} during parsing: {:?} {:?}",
                 kind,
-                &x,
+                x,
                 token.clone().tokens()
             );
             diagnostics.push_error(DatamodelError::new_parser_error(

--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/to_baml_arg.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/to_baml_arg.rs
@@ -76,14 +76,11 @@ fn find_matching_media_type_index(options: &[&TypeIR], value: &BamlValue) -> Opt
     };
 
     // Extract extension, handling URLs with query params/fragments
-    let ext = 'extract_ext: {
+    let ext = {
         let path_part = path.split('?').next().unwrap_or(path);
         let path_part = path_part.split('#').next().unwrap_or(path_part);
         let filename = path_part.rsplit('/').next().unwrap_or(path_part);
-        match Path::new(filename).extension().and_then(|e| e.to_str()) {
-            Some(ext) => break 'extract_ext ext,
-            None => return None,
-        }
+        Path::new(filename).extension().and_then(|e| e.to_str())?
     };
 
     let ext_lower = ext.to_lowercase();

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/cycle.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/cycle.rs
@@ -187,11 +187,9 @@ fn insert_required_class_deps(
                         }
                     }
                 }
-                Some(TypeWalker::TypeAlias(alias)) => {
+                Some(TypeWalker::TypeAlias(alias)) if !alias_cycles.contains(&alias.id) => {
                     // This code runs after aliases are already resolved.
-                    if !alias_cycles.contains(&alias.id) {
-                        insert_required_class_deps(id, alias.resolved(), ctx, deps, alias_cycles)
-                    }
+                    insert_required_class_deps(id, alias.resolved(), ctx, deps, alias_cycles)
                 }
                 _ => {}
             }

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_fns.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_fns.rs
@@ -128,11 +128,9 @@ pub(super) fn validate_expr_fns(ctx: &mut Context<'_>) {
                 Stmt::Let(_) => {
                     scope.insert(s.identifier().name().to_string());
                 }
-                Stmt::ForLoop(fl) => {
+                Stmt::ForLoop(fl) if fl.has_let => {
                     // Only treat as declaration if header included `let`
-                    if fl.has_let {
-                        scope.insert(fl.identifier.name().to_string());
-                    }
+                    scope.insert(fl.identifier.name().to_string());
                 }
                 _ => {}
             }
@@ -273,10 +271,8 @@ fn validate_expr_block(
             Stmt::Let(_) => {
                 scope_for_block.insert(stmt.identifier().name().to_string());
             }
-            Stmt::ForLoop(fl) => {
-                if fl.has_let {
-                    scope_for_block.insert(fl.identifier.name().to_string());
-                }
+            Stmt::ForLoop(fl) if fl.has_let => {
+                scope_for_block.insert(fl.identifier.name().to_string());
             }
             _ => {}
         }

--- a/engine/baml-lib/baml-types/src/ir_type/mod.rs
+++ b/engine/baml-lib/baml-types/src/ir_type/mod.rs
@@ -780,12 +780,8 @@ impl<T> TypeGeneric<T> {
                 TypeGeneric::Union(inner, _) => match inner.view() {
                     UnionTypeViewGeneric::Null => {}
                     UnionTypeViewGeneric::Optional(field_type) => queue.push(field_type),
-                    UnionTypeViewGeneric::OneOf(field_types) => {
-                        queue.extend(field_types.into_iter())
-                    }
-                    UnionTypeViewGeneric::OneOfOptional(field_types) => {
-                        queue.extend(field_types.into_iter())
-                    }
+                    UnionTypeViewGeneric::OneOf(field_types) => queue.extend(field_types),
+                    UnionTypeViewGeneric::OneOfOptional(field_types) => queue.extend(field_types),
                 },
                 TypeGeneric::Tuple(inner, _) => {
                     queue.extend(inner.iter());

--- a/engine/baml-lib/diagnostics/src/error.rs
+++ b/engine/baml-lib/diagnostics/src/error.rs
@@ -639,7 +639,7 @@ impl DatamodelError {
         alternatives: I,
     ) -> DatamodelError
     where
-        I: for<'a> Index<usize, Output = T>,
+        I: Index<usize, Output = T>,
         T: AsRef<str>,
         for<'a> &'a I: IntoIterator<Item = &'a T>,
     {

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_array.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_array.rs
@@ -70,14 +70,10 @@ pub(super) fn try_cast_array(
     let mut last_union_hint: Option<usize> = None;
     for (i, item) in arr.iter().enumerate() {
         let child_ctx = ctx.enter_scope_with_hint(&format!("{i}"), last_union_hint);
-        match element_type.try_cast(&child_ctx, element_type, Some(item)) {
-            Some(v) => {
-                // Extract winning variant index for the next iteration's hint
-                last_union_hint = extract_union_winner_index(&v);
-                items.push(v);
-            }
-            None => return None, // Fail fast on first error
-        }
+        let v = element_type.try_cast(&child_ctx, element_type, Some(item))?;
+        // Extract winning variant index for the next iteration's hint
+        last_union_hint = extract_union_winner_index(&v);
+        items.push(v);
     }
 
     let mut result =

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_map.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_map.rs
@@ -54,12 +54,8 @@ pub(super) fn try_cast_map(
     // Try to cast all values
     let mut items = BamlMap::new();
     for (key, value) in obj {
-        match value_type.try_cast(ctx, value_type, Some(value)) {
-            Some(cast_value) => {
-                items.insert(key.to_string(), (DeserializerConditions::new(), cast_value));
-            }
-            None => return None, // Fail fast on first error
-        }
+        let cast_value = value_type.try_cast(ctx, value_type, Some(value))?;
+        items.insert(key.to_string(), (DeserializerConditions::new(), cast_value));
     }
 
     let mut flags = DeserializerConditions::new();

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -208,18 +208,14 @@ impl TypeCoercer for TypeIR {
             }
         }
         if let Some(CompletionState::Incomplete) = value.map(|v| v.completion_state()) {
-            match result {
-                Ok(mut v) => {
-                    if self.meta().streaming_behavior.done
-                        && ctx.do_not_use_mode == baml_types::StreamingMode::Streaming
-                    {
-                        return Err(ctx.error_internal("Streaming field is not done"));
-                    }
-                    v.add_flag(Flag::Incomplete);
-                    return Ok(v);
-                }
-                Err(e) => return Err(e),
+            let mut v = result?;
+            if self.meta().streaming_behavior.done
+                && ctx.do_not_use_mode == baml_types::StreamingMode::Streaming
+            {
+                return Err(ctx.error_internal("Streaming field is not done"));
             }
+            v.add_flag(Flag::Incomplete);
+            return Ok(v);
         }
         result
     }

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
@@ -87,11 +87,8 @@ impl TypeCoercer for Class {
                 if matches!(val, Triple::Present(_)) {
                     continue;
                 }
-                if let Some(cast_value) = field_type.try_cast(ctx, field_type, Some(v)) {
-                    *val = Triple::Present(Box::new(cast_value));
-                } else {
-                    return None;
-                }
+                let cast_value = field_type.try_cast(ctx, field_type, Some(v))?;
+                *val = Triple::Present(Box::new(cast_value));
             } else {
                 // In try_cast mode, reject objects with extra keys for stricter matching
                 return None;
@@ -292,22 +289,21 @@ impl TypeCoercer for Class {
                     completed_cls.push(Ok(option1));
                 }
             }
-            Some(x) => {
+            Some(x) if self.fields.len() == 1 => {
                 // If the class has a single field, then we can try to coerce it directly
-                if self.fields.len() == 1 {
-                    let field = &self.fields[0];
-                    let scope = ctx.enter_scope(&format!("<implied:{}>", field.0.real_name()));
-                    let parsed = match field.1.coerce(&scope, &field.1, Some(x)) {
-                        Ok(mut v) => {
-                            v.add_flag(Flag::ImpliedKey(field.0.real_name().into()));
-                            flags.add_flag(Flag::InferedObject(x.clone()));
-                            Ok(v)
-                        }
-                        Err(e) => Err(e),
-                    };
-                    update_map(&mut required_values, &mut optional_values, field, parsed);
-                }
+                let field = &self.fields[0];
+                let scope = ctx.enter_scope(&format!("<implied:{}>", field.0.real_name()));
+                let parsed = match field.1.coerce(&scope, &field.1, Some(x)) {
+                    Ok(mut v) => {
+                        v.add_flag(Flag::ImpliedKey(field.0.real_name().into()));
+                        flags.add_flag(Flag::InferedObject(x.clone()));
+                        Ok(v)
+                    }
+                    Err(e) => Err(e),
+                };
+                update_map(&mut required_values, &mut optional_values, field, parsed);
             }
+            Some(_) => {}
         }
 
         // Check what we have / what we need

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
@@ -74,7 +74,7 @@ impl From<JsonCollection> for Option<Value> {
             JsonCollection::Object(keys, values, object_completion) => {
                 // log::debug!("keys: {:?}", keys);
                 let mut object: Vec<_> = Vec::new();
-                for (key, value) in keys.into_iter().zip(values.into_iter()) {
+                for (key, value) in keys.into_iter().zip(values) {
                     object.push((key, value));
                 }
                 Value::Object(object, object_completion)

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -502,13 +502,9 @@ impl JsonParseState {
                     // We'll close the string the next time around.
                     false
                 }
-                '{' | '"' | '\'' | '[' => {
-                    if !has_some_object {
-                        // We're in a string
-                        true
-                    } else {
-                        false
-                    }
+                '{' | '"' | '\'' | '[' if !has_some_object => {
+                    // We're in a string
+                    true
                 }
                 _ => {
                     // Almost every other character should not close the string

--- a/engine/baml-lib/llm-client/src/clientspec.rs
+++ b/engine/baml-lib/llm-client/src/clientspec.rs
@@ -375,7 +375,7 @@ impl UnresolvedRolesSelection {
 
         match (&allowed, &remap) {
             (Some(allowed), Some(remap)) => {
-                for (k, _) in remap.iter() {
+                for k in remap.keys() {
                     if !allowed.contains(k) {
                         return Err(anyhow::anyhow!(
                             "remap_role must be in allowed_roles: {}. Not found in {:?}",
@@ -390,7 +390,7 @@ impl UnresolvedRolesSelection {
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<_>>();
-                for (k, _) in remap.iter() {
+                for k in remap.keys() {
                     if !allowed.contains(k) {
                         return Err(anyhow::anyhow!(
                             "remap_role must be in allowed_roles: {}. Not found in {:?}",

--- a/engine/baml-runtime/src/cli/dump_intermediate.rs
+++ b/engine/baml-runtime/src/cli/dump_intermediate.rs
@@ -134,10 +134,8 @@ impl DumpIntermediateArgs {
                         eprintln!("Class: {} with {} fields", c.name, c.field_names.len());
                     }
                 }
-                Object::Enum(e) => {
-                    if !baml_compiler::builtin::is_builtin_enum(&e.name) {
-                        eprintln!("Enum {}", e.name);
-                    }
+                Object::Enum(e) if !baml_compiler::builtin::is_builtin_enum(&e.name) => {
+                    eprintln!("Enum {}", e.name);
                 }
                 _ => {
                     // Skip other object types (Instance, etc.)

--- a/engine/baml-runtime/src/control_flow/flatten/step2_hoist_branch_arms.rs
+++ b/engine/baml-runtime/src/control_flow/flatten/step2_hoist_branch_arms.rs
@@ -57,7 +57,7 @@ pub fn hoist_branch_arms(viz: &ControlFlowVisualization) -> ControlFlowVisualiza
         })
         .collect();
 
-    groups.sort_by(|a, b| b.depth.cmp(&a.depth));
+    groups.sort_by_key(|a| std::cmp::Reverse(a.depth));
 
     for info in groups {
         // Step 2: move outgoing edges from the branch group onto each arm.

--- a/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
@@ -721,7 +721,7 @@ async fn process_media(
             Ok(BamlMedia::base64(
                 part.media_type,
                 if render_settings.as_shell_commands {
-                    format!("$(curl -L '{}' | base64)", &media_url.url)
+                    format!("$(curl -L '{}' | base64)", media_url.url)
                 } else {
                     base64
                 },

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -1402,7 +1402,7 @@ impl BamlRuntime {
         }
 
         log::trace!("Calling function: {function_name}");
-        log::debug!("collectors: {:#?}", &collectors);
+        log::debug!("collectors: {:#?}", collectors);
 
         let call = self
             .tracer_wrapper
@@ -1742,7 +1742,7 @@ impl BamlRuntime {
             let processed_content = if let Some(spans) = test_spans_by_file.get(path) {
                 // Sort spans by start position in reverse order so we can remove from end to start
                 let mut sorted_spans = spans.clone();
-                sorted_spans.sort_by(|a, b| b.start.cmp(&a.start));
+                sorted_spans.sort_by_key(|a| std::cmp::Reverse(a.start));
 
                 // Remove each test block from the content
                 let mut new_content = content.clone();

--- a/engine/baml-runtime/src/optimize/applier.rs
+++ b/engine/baml-runtime/src/optimize/applier.rs
@@ -562,19 +562,17 @@ fn find_attribute_end(s: &str) -> Option<usize> {
                 }
             }
             '"' => in_string = !in_string,
-            '#' if !in_string => {
+            '#' if !in_string && chars.peek() == Some(&'"') => {
                 // Check for #"..."# raw string
-                if chars.peek() == Some(&'"') {
-                    chars.next();
+                chars.next();
+                pos += 1;
+                // Find the closing "#
+                while let Some(c) = chars.next() {
                     pos += 1;
-                    // Find the closing "#
-                    while let Some(c) = chars.next() {
+                    if c == '"' && chars.peek() == Some(&'#') {
+                        chars.next();
                         pos += 1;
-                        if c == '"' && chars.peek() == Some(&'#') {
-                            chars.next();
-                            pos += 1;
-                            break;
-                        }
+                        break;
                     }
                 }
             }

--- a/engine/baml-runtime/src/sse.rs
+++ b/engine/baml-runtime/src/sse.rs
@@ -87,10 +87,8 @@ impl Decoder {
                 self.data.push('\n');
                 self.has_data = true;
             }
-            "id" => {
-                if !value.contains('\0') {
-                    self.last_id = value.to_string();
-                }
+            "id" if !value.contains('\0') => {
+                self.last_id = value.to_string();
             }
             // "retry" and unknown fields are ignored.
             _ => {}

--- a/engine/baml-runtime/src/test_executor/output_pretty.rs
+++ b/engine/baml-runtime/src/test_executor/output_pretty.rs
@@ -496,7 +496,7 @@ impl RenderTestExecutionStatus for PrettyTestExecutionStatusRenderer {
     ) {
         {
             let mut bars = self.test_bars.borrow_mut();
-            for (_, pb) in bars.iter_mut() {
+            for pb in bars.values_mut() {
                 pb.finish_and_clear();
             }
         }

--- a/engine/baml-runtime/src/tracingv2/storage/storage.rs
+++ b/engine/baml-runtime/src/tracingv2/storage/storage.rs
@@ -361,8 +361,7 @@ fn build_function_log(
 
         if !successful_calls.is_empty() {
             // Sort successful calls by lexicographic order of request_id (ULID UUID)
-            successful_calls
-                .sort_by(|(_, a), (_, b)| a.request_id.to_string().cmp(&b.request_id.to_string()));
+            successful_calls.sort_by_key(|(_, a)| a.request_id.to_string());
 
             // Pick the first (earliest lexicographically)
             selected_idx = Some(successful_calls[0].0);

--- a/engine/baml-schema-wasm/rust-toolchain.toml
+++ b/engine/baml-schema-wasm/rust-toolchain.toml
@@ -1,10 +1,7 @@
 [toolchain]
-# If you set this > 1.81 you may run into this webassembly issue:
-# https://github.com/rustwasm/rust-webpack-template/issues/191
-# If you really want > 1.81 you can try using wasm-bindgen-cli 0.2.105 instead
-# Previously pinned to 1.81.0 but reverted to use stable with wasm-bindgen-cli 0.2.105
-# Using same version as root rust-toolchain.toml to avoid rustup component conflicts in CI
-channel = "1.93.0"
+# Keep wasm-bindgen-cli aligned with the engine workspace's wasm-bindgen pin.
+# Using the same version as engine/rust-toolchain.toml to avoid rustup component conflicts in CI
+channel = "1.98.0"
 components = []
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/engine/baml-schema-wasm/src/lib.rs
+++ b/engine/baml-schema-wasm/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod js_callback_bridge;
 

--- a/engine/cli/src/deploy.rs
+++ b/engine/cli/src/deploy.rs
@@ -203,7 +203,7 @@ impl Deployer {
                         &project_resp
                             .projects
                             .iter()
-                            .map(|p| format!("Deploy to existing project {}", &p.project_fqn))
+                            .map(|p| format!("Deploy to existing project {}", p.project_fqn))
                             .collect::<Vec<_>>(),
                     )
                     .default(0)

--- a/engine/language_server/src/server/api.rs
+++ b/engine/language_server/src/server/api.rs
@@ -91,7 +91,7 @@ pub(super) fn request<'a>(req: lsp_server::Request) -> Task<'a> {
                         .as_ref()
                         .unwrap_or(&default_flags);
 
-                    for (_, project) in projects.iter() {
+                    for project in projects.values() {
                         let functions = project
                             .lock()
                             .baml_project

--- a/engine/language_server/src/session.rs
+++ b/engine/language_server/src/session.rs
@@ -318,7 +318,7 @@ impl Session {
 
     pub fn clear_unsaved_files(&mut self) {
         tracing::info!("Clearing unsaved files");
-        for (_folder, project) in self.baml_src_projects.lock().iter_mut() {
+        for project in self.baml_src_projects.lock().values_mut() {
             project.lock().baml_project.unsaved_files.clear();
         }
     }
@@ -358,7 +358,7 @@ impl Session {
                 )
             }
         };
-        for (_folder, project) in self.baml_src_projects.lock().iter_mut() {
+        for project in self.baml_src_projects.lock().values_mut() {
             let text_document = TextDocument::new(new_contents.clone(), 0);
             project
                 .lock()

--- a/engine/rust-toolchain.toml
+++ b/engine/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.98.0"
 components = [
   "rustfmt",
   "clippy",

--- a/mise.toml
+++ b/mise.toml
@@ -28,8 +28,8 @@ ninja = "1.13.2"
 "cargo:prek" = "0.3.13"
 "cargo:cargo-nextest" = "latest"
 "cargo:cargo-insta" = "latest"
-# cargo-shear >=1.13.3 needs rustc 1.95; the repo is pinned to 1.93.0, so build it with a newer toolchain.
-"cargo:cargo-shear" = { version = "latest", install_env = { RUSTUP_TOOLCHAIN = "1.97.1" } }
+# Build cargo-shear with the engine's pinned Rust toolchain.
+"cargo:cargo-shear" = { version = "latest", install_env = { RUSTUP_TOOLCHAIN = "1.98.0" } }
 "cargo:https://github.com/astral-sh/hawk" = { version = "rev:42b09e72b2bf79f75aa8ce5f4563576f2dedf4c1", crate = "cargo-hawk", locked = true, install_env = { RUSTC_BOOTSTRAP = "1", RUSTUP_TOOLCHAIN = "1.97.1" } }
 
 # Go tools


### PR DESCRIPTION
## Changes

- Move the repository-root `rust-toolchain.toml` to `engine/rust-toolchain.toml` and bump it from Rust 1.93.0 to 1.98.0.
- Bump the dedicated engine setup action and schema-WASM pin to Rust 1.98.
- Apply focused Rust 1.98 compiler and Clippy compatibility changes.
- Raise the schema-WASM recursion limit required by Rust 1.98.
- Update wasm-bindgen 0.2.105 to 0.2.106, the minimum release containing the upstream duplicate-export fix for Rust v0 symbol mangling.
- Leave Salsa unchanged at 0.26.2.

## Validation

- [x] `cargo metadata --locked --no-deps --format-version 1`
- [x] `cargo fmt --check -- --config imports_granularity=Crate --config group_imports=StdExternalCrate`
- [x] `RUSTFLAGS="-A unused -D warnings" cargo clippy --workspace -- -D clippy::print_stdout`
- [x] `RUSTFLAGS="-A unused -D warnings" cargo clippy --target wasm32-unknown-unknown` in `engine/baml-schema-wasm`
- [x] `pnpm run release` in `engine/baml-schema-wasm/web`
- [x] `pnpm run typecheck` in `engine/baml-schema-wasm/nodejs`
- [x] `cargo test -p internal-baml-core -p jsonish -p baml-runtime --lib` (711 passed)

## Stack

1. #4648: decouple engine and baml_language Rust setup.
2. #4681: bump baml_language to Rust 1.98.
3. This PR: move the root pin into engine and bump engine to Rust 1.98.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>