### PR TITLE
chore(release): workflow runs are now "canary release: 0.18.0"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1435,6 +1435,12 @@ jobs:
           RELEASE_WORKFLOW_REF: ${{ steps.release-workflow-ref.outputs.ref }}
         run: |
           set -euo pipefail
+          release_plan="$RUNNER_TEMP/canary-release-plan.json"
+          scripts/baml-language-version plan \
+            --channel canary \
+            --out "$release_plan"
+          release_version="$(jq -r .canonical_version "$release_plan")"
+          echo "Requested canary release version: $release_version"
           # Load the workflow definition from the same immutable commit that the
           # release checks out, even if canary advances while this CI run finishes.
           gh workflow run release-baml-language.yml \
@@ -1442,5 +1448,6 @@ jobs:
             --ref "$RELEASE_WORKFLOW_REF" \
             -f channel=canary \
             -f dry_run=false \
+            -f version="$release_version" \
             -f source_sha="$GITHUB_SHA" \
             -f source_ci_run_id="$GITHUB_RUN_ID"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -230,6 +230,16 @@ jobs:
               ;;
           esac
 
+      - name: Check out the nightly release source
+        if: ${{ steps.decide.outputs.dispatch == 'true' }}
+        uses: actions/checkout@v7.0.1
+        with:
+          # Compute the requested version from the exact source the release
+          # workflow will independently plan and verify.
+          ref: ${{ steps.select.outputs.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+
       - name: Dispatch the nightly release
         if: ${{ steps.decide.outputs.dispatch == 'true' }}
         env:
@@ -252,6 +262,12 @@ jobs:
             echo "::error::$release_ref resolves to $ref_type $ref_sha, expected commit $SOURCE_SHA"
             exit 1
           fi
+          release_plan="$RUNNER_TEMP/nightly-release-plan.json"
+          scripts/baml-language-version plan \
+            --channel nightly \
+            --out "$release_plan"
+          release_version="$(jq -r .canonical_version "$release_plan")"
+          echo "Requested nightly release version: $release_version"
           # The release names the night itself, from the Seattle date at plan
           # time. That is stable however long this run queues -- it would take a
           # 24-hour delay to land on a different local date.
@@ -259,6 +275,7 @@ jobs:
             --ref "$release_ref" \
             -f channel=nightly \
             -f dry_run=false \
+            -f version="$release_version" \
             -f source_sha="$SOURCE_SHA" \
             -f source_ci_run_id="$SOURCE_CI_RUN_ID"
           echo "Dispatched a nightly release for $SOURCE_SHA (CI run $SOURCE_CI_RUN_ID)."

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1,5 +1,7 @@
 name: BAML Language Release
 
+run-name: "${{ inputs.dry_run && 'Dry run' || 'Publish' }} · ${{ inputs.channel }} · ${{ inputs.version || 'auto-version' }}"
+
 # Channel-aware replacement for the legacy BAML language release workflow.
 # Release workflows run packaging smoke tests only; the full suite runs in CI.
 
@@ -10,6 +12,11 @@ name: BAML Language Release
 #     midnight America/Los_Angeles, when canary moved since the last nightly.
 # Both pin the run to the immutable `baml-language-source-<sha>` tag CI created
 # for the commit, which the attestation below re-checks.
+#
+# Dispatchers also compute the release plan before dispatch so the requested
+# canonical version can name the run. This workflow recomputes the plan from the
+# immutable source and refuses production unless both versions match; the input
+# is a request and display label, never the publishing source of truth.
 #
 # One dispatcher per channel is deliberate: a canary release used to chain a
 # nightly of its own, which meant two sites racing to name the same night with
@@ -36,6 +43,11 @@ on:
         type: boolean
         default: true
         required: true
+      version:
+        description: "Canonical release version requested by the dispatcher (required for production)"
+        type: string
+        default: ""
+        required: false
       source_sha:
         description: "Commit to release (defaults to the dispatched ref's head)"
         type: string
@@ -197,6 +209,7 @@ jobs:
         env:
           INPUT_CHANNEL: ${{ inputs.channel }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_VERSION: ${{ inputs.version }}
           INPUT_SOURCE_CI_RUN_ID: ${{ inputs.source_ci_run_id }}
           ATTESTED_SOURCE_BRANCH: ${{ steps.attest.outputs.source_branch }}
           GH_TOKEN: ${{ github.token }}
@@ -205,10 +218,21 @@ jobs:
           channel="${INPUT_CHANNEL:-nightly}"
           dry_run="${INPUT_DRY_RUN:-false}"
           source_branch="${ATTESTED_SOURCE_BRANCH:-${GITHUB_REF_NAME:-}}"
+          if [[ "$dry_run" == "false" && -z "$INPUT_VERSION" ]]; then
+            echo "::error::production releases require an explicit version"
+            exit 1
+          fi
           # `plan` rejects any channel other than canary/nightly.
           scripts/baml-language-version plan --channel "$channel" --out release-plan.json
           source_sha="$(git rev-parse HEAD)"
           version="$(jq -r .canonical_version release-plan.json)"
+          if [[ -n "$INPUT_VERSION" && "$version" != "$INPUT_VERSION" ]]; then
+            echo "::error::requested version $INPUT_VERSION does not match computed version $version"
+            exit 1
+          fi
+          if [[ -n "$INPUT_VERSION" ]]; then
+            echo "Verified requested release version: $version"
+          fi
           pypi_version="$(jq -r .registry_versions.pypi release-plan.json)"
           crates_io_version="$(jq -r .registry_versions.crates_io release-plan.json)"
           nuget_version="$(jq -r .registry_versions.nuget release-plan.json)"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1,6 +1,6 @@
 name: BAML Language Release
 
-run-name: "${{ inputs.dry_run && 'Dry run' || 'Publish' }} · ${{ inputs.channel }} · ${{ inputs.version || 'auto-version' }}"
+run-name: "${{ inputs.channel }} release${{ inputs.dry_run && ' (dry run)' || '' }}: ${{ inputs.version || 'auto-version' }}"
 
 # Channel-aware replacement for the legacy BAML language release workflow.
 # Release workflows run packaging smoke tests only; the full suite runs in CI.

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -47,7 +47,7 @@ jobs:
   size-gate-linux:
     name: "measure-baml-size (linux)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
     continue-on-error: true
     steps:
       - uses: useblacksmith/checkout@v1


### PR DESCRIPTION
When browsing the log of release workflow invocations, see https://github.com/BoundaryML/baml/actions/workflows/release-baml-language.yml, we'll now get names like this:

  - canary release: 0.18.0
  - nightly release: 0.18.1-nightly.20260901.a
  - nightly release (dry run): auto-version
  
This will make it much easier to, at a glance, figure out what the status of past releases is and the current release schedule.

Implemented by asking the release workflow triggers to also compute the release plan and then use the computed release version in the `workflow_dispatch.inputs`. The triggered workflow itself still computes the plan but will now cross-check the requested version against the computed one.