### PR TITLE
ci: move sccache to baml-build3 R2 cache

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -65,9 +65,9 @@ export SCCACHE_IDLE_TIMEOUT=0
 export SCCACHE_ERROR_LOG="${TMPDIR:-/tmp}/sccache-baml.log"
 
 if [ -n "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" ] && [ -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]; then
-    export SCCACHE_BUCKET=baml-build1
+    export SCCACHE_BUCKET=baml-build3
     export SCCACHE_REGION=auto
-    export SCCACHE_ENDPOINT=https://321ca319116f1e5eefa9135d9d019a5a.r2.cloudflarestorage.com
+    export SCCACHE_ENDPOINT=https://c0bf62c013f607c849c6a50cdd627b7b.r2.cloudflarestorage.com
     # Separate the cache namespaces so CI and local builds don't collide.
     if [ "${CI:-}" = "true" ]; then
         export SCCACHE_S3_KEY_PREFIX=baml/ci/

--- a/.github/workflows/canary-cache-refresh.yml
+++ b/.github/workflows/canary-cache-refresh.yml
@@ -46,6 +46,8 @@ jobs:
   cargo-tests:
     needs: purge
     uses: ./.github/workflows/cargo-tests.reusable.yaml
+    # Structural mapping only: the called jobs get the values from their
+    # infisical-github-ci Environment, not from repository secrets.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/canary-cache-refresh.yml
+++ b/.github/workflows/canary-cache-refresh.yml
@@ -46,6 +46,9 @@ jobs:
   cargo-tests:
     needs: purge
     uses: ./.github/workflows/cargo-tests.reusable.yaml
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     # Drop `actions: write` for the called workflow — its jobs run
     # cargo build / test code that we don't want touching the cache
     # API. cargo-tests.reusable.yaml also declares `contents: read`

--- a/.github/workflows/canary-cache-refresh.yml
+++ b/.github/workflows/canary-cache-refresh.yml
@@ -52,4 +52,3 @@ jobs:
     # at its workflow level as defense in depth.
     permissions:
       contents: read
-    secrets: inherit

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -31,6 +31,11 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 # Read-only by design: these jobs run PR-controlled cargo build/test code, so
 # they should not need elevated repository permissions.

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -90,6 +90,20 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
+      - name: "Report R2 credential fingerprints"
+        run: |
+          set -euo pipefail
+
+          fingerprint() {
+            local name="$1"
+            local value="$2"
+            printf '%s length=%d sha256=' "$name" "${#value}"
+            printf '%s' "$value" | sha256sum | awk '{print $1}'
+          }
+
+          fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
+          fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -19,8 +19,8 @@
 #
 # mise installs sccache and direnv, then each cargo job loads .envrc via
 # `direnv export gha` so CI uses the exact same sccache config as local shells:
-# .envrc is the single source of truth. The R2 credentials are passed through
-# GitHub Actions secrets using the same BAML_SCCACHE_R2_* names that the
+# .envrc is the single source of truth. The R2 credentials come from the
+# infisical-github-ci GitHub Environment using the same BAML_SCCACHE_R2_* names that the
 # RUSTC_WRAPPER maps to AWS_* before exec'ing sccache — the `tools/baml-sccache`
 # script on POSIX, and the native `tools_sccache` crate's binary on Windows
 # (built per-job; see the "Build native sccache wrapper" step).
@@ -31,11 +31,6 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
-    secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID:
-        required: false
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
-        required: false
 
 # Read-only by design: these jobs run PR-controlled cargo build/test code, so
 # they should not need elevated repository permissions.
@@ -49,10 +44,7 @@ defaults:
 env:
   # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
   # .envrc itself so it stays the single source of truth across CI and local.
-  # The R2 credentials .envrc maps to AWS_* for sccache (mapped to AWS_*).
   # Native Cargo linker overrides live in baml_language/.cargo/config.toml.
-  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -74,7 +66,11 @@ jobs:
   cargo-test-linux:
     name: "cargo test (x86_64-unknown-linux-gnu)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 25
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -177,8 +173,11 @@ jobs:
   cargo-test-linux-musl:
     name: "cargo test (x86_64-unknown-linux-musl)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 35
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
     steps:
       - uses: useblacksmith/checkout@v1
@@ -371,7 +370,10 @@ jobs:
     # 8-vCPU + CARGO_BUILD_JOBS=16 (2x cores) was the value sweet spot for the
     # native Windows Rust builds (build-caching/04 Exp 7/9).
     runs-on: blacksmith-8vcpu-windows-2025
+    environment: infisical-github-ci
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_JOBS: "16"
       # Windows debug builds emit very large PDBs; full debuginfo across the
       # whole `--all-features` test build overruns the runner's ~130 GB disk
@@ -910,8 +912,11 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
+    environment: infisical-github-ci
     timeout-minutes: ${{ matrix.timeout }}
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       # MSBuild reads environment variables as global properties. The .NET
       # SDK embeds the git commit into every build by default (SourceLink
       # json + SourceRevisionId in InformationalVersion), which changes a
@@ -1230,7 +1235,11 @@ jobs:
   cargo-test-wasm:
     name: "cargo test (wasm32-unknown-unknown)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 45
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -1340,7 +1349,11 @@ jobs:
   cargo-build-msrv:
     name: "cargo build (msrv)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 25
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -1427,7 +1440,11 @@ jobs:
   cargo-doc:
     name: "cargo doc"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 25
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -1502,7 +1519,11 @@ jobs:
   snapshot-tests:
     name: "snapshot tests"
     runs-on: blacksmith-16vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 30
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -99,26 +99,6 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
-      - name: "Report R2 credential fingerprints"
-        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
-        run: |
-          set -euo pipefail
-
-          fingerprint() {
-            local name="$1"
-            local value="$2"
-            printf '%s length=%d sha256=' "$name" "${#value}"
-            printf '%s' "$value" | sha256sum | awk '{print $1}'
-          }
-
-          fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
-          fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
-
-          if [[ -z "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" || -z "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
-            echo "::error::Trusted CI requires both R2 sccache credentials"
-            exit 1
-          fi
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -31,6 +31,10 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
+    # Callers intentionally map these names even though the values exist only
+    # in the GitHub Environment. The mapping establishes the reusable-workflow
+    # secret contract; each job's environment supplies the actual value.
+    # Keep them optional so fork PRs retain the secretless local-cache path.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -91,6 +91,7 @@ jobs:
         run: sccache --version
 
       - name: "Report R2 credential fingerprints"
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -euo pipefail
 
@@ -103,6 +104,11 @@ jobs:
 
           fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
           fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
+
+          if [[ -z "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" || -z "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "::error::Trusted CI requires both R2 sccache credentials"
+            exit 1
+          fi
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1069,7 +1069,9 @@ jobs:
       # index + git checkouts, not the unpacked sources, so this keeps the
       # artifact (and the run job's download/untar) small.
       - name: "Pack cargo home for benchmarks-run"
-        run: tar -C "$HOME" --exclude='.cargo/registry/src' -cf cargo-home.tar .cargo/registry .cargo/git
+        run: |
+          mkdir -p "$HOME/.cargo/git"
+          tar -C "$HOME" --exclude='.cargo/registry/src' -cf cargo-home.tar .cargo/registry .cargo/git
       - name: "Upload cargo home"
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -616,6 +616,7 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/cargo-tests.reusable.yaml
+    secrets: inherit
 
   size-gate:
     name: "Size Gate"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -589,14 +589,12 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/cargo-tests.reusable.yaml
-    secrets: inherit
 
   size-gate:
     name: "Size Gate"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/size-gate.reusable.yaml
-    secrets: inherit
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,9 @@ env:
 
 jobs:
   r2-credential-diagnostic:
-    name: "R2 credential diagnostic"
+    name: "R2 repository credential diagnostic"
     if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    environment: infisical-github-ci
     env:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,33 +26,6 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  r2-credential-diagnostic:
-    name: "R2 repository credential diagnostic"
-    if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
-    steps:
-      - name: "Report R2 credential fingerprints"
-        run: |
-          set -euo pipefail
-
-          fingerprint() {
-            local name="$1"
-            local value="$2"
-            printf '%s length=%d sha256=' "$name" "${#value}"
-            printf '%s' "$value" | sha256sum | awk '{print $1}'
-          }
-
-          fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
-          fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
-
-          if [[ -z "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" || -z "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
-            echo "::error::Trusted CI requires both R2 sccache credentials"
-            exit 1
-          fi
-
   determine_changes:
     name: "Determine changes"
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -616,13 +589,18 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/cargo-tests.reusable.yaml
-    secrets: inherit
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
 
   size-gate:
     name: "Size Gate"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/size-gate.reusable.yaml
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -589,6 +589,8 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/cargo-tests.reusable.yaml
+    # Structural mapping only: the called jobs get the values from their
+    # infisical-github-ci Environment, not from repository secrets.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -598,6 +600,7 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/size-gate.reusable.yaml
+    # Structural mapping only; see cargo-tests above.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,34 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  r2-credential-diagnostic:
+    name: "R2 credential diagnostic"
+    if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    environment: infisical-github-ci
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+    steps:
+      - name: "Report R2 credential fingerprints"
+        run: |
+          set -euo pipefail
+
+          fingerprint() {
+            local name="$1"
+            local value="$2"
+            printf '%s length=%d sha256=' "$name" "${#value}"
+            printf '%s' "$value" | sha256sum | awk '{print $1}'
+          }
+
+          fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
+          fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
+
+          if [[ -z "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" || -z "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "::error::Trusted CI requires both R2 sccache credentials"
+            exit 1
+          fi
+
   determine_changes:
     name: "Determine changes"
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -26,8 +26,8 @@
 #
 # mise installs sccache and direnv, then each cargo job loads .envrc via
 # `direnv export gha` so CI uses the exact same sccache config as local shells:
-# .envrc is the single source of truth. The R2 credentials are passed through
-# GitHub Actions secrets using the same BAML_SCCACHE_R2_* names that the
+# .envrc is the single source of truth. The R2 credentials come from the
+# infisical-github-ci GitHub Environment using the same BAML_SCCACHE_R2_* names that the
 # RUSTC_WRAPPER maps to AWS_* before exec'ing sccache — the `tools/baml-sccache`
 # script on POSIX, and the native `tools_sccache` crate's binary on Windows
 # (built per-job; see the "Build native sccache wrapper" step).
@@ -38,11 +38,6 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
-    secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID:
-        required: false
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
-        required: false
 
 # Read-only by design: these jobs run PR-controlled cargo build/test code, so
 # they should not need elevated repository permissions.
@@ -56,10 +51,7 @@ defaults:
 env:
   # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
   # .envrc itself so it stays the single source of truth across CI and local.
-  # The R2 credentials .envrc maps to AWS_* for sccache (mapped to AWS_*).
   # Native Cargo linker overrides live in baml_language/.cargo/config.toml.
-  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -91,9 +83,13 @@ jobs:
     name: "cargo test (x86_64-unknown-linux-gnu)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     # 40, not 25: a machine without a warm seed compiles cold and can
     # exceed 25 minutes; the cap is a hang backstop, not a perf gate.
     timeout-minutes: 40
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -192,9 +188,12 @@ jobs:
     name: "cargo test (x86_64-unknown-linux-musl)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-musl"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     # 45, not 35: same reasoning as the gnu lane above.
     timeout-minutes: 45
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
       # The ix machine image ships musl-gcc; setup-musl-cross is skipped
       # there, so wire the same env the action would export.
@@ -819,8 +818,11 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
+    environment: infisical-github-ci
     timeout-minutes: ${{ matrix.timeout }}
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       # The machine image defaults these to 16; 32 runs clean on the
       # 64-vCPU machines.
       NEXTEST_TEST_THREADS: "32"
@@ -1043,7 +1045,11 @@ jobs:
     name: "cargo test (wasm32-unknown-unknown)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-wasm"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     timeout-minutes: 45
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1157,10 +1163,14 @@ jobs:
     name: "cargo build (msrv)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-msrv"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     # 40, not 25: the MSRV toolchain is unique to this job, so a machine
     # without a warm seed rebuilds everything from cold and can exceed 25
     # minutes. Warm runs sit far inside the old budget.
     timeout-minutes: 40
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1251,7 +1261,11 @@ jobs:
     name: "cargo doc"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     timeout-minutes: 25
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1330,8 +1344,12 @@ jobs:
     name: "snapshot tests"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     # 45, not 30: cold headroom, same reasoning as the gnu lane above.
     timeout-minutes: 45
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -113,6 +113,7 @@ jobs:
         run: sccache --version
 
       - name: "Report R2 credential fingerprints"
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -euo pipefail
 
@@ -125,6 +126,11 @@ jobs:
 
           fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
           fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
+
+          if [[ -z "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" || -z "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
+            echo "::error::Trusted CI requires both R2 sccache credentials"
+            exit 1
+          fi
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -38,6 +38,11 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 # Read-only by design: these jobs run PR-controlled cargo build/test code, so
 # they should not need elevated repository permissions.

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -112,6 +112,20 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
+      - name: "Report R2 credential fingerprints"
+        run: |
+          set -euo pipefail
+
+          fingerprint() {
+            local name="$1"
+            local value="$2"
+            printf '%s length=%d sha256=' "$name" "${#value}"
+            printf '%s' "$value" | sha256sum | awk '{print $1}'
+          }
+
+          fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
+          fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -38,6 +38,10 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
+    # Callers intentionally map these names even though the values exist only
+    # in the GitHub Environment. The mapping establishes the reusable-workflow
+    # secret contract; each job's environment supplies the actual value.
+    # Keep them optional so fork PRs retain the secretless local-cache path.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -121,26 +121,6 @@ jobs:
       - name: "Verify sccache"
         run: sccache --version
 
-      - name: "Report R2 credential fingerprints"
-        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository }}
-        run: |
-          set -euo pipefail
-
-          fingerprint() {
-            local name="$1"
-            local value="$2"
-            printf '%s length=%d sha256=' "$name" "${#value}"
-            printf '%s' "$value" | sha256sum | awk '{print $1}'
-          }
-
-          fingerprint BAML_SCCACHE_R2_ACCESS_KEY_ID "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}"
-          fingerprint BAML_SCCACHE_R2_SECRET_ACCESS_KEY "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}"
-
-          if [[ -z "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" || -z "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
-            echo "::error::Trusted CI requires both R2 sccache credentials"
-            exit 1
-          fi
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -114,6 +114,8 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
+    # Structural mapping only: the called jobs get the values from their
+    # infisical-github-ci Environment, not from repository secrets.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -123,6 +125,7 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-size-gate.reusable.yaml
+    # Structural mapping only; see cargo-tests above.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -114,12 +114,18 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
 
   size-gate:
     name: "Size Gate"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-size-gate.reusable.yaml
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     # The ix copy drops the report's PR-comment step outright, so the
     # gating workflow's comment stays the only one; the report is still in
     # the job summary.

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -113,22 +113,13 @@ jobs:
     name: "Cargo Tests"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
-    # Match ci.yaml's Blacksmith gating lane: same-repository PRs receive the
-    # existing R2 credentials, while GitHub withholds repository secrets from
-    # fork and Dependabot PRs. Both lanes execute the same checked-out code.
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
-    secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
 
   size-gate:
     name: "Size Gate"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-size-gate.reusable.yaml
-    secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     # The ix copy drops the report's PR-comment step outright, so the
     # gating workflow's comment stays the only one; the report is still in
     # the job summary.

--- a/.github/workflows/ix-size-gate.reusable.yaml
+++ b/.github/workflows/ix-size-gate.reusable.yaml
@@ -23,6 +23,10 @@ name: Size Gate (Reusable)
 
 on:
   workflow_call:
+    # Callers intentionally map these names even though the values exist only
+    # in the GitHub Environment. The mapping establishes the reusable-workflow
+    # secret contract; each job's environment supplies the actual value.
+    # Keep them optional so fork PRs retain the secretless local-cache path.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false

--- a/.github/workflows/ix-size-gate.reusable.yaml
+++ b/.github/workflows/ix-size-gate.reusable.yaml
@@ -23,6 +23,11 @@ name: Size Gate (Reusable)
 
 on:
   workflow_call:
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 # Read-only: these jobs run PR-controlled code and only upload artifacts,
 # so they must not inherit whatever the caller grants.

--- a/.github/workflows/ix-size-gate.reusable.yaml
+++ b/.github/workflows/ix-size-gate.reusable.yaml
@@ -23,11 +23,6 @@ name: Size Gate (Reusable)
 
 on:
   workflow_call:
-    secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID:
-        required: false
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
-        required: false
 
 # Read-only: these jobs run PR-controlled code and only upload artifacts,
 # so they must not inherit whatever the caller grants.
@@ -41,9 +36,6 @@ defaults:
 env:
   # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
   # .envrc itself so it stays the single source of truth across CI and local.
-  # The R2 credentials .envrc maps to AWS_* for sccache.
-  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -61,8 +53,12 @@ jobs:
     name: "measure-baml-size (linux)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     timeout-minutes: 20
     continue-on-error: true
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -150,8 +146,12 @@ jobs:
   size-gate-wasm:
     name: "measure-baml-size (wasm)"
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-wasm"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     timeout-minutes: 25
     continue-on-error: true
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -241,10 +241,14 @@ jobs:
   size-gate-report:
     name: "enforce-baml-size"
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-light"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    environment: infisical-github-ci
     if: ${{ always() && !cancelled() }}
     needs: [size-gate-linux, size-gate-wasm]
     permissions:
       contents: read
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -15,6 +15,10 @@ name: Size Gate (Reusable)
 
 on:
   workflow_call:
+    # Callers intentionally map these names even though the values exist only
+    # in the GitHub Environment. The mapping establishes the reusable-workflow
+    # secret contract; each job's environment supplies the actual value.
+    # Keep them optional so fork PRs retain the secretless local-cache path.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -15,11 +15,6 @@ name: Size Gate (Reusable)
 
 on:
   workflow_call:
-    secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID:
-        required: false
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
-        required: false
 
 defaults:
   run:
@@ -28,9 +23,6 @@ defaults:
 env:
   # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
   # .envrc itself so it stays the single source of truth across CI and local.
-  # The R2 credentials .envrc maps to AWS_* for sccache.
-  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -47,8 +39,12 @@ jobs:
   size-gate-linux:
     name: "measure-baml-size (linux)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 30
     continue-on-error: true
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -133,8 +129,12 @@ jobs:
   size-gate-macos:
     name: "measure-baml-size (macos)"
     runs-on: blacksmith-6vcpu-macos-latest
+    environment: infisical-github-ci
     timeout-minutes: 20
     continue-on-error: true
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -219,11 +219,14 @@ jobs:
   size-gate-windows:
     name: "measure-baml-size (windows)"
     runs-on: blacksmith-8vcpu-windows-2025
+    environment: infisical-github-ci
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 45
     continue-on-error: true
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_JOBS: "16"
     steps:
       - uses: actions/checkout@v6
@@ -327,8 +330,12 @@ jobs:
   size-gate-wasm:
     name: "measure-baml-size (wasm)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: infisical-github-ci
     timeout-minutes: 25
     continue-on-error: true
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -415,11 +422,15 @@ jobs:
   size-gate-report:
     name: "enforce-baml-size"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: infisical-github-ci
     if: ${{ always() && !cancelled() }}
     needs: [size-gate-linux, size-gate-macos, size-gate-windows, size-gate-wasm]
     permissions:
       contents: read
       pull-requests: write
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -15,6 +15,11 @@ name: Size Gate (Reusable)
 
 on:
   workflow_call:
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 defaults:
   run:


### PR DESCRIPTION
Move the shared Rust build cache into the BoundaryML cloudflare account, instead of my [sam@boundaryml.com](mailto:sam@boundaryml.com) personal cloudflare account.

At the same time, we've also got a new strategy for infisical secrets, which is that the infisical-github-ci environment will contain all of the secrets for ci.yaml workflows only, and has source-of-truth in infisical in the GitHub / CI environment.