### PR TITLE
Fix LSP panic + diagnostic improvements

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -4343,13 +4343,14 @@ impl<'db> InferenceContext<'db> {
                 // (literal -> base, variant -> enum) and must be the SAME
                 // type - subtyping is not enough - and that type must
                 // implement `baml.ops.Compare`. Open/error operands skip
-                // (cascades; a var may still solve either way).
+                // (cascades; a var may still solve either way) - but the
+                // `unknown` top type does NOT skip: it is a type the reader
+                // wrote, not a cascade, and it orders against nothing, so it
+                // reports here like any other non-comparable operand.
                 if !lhs_ty.has_infer()
                     && !rhs_ty.has_infer()
                     && !lhs_ty.has_error()
                     && !rhs_ty.has_error()
-                    && !matches!(lhs_ty.kind(), TyKind::Unknown { .. })
-                    && !matches!(rhs_ty.kind(), TyKind::Unknown { .. })
                 {
                     let widen = |this: &mut Self, ty: &Ty| -> baml_type::Ty {
                         use baml_base::Literal as Lit;
@@ -4834,7 +4835,7 @@ impl<'db> InferenceContext<'db> {
     }
 
     /// A ground operator dispatch found NO impl for clean operands - the
-    /// committed E0004 (an error/unknown/var operand is a cascade and
+    /// committed E0004 (an error or inference-var operand is a cascade and
     /// stays silent, the same `tainted_by_errors` rule everywhere).
     pub(super) fn report_operator_failure(
         &mut self,
@@ -4843,13 +4844,17 @@ impl<'db> InferenceContext<'db> {
         lhs: &Ty,
         rhs: Option<&Ty>,
     ) {
-        // SHALLOW error/unknown screening (TIR's gate): a nested error slot
-        // (an incomplete existential's recovered pin) does not silence the
+        // SHALLOW error screening (TIR's gate): a nested error slot (an
+        // incomplete existential's recovered pin) does not silence the
         // operator report - the operand as written still has no impl, and
         // that is this diagnostic's claim.
-        let dirty = |ty: &Ty| {
-            matches!(ty.kind(), TyKind::Error { .. } | TyKind::Unknown { .. }) || ty.has_infer()
-        };
+        //
+        // The `unknown` top type is NOT screened: it is a type the reader
+        // wrote, not a cascade from an earlier failure, and it implements
+        // no operator - so `a + 1` on an `unknown` is a real E0004 rather
+        // than something to stay quiet about. Only the error sentinel and
+        // an unresolved inference var are cascades.
+        let dirty = |ty: &Ty| matches!(ty.kind(), TyKind::Error { .. }) || ty.has_infer();
         if dirty(lhs) || rhs.is_some_and(dirty) {
             return;
         }
@@ -5481,10 +5486,11 @@ impl<'db> InferenceContext<'db> {
                 }
                 _ => None,
             };
-            if !callee_fn_ty.has_error()
-                && !callee_fn_ty.has_infer()
-                && !matches!(callee_fn_ty.kind(), TyKind::Unknown { .. })
-            {
+            // A value typed `unknown` is not callable, and saying so is
+            // this diagnostic's whole job - the top type is not a cascade.
+            // Only a genuine one (an errored callee, or one still carrying
+            // inference vars) stays quiet.
+            if !callee_fn_ty.has_error() && !callee_fn_ty.has_infer() {
                 self.pending_diags.push(PendingDiag::NotCallable {
                     expr: callee,
                     ty: callee_fn_ty.clone(),

--- a/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
@@ -2451,11 +2451,62 @@ fn plain_scope_bounds(
 /// The check layer's CLASS-declaration diagnostic walk: generic-param
 /// bounds re-lowered with the sink under the class frame (unresolved,
 /// arity, non-interface and builtin-not-a-bound rules).
+/// Judge one constraint head (`T extends B`, `type A extends B`): lower it
+/// with the sink so unresolved names and wrong type-argument counts are
+/// reported, then apply the shape rules a bound must satisfy.
+///
+/// Every bound position in the language routes here — class and interface
+/// generic parameters, and associated-type bounds — so a rule added for one
+/// cannot silently miss the others. Each had drifted: interface generic
+/// parameters had no diagnostic walk at all, and associated-type bounds
+/// lowered through a sink-less context. Both left an unresolved bound as a
+/// silent `Ty::Error`, which is fail-open where the bound should have been
+/// enforced (a typo'd bound constrains nothing) and an `unreachable!` in
+/// emit once it reaches runtime lowering.
+fn judge_constraint_head(
+    db: &dyn baml_compiler2_ppir::Db,
+    ctx: &LowerCtx<'_>,
+    store: &TypeRefStore,
+    source_map: &baml_compiler2_hir::type_ref::TypeRefSourceMap,
+    bound: TypeRefId,
+    out: &mut Vec<(text_size::TextRange, crate::diagnostics::TirTypeError)>,
+) {
+    use crate::diagnostics::TirTypeError;
+    let (lowered, diagnostics) =
+        ctx.lower_type_ref_at_with_diagnostics(store, bound, TypePosition::ConstraintHead);
+    extend_lowering_diagnostics(out, source_map, diagnostics);
+    match lowered.kind() {
+        TyKind::Interface(qtn, ..) if qtn.is_reflect_root_type("AnyFunction") => {
+            out.push((
+                source_map.span(bound),
+                TirTypeError::BuiltinInterfaceNotABound {
+                    interface: qtn.clone(),
+                },
+            ));
+        }
+        TyKind::Interface(..) => {
+            for error in bound_binding_violations(db, store, bound, &lowered) {
+                out.push((source_map.span(bound), error));
+            }
+        }
+        // The lowering above already reported why the head is an error;
+        // a shape complaint on top would name the same mistake twice.
+        _ if lowered.has_error() => {}
+        _ => {
+            out.push((
+                source_map.span(bound),
+                TirTypeError::GenericBoundNotInterface {
+                    bound: lowered.to_plain(),
+                },
+            ));
+        }
+    }
+}
+
 pub fn class_lowering_diagnostics<'db>(
     db: &'db dyn baml_compiler2_ppir::Db,
     class: ClassLoc<'db>,
 ) -> Vec<(text_size::TextRange, crate::diagnostics::TirTypeError)> {
-    use crate::diagnostics::TirTypeError;
     let data = baml_compiler2_ppir::item_data::class_data(db, class);
     let source_map = baml_compiler2_ppir::item_data::class_source_map(db, class);
     // PPIR synthesizes `$stream` companions with an empty declaration span.
@@ -2485,36 +2536,14 @@ pub fn class_lowering_diagnostics<'db>(
         }
     }
     for bound in data.generic_params.iter().flat_map(|g| g.bounds.iter()) {
-        let (lowered, diagnostics) = ctx.lower_type_ref_at_with_diagnostics(
+        judge_constraint_head(
+            db,
+            &ctx,
             &data.type_refs,
+            &source_map.type_refs,
             *bound,
-            TypePosition::ConstraintHead,
+            &mut out,
         );
-        extend_lowering_diagnostics(&mut out, &source_map.type_refs, diagnostics);
-        match lowered.kind() {
-            TyKind::Interface(qtn, ..) if qtn.is_reflect_root_type("AnyFunction") => {
-                out.push((
-                    source_map.type_refs.span(*bound),
-                    TirTypeError::BuiltinInterfaceNotABound {
-                        interface: qtn.clone(),
-                    },
-                ));
-            }
-            TyKind::Interface(..) => {
-                for error in bound_binding_violations(db, &data.type_refs, *bound, &lowered) {
-                    out.push((source_map.type_refs.span(*bound), error));
-                }
-            }
-            _ if lowered.has_error() => {}
-            _ => {
-                out.push((
-                    source_map.type_refs.span(*bound),
-                    TirTypeError::GenericBoundNotInterface {
-                        bound: lowered.to_plain(),
-                    },
-                ));
-            }
-        }
     }
     out
 }
@@ -2573,30 +2602,50 @@ pub fn interface_lowering_diagnostics<'db>(
             }
         }
     }
+    // The interface's own generic parameters carry the same bound rules a
+    // class's do.
+    for bound in data.generic_params.iter().flat_map(|g| g.bounds.iter()) {
+        judge_constraint_head(
+            db,
+            &ctx,
+            &data.type_refs,
+            &source_map.type_refs,
+            *bound,
+            &mut out,
+        );
+    }
     // Associated-type bounds (`type X extends B`): the same bound rules
     // generic params carry.
     for assoc in &data.associated_types {
         let Some(bound) = assoc.bound else { continue };
-        let lowered = ctx.lower_type_ref_at(&data.type_refs, bound, TypePosition::ConstraintHead);
-        match lowered.kind() {
-            TyKind::Interface(qtn, ..) if qtn.is_reflect_root_type("AnyFunction") => {
-                out.push((
-                    source_map.type_refs.span(bound),
-                    TirTypeError::BuiltinInterfaceNotABound {
-                        interface: qtn.clone(),
-                    },
-                ));
-            }
-            TyKind::Interface(..) => {}
-            _ if lowered.has_error() => {}
-            _ => {
-                out.push((
-                    source_map.type_refs.span(bound),
-                    TirTypeError::GenericBoundNotInterface {
-                        bound: lowered.to_plain(),
-                    },
-                ));
-            }
+        judge_constraint_head(
+            db,
+            &ctx,
+            &data.type_refs,
+            &source_map.type_refs,
+            bound,
+            &mut out,
+        );
+    }
+    // An associated type's DEFAULT is a written type reference like any
+    // other. `interface_associated_type_default` lowers it and hands back
+    // its diagnostics precisely so this walk — the declaration checker —
+    // surfaces them once; every other caller consumes the type and drops
+    // them by design. Defaults with no declared bound are drained here too:
+    // the bound-satisfaction pass below only visits bounded ones, so
+    // skipping them here left an unresolved default silently poisoning the
+    // interface until it reached runtime lowering.
+    for assoc in &data.associated_types {
+        let Some(default_ref) = assoc.default else {
+            continue;
+        };
+        let Some((_, diagnostics)) =
+            crate::interfaces::interface_associated_type_default(db, interface, assoc.name.clone())
+        else {
+            continue;
+        };
+        for error in diagnostics {
+            out.push((source_map.type_refs.span(default_ref), error));
         }
     }
     // An associated type's default must implement its declared bound

--- a/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
@@ -2265,13 +2265,6 @@ pub fn signature_lowering_diagnostics<'db>(
     function: FunctionLoc<'db>,
 ) -> Vec<(text_size::TextRange, crate::diagnostics::TirTypeError)> {
     use crate::diagnostics::TirTypeError;
-    // Required interface methods are signature-only items checked by the
-    // interface-scope driver with `Self` in scope; this pass would
-    // misreport their `Self.*` references (the same exclusion the
-    // pre-S17 signature pass carried).
-    if baml_compiler2_ppir::item_data::is_required_interface_method(db, function) {
-        return Vec::new();
-    }
     let data = baml_compiler2_ppir::item_data::elaborated_function_data(db, function);
     let frame = function_generic_frame(db, function);
     let bounds = function_generic_bounds(db, function);

--- a/baml_language/crates/baml_db/src/check.rs
+++ b/baml_language/crates/baml_db/src/check.rs
@@ -2281,6 +2281,57 @@ function demo() -> int throws never {
     }
 
     #[test]
+    fn an_unresolved_type_in_a_required_interface_method_is_reported() {
+        // A required (bodyless) interface method's signature is still a
+        // signature: an unresolved reference in it is E0002 like anywhere
+        // else. The signature pass used to skip these items outright, so
+        // nothing reported them and the `Error` sentinel travelled all the
+        // way to emit, which converts interface declarations under an
+        // `unreachable!` — a three-line file aborted `baml check`.
+        let source =
+            "interface Store {\n    function get(self, key: string) -> Missing throws never\n}\n";
+        let (db, file) = single_file(source);
+        let unresolved: Vec<_> = check_file(&db, file)
+            .into_iter()
+            .filter(|diag| diag.id == DiagnosticId::UnknownType)
+            .collect();
+        assert_eq!(unresolved.len(), 1, "{unresolved:?}");
+        let span = unresolved[0].annotations[0].span.range;
+        assert_eq!(&source[span], "Missing", "the report underlines the type");
+    }
+
+    #[test]
+    fn required_interface_signatures_resolve_self_and_method_generics() {
+        // Why the pass skipped required methods: the exclusion assumed a
+        // re-lowering would false-fire E0002 on every `Self.*`. It does not.
+        // `function_generic_frame` binds `Self`, the interface's generics,
+        // and the method's own; an associated type is not a frame slot at
+        // all — `Self.X` is a projection over the `Self` slot, reduced by
+        // the resolver at use. Either way these must check clean, and that
+        // is what makes reporting the genuinely-unresolved case above safe.
+        let (db, file) = single_file(
+            r#"interface Iter {
+    type Item
+    type Error
+    function next(self) -> Self.Item throws Self.Error
+    function map_to<Out>(self, seed: Out) -> Out throws Self.Error
+    function clone_me(self) -> Self throws never
+}
+
+interface Pair<A, B> {
+    type Joined
+    function join<Extra>(self, a: A, b: B, e: Extra) -> Self.Joined throws never
+}
+"#,
+        );
+        let unresolved: Vec<_> = check_file(&db, file)
+            .into_iter()
+            .filter(|diag| diag.id == DiagnosticId::UnknownType)
+            .collect();
+        assert!(unresolved.is_empty(), "{unresolved:?}");
+    }
+
+    #[test]
     fn self_referential_associated_bound_checks_clean() {
         // `type Assoc extends Iface` on `Iface` itself is valid (a bound is
         // a constraint head — it never demands the target's associated

--- a/baml_language/crates/baml_db/src/check.rs
+++ b/baml_language/crates/baml_db/src/check.rs
@@ -2332,6 +2332,51 @@ interface Pair<A, B> {
     }
 
     #[test]
+    fn unknown_is_not_operator_permissive_but_error_cascades_stay_quiet() {
+        // `unknown` is the user-visible top type, and it implements no
+        // operator and is not callable — so using it as one is a real
+        // diagnostic, not silence.
+        //
+        // Inference used to screen the top type as if it were the error
+        // sentinel, so every use of `unknown` type-checked vacuously.
+        let (db, file) = single_file(
+            "function op(a: unknown) -> int throws never { return a + 1 }\nfunction call(g: unknown) -> int throws never { return g(1) }\n",
+        );
+        let ids: Vec<_> = check_file(&db, file).into_iter().map(|d| d.id).collect();
+        assert!(ids.contains(&DiagnosticId::InvalidOperator), "{ids:?}");
+        assert!(ids.contains(&DiagnosticId::NotCallable), "{ids:?}");
+
+        // Ordering is a third operator road with its own screen, so it needs
+        // its own case: against another type it is a different-types report,
+        // and against itself it fails the `baml.ops.Compare` requirement.
+        for source in [
+            "function ord(a: unknown) -> bool throws never { return a < 1 }\n",
+            "function ord(a: unknown, b: unknown) -> bool throws never { return a < b }\n",
+        ] {
+            let (db, file) = single_file(source);
+            let ids: Vec<_> = check_file(&db, file).into_iter().map(|d| d.id).collect();
+            assert!(
+                ids.contains(&DiagnosticId::InvalidOperator),
+                "ordering on `unknown` must report: {source} gave {ids:?}"
+            );
+        }
+
+        // The other half of the rule: a GENUINE cascade still stays quiet.
+        // The operand here is the error sentinel (its annotation did not
+        // resolve), so the unresolved type is reported once and no operator
+        // complaint piles on top of it.
+        let (db, file) = single_file(
+            "function f() -> int throws never {\n  let a: NoSuchType = 1\n  return a + 1\n}\n",
+        );
+        let ids: Vec<_> = check_file(&db, file).into_iter().map(|d| d.id).collect();
+        assert!(ids.contains(&DiagnosticId::UnknownType), "{ids:?}");
+        assert!(
+            !ids.contains(&DiagnosticId::InvalidOperator),
+            "an errored operand must not cascade an operator report: {ids:?}"
+        );
+    }
+
+    #[test]
     fn every_interface_bound_position_reports_an_unresolved_head() {
         // The three constraint positions an interface declares. Each used to
         // leave the unresolved head as a silent `Ty::Error`: the generic

--- a/baml_language/crates/baml_db/src/check.rs
+++ b/baml_language/crates/baml_db/src/check.rs
@@ -2332,6 +2332,59 @@ interface Pair<A, B> {
     }
 
     #[test]
+    fn every_interface_bound_position_reports_an_unresolved_head() {
+        // The three constraint positions an interface declares. Each used to
+        // leave the unresolved head as a silent `Ty::Error`: the generic
+        // parameter had no diagnostic walk at all, the associated-type bound
+        // lowered through a sink-less context, and the default's diagnostics
+        // were computed and dropped by every caller. Each is fail-open (a
+        // typo'd bound constrains nothing) and each reaches emit, where a
+        // non-runtime type is `unreachable!`.
+        let cases = [
+            (
+                "generic parameter",
+                "interface Named<T> { function n(self) -> T throws never }\ninterface Box<T extends Named<NoSuchType>> {\n    function get(self) -> int throws never\n}\n",
+            ),
+            (
+                "associated-type bound",
+                "interface Named<T> { function n(self) -> T throws never }\ninterface Box {\n    type A extends Named<NoSuchType>\n    function get(self) -> int throws never\n}\n",
+            ),
+            (
+                "associated-type default",
+                "interface Box {\n    type Item = NoSuchType\n    function get(self) -> int throws never\n}\n",
+            ),
+        ];
+        for (position, source) in cases {
+            let (db, file) = single_file(source);
+            let unresolved: Vec<_> = check_file(&db, file)
+                .into_iter()
+                .filter(|diag| diag.id == DiagnosticId::UnknownType)
+                .collect();
+            assert_eq!(unresolved.len(), 1, "{position}: {unresolved:?}");
+            let span = unresolved[0].annotations[0].span.range;
+            assert_eq!(
+                &source[span], "NoSuchType",
+                "{position}: the report underlines the unresolved head"
+            );
+        }
+    }
+
+    #[test]
+    fn an_interface_generic_bound_obeys_the_rules_a_class_bound_does() {
+        // Bound shape is judged by one helper for every position, so these
+        // must match what the byte-identical `class` form reports — they
+        // previously produced nothing at all on an interface.
+        let (db, file) = single_file(
+            "class Plain { f: int }\ninterface I<T extends Plain> { function g(self) -> T throws never }\n",
+        );
+        let ids: Vec<_> = check_file(&db, file).into_iter().map(|d| d.id).collect();
+        assert!(
+            ids.contains(&DiagnosticId::GenericBoundNotInterface),
+            "{ids:?}"
+        );
+    }
+
+    #[test]
     fn self_referential_associated_bound_checks_clean() {
         // `type Assoc extends Iface` on `Iface` itself is valid (a bound is
         // a constraint head — it never demands the target's associated

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -323,9 +323,13 @@ impl BamlWasmRuntime {
     /// Recovery is the host's: the state is half-applied by construction, so
     /// this runtime cannot be trusted again and the page must be reloaded.
     fn is_unavailable(&self) -> bool {
-        // A successful test borrow is released immediately; only a leaked
-        // guard from a panicked call can keep this `Err`.
+        // A successful test borrow is released immediately, and it also
+        // proves any earlier conflict was transient - a nested call that has
+        // since returned, not a guard leaked by a panic. Re-arm the one-shot
+        // so a later genuine failure is still reported rather than swallowed
+        // by that earlier transient.
         if self.state.try_borrow_mut().is_ok() {
+            self.unavailable_reported.set(false);
             return false;
         }
         if !self.unavailable_reported.replace(true) {

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -28,7 +28,7 @@ use std::{
     sync::{Arc, Once},
 };
 
-use baml_lsp::{GlobalState, SessionKey, executor::Executors};
+use baml_lsp::{GlobalState, LspError, SessionKey, executor::Executors};
 use js_sys::Function;
 use wasm_bindgen::prelude::*;
 
@@ -206,6 +206,11 @@ pub struct BamlWasmRuntime {
     /// access. Every borrow is confined to one JS callback, and no borrow is
     /// ever held across a call back into JS, so re-entrancy cannot observe a
     /// half-applied state.
+    ///
+    /// One case escapes that: `wasm32-unknown-unknown` cannot unwind, so a
+    /// panic inside a borrow never runs the guard's destructor and the cell
+    /// stays borrowed for the life of the tab. Entry points test for it with
+    /// [`Self::is_unavailable`] rather than tripping `already borrowed`.
     state: Rc<RefCell<GlobalState>>,
     /// `Arc` because [`baml_lsp::ClientSender`] is a `Send + Sync` trait
     /// (the native host shares one across threads); the sender's own JS
@@ -230,7 +235,17 @@ pub struct BamlWasmRuntime {
     /// knows a rebuild is owed. The observer runs *inside* `apply`, where the
     /// state is already mutably borrowed, so it can only record the fact.
     build_owed: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether the user has already been told the server is unavailable, so
+    /// a wedged tab reports once instead of on every keystroke.
+    unavailable_reported: std::cell::Cell<bool>,
 }
+
+/// What the user is told when an internal error has left the tab's language
+/// server unusable. It names the fault as ours, not their file, and asks for
+/// the report that would let us fix it.
+const UNAVAILABLE_MESSAGE: &str = "BAML internal error: the language server for this tab hit a bug \
+     and can no longer analyze your code. Reload the page to restart it. Please report this at \
+     https://github.com/BoundaryML/baml/issues — including what you were editing — so we can fix it.";
 
 /// The browser session's key. One runtime, one client, one session.
 const BROWSER_SESSION: SessionKey = SessionKey(1);
@@ -291,7 +306,46 @@ impl BamlWasmRuntime {
             value_store,
             playground_callback,
             build_owed,
+            unavailable_reported: std::cell::Cell::new(false),
         }
+    }
+
+    /// Whether an earlier internal error left this runtime unusable, telling
+    /// the user once when it has.
+    ///
+    /// `wasm32-unknown-unknown` has no unwinding, so a panic raised while the
+    /// owner state was borrowed never runs the borrow guard's destructor: the
+    /// cell stays borrowed for the life of the tab and every later entry point
+    /// would trap on `already borrowed`. That trap names the symptom and not
+    /// the cause, repeats on every keystroke, and reads like the user's own
+    /// file is at fault — so entry points ask here first and refuse honestly.
+    ///
+    /// Recovery is the host's: the state is half-applied by construction, so
+    /// this runtime cannot be trusted again and the page must be reloaded.
+    fn is_unavailable(&self) -> bool {
+        // A successful test borrow is released immediately; only a leaked
+        // guard from a panicked call can keep this `Err`.
+        if self.state.try_borrow_mut().is_ok() {
+            return false;
+        }
+        if !self.unavailable_reported.replace(true) {
+            log::error!(
+                "the BAML language server is unavailable: an earlier internal error left its \
+                 state unrecoverable (wasm cannot unwind, so the owner borrow was never released)"
+            );
+            let params = lsp_types::ShowMessageParams {
+                typ: lsp_types::MessageType::ERROR,
+                message: UNAVAILABLE_MESSAGE.to_owned(),
+            };
+            if let Ok(params) = serde_json::to_value(params) {
+                let _ = baml_lsp::ClientSender::send_notification(
+                    self.sender.as_ref(),
+                    "window/showMessage",
+                    params,
+                );
+            }
+        }
+        true
     }
 
     /// Handle one client request and answer it through `lsp_send_response`.
@@ -299,6 +353,12 @@ impl BamlWasmRuntime {
     pub fn handle_lsp_request(&self, request: LspRequest) {
         let request: lsp_server::Request = request.into();
         let id = request.id.clone();
+        if self.is_unavailable() {
+            // Answer rather than drop: an unanswered id hangs the client.
+            self.sender
+                .respond(id, Err(LspError::Internal(UNAVAILABLE_MESSAGE.to_owned())));
+            return;
+        }
         let sender = Arc::clone(&self.sender);
         self.state.borrow_mut().dispatch_request(
             self.session,
@@ -312,6 +372,9 @@ impl BamlWasmRuntime {
     /// schedules (discovery, diagnostics) is drained by `pump`.
     #[wasm_bindgen(js_name = handleLspNotification)]
     pub fn handle_lsp_notification(&self, notification: LspNotification) {
+        if self.is_unavailable() {
+            return;
+        }
         let notification: lsp_server::Notification = notification.into();
         let method = notification.method.clone();
         if let Err(error) = self
@@ -327,6 +390,9 @@ impl BamlWasmRuntime {
     /// Push the project surface: what can be run, and what is wrong with it.
     #[wasm_bindgen(js_name = requestPlaygroundState)]
     pub fn request_playground_state(&self) {
+        if self.is_unavailable() {
+            return;
+        }
         let state = self.state.borrow();
         let playground = self.playground.borrow();
         let Some((project, update)) = playground::project_update(&state, &playground) else {
@@ -350,6 +416,9 @@ impl BamlWasmRuntime {
         function_name: &str,
         request_id: Option<u32>,
     ) {
+        if self.is_unavailable() {
+            return;
+        }
         if !self.serves(project) {
             return;
         }
@@ -366,6 +435,9 @@ impl BamlWasmRuntime {
     /// Report what the cursor is inside, so the graph view can follow along.
     #[wasm_bindgen(js_name = handleCursorPosition)]
     pub fn handle_cursor_position(&self, file: &str, line: u32, column: u32) {
+        if self.is_unavailable() {
+            return;
+        }
         let Some(context) = playground::cursor_context(&self.state.borrow(), file, line, column)
         else {
             return;
@@ -380,6 +452,9 @@ impl BamlWasmRuntime {
     /// notification, or not at all if a rebuild overtakes the collection.
     #[wasm_bindgen(js_name = requestCollectTests)]
     pub fn request_collect_tests(&self, project: &str) {
+        if self.is_unavailable() {
+            return;
+        }
         if !self.serves(project) {
             return;
         }
@@ -409,6 +484,9 @@ impl BamlWasmRuntime {
     /// parameter would reject every call the worker makes.
     #[wasm_bindgen(js_name = expandTestSet)]
     pub fn expand_test_set(&self, project: String, generation: u32, testset_name: String) {
+        if self.is_unavailable() {
+            return;
+        }
         if !self.serves(&project) {
             return;
         }
@@ -444,6 +522,9 @@ impl BamlWasmRuntime {
     /// freed by `wasm_bindgen`.
     #[wasm_bindgen(js_name = closeSession)]
     pub fn close_session(&self) {
+        if self.is_unavailable() {
+            return;
+        }
         self.state.borrow_mut().close_session(self.session);
         self.playground.borrow_mut().shutdown();
     }


### PR DESCRIPTION
- Unresolved types in the signature of a required interface method now emit a diagnostic instead of panicking the compiler. This was most often hit in the LSP while writing out a type.
- Invalid type bounds should produce diagnostics. Previously they lowered to a poisoned state without emitting diagnostics, which resulted in a compiler panic when the poisoned state reached emit without any error diagnostics.
- `TyKind::Unknown` should not suppress diagnostics: it had been incorrectly conflated with the now-removed `Unknown` error sentinel
- Promptfiddle will now report a user-friendly message if the LSP panics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for invalid operators, ordering comparisons, and calls involving `unknown` values.
  - Unresolved types in interface method signatures and bounds are now reported at the correct location.
  - Added clearer validation for invalid interface and class constraints, including unsupported bounds and defaults.
  - Removed misleading omissions from required interface method checks.

- **Reliability**
  - Language-server and playground requests now fail gracefully with a clear error after an unrecoverable runtime failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->