### PR TITLE
ci: use shared Infisical credentials for release mirrors

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1319,14 +1319,14 @@ jobs:
       }}
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
-    env:
-      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: go-sdk-mirror
           path: /tmp/go-sdk-package
       - name: Clone BoundaryML/baml-go
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -1339,6 +1339,7 @@ jobs:
         env:
           SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
           CANONICAL_VERSION: ${{ needs.plan.outputs.version }}
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
           GO_VERSION: ${{ needs.plan.outputs.go_version }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -928,12 +928,12 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           # In-memory PGP signing path in build.gradle.kts keys on GPG_PRIVATE_KEY.
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
         run: |
           set -euo pipefail
           if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
-            echo "::error::GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
+            echo "::error::MAVEN_CENTRAL_GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
             exit 1
           fi
           # One staging run produces the full main+sources+javadoc+pom+module
@@ -948,12 +948,12 @@ jobs:
         working-directory: baml_language/sdks/java/gradle-plugin
         env:
           VERSION: ${{ steps.ver.outputs.version }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
         run: |
           set -euo pipefail
           if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
-            echo "::error::GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
+            echo "::error::MAVEN_CENTRAL_GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
             exit 1
           fi
           # Stage the plugin jar+sources+javadoc AND the plugin-marker POM
@@ -970,12 +970,12 @@ jobs:
         working-directory: baml_language/sdks/java/baml-bridge-kotlin
         env:
           VERSION: ${{ steps.ver.outputs.version }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
         run: |
           set -euo pipefail
           if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
-            echo "::error::GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
+            echo "::error::MAVEN_CENTRAL_GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
             exit 1
           fi
           # Stage the kotlin jar+sources+javadoc+POM into baml-bridge's
@@ -995,8 +995,8 @@ jobs:
           BRIDGE_PUBLISH: ${{ steps.exists.outputs.bridge_publish }}
           PLUGIN_PUBLISH: ${{ steps.exists.outputs.plugin_publish }}
           KOTLIN_PUBLISH: ${{ steps.exists.outputs.kotlin_publish }}
-          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
           set -euo pipefail
           staging="baml_language/sdks/java/baml_bridge/build/staging-deploy"
@@ -1024,7 +1024,7 @@ jobs:
           unzip -l "$GITHUB_WORKSPACE/central-bundle.zip"
 
           if [[ -z "$CENTRAL_USERNAME" || -z "$CENTRAL_PASSWORD" ]]; then
-            echo "::error::CENTRAL_USERNAME / CENTRAL_PASSWORD secrets are not set — cannot publish to Maven Central"
+            echo "::error::MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD secrets are not set — cannot publish to Maven Central"
             exit 1
           fi
           # Portal auth: Bearer <base64(username:password)> (env → shell var, never

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1318,23 +1318,20 @@ jobs:
         needs.plan.outputs.source_branch == 'canary'
       }}
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    env:
+      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: go-sdk-mirror
           path: /tmp/go-sdk-package
       - name: Clone BoundaryML/baml-go
-        env:
-          DEPLOY_KEY: ${{ secrets.BAML_GO_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          test -n "$DEPLOY_KEY"
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/baml_go_mirror_key
-          chmod 600 ~/.ssh/baml_go_mirror_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/baml_go_mirror_key -o IdentitiesOnly=yes"
-          git clone git@github.com:BoundaryML/baml-go.git /tmp/baml-go
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          git clone https://github.com/BoundaryML/baml-go.git /tmp/baml-go
           if ! git -C /tmp/baml-go rev-parse --verify HEAD >/dev/null 2>&1; then
             git -C /tmp/baml-go switch --orphan main
           fi
@@ -1345,7 +1342,6 @@ jobs:
           GO_VERSION: ${{ needs.plan.outputs.go_version }}
         run: |
           set -euo pipefail
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/baml_go_mirror_key -o IdentitiesOnly=yes"
           tag="$GO_VERSION"
           manifest_url="https://pkg.boundaryml.com/manifest/v1/version/$CANONICAL_VERSION.json"
 

--- a/.github/workflows/sync-grammar-mirror.yml
+++ b/.github/workflows/sync-grammar-mirror.yml
@@ -45,6 +45,9 @@ on:
       - ".github/workflows/sync-grammar-mirror.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: sync-grammar-mirror
   cancel-in-progress: false
@@ -58,8 +61,6 @@ jobs:
     name: Sync to BoundaryML/textMate-baml
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
-    env:
-      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,6 +81,8 @@ jobs:
         run: pnpm --filter @b/pkg-grammar test
 
       - name: Clone mirror
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -112,6 +115,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           CURRENT: ${{ steps.diff.outputs.current }}
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -172,8 +176,6 @@ jobs:
     name: Sync to BoundaryML/baml-highlightjs
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
-    env:
-      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -187,6 +189,8 @@ jobs:
         run: pnpm --filter @b/pkg-grammar-hljs test
 
       - name: Clone mirror
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -216,6 +220,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         env:
           CURRENT: ${{ steps.diff.outputs.current }}
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -268,8 +273,6 @@ jobs:
     name: Sync to BoundaryML/baml-treesitter
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
-    env:
-      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -283,6 +286,8 @@ jobs:
         run: pnpm --filter @b/pkg-grammar-treesitter test
 
       - name: Clone mirror
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -307,6 +312,7 @@ jobs:
       - name: Push
         if: steps.diff.outputs.changed == 'true'
         env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-grammar-mirror.yml
+++ b/.github/workflows/sync-grammar-mirror.yml
@@ -17,9 +17,10 @@
 #       consumed as a git repo (nvim-treesitter revisions, Zed grammar pins,
 #       Helix); ships the generated src/parser.c.
 #
-# Auth: each *_DEPLOY_KEY secret holds an SSH private key whose public half is
-# a write-access deploy key on the matching mirror repo. (A deploy key, not a
-# PAT, so pushes may update the mirror's workflow files.)
+# Auth: all mirror jobs use the shared GitHub token synced from Infisical's
+# gh-baml-language-release environment. The token needs Contents write access
+# to every mirror and Workflows write access because syncs can update each
+# mirror's publish workflow.
 #
 # Versioning: npm-published mirrors get a patch bump + a v<version> git tag on
 # every content change. The treesitter mirror is consumed by commit pin, so it
@@ -56,6 +57,9 @@ jobs:
   sync-textmate:
     name: Sync to BoundaryML/textMate-baml
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    env:
+      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,16 +80,11 @@ jobs:
         run: pnpm --filter @b/pkg-grammar test
 
       - name: Clone mirror
-        env:
-          DEPLOY_KEY: ${{ secrets.TEXTMATE_BAML_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/mirror_key
-          chmod 600 ~/.ssh/mirror_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes"
-          git clone --depth 50 git@github.com:BoundaryML/textMate-baml.git /tmp/mirror-repo
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          git clone --depth 50 https://github.com/BoundaryML/textMate-baml.git /tmp/mirror-repo
 
       - name: Assemble and diff against mirror
         id: diff
@@ -130,7 +129,6 @@ jobs:
           jq --arg v "$next" '.version = $v' /tmp/mirror-repo/package.json > /tmp/pkg.json
           mv /tmp/pkg.json /tmp/mirror-repo/package.json
 
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes"
           cd /tmp/mirror-repo
           # -A, not commit -a: newly assembled files (dist/, package.json, the
           # publish workflow) are untracked in the mirror and -a would drop them.
@@ -173,6 +171,9 @@ jobs:
   sync-highlightjs:
     name: Sync to BoundaryML/baml-highlightjs
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    env:
+      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -186,16 +187,11 @@ jobs:
         run: pnpm --filter @b/pkg-grammar-hljs test
 
       - name: Clone mirror
-        env:
-          DEPLOY_KEY: ${{ secrets.BAML_HIGHLIGHTJS_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/mirror_key
-          chmod 600 ~/.ssh/mirror_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes"
-          git clone --depth 50 git@github.com:BoundaryML/baml-highlightjs.git /tmp/mirror-repo
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          git clone --depth 50 https://github.com/BoundaryML/baml-highlightjs.git /tmp/mirror-repo
 
       - name: Assemble and diff against mirror
         id: diff
@@ -234,7 +230,6 @@ jobs:
           jq --arg v "$next" '.version = $v' /tmp/mirror-repo/package.json > /tmp/pkg.json
           mv /tmp/pkg.json /tmp/mirror-repo/package.json
 
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes"
           cd /tmp/mirror-repo
           git add -A
           git -c user.name="github-actions[bot]" \
@@ -272,6 +267,9 @@ jobs:
   sync-treesitter:
     name: Sync to BoundaryML/baml-treesitter
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    env:
+      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -285,16 +283,11 @@ jobs:
         run: pnpm --filter @b/pkg-grammar-treesitter test
 
       - name: Clone mirror
-        env:
-          DEPLOY_KEY: ${{ secrets.BAML_TREESITTER_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/mirror_key
-          chmod 600 ~/.ssh/mirror_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes"
-          git clone --depth 50 git@github.com:BoundaryML/baml-treesitter.git /tmp/mirror-repo
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          git clone --depth 50 https://github.com/BoundaryML/baml-treesitter.git /tmp/mirror-repo
 
       - name: Assemble and diff against mirror
         id: diff
@@ -317,7 +310,6 @@ jobs:
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes"
           cd /tmp/mirror-repo
           git add -A
           git -c user.name="github-actions[bot]" \


### PR DESCRIPTION
[B-1672](https://linear.app/boundaryml2/issue/B-1672/incident-reissue-accidentally-deleted-boundarymlbaml-actions-secrets) - I accidentally nuked all of our GH secrets. Fortunately still had another tab open so have a recovery list.

This does two things:

1. switch all the secrets over from manually controlled GH secrets into having source-of-truth in infisical
2. create a new secret for syncing subdirs of the monorepo into other release artifact repos, and also renames the maven envvars we use for releasing Java