### PR TITLE
ci: use shared Infisical token for Swift and Homebrew

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1448,8 +1448,10 @@ jobs:
     needs: [plan, build-swift-sdk, all-builds, publish-toolchain-release]
     if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
     env:
       GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     permissions:
       contents: write
     steps:
@@ -1482,17 +1484,11 @@ jobs:
             echo "uploaded: $name"
           fi
       - name: Clone BoundaryML/baml-swift
-        env:
-          DEPLOY_KEY: ${{ secrets.BAML_SWIFT_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          test -n "$DEPLOY_KEY"
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/baml_swift_mirror_key
-          chmod 600 ~/.ssh/baml_swift_mirror_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/baml_swift_mirror_key -o IdentitiesOnly=yes"
-          git clone git@github.com:BoundaryML/baml-swift.git /tmp/baml-swift
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          git clone https://github.com/BoundaryML/baml-swift.git /tmp/baml-swift
           if ! git -C /tmp/baml-swift rev-parse --verify HEAD >/dev/null 2>&1; then
             git -C /tmp/baml-swift switch --orphan main
           fi
@@ -1502,7 +1498,6 @@ jobs:
           VERSION: ${{ needs.plan.outputs.swiftpm_version }}
         run: |
           set -euo pipefail
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/baml_swift_mirror_key -o IdentitiesOnly=yes"
           tag="v$VERSION"
           rsync -a --delete --exclude .git /tmp/swift-sdk-mirror/ /tmp/baml-swift/
           cd /tmp/baml-swift

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2021,6 +2021,7 @@ jobs:
     needs: [plan, all-builds, publish-wrapper-release]
     if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: macos-14
+    environment: infisical-github-baml-language-release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2054,16 +2055,17 @@ jobs:
           brew linkage --test boundaryml/tap/baml
       - name: Push formula to BoundaryML/homebrew-tap
         env:
-          TOKEN: ${{ secrets.HOMEBREW_BAML_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
           WRAPPER_VERSION: ${{ needs.plan.outputs.wrapper_version }}
         run: |
           set -euo pipefail
-          test -n "$TOKEN"
+          test -n "$GH_TOKEN"
+          gh auth setup-git
           tap="$(brew --repo boundaryml/tap)"
           cd "$tap"
           git config user.name "boundaryml-release-bot"
           git config user.email "boundaryml-release-bot@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/BoundaryML/homebrew-tap.git"
+          git remote set-url origin "https://github.com/BoundaryML/homebrew-tap.git"
           git add Formula/baml.rb
           git commit -m "Update baml wrapper to ${WRAPPER_VERSION}" || exit 0
           git push origin HEAD

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1451,7 +1451,6 @@ jobs:
     environment: infisical-github-baml-language-release
     env:
       GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
     permissions:
       contents: write
     steps:
@@ -1484,6 +1483,8 @@ jobs:
             echo "uploaded: $name"
           fi
       - name: Clone BoundaryML/baml-swift
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
         run: |
           set -euo pipefail
           test -n "$GH_TOKEN"
@@ -1494,6 +1495,7 @@ jobs:
           fi
       - name: Publish immutable package tag
         env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
           SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
           VERSION: ${{ needs.plan.outputs.swiftpm_version }}
         run: |


### PR DESCRIPTION
More work on fixing [B-1672](https://linear.app/boundaryml2/issue/B-1672/incident-reissue-accidentally-deleted-boundarymlbaml-actions-secrets). This was supposed to be part of #4688 but I forgot to include these.

## Summary

- replace `BAML_SWIFT_DEPLOY_KEY` with `SAM_GITHUB_BOUNDARYML_READWRITE2` for the Swift mirror
- replace `HOMEBREW_BAML_DISPATCH_TOKEN` with the same shared token for the Homebrew tap
- bind both publishing jobs to `infisical-github-baml-language-release`
- use `gh auth setup-git` with clean HTTPS remotes instead of SSH credentials or tokens embedded in URLs
- scope the shared token to only the Swift clone/publish steps and the Homebrew push step

## Validation

- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`
- authenticated `git ls-remote` against `BoundaryML/baml-swift` and `BoundaryML/homebrew-tap` using the shared Infisical token and `gh auth setup-git`

Supersedes #4694.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved authentication handling for Swift SDK release publishing.
  * Updated automated Homebrew publishing configuration.
  * Removed obsolete authentication settings to support more reliable package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->