### PR TITLE
ci: upgrade BAML Language CI to Node 24 and Rust 1.98

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -77,7 +77,7 @@ Sets up the BAML Language Rust toolchain with caching and optional WASM support.
 - name: Setup Rust
   uses: ./.github/actions/setup-rust
   with:
-    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
+    toolchain: '1.98.0'                          # Optional, default: '1.98.0'
     enable-wasm: 'false'                         # Optional, default: 'false'
     targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
     workspace: 'baml_language'                   # Optional, default: 'baml_language'

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -26,18 +26,12 @@ inputs:
     description: 'Path for Turbo cache directory'
     required: false
     default: '.turbo'
-  node-action-version:
-    description: 'Version of actions/setup-node to use (v4 or v6)'
-    required: false
-    # Default to v4 for backwards compatibility.
-    default: 'v4'
-
 runs:
   using: 'composite'
   steps:
     - name: Cache Turbo build setup
       if: inputs.enable-turbo-cache == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ inputs.turbo-cache-path }}
         key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -45,23 +39,13 @@ runs:
           ${{ runner.os }}-turbo-
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: ${{ inputs.pnpm-version }}
         run_install: false
 
-    - name: Setup Node.js (v4)
-      if: inputs.node-action-version == 'v4'
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ inputs.node-version }}
-        cache: pnpm
-        cache-dependency-path: pnpm-lock.yaml
-        registry-url: "https://registry.npmjs.org"
-
-    - name: Setup Node.js (v6)
-      if: inputs.node-action-version == 'v6'
-      uses: actions/setup-node@v6
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/actions/setup-node2/action.yml
+++ b/.github/actions/setup-node2/action.yml
@@ -4,7 +4,7 @@
 # Key differences from setup-node:
 # - Defaults to typescript2/ working directory and lockfile
 # - No Turbo cache (typescript2 doesn't use Turbo for caching)
-# - Uses Node 24 and actions/setup-node@v6
+# - Uses Node 24 and actions/setup-node@v7
 
 name: 'Setup Node.js for typescript2'
 description: 'Setup Node.js with pnpm for the typescript2 workspace'
@@ -25,7 +25,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: ${{ inputs.pnpm-version }}
         # Point at typescript2/package.json explicitly — otherwise the action
@@ -35,7 +35,7 @@ runs:
         run_install: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: '24'
         cache: pnpm

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -5,7 +5,7 @@ inputs:
   toolchain:
     description: "Rust toolchain version"
     required: false
-    default: "1.93.0"
+    default: "1.98.0"
   enable-wasm:
     description: "Enable WASM support (adds wasm32-unknown-unknown target and wasm-pack)"
     required: false
@@ -78,6 +78,10 @@ runs:
         toolchain: ${{ inputs.toolchain }}
         targets: ${{ inputs.targets }}
         components: rustfmt
+
+    - name: Export BAML build fingerprint
+      run: echo "BAML_GIT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+      shell: bash
 
     - name: Add additional targets
       if: inputs.targets != ''

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -86,7 +86,7 @@ jobs:
     outputs:
       include: ${{ steps.gen.outputs.include }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -136,7 +136,7 @@ jobs:
               Add-Content -Path "$env:GITHUB_PATH" -Value "$env:USERPROFILE\.cargo\bin" -Encoding utf8
           }
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -408,7 +408,7 @@ jobs:
           }
 
       - name: Upload cdylib artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bridge-cffi-${{ matrix._.target }}
           path: |

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -119,6 +119,7 @@ jobs:
     # Experimental targets are built when possible but never block the release.
     continue-on-error: ${{ matrix._.experimental || false }}
     env:
+      BAML_GIT_SHA: ${{ inputs.source_sha || github.sha }}
       CARGO: cargo
       # Let aws-lc-sys use its prebuilt NASM objects on Windows x86-64 if the
       # runner has no NASM installed (consulted only there; harmless elsewhere).

--- a/.github/workflows/build2-java-sdk.reusable.yaml
+++ b/.github/workflows/build2-java-sdk.reusable.yaml
@@ -74,7 +74,7 @@ jobs:
     outputs:
       include: ${{ steps.gen.outputs.include }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -111,7 +111,7 @@ jobs:
       # runner has no NASM installed (consulted only there; harmless elsewhere).
       AWS_LC_SYS_PREBUILT_NASM: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -214,7 +214,7 @@ jobs:
           ls -la build/libs
 
       - name: Upload natives jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: java-sdk-natives-${{ matrix._.platform }}
           path: baml_language/sdks/java/baml_bridge/build/libs/*natives*.jar
@@ -227,7 +227,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -265,7 +265,7 @@ jobs:
           ls -la build/libs
 
       - name: Upload main/sources/javadoc jars
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: java-sdk-main
           path: |

--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix._.host }}
     container: ${{ matrix._.container }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -143,7 +143,7 @@ jobs:
         # npm on PATH here, but pnpm/action-setup shells out to npm. Provide a real
         # node/npm first (this is what the setup-node composite did in the original
         # all-green run).
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/build2-python-sdk.reusable.yaml
+++ b/.github/workflows/build2-python-sdk.reusable.yaml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       include: ${{ steps.gen.outputs.include }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -78,7 +78,7 @@ jobs:
               Add-Content -Path "$env:GITHUB_PATH" -Value "$env:USERPROFILE\.cargo\bin" -Encoding utf8
           }
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -100,7 +100,7 @@ jobs:
       # so we want a specific Python (3.10, matching the abi3-py310 target)
       # rather than whatever mise.toml's `python` is pinned to today.
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           # abi3-py310 produces one interpreter-agnostic wheel per platform,
           # so a single Python is enough for the whole 3.10..3.13+ range.

--- a/.github/workflows/build2-rust-sdk.reusable.yaml
+++ b/.github/workflows/build2-rust-sdk.reusable.yaml
@@ -40,7 +40,7 @@ jobs:
     name: package baml_bridge crate
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -83,7 +83,7 @@ jobs:
           cat "${crate}.sha256"
 
       - name: Upload crate artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-sdk-crate
           path: |

--- a/.github/workflows/build2-web-sdk.reusable.yaml
+++ b/.github/workflows/build2-web-sdk.reusable.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -89,7 +89,7 @@ jobs:
           # CROSS_CONFIG makes the plan's image control linking; the image's
           # host ldd does not determine the wrapper's compatibility floor.
           cross_config="$RUNNER_TEMP/baml-wrapper-cross.toml"
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_WORKOS_CLIENT_ID"]\n' \
+          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       include: ${{ steps.gen.outputs.include }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.matrix.outputs.include) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -146,7 +146,7 @@ jobs:
           if [[ "$NO_SELF_UPDATE" == "true" ]]; then
             archive staging-no-self-update baml-wrapper-no-self-update
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wrapper-${{ matrix.target }}
           path: |

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -286,7 +286,7 @@ jobs:
   #   runs-on: blacksmith-6vcpu-macos-latest
   #   timeout-minutes: 35
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@v7
   #       with:
   #         persist-credentials: false
 
@@ -387,7 +387,7 @@ jobs:
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 50
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -507,7 +507,7 @@ jobs:
     steps:
       - name: "Build matrix"
         id: matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const baseMatrix = [
@@ -843,12 +843,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: sdk-test-matrix
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: "Assert every SDK directory has a matrix entry"
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           MATRIX_SDK_DIRS: ${{ needs.sdk-test-matrix.outputs.sdk-dirs }}
           TEMPORARILY_DISABLED_SDK_DIRS: ${{ needs.sdk-test-matrix.outputs.temporarily-disabled-sdk-dirs }}
@@ -921,7 +921,7 @@ jobs:
       EnableSourceLink: "false"
       IncludeSourceRevisionInInformationalVersion: "false"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -987,7 +987,7 @@ jobs:
       # under `if: always()`.
       - name: "Restore C# build cache"
         if: matrix.sdk-label == 'csharp'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.nuget/packages
@@ -1166,7 +1166,7 @@ jobs:
       # collides with an existing entry.
       - name: "Save C# build cache"
         if: always() && matrix.sdk-label == 'csharp'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             ~/.nuget/packages
@@ -1615,7 +1615,7 @@ jobs:
       - snapshot-tests
     steps:
       - name: "Merge cargo timings artifacts"
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cargo-timings
           pattern: cargo-timings-*
@@ -1634,7 +1634,7 @@ jobs:
       - snapshot-tests
     steps:
       - name: "Merge sccache stats artifacts"
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: sccache-stats
           pattern: sccache-stats-*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -466,7 +466,7 @@ jobs:
           install_args: "sccache cargo:prek python uv node clang-format"
 
       - name: "Cache prek"
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -1005,7 +1005,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout Branch"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -1085,7 +1085,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout Branch"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -1100,7 +1100,7 @@ jobs:
       # re-cloning git deps on the bare codspeed-macro runner (~24 min). Comes
       # via artifact, not cache — see the build job for why cache misses here.
       - name: "Download cargo home"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: codspeed-cargo-home
           path: /tmp/cargo-home
@@ -1113,7 +1113,7 @@ jobs:
           tool: cargo-codspeed@4.7.0
 
       - name: "Download prebuilt benchmark binaries"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: codspeed-walltime-benches
           path: baml_language/target/codspeed/walltime
@@ -1177,7 +1177,7 @@ jobs:
       pull-requests: write
     steps:
       - name: "Comment perf opt-in instructions"
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RUN_PERF: ${{ needs.determine_changes.outputs.run_perf }}
         with:

--- a/.github/workflows/docs.reusable.yaml
+++ b/.github/workflows/docs.reusable.yaml
@@ -38,7 +38,7 @@ jobs:
           env: docs-${{ inputs.is_canary && 'prod' || 'dev' }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -95,7 +95,7 @@ jobs:
     # exceed 25 minutes; the cap is a hang backstop, not a perf gate.
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -201,7 +201,7 @@ jobs:
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
       CC_x86_64_unknown_linux_musl: musl-gcc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -312,7 +312,7 @@ jobs:
   #   runs-on: blacksmith-6vcpu-macos-latest
   #   timeout-minutes: 35
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@v7
   #       with:
   #         persist-credentials: false
 
@@ -399,7 +399,7 @@ jobs:
     steps:
       - name: "Build matrix"
         id: matrix
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Fork PRs stay on the hosted runners; untrusted code never
@@ -752,12 +752,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: sdk-test-matrix
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: "Assert every SDK directory has a matrix entry"
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           MATRIX_SDK_DIRS: ${{ needs.sdk-test-matrix.outputs.sdk-dirs }}
           TEMPORARILY_DISABLED_SDK_DIRS: ${{ needs.sdk-test-matrix.outputs.temporarily-disabled-sdk-dirs }}
@@ -833,7 +833,7 @@ jobs:
       # space, so -w alone, not -s -w).
       GOFLAGS: "-ldflags=-w"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -1045,7 +1045,7 @@ jobs:
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-wasm"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -1162,7 +1162,7 @@ jobs:
     # minutes. Warm runs sit far inside the old budget.
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -1253,7 +1253,7 @@ jobs:
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -1333,7 +1333,7 @@ jobs:
     # 45, not 30: cold headroom, same reasoning as the gnu lane above.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -1446,7 +1446,7 @@ jobs:
       - snapshot-tests
     steps:
       - name: "Merge cargo timings artifacts"
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cargo-timings
           pattern: cargo-timings-*
@@ -1464,7 +1464,7 @@ jobs:
       - snapshot-tests
     steps:
       - name: "Merge sccache stats artifacts"
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: sccache-stats
           pattern: sccache-stats-*

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -45,7 +45,7 @@ jobs:
       code: ${{ steps.check_code.outputs.changed }}
       webview: ${{ steps.check_webview.outputs.changed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ix-size-gate.reusable.yaml
+++ b/.github/workflows/ix-size-gate.reusable.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -153,7 +153,7 @@ jobs:
     timeout-minutes: 25
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -246,7 +246,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);

--- a/.github/workflows/ix-wasm-pack-tests.reusable.yaml
+++ b/.github/workflows/ix-wasm-pack-tests.reusable.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-wasm"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);

--- a/.github/workflows/ix-webview-tests.reusable.yaml
+++ b/.github/workflows/ix-webview-tests.reusable.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-web"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-web"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);
@@ -139,7 +139,7 @@ jobs:
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-web"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Keep the warm seed's ignored files (target/, node_modules);

--- a/.github/workflows/prepare-csharp-sdk.reusable.yaml
+++ b/.github/workflows/prepare-csharp-sdk.reusable.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -107,7 +107,7 @@ jobs:
             baml_language/sdks/csharp/bridge_csharp/tools/Baml.NuGetNormalizer/Baml.NuGetNormalizer.csproj \
             -- --self-test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: csharp-neutral-preparation
           path: ${{ runner.temp }}/csharp-neutral

--- a/.github/workflows/product-metrics-slack-report.yml
+++ b/.github/workflows/product-metrics-slack-report.yml
@@ -25,7 +25,7 @@ jobs:
       SLACK_CHANNEL_ID: C03KV1PJ6EM
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node2
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload screenshot when delivery fails
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: product-metrics-dashboard
           path: ${{ runner.temp }}/product-metrics-dashboard.png

--- a/.github/workflows/publish-gradle-plugin-manual.yml
+++ b/.github/workflows/publish-gradle-plugin-manual.yml
@@ -43,7 +43,7 @@ jobs:
     name: Publish com.boundaryml.baml to the Portal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false

--- a/.github/workflows/publish2-csharp-sdk.yaml
+++ b/.github/workflows/publish2-csharp-sdk.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -39,7 +39,7 @@ jobs:
         with:
           dotnet-version: 10.0.301
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: csharp-product-package
           path: product-package

--- a/.github/workflows/publish2-nodejs-sdk.yaml
+++ b/.github/workflows/publish2-nodejs-sdk.yaml
@@ -39,12 +39,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
       - name: Download per-platform npm packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           # Each build matrix job uploaded a single npm/<platform>/ sub-package
           # (stamped package.json + baml_node.<platform>.node); merge-multiple
@@ -53,7 +53,7 @@ jobs:
           path: baml_language/sdks/typescript/bridge_typescript/npm
           merge-multiple: true
       - name: Download umbrella dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           # The umbrella ships `files: ["dist"]`; the build job assembled this
           # platform-agnostic dist/ once (on the linux-gnu target). Restore it here
@@ -64,7 +64,7 @@ jobs:
         # The publisher only uses npm. Avoid the repository composite here because
         # it always enables pnpm caching, whose post-job save fails when this job
         # intentionally does not install a pnpm store.
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: latest
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish2-web-sdk.yaml
+++ b/.github/workflows/publish2-web-sdk.yaml
@@ -36,13 +36,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
 
       - name: Download Web SDK dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-sdk-dist
           path: baml_language/sdks/typescript/bridge_typescript_web/dist
@@ -51,7 +51,7 @@ jobs:
         # This publisher only uses npm. Enabling the repository composite's pnpm
         # cache without installing dependencies makes its post-job cache save fail
         # after a successful publish.
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: latest
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -108,7 +108,7 @@ jobs:
       wrapper_version: ${{ steps.wrapper.outputs.wrapper_version }}
       wrapper_changed: ${{ steps.wrapper.outputs.wrapper_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           fetch-depth: 2
@@ -284,7 +284,7 @@ jobs:
             echo "wrapper_changed=$changed"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-plan
           path: release-plan.json
@@ -301,7 +301,7 @@ jobs:
       toolchain: ${{ steps.gen.outputs.toolchain }}
       csharp: ${{ steps.gen.outputs.csharp }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
@@ -333,18 +333,18 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.build-matrix.outputs.toolchain) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-plan
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: baml-vscode-vsix
           path: vsix
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: baml-playground-dist
           path: playground-dist
@@ -413,7 +413,7 @@ jobs:
           else
             tar -C staging -czf "baml-language-$version-$target.tar.gz" .
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: toolchain-${{ matrix.target }}
           path: baml-language-${{ needs.plan.outputs.version }}-${{ matrix.target }}.*
@@ -423,11 +423,11 @@ jobs:
     needs: [plan]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-plan
       - run: scripts/baml-language-version stamp --plan release-plan.json
@@ -469,11 +469,11 @@ jobs:
           grep -Fxq 'extension/readme.md' vsix-list.txt
           grep -Fxq 'extension/baml-logo.png' vsix-list.txt
           ! grep -E 'dist/baml-cli|baml-cli|baml-pack-host' vsix-list.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: baml-vscode-vsix
           path: typescript2/app-vscode-ext/*.vsix
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: baml-playground-dist
           path: typescript2/app-vscode-webview/dist
@@ -556,16 +556,16 @@ jobs:
     needs: [plan]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-plan
       - name: Stamp version
         run: scripts/baml-language-version stamp --plan release-plan.json
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: baml_language/sdks/go/baml_go/go.mod
           cache-dependency-path: baml_language/sdks/go/baml_go/go.sum
@@ -583,7 +583,7 @@ jobs:
           test "$(go list -m)" = "github.com/boundaryml/baml-go"
           go test ./...
           go vet ./...
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: go-sdk-mirror
           path: ${{ runner.temp }}/go-sdk-mirror
@@ -594,11 +594,11 @@ jobs:
     needs: [plan]
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-plan
       - name: Stamp version
@@ -637,12 +637,12 @@ jobs:
             --out "$RUNNER_TEMP/swift-sdk-mirror" \
             --version "$VERSION" --source-sha "$SOURCE_SHA" \
             --zip-url "$url" --checksum "$CHECKSUM"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: swift-xcframework
           path: ${{ runner.temp }}/BamlBridgeFFI-*.xcframework.zip
           if-no-files-found: error
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: swift-sdk-mirror
           path: ${{ runner.temp }}/swift-sdk-mirror
@@ -657,11 +657,11 @@ jobs:
     needs: [plan, build-swift-sdk]
     runs-on: macos-15
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: swift-xcframework
           path: ${{ runner.temp }}/xcf
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: swift-sdk-mirror
           path: ${{ runner.temp }}/mirror
@@ -793,7 +793,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: python-sdk-*
           path: dist
@@ -882,7 +882,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
@@ -939,7 +939,7 @@ jobs:
           install_args: java gradle
       - name: Download native jars
         if: ${{ steps.exists.outputs.bridge_publish == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           # The 8 per-target natives-<platform> jars (fewer if an experimental
           # target's build failed — continue-on-error — which never blocks).
@@ -1103,7 +1103,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
@@ -1159,12 +1159,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: toolchain-*
           path: dist/toolchain
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: baml-vscode-vsix
           path: dist/vsix
@@ -1210,11 +1210,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wrapper-*
           path: dist/wrapper
@@ -1275,7 +1275,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: bridge-cffi-*
           path: dist/cffi
@@ -1344,7 +1344,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: go-sdk-mirror
           path: /tmp/go-sdk-package
@@ -1453,11 +1453,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: swift-xcframework
           path: /tmp/swift-xcframework
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: swift-sdk-mirror
           path: /tmp/swift-sdk-mirror
@@ -1542,7 +1542,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
@@ -1555,7 +1555,7 @@ jobs:
           scripts/baml-language-version stamp --plan release-plan.json
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: rust-sdk-crate
           path: dist/rust
@@ -1732,37 +1732,37 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-plan
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: toolchain-*
           path: dist/toolchain
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: bridge-cffi-*
           path: dist/cffi
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wrapper-*
           path: dist/wrapper
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: baml-vscode-vsix
           path: dist/vsix
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: csharp-product-package
           path: dist/csharp
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: swift-xcframework
           path: dist/swift
@@ -1822,7 +1822,7 @@ jobs:
             --pypi-version "$PYPI_VERSION" \
             --wrapper-version "$WRAPPER_VERSION" \
             "${args[@]}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-manifests
           path: manifests
@@ -1893,14 +1893,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: baml_language/sdks/go/baml_go/go.mod
           cache: false
@@ -1997,7 +1997,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-manifests
           path: manifests
@@ -2022,11 +2022,11 @@ jobs:
     if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wrapper-*
           path: dist/wrapper
@@ -2077,11 +2077,11 @@ jobs:
   #   if: ${{ needs.plan.outputs.wrapper_changed == 'true' && needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' }}
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v7
   #       with:
   #         ref: ${{ needs.plan.outputs.source_sha }}
   #         persist-credentials: false
-  #     - uses: actions/download-artifact@v4
+  #     - uses: actions/download-artifact@v8
   #       with:
   #         pattern: wrapper-*
   #         path: dist/wrapper
@@ -2135,34 +2135,34 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: toolchain-*
           path: dist/toolchain
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: bridge-cffi-*
           path: dist/cffi
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wrapper-*
           path: dist/wrapper
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: baml-vscode-vsix
           path: dist/vsix
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: csharp-product-package
           path: dist/csharp
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: swift-xcframework
           path: dist/swift
@@ -2223,7 +2223,7 @@ jobs:
             --wrapper-dir dist/wrapper \
             --version "$WRAPPER_VERSION" \
             --out dry-run/package-manager
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dry-run-release-files
           path: dry-run

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -357,28 +357,34 @@ jobs:
           workspace: baml_language
           prefix-key: v5-rust-baml-language-toolchain-${{ matrix.target }}
           cache-on-failure: true
-          enable-cross: false
+          enable-cross: ${{ matrix.libc == 'gnu' && 'true' || 'false' }}
           skip-protoc: true
       - name: Setup musl cross toolchain
         if: ${{ matrix.libc == 'musl' }}
         uses: ./.github/actions/setup-musl-cross
         with:
           target: ${{ matrix.target }}
-      - name: Setup cross for backward-compatible GNU toolchain
+      - name: Setup sccache for backward-compatible GNU toolchain
         if: ${{ matrix.libc == 'gnu' }}
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache cargo:cross"
+          install_args: "sccache"
       - name: Configure cross for GNU toolchain
         if: ${{ matrix.libc == 'gnu' }}
         env:
           CROSS_IMAGE: ${{ matrix.cross_image }}
           TARGET: ${{ matrix.target }}
+          MANYLINUX2014_PRE_BUILD: 'for tool in gcc g++ ar ranlib strip; do ln -sf "$(command -v "$tool")" "/usr/local/bin/x86_64-unknown-linux-gnu-$tool"; done'
         run: |
           set -euo pipefail
           cross_config="$RUNNER_TEMP/baml-toolchain-cross.toml"
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_WORKOS_CLIENT_ID"]\n' \
-            "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
+          {
+            printf '[target.%s]\nimage = "%s"\n' "$TARGET" "$CROSS_IMAGE"
+            if [[ "$TARGET" == 'x86_64-unknown-linux-gnu' ]]; then
+              printf "pre-build = ['%s']\n" "$MANYLINUX2014_PRE_BUILD"
+            fi
+            printf '[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' "$TARGET"
+          } > "$cross_config"
           {
             echo 'CARGO=cross'
             echo "CROSS_CONFIG=$cross_config"

--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: canary
           persist-credentials: false

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -226,7 +226,7 @@ jobs:
     env:
       CARGO_BUILD_JOBS: "16"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/stdlib-matrix.yml
+++ b/.github/workflows/stdlib-matrix.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: "Upload the site"
         if: steps.ratchet.outputs.changed == 'true'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: typescript2/app-stdlib-matrix/dist
 
@@ -277,4 +277,4 @@ jobs:
     steps:
       - name: "Deploy"
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/sync-grammar-mirror.yml
+++ b/.github/workflows/sync-grammar-mirror.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -274,7 +274,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: infisical-github-baml-language-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/verify-cpp-sdk.reusable.yaml
+++ b/.github/workflows/verify-cpp-sdk.reusable.yaml
@@ -44,7 +44,7 @@ jobs:
     outputs:
       matrix: ${{ steps.derive.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -76,12 +76,12 @@ jobs:
     name: verify ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: bridge-cffi-${{ matrix.target }}
           path: runtime-dist

--- a/.github/workflows/verify-csharp-product-slice.reusable.yaml
+++ b/.github/workflows/verify-csharp-product-slice.reusable.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -49,13 +49,13 @@ jobs:
           done
           echo "$llvm_bin" >> "$GITHUB_PATH"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: bridge-cffi-*
           path: native-downloads
           merge-multiple: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: csharp-neutral-preparation
           path: neutral-preparation
@@ -164,7 +164,7 @@ jobs:
             sha256sum "$(basename "$package")" > product-package.sha256
           )
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: csharp-product-package
           path: product-output
@@ -180,7 +180,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
@@ -190,7 +190,7 @@ jobs:
         with:
           dotnet-version: 10.0.301
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: csharp-product-package
           path: product-package

--- a/.github/workflows/verify-rust-sdk.reusable.yaml
+++ b/.github/workflows/verify-rust-sdk.reusable.yaml
@@ -57,7 +57,7 @@ jobs:
     outputs:
       matrix: ${{ steps.derive.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -90,7 +90,7 @@ jobs:
     env:
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
@@ -124,7 +124,7 @@ jobs:
           enable-cache: false
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/verify-rust-sdk.reusable.yaml
+++ b/.github/workflows/verify-rust-sdk.reusable.yaml
@@ -70,7 +70,7 @@ jobs:
                      and .libc != "musl"
                      and .artifacts.toolchain != null
                      and .artifacts.cffi != null)
-            | {target: .triple, os: .artifacts.toolchain.runner}]
+            | {target: .triple, os: (.artifacts.toolchain.verify_runner // .artifacts.toolchain.runner)}]
             + [{target: "x86_64-unknown-linux-gnu",
                 os: (.targets[]
                      | select(.triple == "x86_64-unknown-linux-gnu")
@@ -120,7 +120,7 @@ jobs:
         with:
           # Default mirrors the setup-rust action default; the MSRV leg pins the
           # crate's minimum supported Rust instead.
-          toolchain: ${{ matrix.toolchain || '1.93.0' }}
+          toolchain: ${{ matrix.toolchain || '1.98.0' }}
           enable-cache: false
 
       - name: Download release artifacts

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -7,16 +7,16 @@
 # rustc silently drops the `cdylib` crate type and only the `.rlib` is built.
 #
 # `cross` runs the build inside a container and forwards only a curated set of
-# environment variables, so the Rust and native C/C++ remapping flags must be
-# listed here explicitly or they never reach the compilers.
+# environment variables, so the source fingerprint and Rust/native remapping
+# flags must be listed here explicitly or they never reach the compilers.
 [target.x86_64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-gnu.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.x86_64-unknown-linux-musl.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-musl.env]
-passthrough = ["RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]

--- a/baml_language/crates/baml_ide/src/export.rs
+++ b/baml_language/crates/baml_ide/src/export.rs
@@ -902,13 +902,13 @@ pub fn export_package<'db>(db: &'db Db, package: PackageId<'db>) -> PackageExpor
             .iter()
             .map(|(name, def)| (name, *def))
             .collect();
-        named.sort_by(|(a, _), (b, _)| a.cmp(b));
+        named.sort_by_key(|(name, _)| *name);
         let mut values: Vec<(&Name, Definition<'db>)> = ns_items
             .values
             .iter()
             .map(|(name, def)| (name, *def))
             .collect();
-        values.sort_by(|(a, _), (b, _)| a.cmp(b));
+        values.sort_by_key(|(name, _)| *name);
         named.extend(values);
         for (_, def) in named {
             if let Some(item) = export_item(db, def, &impl_index) {

--- a/baml_language/crates/baml_ide/src/resolve.rs
+++ b/baml_language/crates/baml_ide/src/resolve.rs
@@ -1172,10 +1172,8 @@ fn operator_target_at(
                     narrower(span, dispatch, *operand, None);
                 }
             }
-            Expr::Index { base, index } => {
-                if !inside(*base) && !inside(*index) {
-                    narrower(span, ops::INDEX_DISPATCH, *base, Some(*index));
-                }
+            Expr::Index { base, index } if !inside(*base) && !inside(*index) => {
+                narrower(span, ops::INDEX_DISPATCH, *base, Some(*index));
             }
             _ => {}
         }

--- a/baml_language/crates/baml_query/src/session.rs
+++ b/baml_language/crates/baml_query/src/session.rs
@@ -368,6 +368,7 @@ impl QuerySession {
     ///
     /// A planning failure still produces a terminal outcome — take it
     /// from the returned error via the second tuple element.
+    #[allow(clippy::result_large_err)] // Preserve the public result shape without adding boxing.
     pub async fn execute(&self, sql: &str) -> Result<QueryExecution, (QueryError, QueryOutcome)> {
         match self.plan_and_run(sql).await {
             Ok(stream) => Ok(QueryExecution {

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -58,8 +58,11 @@ pub struct Artifacts {
 /// The CLI toolchain artifact (baml-cli + pack host, archived per target).
 #[derive(Debug, Clone, Deserialize)]
 pub struct ToolchainArtifact {
-    /// GitHub Actions runner label (distinct from the target's `os` family).
+    /// GitHub Actions runner label used to build the artifact (distinct from the target's `os` family).
     pub runner: String,
+    /// Native GitHub Actions runner used to execute the artifact when the build runner cross-compiles it.
+    #[serde(default)]
+    pub verify_runner: Option<String>,
     /// Built best-effort: a build failure must not block the release.
     #[serde(default)]
     pub experimental: bool,

--- a/baml_language/crates/baml_tests/src/corpus.rs
+++ b/baml_language/crates/baml_tests/src/corpus.rs
@@ -399,7 +399,7 @@ fn corpus_snapshots() {
             crate::engine::named_and_interface_body_functions(&program)
                 .filter(|(name, _)| name.starts_with(&prefix))
                 .collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        entries.sort_by_key(|(name, _)| *name);
 
         let functions: Vec<(String, &Function)> = entries
             .iter()

--- a/baml_language/crates/bex_cache/src/lib.rs
+++ b/baml_language/crates/bex_cache/src/lib.rs
@@ -1280,7 +1280,7 @@ impl BytecodeCache {
 mod remote_tests {
     use std::{
         collections::HashMap,
-        io::{BufRead, BufReader, Read as _, Write as _},
+        io::{BufRead, BufReader},
         net::TcpListener,
         sync::{Arc, Mutex},
     };

--- a/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
+++ b/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
@@ -34,8 +34,8 @@ fn rec(seq: u64) -> [u8; 8] {
 
 fn collect_seqs(bytes: &[u8], out: &mut Vec<u64>) {
     assert_eq!(bytes.len() % 8, 0, "drained range split a record");
-    for chunk in bytes.chunks_exact(8) {
-        out.push(u64::from_le_bytes(chunk.try_into().unwrap()));
+    for chunk in bytes.as_chunks::<8>().0 {
+        out.push(u64::from_le_bytes(*chunk));
     }
 }
 

--- a/baml_language/crates/bex_prof_store/src/prof/backend/decoder.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/decoder.rs
@@ -93,10 +93,10 @@ impl ExecutionHealthSnapshot {
         if bytes.len() != Self::ENCODED_LEN {
             return None;
         }
-        let mut chunks = bytes.chunks_exact(8);
+        let mut chunks = bytes.as_chunks::<8>().0.iter();
         let mut next = || {
-            let chunk: [u8; 8] = chunks.next()?.try_into().ok()?;
-            Some(u64::from_be_bytes(chunk))
+            let chunk = chunks.next()?;
+            Some(u64::from_be_bytes(*chunk))
         };
         Some(Self {
             corrupt_records: next()?,
@@ -1753,15 +1753,12 @@ impl DirectDecoder {
         // consuming a parked end never can, so opening every ready start
         // before any parked end runs resolves the same set.
         let mut opened = Vec::new();
-        loop {
+        while let Some(parked) = self.pending_starts.get(&thread_ref) {
             // A consumer can observe a spawned child's descendants before the
             // spawning thread's ring publishes the child's entry call. Only
             // remove a fact whose parent is already resolvable; removing and
             // immediately reinserting an unready fact can otherwise select the
             // same map entry forever and livelock the sole consumer.
-            let Some(parked) = self.pending_starts.get(&thread_ref) else {
-                break;
-            };
             let next = parked
                 .iter()
                 .find(|(_, pending)| self.call_start_dependency_ready(&pending.fact))

--- a/baml_language/rust-toolchain.toml
+++ b/baml_language/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.98.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["clippy", "rust-analyzer", "rustfmt"]

--- a/baml_language/sdk_tests/crates/java/setup.ps1
+++ b/baml_language/sdk_tests/crates/java/setup.ps1
@@ -34,9 +34,6 @@ if (Get-Command gradle -ErrorAction SilentlyContinue) {
 Write-Host "==> cargo build -p bridge_java (native bridge library)"
 Push-Location $WorkspaceRoot
 try {
-    # Toolchain pinning comes from the workspace rust-toolchain.toml (1.93.0);
-    # keep in sync with setup.sh, which cannot use `rustup run` (the nix CI
-    # arm's rustup owns no toolchains).
     cargo build -p bridge_java
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 } finally {

--- a/baml_language/sdk_tests/crates/java/setup.sh
+++ b/baml_language/sdk_tests/crates/java/setup.sh
@@ -47,12 +47,7 @@ else
 fi
 
 # 1. Native bridge library the fixtures load at runtime (the JVM analog of
-#    typescript_node's `.node` addon build). Toolchain pinning comes from the
-#    workspace rust-toolchain.toml (1.93.0), which whichever cargo is on PATH
-#    honors - the rustup shim resolves it on the mise arm, and the nix CI
-#    shell ships that exact toolchain directly. An explicit `rustup run` here
-#    breaks the nix arm outright (its rustup owns no toolchains) and is
-#    redundant on the mise arm. Produces target/debug/libbridge_java.so.
+#    typescript_node's `.node` addon build). Produces target/debug/libbridge_java.so.
 echo "==> cargo build -p bridge_java (native bridge library)"
 (cd "$WORKSPACE_ROOT" && cargo build -p bridge_java)
 

--- a/baml_language/sdks/java/baml_bridge/PUBLISHING.md
+++ b/baml_language/sdks/java/baml_bridge/PUBLISHING.md
@@ -60,7 +60,7 @@ working against a locally built cdylib uses step 1 or 2.
 Build the release cdylib first (from the repo root):
 
 ```
-rustup run 1.93.0 cargo build -p bridge_java --release
+cargo build -p bridge_java --release
 # → target/release/libbridge_java.so
 ```
 

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -587,7 +587,7 @@ fn render_function_registry(pool: &SymbolPool, names: &PythonNames) -> String {
                     suffix.to_string()
                 };
                 let binding = names.callable(&companion_fqn, role);
-                let _ = writeln!(out, "        {}: {},", py_string(&key), py_string(&binding),);
+                let _ = writeln!(out, "        {}: {},", py_string(&key), py_string(&binding));
             }
         }
         out.push_str("    },\n");

--- a/baml_language/sdks/swift/rust/sdkgen_swift/src/translate_ty.rs
+++ b/baml_language/sdks/swift/rust/sdkgen_swift/src/translate_ty.rs
@@ -136,7 +136,7 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> Option<String> {
                     return None;
                 }
                 let final_ty = translate_ty(&args[0], ctx)?;
-                return Some(format!("BamlFunctionSpec<{final_ty}>",));
+                return Some(format!("BamlFunctionSpec<{final_ty}>"));
             }
             // `ai.Prompt` is the nominal stdlib facade around PromptAst. The
             // generated SDK aliases it to the same portable bridge wrapper.

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -41,7 +41,7 @@
       "libc": "gnu",
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "ubuntu-24.04-arm", "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
+        "toolchain": { "runner": "ubuntu-latest", "verify_runner": "ubuntu-24.04-arm", "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
         "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"], "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
@@ -73,7 +73,7 @@
       "libc": "gnu",
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "ubuntu-latest", "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64" },
+        "toolchain": { "runner": "ubuntu-latest", "cross_image": "quay.io/pypa/manylinux2014_x86_64:latest" },
         "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"], "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64" },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},


### PR DESCRIPTION
## Summary

Upgrade the BAML Language side of CI to Node 24-capable action runtimes and Rust 1.98.0, stacked on the setup separation foundation in #4696.

## Canonical stack

| Merge order | PR | Base arrow | Scope |
| --- | --- | --- | --- |
| 1 | [#4696](https://github.com/BoundaryML/baml/pull/4696) | `canary` ← `sxlijin/split-engine-github-actions` | Separate engine setup actions without changing toolchain versions or behavior. |
| 2 | **#4695** | `sxlijin/split-engine-github-actions` ← `sxlijin/upgrade-github-actions-node-runtime` | BAML Language Node 24 action upgrades and Rust 1.98.0. |
| 3 | [#4697](https://github.com/BoundaryML/baml/pull/4697) | `sxlijin/upgrade-github-actions-node-runtime` ← `sxlijin/upgrade-engine-github-actions-node-runtime` | Engine Node 24 action upgrades, Go 1.24, and Rust 1.98.0. |

## Scope

- Upgrade the BAML Language workflows and setup composites to the Node 24-capable action versions selected by the source runtime work, including checkout v7, upload-artifact v7, download-artifact v8, cache v6, setup-node v7, setup-python v7, github-script v9, Pages v5, and pnpm v6.
- Bump `baml_language/rust-toolchain.toml`, the BAML Language `setup-rust` default, and the Rust SDK verification fallback to Rust 1.98.0.
- Carry the Rust 1.98 compiler and Clippy compatibility fixes, build fingerprint propagation, GNU cross-release configuration, and native verification-runner metadata from #4681.
- Keep the runtime upgrade and Rust upgrade as separate authored commits inside this PR.

## Migration-sensitive behavior

- This PR changes only the BAML Language-owned side of the setup boundary created by #4696; engine and legacy callers remain unchanged relative to its base.
- Artifact upload/download pairs, cache paths and keys, platform matrices, and reusable-workflow inputs were audited after the runtime-major changes.
- Rust ownership stays local to `baml_language/rust-toolchain.toml`; no root or engine pin is introduced by this layer.
- This PR absorbs all still-needed changes from [#4681](https://github.com/BoundaryML/baml/pull/4681).

## Validation

- Parsed all 72 `.github` YAML files.
- `actionlint` matches the five findings on current `origin/canary`; the stack introduces no new findings.
- `scripts/baml-language-version check` passed.
- All 23 targeted script tests passed.
- `git diff --check` passed for this PR and the cumulative stack.
- Under Rust 1.98.0, `cargo fmt --all -- --check`, `cargo check --workspace --all-targets --all-features --locked`, and workspace Clippy with `-D warnings` passed for BAML Language.
- Audited BAML Language reusable/composite callers, cache behavior, runtime declarations, and release-platform coverage.

## Supersession

Absorbs and supersedes [#4681](https://github.com/BoundaryML/baml/pull/4681). Its Rust-toolchain commit retains Sam Lijin's authorship in this PR.
