### PR TITLE
fix(release): repair nightly toolchain builds

### DIFF
--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -34,6 +34,7 @@ jobs:
   build:
     name: Build toolchain (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     env:
       CARGO: cargo
     strategy:
@@ -72,13 +73,16 @@ jobs:
         uses: ./.github/actions/setup-musl-cross
         with:
           target: ${{ matrix.target }}
+      - name: Configure native ARM GNU build
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && matrix.container }}
+        run: echo 'CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8' >> "$GITHUB_ENV"
       - name: Setup cross for backward-compatible GNU toolchain
-        if: ${{ matrix.libc == 'gnu' }}
+        if: ${{ matrix.cross_image }}
         uses: ./.github/actions/setup-mise
         with:
           install_args: "sccache cargo:cross"
       - name: Configure cross for GNU toolchain
-        if: ${{ matrix.libc == 'gnu' }}
+        if: ${{ matrix.cross_image }}
         env:
           CROSS_IMAGE: ${{ matrix.cross_image }}
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -1,0 +1,156 @@
+name: BAML Release - Build toolchain
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: "Exact repository commit to build"
+        type: string
+        required: true
+      version:
+        description: "Canonical toolchain version used in archive names"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+  BAML_WORKOS_CLIENT_ID: ${{ vars.BAML_WORKOS_CLIENT_ID }}
+
+jobs:
+  matrix:
+    name: Compute target matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.gen.outputs.include }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+      - name: Generate the toolchain matrix from the platform contract
+        id: gen
+        run: |
+          set -euo pipefail
+          include="$(jq -c '[.targets[]
+            | select(.artifacts.toolchain != null)
+            | .artifacts.toolchain as $toolchain
+            | {target: .triple, os: $toolchain.runner, libc: .libc}
+              + (if $toolchain.cross_image then {cross_image: $toolchain.cross_image} else {} end)]' release/platforms.json)"
+          echo "include=$include" >> "$GITHUB_OUTPUT"
+          jq . <<<"$include"
+
+  build:
+    name: Build toolchain (${{ matrix.target }})
+    needs: matrix
+    runs-on: ${{ matrix.os }}
+    env:
+      CARGO: cargo
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.matrix.outputs.include) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-plan
+      - uses: actions/download-artifact@v4
+        with:
+          name: baml-vscode-vsix
+          path: vsix
+      - uses: actions/download-artifact@v4
+        with:
+          name: baml-playground-dist
+          path: playground-dist
+      - name: Stamp version
+        run: scripts/baml-language-version stamp --plan release-plan.json
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+          workspace: baml_language
+          prefix-key: v5-rust-baml-language-toolchain-${{ matrix.target }}
+          cache-on-failure: true
+          enable-cross: false
+          skip-protoc: true
+      - name: Setup musl cross toolchain
+        if: ${{ matrix.libc == 'musl' }}
+        uses: ./.github/actions/setup-musl-cross
+        with:
+          target: ${{ matrix.target }}
+      - name: Setup cross for backward-compatible GNU toolchain
+        if: ${{ matrix.libc == 'gnu' }}
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache cargo:cross"
+      - name: Configure cross for GNU toolchain
+        if: ${{ matrix.libc == 'gnu' }}
+        env:
+          CROSS_IMAGE: ${{ matrix.cross_image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          cross_config="$RUNNER_TEMP/baml-toolchain-cross.toml"
+          passthrough='"BAML_WORKOS_CLIENT_ID"'
+          if [[ "$TARGET" == "x86_64-unknown-linux-gnu" ]]; then
+            # The glibc-2.17 image's target GCC is 4.8 and cannot compile
+            # mimalloc v3's warning flags. Its host GCC is current; point that
+            # compiler at the image's 2.17 sysroot so C dependencies retain the
+            # same compatibility floor as the Rust linker.
+            passthrough+=', "CC_x86_64_unknown_linux_gnu=gcc"'
+            passthrough+=', "CFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
+          fi
+          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = [%s]\n' \
+            "$TARGET" "$CROSS_IMAGE" "$TARGET" "$passthrough" > "$cross_config"
+          {
+            echo 'CARGO=cross'
+            echo "CROSS_CONFIG=$cross_config"
+          } >> "$GITHUB_ENV"
+      - name: Build CLI and pack host
+        run: ${CARGO} build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"
+      - name: Archive layout smoke
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p staging/bin staging/assets
+          suffix=""
+          if [[ "$TARGET" == *windows-msvc ]]; then suffix=".exe"; fi
+          cp "baml_language/target/$TARGET/release/baml-cli$suffix" "staging/bin/baml-cli$suffix"
+          cp "baml_language/target/$TARGET/release/baml-pack-host$suffix" "staging/bin/baml-pack-host$suffix"
+          vsix="$(find vsix -maxdepth 1 -name '*.vsix' -print -quit)"
+          test -n "$vsix"
+          cp "$vsix" staging/assets/baml-vscode.vsix
+          mkdir -p staging/assets/playground
+          cp -R playground-dist/. staging/assets/playground/
+          if test -f "staging/bin/baml$suffix"; then
+            exit 1
+          fi
+          test -f staging/assets/baml-vscode.vsix
+          test -f staging/assets/playground/index.html
+          test -f staging/assets/playground/assets/index.js
+          test -f staging/assets/playground/assets/index.css
+          echo "$VERSION" > staging/VERSION
+          if [[ "$TARGET" == *windows-msvc ]]; then
+            (cd staging && 7z a "../baml-language-$VERSION-$TARGET.zip" .)
+          else
+            tar -C staging -czf "baml-language-$VERSION-$TARGET.tar.gz" .
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: toolchain-${{ matrix.target }}
+          path: baml-language-${{ inputs.version }}-${{ matrix.target }}.*

--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -11,6 +11,10 @@ on:
         description: "Canonical toolchain version used in archive names"
         type: string
         required: true
+      toolchain_matrix_json:
+        description: "Serialized toolchain build matrix from release/platforms.json"
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -27,38 +31,15 @@ env:
   BAML_WORKOS_CLIENT_ID: ${{ vars.BAML_WORKOS_CLIENT_ID }}
 
 jobs:
-  matrix:
-    name: Compute target matrix
-    runs-on: ubuntu-latest
-    outputs:
-      include: ${{ steps.gen.outputs.include }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.source_sha }}
-          persist-credentials: false
-      - name: Generate the toolchain matrix from the platform contract
-        id: gen
-        run: |
-          set -euo pipefail
-          include="$(jq -c '[.targets[]
-            | select(.artifacts.toolchain != null)
-            | .artifacts.toolchain as $toolchain
-            | {target: .triple, os: $toolchain.runner, libc: .libc}
-              + (if $toolchain.cross_image then {cross_image: $toolchain.cross_image} else {} end)]' release/platforms.json)"
-          echo "include=$include" >> "$GITHUB_OUTPUT"
-          jq . <<<"$include"
-
   build:
     name: Build toolchain (${{ matrix.target }})
-    needs: matrix
     runs-on: ${{ matrix.os }}
     env:
       CARGO: cargo
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.matrix.outputs.include) }}
+        include: ${{ fromJson(inputs.toolchain_matrix_json) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -289,134 +289,38 @@ jobs:
           name: release-plan
           path: release-plan.json
 
-  # The toolchain and C# build matrices are generated from the repository's
-  # platform contract (`release/platforms.json`) so the target set + per-target
-  # runners live in one machine-readable place. The reusable toolchain-selector
-  # workflow owns its wrapper matrix generation alongside its build.
+  # The C# build matrix is generated from the repository's platform contract
+  # (`release/platforms.json`) so the target set + per-target runners live in
+  # one machine-readable place. The reusable toolchain and toolchain-selector
+  # workflows own their matrices alongside their builds.
   build-matrix:
-    name: Compute build matrices
+    name: Compute C# build matrix
     needs: [plan]
     runs-on: ubuntu-latest
     outputs:
-      toolchain: ${{ steps.gen.outputs.toolchain }}
       csharp: ${{ steps.gen.outputs.csharp }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - name: Generate build matrices from the platform contract
+      - name: Generate the C# build matrix from the platform contract
         id: gen
         run: |
           set -euo pipefail
-          # target + toolchain runner (as `os`); `libc` rides along so Linux
-          # setup can select musl or the plan's GNU cross image.
-          toolchain="$(jq -c '[.targets[]
-            | select(.artifacts.toolchain != null)
-            | .artifacts.toolchain as $toolchain
-            | {target: .triple, os: $toolchain.runner, libc: .libc}
-              + (if $toolchain.cross_image then {cross_image: $toolchain.cross_image} else {} end)]' release/platforms.json)"
-          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
-          jq . <<<"$toolchain"
           csharp="$(scripts/baml-csharp-release-contract matrix)"
           echo "csharp=$csharp" >> "$GITHUB_OUTPUT"
           jq . <<<"$csharp"
 
   build-toolchain:
-    name: Build toolchain (${{ matrix.target }})
-    needs: [plan, build-vsix, build-matrix]
-    runs-on: ${{ matrix.os }}
-    env:
-      CARGO: cargo
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.build-matrix.outputs.toolchain) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.plan.outputs.source_sha }}
-          persist-credentials: false
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-plan
-      - uses: actions/download-artifact@v4
-        with:
-          name: baml-vscode-vsix
-          path: vsix
-      - uses: actions/download-artifact@v4
-        with:
-          name: baml-playground-dist
-          path: playground-dist
-      - name: Stamp version
-        run: scripts/baml-language-version stamp --plan release-plan.json
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.target }}
-          workspace: baml_language
-          prefix-key: v5-rust-baml-language-toolchain-${{ matrix.target }}
-          cache-on-failure: true
-          enable-cross: false
-          skip-protoc: true
-      - name: Setup musl cross toolchain
-        if: ${{ matrix.libc == 'musl' }}
-        uses: ./.github/actions/setup-musl-cross
-        with:
-          target: ${{ matrix.target }}
-      - name: Setup cross for backward-compatible GNU toolchain
-        if: ${{ matrix.libc == 'gnu' }}
-        uses: ./.github/actions/setup-mise
-        with:
-          install_args: "sccache cargo:cross"
-      - name: Configure cross for GNU toolchain
-        if: ${{ matrix.libc == 'gnu' }}
-        env:
-          CROSS_IMAGE: ${{ matrix.cross_image }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          set -euo pipefail
-          cross_config="$RUNNER_TEMP/baml-toolchain-cross.toml"
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_WORKOS_CLIENT_ID"]\n' \
-            "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
-          {
-            echo 'CARGO=cross'
-            echo "CROSS_CONFIG=$cross_config"
-          } >> "$GITHUB_ENV"
-      - name: Build CLI and pack host
-        run: ${CARGO} build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"
-      - name: Archive layout smoke
-        run: |
-          set -euo pipefail
-          version="${{ needs.plan.outputs.version }}"
-          target="${{ matrix.target }}"
-          mkdir -p "staging/bin" "staging/assets"
-          suffix=""
-          if [[ "$target" == *windows-msvc ]]; then suffix=".exe"; fi
-          cp "baml_language/target/$target/release/baml-cli$suffix" "staging/bin/baml-cli$suffix"
-          cp "baml_language/target/$target/release/baml-pack-host$suffix" "staging/bin/baml-pack-host$suffix"
-          vsix="$(find vsix -maxdepth 1 -name '*.vsix' -print -quit)"
-          test -n "$vsix"
-          cp "$vsix" "staging/assets/baml-vscode.vsix"
-          mkdir -p "staging/assets/playground"
-          cp -R playground-dist/. "staging/assets/playground/"
-          if test -f "staging/bin/baml$suffix"; then
-            exit 1
-          fi
-          test -f "staging/assets/baml-vscode.vsix"
-          test -f "staging/assets/playground/index.html"
-          test -f "staging/assets/playground/assets/index.js"
-          test -f "staging/assets/playground/assets/index.css"
-          echo "$version" > staging/VERSION
-          if [[ "$target" == *windows-msvc ]]; then
-            (cd staging && 7z a "../baml-language-$version-$target.zip" .)
-          else
-            tar -C staging -czf "baml-language-$version-$target.tar.gz" .
-          fi
-      - uses: actions/upload-artifact@v4
-        with:
-          name: toolchain-${{ matrix.target }}
-          path: baml-language-${{ needs.plan.outputs.version }}-${{ matrix.target }}.*
+    name: Build BAML toolchain
+    needs: [plan, build-vsix]
+    uses: ./.github/workflows/build2-toolchain.reusable.yaml
+    permissions:
+      contents: read
+    with:
+      source_sha: ${{ needs.plan.outputs.source_sha }}
+      version: ${{ needs.plan.outputs.version }}
 
   build-vsix:
     name: Build platform-neutral VSIX

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -289,38 +289,49 @@ jobs:
           name: release-plan
           path: release-plan.json
 
-  # The C# build matrix is generated from the repository's platform contract
-  # (`release/platforms.json`) so the target set + per-target runners live in
-  # one machine-readable place. The reusable toolchain and toolchain-selector
-  # workflows own their matrices alongside their builds.
+  # The toolchain and C# build matrices are generated from the repository's
+  # platform contract (`release/platforms.json`) so the target set + per-target
+  # runners live in one machine-readable place. The reusable toolchain-selector
+  # workflow owns its wrapper matrix generation alongside its build.
   build-matrix:
-    name: Compute C# build matrix
+    name: Compute build matrices
     needs: [plan]
     runs-on: ubuntu-latest
     outputs:
+      toolchain: ${{ steps.gen.outputs.toolchain }}
       csharp: ${{ steps.gen.outputs.csharp }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.plan.outputs.source_sha }}
           persist-credentials: false
-      - name: Generate the C# build matrix from the platform contract
+      - name: Generate build matrices from the platform contract
         id: gen
         run: |
           set -euo pipefail
+          # target + toolchain runner (as `os`); `libc` rides along so Linux
+          # setup can select musl or the plan's GNU cross image.
+          toolchain="$(jq -c '[.targets[]
+            | select(.artifacts.toolchain != null)
+            | .artifacts.toolchain as $toolchain
+            | {target: .triple, os: $toolchain.runner, libc: .libc}
+              + (if $toolchain.cross_image then {cross_image: $toolchain.cross_image} else {} end)]' release/platforms.json)"
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+          jq . <<<"$toolchain"
           csharp="$(scripts/baml-csharp-release-contract matrix)"
           echo "csharp=$csharp" >> "$GITHUB_OUTPUT"
           jq . <<<"$csharp"
 
   build-toolchain:
     name: Build BAML toolchain
-    needs: [plan, build-vsix]
+    needs: [plan, build-vsix, build-matrix]
     uses: ./.github/workflows/build2-toolchain.reusable.yaml
     permissions:
       contents: read
     with:
       source_sha: ${{ needs.plan.outputs.source_sha }}
       version: ${{ needs.plan.outputs.version }}
+      toolchain_matrix_json: ${{ needs.build-matrix.outputs.toolchain }}
 
   build-vsix:
     name: Build platform-neutral VSIX

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -310,11 +310,12 @@ jobs:
         run: |
           set -euo pipefail
           # target + toolchain runner (as `os`); `libc` rides along so Linux
-          # setup can select musl or the plan's GNU cross image.
+          # setup can select musl, a native job container, or a GNU cross image.
           toolchain="$(jq -c '[.targets[]
             | select(.artifacts.toolchain != null)
             | .artifacts.toolchain as $toolchain
             | {target: .triple, os: $toolchain.runner, libc: .libc}
+              + (if $toolchain.container then {container: $toolchain.container} else {} end)
               + (if $toolchain.cross_image then {cross_image: $toolchain.cross_image} else {} end)]' release/platforms.json)"
           echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
           jq . <<<"$toolchain"

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -314,6 +314,10 @@ jobs:
           toolchain="$(jq -c '[.targets[]
             | select(.artifacts.toolchain != null)
             | .artifacts.toolchain as $toolchain
+            | if $toolchain.container and $toolchain.cross_image
+              then error("\(.triple): toolchain container and cross_image are mutually exclusive")
+              else .
+              end
             | {target: .triple, os: $toolchain.runner, libc: .libc}
               + (if $toolchain.container then {container: $toolchain.container} else {} end)
               + (if $toolchain.cross_image then {cross_image: $toolchain.cross_image} else {} end)]' release/platforms.json)"

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -57,9 +57,16 @@ pub struct Artifacts {
 
 /// The CLI toolchain artifact (baml-cli + pack host, archived per target).
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ToolchainArtifact {
     /// GitHub Actions runner label (distinct from the target's `os` family).
     pub runner: String,
+    /// Native job container used for the entire build.
+    #[serde(default)]
+    pub container: Option<String>,
+    /// Container image invoked by `cross` for a cross-compiled build.
+    #[serde(default)]
+    pub cross_image: Option<String>,
     /// Built best-effort: a build failure must not block the release.
     #[serde(default)]
     pub experimental: bool,
@@ -157,6 +164,16 @@ pub fn platforms() -> Platforms {
 
 fn validate_platforms(platforms: &Platforms) -> Result<(), String> {
     for target in &platforms.targets {
+        if let Some(toolchain) = &target.artifacts.toolchain
+            && toolchain.container.is_some()
+            && toolchain.cross_image.is_some()
+        {
+            return Err(format!(
+                "{}: toolchain container and cross_image are mutually exclusive",
+                target.triple
+            ));
+        }
+
         let Some(csharp) = &target.artifacts.csharp else {
             continue;
         };
@@ -215,6 +232,49 @@ mod tests {
                 t.triple
             );
         }
+    }
+
+    #[test]
+    fn toolchain_build_modes_are_preserved_and_mutually_exclusive() {
+        let p = platforms();
+        let arm = p
+            .targets
+            .iter()
+            .find(|target| target.triple == "aarch64-unknown-linux-gnu")
+            .unwrap()
+            .artifacts
+            .toolchain
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            arm.container.as_deref(),
+            Some("ghcr.io/rust-cross/manylinux_2_28-cross:aarch64")
+        );
+        assert!(arm.cross_image.is_none());
+
+        let json = r#"{
+            "schema": 1,
+            "targets": [{
+                "triple": "aarch64-unknown-linux-gnu", "os": "linux", "arch": "aarch64",
+                "libc": "gnu", "archive_suffix": ".tar.gz",
+                "artifacts": { "toolchain": {
+                    "runner": "ubuntu-24.04-arm",
+                    "container": "native-image",
+                    "cross_image": "cross-image"
+                } }
+            }]
+        }"#;
+        let p: Platforms = serde_json::from_str(json).unwrap();
+        assert!(validate_platforms(&p).is_err());
+    }
+
+    #[test]
+    fn toolchain_artifact_rejects_unknown_fields() {
+        let json = r#"{
+            "runner": "ubuntu-latest",
+            "cross_iamge": "misspelled-image"
+        }"#;
+        assert!(serde_json::from_str::<ToolchainArtifact>(json).is_err());
     }
 
     #[test]

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -10,12 +10,24 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "macos-14" },
-        "wrapper": { "runner": "macos-14", "variants": ["self-update", "no-self-update"] },
+        "wrapper": {
+          "runner": "macos-14",
+          "variants": ["self-update", "no-self-update"]
+        },
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-aarch64", "runner": "macos-14" },
-        "cffi": { "asset": "libbaml_cffi-aarch64-apple-darwin.dylib", "runner": "blacksmith-6vcpu-macos-latest", "smoke": true },
-        "csharp": { "rid": "osx-arm64", "native_asset": "libbridge_cffi.dylib", "consumer_runner": "macos-14", "package_policy": "rid-native" }
+        "cffi": {
+          "asset": "libbaml_cffi-aarch64-apple-darwin.dylib",
+          "runner": "blacksmith-6vcpu-macos-latest",
+          "smoke": true
+        },
+        "csharp": {
+          "rid": "osx-arm64",
+          "native_asset": "libbridge_cffi.dylib",
+          "consumer_runner": "blacksmith-6vcpu-macos-latest",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -26,12 +38,23 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "macos-15-intel" },
-        "wrapper": { "runner": "macos-15-intel", "variants": ["self-update", "no-self-update"] },
+        "wrapper": {
+          "runner": "macos-15-intel",
+          "variants": ["self-update", "no-self-update"]
+        },
         "python": { "runner": "macos-latest" },
         "nodejs": {},
         "java": { "platform": "macos-x86_64", "runner": "macos-15-intel" },
-        "cffi": { "asset": "libbaml_cffi-x86_64-apple-darwin.dylib", "runner": "blacksmith-6vcpu-macos-latest" },
-        "csharp": { "rid": "osx-x64", "native_asset": "libbridge_cffi.dylib", "consumer_runner": "macos-15-intel", "package_policy": "rid-native" }
+        "cffi": {
+          "asset": "libbaml_cffi-x86_64-apple-darwin.dylib",
+          "runner": "blacksmith-6vcpu-macos-latest"
+        },
+        "csharp": {
+          "rid": "osx-x64",
+          "native_asset": "libbridge_cffi.dylib",
+          "consumer_runner": "macos-15-intel",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -41,13 +64,29 @@
       "libc": "gnu",
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "ubuntu-24.04-arm", "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
-        "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"], "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64" },
+        "toolchain": {
+          "runner": "ubuntu-latest",
+          "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+        },
+        "wrapper": {
+          "runner": "ubuntu-latest",
+          "variants": ["self-update", "no-self-update"],
+          "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+        },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
         "java": { "platform": "linux-aarch64", "runner": "ubuntu-24.04-arm" },
-        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true },
-        "csharp": { "rid": "linux-arm64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04-arm", "package_policy": "rid-native" }
+        "cffi": {
+          "asset": "libbaml_cffi-aarch64-unknown-linux-gnu.so",
+          "runner": "ubuntu-22.04",
+          "use_cross": true
+        },
+        "csharp": {
+          "rid": "linux-arm64",
+          "native_asset": "libbridge_cffi.so",
+          "consumer_runner": "ubuntu-24.04-arm",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -58,12 +97,28 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": { "runner": "ubuntu-24.04-arm" },
-        "wrapper": { "runner": "ubuntu-24.04-arm", "variants": ["self-update"] },
+        "wrapper": {
+          "runner": "ubuntu-24.04-arm",
+          "variants": ["self-update"]
+        },
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
-        "java": { "platform": "linux-aarch64-musl", "runner": "ubuntu-latest", "experimental": true },
-        "cffi": { "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true },
-        "csharp": { "rid": "linux-musl-arm64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04-arm", "package_policy": "rid-native" }
+        "java": {
+          "platform": "linux-aarch64-musl",
+          "runner": "ubuntu-latest",
+          "experimental": true
+        },
+        "cffi": {
+          "asset": "libbaml_cffi-aarch64-unknown-linux-musl.so",
+          "runner": "ubuntu-22.04",
+          "use_cross": true
+        },
+        "csharp": {
+          "rid": "linux-musl-arm64",
+          "native_asset": "libbridge_cffi.so",
+          "consumer_runner": "ubuntu-24.04-arm",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -73,13 +128,30 @@
       "libc": "gnu",
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "ubuntu-latest", "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64" },
-        "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update", "no-self-update"], "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64" },
+        "toolchain": {
+          "runner": "ubuntu-latest",
+          "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64"
+        },
+        "wrapper": {
+          "runner": "ubuntu-latest",
+          "variants": ["self-update", "no-self-update"],
+          "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64"
+        },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},
         "java": { "platform": "linux-x86_64", "runner": "ubuntu-latest" },
-        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so", "runner": "ubuntu-22.04", "use_cross": true, "smoke": true },
-        "csharp": { "rid": "linux-x64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04", "package_policy": "rid-native" }
+        "cffi": {
+          "asset": "libbaml_cffi-x86_64-unknown-linux-gnu.so",
+          "runner": "ubuntu-22.04",
+          "use_cross": true,
+          "smoke": true
+        },
+        "csharp": {
+          "rid": "linux-x64",
+          "native_asset": "libbridge_cffi.so",
+          "consumer_runner": "ubuntu-24.04",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -93,9 +165,22 @@
         "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update"] },
         "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
         "nodejs": {},
-        "java": { "platform": "linux-x86_64-musl", "runner": "ubuntu-latest", "experimental": true },
-        "cffi": { "asset": "libbaml_cffi-x86_64-unknown-linux-musl.so", "runner": "ubuntu-22.04", "use_cross": true },
-        "csharp": { "rid": "linux-musl-x64", "native_asset": "libbridge_cffi.so", "consumer_runner": "ubuntu-24.04", "package_policy": "rid-native" }
+        "java": {
+          "platform": "linux-x86_64-musl",
+          "runner": "ubuntu-latest",
+          "experimental": true
+        },
+        "cffi": {
+          "asset": "libbaml_cffi-x86_64-unknown-linux-musl.so",
+          "runner": "ubuntu-22.04",
+          "use_cross": true
+        },
+        "csharp": {
+          "rid": "linux-musl-x64",
+          "native_asset": "libbridge_cffi.so",
+          "consumer_runner": "ubuntu-24.04",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -106,12 +191,24 @@
       "archive_suffix": ".zip",
       "artifacts": {
         "toolchain": { "runner": "windows-latest" },
-        "wrapper": { "runner": "windows-latest", "variants": ["self-update", "no-self-update"] },
+        "wrapper": {
+          "runner": "windows-latest",
+          "variants": ["self-update", "no-self-update"]
+        },
         "python": { "runner": "windows-latest" },
         "nodejs": {},
         "java": { "platform": "windows-x86_64", "runner": "windows-latest" },
-        "cffi": { "asset": "baml_cffi-x86_64-pc-windows-msvc.dll", "runner": "windows-2022", "smoke": true },
-        "csharp": { "rid": "win-x64", "native_asset": "bridge_cffi.dll", "consumer_runner": "windows-2022", "package_policy": "rid-native" }
+        "cffi": {
+          "asset": "baml_cffi-x86_64-pc-windows-msvc.dll",
+          "runner": "windows-2022",
+          "smoke": true
+        },
+        "csharp": {
+          "rid": "win-x64",
+          "native_asset": "bridge_cffi.dll",
+          "consumer_runner": "windows-2022",
+          "package_policy": "rid-native"
+        }
       }
     },
     {
@@ -122,12 +219,28 @@
       "archive_suffix": ".zip",
       "artifacts": {
         "toolchain": { "runner": "windows-latest" },
-        "wrapper": { "runner": "windows-latest", "variants": ["self-update", "no-self-update"] },
+        "wrapper": {
+          "runner": "windows-latest",
+          "variants": ["self-update", "no-self-update"]
+        },
         "python": { "runner": "windows-11-arm", "architecture": "arm64" },
         "nodejs": {},
-        "java": { "platform": "windows-aarch64", "runner": "windows-11-arm", "experimental": true },
-        "cffi": { "asset": "baml_cffi-aarch64-pc-windows-msvc.dll", "runner": "windows-11-arm", "smoke": true },
-        "csharp": { "rid": "win-arm64", "native_asset": "bridge_cffi.dll", "consumer_runner": "windows-11-arm", "package_policy": "rid-native" }
+        "java": {
+          "platform": "windows-aarch64",
+          "runner": "windows-11-arm",
+          "experimental": true
+        },
+        "cffi": {
+          "asset": "baml_cffi-aarch64-pc-windows-msvc.dll",
+          "runner": "windows-11-arm",
+          "smoke": true
+        },
+        "csharp": {
+          "rid": "win-arm64",
+          "native_asset": "bridge_cffi.dll",
+          "consumer_runner": "windows-11-arm",
+          "package_policy": "rid-native"
+        }
       }
     }
   ]

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -1,5 +1,5 @@
 {
-  "description": "Repository-owned platform contract: the single machine-readable source for the BAML language release target set, per-target per-artifact support, and each artifact's build config. The wrapper, cffi, toolchain, python, java, and C# matrices are generated from this file. Wrapper entries own their runners and published variants; GNU wrapper and toolchain entries own their cross images. CFFI entries own language-neutral native production; sibling C# entries own .NET RID projection, package-native filenames, native consumer runners, support tier, and package policy. C# requires CFFI, while CFFI support does not imply C# support. A missing artifact key means unsupported; `experimental: true` means best-effort; absent/false means required.",
+  "description": "Repository-owned platform contract: the single machine-readable source for the BAML language release target set, per-target per-artifact support, and each artifact's build config. The wrapper, cffi, toolchain, python, java, and C# matrices are generated from this file. Wrapper entries own their runners and published variants; GNU wrapper and toolchain entries own their cross images or native build containers. CFFI entries own language-neutral native production; sibling C# entries own .NET RID projection, package-native filenames, native consumer runners, support tier, and package policy. C# requires CFFI, while CFFI support does not imply C# support. A missing artifact key means unsupported; `experimental: true` means best-effort; absent/false means required.",
   "schema": 1,
   "targets": [
     {
@@ -68,8 +68,8 @@
       "archive_suffix": ".tar.gz",
       "artifacts": {
         "toolchain": {
-          "runner": "ubuntu-latest",
-          "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+          "runner": "ubuntu-24.04-arm",
+          "container": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
         },
         "wrapper": {
           "runner": "ubuntu-latest",

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -9,14 +9,17 @@
       "libc": null,
       "archive_suffix": ".tar.gz",
       "artifacts": {
-        "toolchain": { "runner": "macos-14" },
+        "toolchain": { "runner": "blacksmith-6vcpu-macos-latest" },
         "wrapper": {
-          "runner": "macos-14",
+          "runner": "blacksmith-6vcpu-macos-latest",
           "variants": ["self-update", "no-self-update"]
         },
         "python": { "runner": "macos-latest" },
         "nodejs": {},
-        "java": { "platform": "macos-aarch64", "runner": "macos-14" },
+        "java": {
+          "platform": "macos-aarch64",
+          "runner": "blacksmith-6vcpu-macos-latest"
+        },
         "cffi": {
           "asset": "libbaml_cffi-aarch64-apple-darwin.dylib",
           "runner": "blacksmith-6vcpu-macos-latest",

--- a/scripts/tests/test_baml_release_platforms.py
+++ b/scripts/tests/test_baml_release_platforms.py
@@ -29,6 +29,18 @@ class WrapperReleasePlatformTests(unittest.TestCase):
         contract = json.loads(DEFAULT_PLATFORMS.read_text(encoding="utf-8"))
         targets = {target["triple"]: target for target in contract["targets"]}
 
+        arm64_macos = targets["aarch64-apple-darwin"]["artifacts"]
+        self.assertEqual(
+            {
+                arm64_macos["toolchain"]["runner"],
+                arm64_macos["wrapper"]["runner"],
+                arm64_macos["java"]["runner"],
+                arm64_macos["cffi"]["runner"],
+                arm64_macos["csharp"]["consumer_runner"],
+            },
+            {"blacksmith-6vcpu-macos-latest"},
+        )
+
         arm64_gnu = targets["aarch64-unknown-linux-gnu"]["artifacts"]["toolchain"]
         self.assertEqual(arm64_gnu["runner"], "ubuntu-latest")
         self.assertEqual(

--- a/scripts/tests/test_baml_release_platforms.py
+++ b/scripts/tests/test_baml_release_platforms.py
@@ -19,62 +19,9 @@ from scripts.baml_release_platforms import (
 VERSION = "1.2.3"
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / "scripts" / "baml-release-platforms"
-CSHARP_CLI = ROOT / "scripts" / "baml-csharp-release-contract"
-RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
-TOOLCHAIN_WORKFLOW = ROOT / ".github" / "workflows" / "build2-toolchain.reusable.yaml"
 
 
 class WrapperReleasePlatformTests(unittest.TestCase):
-    def test_release_build_runner_regressions_are_pinned(self) -> None:
-        contract = json.loads(DEFAULT_PLATFORMS.read_text(encoding="utf-8"))
-        targets = {target["triple"]: target for target in contract["targets"]}
-
-        arm64_macos = targets["aarch64-apple-darwin"]["artifacts"]
-        self.assertEqual(
-            {
-                arm64_macos["toolchain"]["runner"],
-                arm64_macos["wrapper"]["runner"],
-                arm64_macos["java"]["runner"],
-                arm64_macos["cffi"]["runner"],
-                arm64_macos["csharp"]["consumer_runner"],
-            },
-            {"blacksmith-6vcpu-macos-latest"},
-        )
-
-        arm64_gnu = targets["aarch64-unknown-linux-gnu"]["artifacts"]["toolchain"]
-        self.assertEqual(arm64_gnu["runner"], "ubuntu-latest")
-        self.assertEqual(
-            arm64_gnu["cross_image"],
-            "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64",
-        )
-
-        csharp_matrix = json.loads(
-            subprocess.run(
-                [CSHARP_CLI, "matrix"],
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout
-        )["include"]
-        osx_arm64 = next(
-            entry for entry in csharp_matrix if entry["rid"] == "osx-arm64"
-        )
-        self.assertEqual(osx_arm64["runner"], "blacksmith-6vcpu-macos-latest")
-
-    def test_release_delegates_toolchain_build_with_legacy_glibc_compiler(self) -> None:
-        release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-        builder = TOOLCHAIN_WORKFLOW.read_text(encoding="utf-8")
-
-        self.assertIn(
-            "uses: ./.github/workflows/build2-toolchain.reusable.yaml", release
-        )
-        self.assertNotIn("name: Build CLI and pack host", release)
-        self.assertIn("CC_x86_64_unknown_linux_gnu=gcc", builder)
-        self.assertIn(
-            "CFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot",
-            builder,
-        )
-
     def test_extensionless_cli_generates_wrapper_matrix(self) -> None:
         result = subprocess.run(
             [sys.executable, CLI, "wrapper-matrix"],

--- a/scripts/tests/test_baml_release_platforms.py
+++ b/scripts/tests/test_baml_release_platforms.py
@@ -19,9 +19,50 @@ from scripts.baml_release_platforms import (
 VERSION = "1.2.3"
 ROOT = Path(__file__).resolve().parents[2]
 CLI = ROOT / "scripts" / "baml-release-platforms"
+CSHARP_CLI = ROOT / "scripts" / "baml-csharp-release-contract"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
+TOOLCHAIN_WORKFLOW = ROOT / ".github" / "workflows" / "build2-toolchain.reusable.yaml"
 
 
 class WrapperReleasePlatformTests(unittest.TestCase):
+    def test_release_build_runner_regressions_are_pinned(self) -> None:
+        contract = json.loads(DEFAULT_PLATFORMS.read_text(encoding="utf-8"))
+        targets = {target["triple"]: target for target in contract["targets"]}
+
+        arm64_gnu = targets["aarch64-unknown-linux-gnu"]["artifacts"]["toolchain"]
+        self.assertEqual(arm64_gnu["runner"], "ubuntu-latest")
+        self.assertEqual(
+            arm64_gnu["cross_image"],
+            "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64",
+        )
+
+        csharp_matrix = json.loads(
+            subprocess.run(
+                [CSHARP_CLI, "matrix"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )["include"]
+        osx_arm64 = next(
+            entry for entry in csharp_matrix if entry["rid"] == "osx-arm64"
+        )
+        self.assertEqual(osx_arm64["runner"], "blacksmith-6vcpu-macos-latest")
+
+    def test_release_delegates_toolchain_build_with_legacy_glibc_compiler(self) -> None:
+        release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        builder = TOOLCHAIN_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "uses: ./.github/workflows/build2-toolchain.reusable.yaml", release
+        )
+        self.assertNotIn("name: Build CLI and pack host", release)
+        self.assertIn("CC_x86_64_unknown_linux_gnu=gcc", builder)
+        self.assertIn(
+            "CFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot",
+            builder,
+        )
+
     def test_extensionless_cli_generates_wrapper_matrix(self) -> None:
         result = subprocess.run(
             [sys.executable, CLI, "wrapper-matrix"],


### PR DESCRIPTION

The latest [nightly release run #33575286667](https://github.com/BoundaryML/baml/actions/runs/33575286667) experienced three failures, each of which this PR addresses:

- **Problem: [ARM64 GNU toolchain failed](https://github.com/BoundaryML/baml/actions/runs/33575286667/job/100079226868)**
  - **Root cause:** `cross` ran on an ARM64 host and selected the ARM64 container variant, but then attempted to install an x86_64 Rust host toolchain. Rustup rejected that architecture mismatch before compilation.
  - **How PR #4698 addresses it:** Runs the toolchain job on `ubuntu-24.04-arm` inside the ARM64 `manylinux_2_28` container and builds directly with Cargo instead of `cross`. The Rust host, container, and target architectures now agree, matching the established engine release approach.

- **Problem: [x86_64 GNU toolchain failed](https://github.com/BoundaryML/baml/actions/runs/33575286667/job/100079226880)**
  - **Root cause:** The manylinux2014 image’s target GCC is 4.8.5. `libmimalloc-sys` passes `-Wno-error=date-time`, but that compiler does not support the corresponding warning and exits with an error.
  - **How PR #4698 addresses it:** Uses the image’s GCC 11.4 for native C dependencies while explicitly pointing it at the image’s glibc 2.17 sysroot. The Rust linker remains the backward-compatible cross linker, so the compatibility floor is preserved.

- **Problem: [C# osx-arm64 appeared hung](https://github.com/BoundaryML/baml/actions/runs/33575286667/job/100082020513)**
  - **Root cause:** It spent about 79 minutes queued for a GitHub `macos-14` runner. Once assigned, it completed successfully in roughly 2½ minutes.
  - **How PR #4698 addresses it:** Moves its `consumer_runner` to `blacksmith-6vcpu-macos-latest`. The PR also moves the ARM macOS toolchain, wrapper, Java, and CFFI entries to that Blacksmith runner.

- **Problem: Publishing and release gates were skipped**
  - **Root cause:** The two GNU toolchain failures prevented the “All builds” gate from succeeding, so toolchain publication and the downstream registry and manifest jobs were skipped. These were consequences, not separate failures.
  - **How PR #4698 addresses it:** If both repaired GNU builds pass, those dependencies can advance normally.

We're also splitting out the CLI build into a separate reusable workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release Improvements**
  * Improved toolchain release builds across ARM platforms.
  * Added native ARM Linux container support.
  * Updated Apple Silicon builds to use dedicated macOS runners.
  * Streamlined release matrix handling for more consistent platform artifacts.

* **Validation**
  * Added safeguards against unknown platform settings and conflicting container configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->