### PR TITLE
ci: use R2 sccache for BAML v1 release builds

### DIFF
--- a/.github/actions/setup-r2-sccache/action.yml
+++ b/.github/actions/setup-r2-sccache/action.yml
@@ -25,7 +25,9 @@ runs:
         set -euo pipefail
 
         direnv allow .envrc
-        direnv export gha >> "$GITHUB_ENV"
+        # This linker override is for host cross-compilation. Containerized
+        # builds provide and select their own target linker.
+        direnv export gha | sed '/^CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/d' >> "$GITHUB_ENV"
 
         # Release workflows invoke sccache directly on every host platform.
         # The repository wrapper performs this BAML_* -> AWS_* mapping for

--- a/.github/actions/setup-r2-sccache/action.yml
+++ b/.github/actions/setup-r2-sccache/action.yml
@@ -1,0 +1,53 @@
+name: "Setup R2 sccache"
+description: "Install sccache and configure the shared BAML R2 backend from .envrc"
+
+inputs:
+  extra-tools:
+    description: "Additional mise tools required by the calling build job"
+    required: false
+    default: ""
+  prepare-cross:
+    description: "Copy the host sccache binary into the workspace for cross containers"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install sccache, direnv, and build tools
+      uses: ./.github/actions/setup-mise
+      with:
+        install_args: "sccache direnv ${{ inputs.extra-tools }}"
+
+    - name: Configure shared R2 sccache
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        direnv allow .envrc
+        direnv export gha >> "$GITHUB_ENV"
+
+        # Release workflows invoke sccache directly on every host platform.
+        # The repository wrapper performs this BAML_* -> AWS_* mapping for
+        # POSIX cargo jobs, but Windows release builds also need the aliases.
+        if [[ -n "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" && -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
+          {
+            printf 'AWS_ACCESS_KEY_ID=%s\n' "$BAML_SCCACHE_R2_ACCESS_KEY_ID"
+            printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$BAML_SCCACHE_R2_SECRET_ACCESS_KEY"
+          } >> "$GITHUB_ENV"
+        fi
+        echo 'RUSTC_WRAPPER=sccache' >> "$GITHUB_ENV"
+
+    - name: Prepare sccache for cross containers
+      if: ${{ inputs.prepare-cross == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        mkdir -p baml_language/target
+        cp "$(command -v sccache)" baml_language/target/sccache-host
+        chmod +x baml_language/target/sccache-host
+        {
+          echo 'RUSTC_WRAPPER=/project/target/sccache-host'
+          echo 'SCCACHE_ERROR_LOG=/tmp/sccache-baml.log'
+        } >> "$GITHUB_ENV"

--- a/.github/actions/setup-r2-sccache/action.yml
+++ b/.github/actions/setup-r2-sccache/action.yml
@@ -47,7 +47,4 @@ runs:
         mkdir -p baml_language/target
         cp "$(command -v sccache)" baml_language/target/sccache-host
         chmod +x baml_language/target/sccache-host
-        {
-          echo 'RUSTC_WRAPPER=/project/target/sccache-host'
-          echo 'SCCACHE_ERROR_LOG=/tmp/sccache-baml.log'
-        } >> "$GITHUB_ENV"
+        echo 'SCCACHE_ERROR_LOG=/tmp/sccache-baml.log' >> "$GITHUB_ENV"

--- a/.github/actions/setup-r2-sccache/action.yml
+++ b/.github/actions/setup-r2-sccache/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: ""
   prepare-cross:
-    description: "Copy the host sccache binary into the workspace for cross containers"
+    description: "Copy the BAML wrapper and host sccache binary into the workspace for cross containers"
     required: false
     default: "false"
 
@@ -58,6 +58,7 @@ runs:
         set -euo pipefail
 
         mkdir -p baml_language/target
+        cp tools/baml-sccache baml_language/target/baml-sccache
         cp "$(command -v sccache)" baml_language/target/sccache-host
-        chmod +x baml_language/target/sccache-host
+        chmod +x baml_language/target/baml-sccache baml_language/target/sccache-host
         echo 'SCCACHE_ERROR_LOG=/tmp/sccache-baml.log' >> "$GITHUB_ENV"

--- a/.github/actions/setup-r2-sccache/action.yml
+++ b/.github/actions/setup-r2-sccache/action.yml
@@ -27,7 +27,18 @@ runs:
         direnv allow .envrc
         # This linker override is for host cross-compilation. Containerized
         # builds provide and select their own target linker.
-        direnv export gha | sed '/^CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/d' >> "$GITHUB_ENV"
+        direnv export gha | awk '
+          /^CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER<</ {
+            delimiter = substr($0, index($0, "<<") + 2)
+            skip = 1
+            next
+          }
+          skip && $0 == delimiter {
+            skip = 0
+            next
+          }
+          !skip { print }
+        ' >> "$GITHUB_ENV"
 
         # Release workflows invoke sccache directly on every host platform.
         # The repository wrapper performs this BAML_* -> AWS_* mapping for

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: "Cache even if the workflow fails"
     required: false
     default: "false"
+  cache-all-crates:
+    description: "Cache all Cargo registry crates"
+    required: false
+    default: "false"
+  cache-targets:
+    description: "Cache compiled target directories"
+    required: false
+    default: "true"
   enable-cache:
     description: "Enable Rust cache"
     required: false
@@ -100,6 +108,8 @@ runs:
         workspaces: ${{ inputs.workspace }}
         prefix-key: ${{ inputs.prefix-key }}
         cache-on-failure: ${{ inputs.cache-on-failure }}
+        cache-all-crates: ${{ inputs.cache-all-crates }}
+        cache-targets: ${{ inputs.cache-targets }}
 
     - name: Add wasm32 target
       if: inputs.enable-wasm == 'true'

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -77,6 +77,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+
 jobs:
   # The cffi build matrix is generated from the repository's platform contract
   # (`release/platforms.json`) so the target set + per-target build config live
@@ -121,13 +125,10 @@ jobs:
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.os }}
-    environment: infisical-github-ci
     # Experimental targets are built when possible but never block the release.
     continue-on-error: ${{ matrix._.experimental || false }}
     env:
       BAML_GIT_SHA: ${{ inputs.source_sha || github.sha }}
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO: cargo
       # Let aws-lc-sys use its prebuilt NASM objects on Windows x86-64 if the
       # runner has no NASM installed (consulted only there; harmless elsewhere).

--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -58,6 +58,11 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
   # Manual-only standalone trigger for testing this reusable workflow before it
   # is wired into the release graph (with no inputs it builds a canary-stamped
   # artifact). It is otherwise invoked via `workflow_call`.
@@ -116,10 +121,13 @@ jobs:
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.os }}
+    environment: infisical-github-ci
     # Experimental targets are built when possible but never block the release.
     continue-on-error: ${{ matrix._.experimental || false }}
     env:
       BAML_GIT_SHA: ${{ inputs.source_sha || github.sha }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO: cargo
       # Let aws-lc-sys use its prebuilt NASM objects on Windows x86-64 if the
       # runner has no NASM installed (consulted only there; harmless elsewhere).
@@ -161,6 +169,11 @@ jobs:
           enable-cache: false
           skip-protoc: true
 
+      - name: Setup shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
+        with:
+          prepare-cross: ${{ matrix._.use_cross || false }}
+
       - name: Exclude optional AWS-LC jitter exports on Windows
         if: contains(matrix._.target, 'windows-msvc')
         shell: bash
@@ -177,7 +190,7 @@ jobs:
         if: matrix._.use_cross
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache cargo:cross"
+          install_args: "cargo:cross"
 
       - name: Select cross (Linux targets)
         if: matrix._.use_cross

--- a/.github/workflows/build2-java-sdk.reusable.yaml
+++ b/.github/workflows/build2-java-sdk.reusable.yaml
@@ -48,6 +48,11 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
   # Manual standalone trigger for validating this reusable workflow before it is
   # wired into the release graph (with no inputs it builds a canary-stamped set).
   workflow_dispatch:
@@ -104,9 +109,12 @@ jobs:
       matrix:
         _: ${{ fromJson(needs.matrix.outputs.include) }}
     runs-on: ${{ matrix._.os }}
+    environment: infisical-github-ci
     # Experimental targets are built when possible but never block the release.
     continue-on-error: ${{ matrix._.experimental || false }}
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       # Let aws-lc-sys use its prebuilt NASM objects on Windows x86-64 if the
       # runner has no NASM installed (consulted only there; harmless elsewhere).
       AWS_LC_SYS_PREBUILT_NASM: "1"
@@ -145,8 +153,15 @@ jobs:
           workspace: baml_language
           prefix-key: v5-rust-baml-java-${{ matrix._.target }}
           cache-on-failure: true
+          cache-all-crates: true
+          cache-targets: false
           enable-cross: false
           skip-protoc: true
+
+      - name: Setup shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
+        with:
+          prepare-cross: ${{ matrix._.libc == 'musl' }}
 
       - name: Setup cross (musl targets)
         # musl builds run inside `cross` containers (mirroring
@@ -158,7 +173,7 @@ jobs:
         if: ${{ matrix._.libc == 'musl' }}
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache cargo:cross"
+          install_args: "cargo:cross"
 
       - name: Select cross (musl targets)
         if: ${{ matrix._.libc == 'musl' }}

--- a/.github/workflows/build2-java-sdk.reusable.yaml
+++ b/.github/workflows/build2-java-sdk.reusable.yaml
@@ -66,6 +66,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+
 jobs:
   # The java build matrix is generated from the platform contract
   # (`release/platforms.json`) so the target set + per-target runner live in one
@@ -109,12 +113,9 @@ jobs:
       matrix:
         _: ${{ fromJson(needs.matrix.outputs.include) }}
     runs-on: ${{ matrix._.os }}
-    environment: infisical-github-ci
     # Experimental targets are built when possible but never block the release.
     continue-on-error: ${{ matrix._.experimental || false }}
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       # Let aws-lc-sys use its prebuilt NASM objects on Windows x86-64 if the
       # runner has no NASM installed (consulted only there; harmless elsewhere).
       AWS_LC_SYS_PREBUILT_NASM: "1"

--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -44,6 +44,8 @@ defaults:
     shell: bash
 
 env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   MACOSX_DEPLOYMENT_TARGET: "10.13"
 
 jobs:
@@ -107,10 +109,6 @@ jobs:
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.host }}
     container: ${{ matrix._.container }}
-    environment: infisical-github-ci
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -23,6 +23,11 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
   push:
     branches:
       # Mirror the Python reusable workflow's rehearsal-branch trigger so the
@@ -102,6 +107,10 @@ jobs:
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.host }}
     container: ${{ matrix._.container }}
+    environment: infisical-github-ci
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -132,10 +141,10 @@ jobs:
         # HOME at the real root home before any tool setup runs.
         run: echo "HOME=/root" >> "$GITHUB_ENV"
 
-      - name: Setup tools (sccache, direnv, node, pnpm)
-        uses: ./.github/actions/setup-mise
+      - name: Setup tools and shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
         with:
-          install_args: "sccache direnv node npm:pnpm"
+          extra-tools: "node npm:pnpm"
 
       - name: Set up Node.js (container)
         if: matrix._.container

--- a/.github/workflows/build2-python-sdk.reusable.yaml
+++ b/.github/workflows/build2-python-sdk.reusable.yaml
@@ -155,9 +155,6 @@ jobs:
             # container while preserving the R2 configuration from .envrc.
             uv tool install "sccache>=0.10.0"
             sccache --version
-            # This .envrc override is for host cross-compilation. The manylinux
-            # image supplies and selects its own target linker.
-            unset CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
             else

--- a/.github/workflows/build2-python-sdk.reusable.yaml
+++ b/.github/workflows/build2-python-sdk.reusable.yaml
@@ -155,6 +155,9 @@ jobs:
             # container while preserving the R2 configuration from .envrc.
             uv tool install "sccache>=0.10.0"
             sccache --version
+            # This .envrc override is for host cross-compilation. The manylinux
+            # image supplies and selects its own target linker.
+            unset CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
             else

--- a/.github/workflows/build2-python-sdk.reusable.yaml
+++ b/.github/workflows/build2-python-sdk.reusable.yaml
@@ -32,6 +32,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+
 jobs:
   # Target set + per-target runner/manylinux/architecture come from the platform
   # contract (`release/platforms.json`), not a hand-copied matrix list.
@@ -70,10 +74,6 @@ jobs:
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
-    environment: infisical-github-ci
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - name: Setup build environment (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'

--- a/.github/workflows/build2-python-sdk.reusable.yaml
+++ b/.github/workflows/build2-python-sdk.reusable.yaml
@@ -13,6 +13,11 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
   push:
     branches:
       - sam/publish-python
@@ -65,6 +70,10 @@ jobs:
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
+    environment: infisical-github-ci
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - name: Setup build environment (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
@@ -94,6 +103,9 @@ jobs:
             scripts/baml-language-version plan --channel canary --out release-plan.json
           fi
           scripts/baml-language-version stamp --plan release-plan.json
+
+      - name: Setup shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
 
       # NOTE: we deliberately do NOT use ./.github/actions/setup-mise here.
       # The host Python version pins the abi3 floor of the resulting wheel,
@@ -134,7 +146,15 @@ jobs:
           # baml_language/Cargo.toml.
           args: --release --strip --out dist
           manylinux: ${{ matrix._.manylinux }}
+          # maturin-action forwards SCCACHE_* automatically, but its Docker
+          # allowlist intentionally excludes AWS credential variable names.
+          docker-options: "-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY"
           before-script-linux: |
+            # Do not use maturin-action's `sccache: true`: it unconditionally
+            # enables the GHA backend. Install the wrapper in the build
+            # container while preserving the R2 configuration from .envrc.
+            uv tool install "sccache>=0.10.0"
+            sccache --version
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
             else

--- a/.github/workflows/build2-rust-sdk.reusable.yaml
+++ b/.github/workflows/build2-rust-sdk.reusable.yaml
@@ -40,14 +40,14 @@ defaults:
   run:
     shell: bash
 
+env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+
 jobs:
   package-crate:
     name: package baml_bridge crate
     runs-on: ubuntu-22.04
-    environment: infisical-github-ci
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/build2-rust-sdk.reusable.yaml
+++ b/.github/workflows/build2-rust-sdk.reusable.yaml
@@ -21,6 +21,11 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
   # Manual-only standalone trigger for testing this reusable workflow before it
   # is wired into the release graph (with no inputs it packages a canary-stamped
   # crate). It is otherwise invoked via `workflow_call`.
@@ -39,6 +44,10 @@ jobs:
   package-crate:
     name: package baml_bridge crate
     runs-on: ubuntu-22.04
+    environment: infisical-github-ci
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -61,6 +70,9 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           enable-cache: false
+
+      - name: Setup shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
 
       - name: Package and verify the crate
         working-directory: baml_language

--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -117,7 +117,7 @@ jobs:
             passthrough+=', "CFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
             passthrough+=', "CXXFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
           fi
-          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/target/sccache-host", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = [%s]\n' \
+          printf '[build.env]\npassthrough = ["BAML_SCCACHE_BIN=/target/sccache-host", "BAML_SCCACHE_R2_ACCESS_KEY_ID", "BAML_SCCACHE_R2_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/target/baml-sccache", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = [%s]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" "$passthrough" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -15,6 +15,11 @@ on:
         description: "Serialized toolchain build matrix from release/platforms.json"
         type: string
         required: true
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -35,8 +40,11 @@ jobs:
     name: Build toolchain (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    environment: infisical-github-ci
     env:
       CARGO: cargo
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -66,8 +74,14 @@ jobs:
           workspace: baml_language
           prefix-key: v5-rust-baml-language-toolchain-${{ matrix.target }}
           cache-on-failure: true
+          cache-all-crates: true
+          cache-targets: false
           enable-cross: false
           skip-protoc: true
+      - name: Setup shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
+        with:
+          prepare-cross: ${{ matrix.cross_image && 'true' || 'false' }}
       - name: Setup musl cross toolchain
         if: ${{ matrix.libc == 'musl' }}
         uses: ./.github/actions/setup-musl-cross
@@ -80,7 +94,7 @@ jobs:
         if: ${{ matrix.cross_image }}
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache cargo:cross"
+          install_args: "cargo:cross"
       - name: Configure cross for GNU toolchain
         if: ${{ matrix.cross_image }}
         env:
@@ -103,7 +117,7 @@ jobs:
             passthrough+=', "CFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
             passthrough+=', "CXXFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
           fi
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = [%s]\n' \
+          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/target/sccache-host", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = [%s]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" "$passthrough" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -29,6 +29,8 @@ defaults:
     shell: bash
 
 env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -40,11 +42,8 @@ jobs:
     name: Build toolchain (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    environment: infisical-github-ci
     env:
       CARGO: cargo
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build2-web-sdk.reusable.yaml
+++ b/.github/workflows/build2-web-sdk.reusable.yaml
@@ -17,6 +17,11 @@ on:
         type: string
         default: ""
         required: false
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-build-web-sdk
@@ -36,7 +41,11 @@ jobs:
   build:
     name: Build Web SDK
     runs-on: ubuntu-latest
+    environment: infisical-github-ci
     timeout-minutes: 30
+    env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -55,10 +64,10 @@ jobs:
           fi
           scripts/baml-language-version stamp --plan release-plan.json
 
-      - name: Setup Node.js, pnpm, and wasm-pack
-        uses: ./.github/actions/setup-mise
+      - name: Setup build tools and shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
         with:
-          install_args: "node npm:pnpm github:rustwasm/wasm-pack"
+          extra-tools: "node npm:pnpm github:rustwasm/wasm-pack"
 
       - name: Setup Rust WASM target
         working-directory: baml_language
@@ -70,6 +79,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "baml_language -> target"
+          cache-all-crates: true
+          cache-targets: false
           shared-key: "linux-wasm"
           save-if: false
 

--- a/.github/workflows/build2-web-sdk.reusable.yaml
+++ b/.github/workflows/build2-web-sdk.reusable.yaml
@@ -32,6 +32,8 @@ defaults:
     shell: bash
 
 env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -41,11 +43,7 @@ jobs:
   build:
     name: Build Web SDK
     runs-on: ubuntu-latest
-    environment: infisical-github-ci
     timeout-minutes: 30
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -103,7 +103,7 @@ jobs:
           # CROSS_CONFIG makes the plan's image control linking; the image's
           # host ldd does not determine the wrapper's compatibility floor.
           cross_config="$RUNNER_TEMP/baml-wrapper-cross.toml"
-          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
+          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/project/target/sccache-host", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -103,7 +103,7 @@ jobs:
           # CROSS_CONFIG makes the plan's image control linking; the image's
           # host ldd does not determine the wrapper's compatibility floor.
           cross_config="$RUNNER_TEMP/baml-wrapper-cross.toml"
-          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/project/target/sccache-host", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
+          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/target/sccache-host", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -103,7 +103,7 @@ jobs:
           # CROSS_CONFIG makes the plan's image control linking; the image's
           # host ldd does not determine the wrapper's compatibility floor.
           cross_config="$RUNNER_TEMP/baml-wrapper-cross.toml"
-          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/target/sccache-host", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
+          printf '[build.env]\npassthrough = ["BAML_SCCACHE_BIN=/target/sccache-host", "BAML_SCCACHE_R2_ACCESS_KEY_ID", "BAML_SCCACHE_R2_SECRET_ACCESS_KEY", "RUSTC_WRAPPER=/target/baml-sccache", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -25,6 +25,8 @@ defaults:
     shell: bash
 
 env:
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -54,10 +56,7 @@ jobs:
     name: Build wrapper (${{ matrix.target }})
     needs: matrix
     runs-on: ${{ matrix.os }}
-    environment: infisical-github-ci
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO: cargo
     strategy:
       fail-fast: false

--- a/.github/workflows/build2-wrapper.reusable.yaml
+++ b/.github/workflows/build2-wrapper.reusable.yaml
@@ -11,6 +11,11 @@ on:
         description: "Wrapper version used in archive names"
         type: string
         required: true
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -49,7 +54,10 @@ jobs:
     name: Build wrapper (${{ matrix.target }})
     needs: matrix
     runs-on: ${{ matrix.os }}
+    environment: infisical-github-ci
     env:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO: cargo
     strategy:
       fail-fast: false
@@ -67,6 +75,8 @@ jobs:
           workspace: baml_language
           prefix-key: v5-rust-baml-wrapper-${{ matrix.target }}
           cache-on-failure: true
+          cache-all-crates: true
+          cache-targets: false
           enable-cross: false
           skip-protoc: true
       - name: Setup musl cross toolchain
@@ -74,11 +84,15 @@ jobs:
         uses: ./.github/actions/setup-musl-cross
         with:
           target: ${{ matrix.target }}
+      - name: Setup shared R2 sccache
+        uses: ./.github/actions/setup-r2-sccache
+        with:
+          prepare-cross: ${{ matrix.libc == 'gnu' }}
       - name: Setup cross for backward-compatible GNU wrapper
         if: ${{ matrix.libc == 'gnu' }}
         uses: ./.github/actions/setup-mise
         with:
-          install_args: "sccache cargo:cross"
+          install_args: "cargo:cross"
       - name: Configure cross for GNU wrapper
         if: ${{ matrix.libc == 'gnu' }}
         env:
@@ -89,7 +103,7 @@ jobs:
           # CROSS_CONFIG makes the plan's image control linking; the image's
           # host ldd does not determine the wrapper's compatibility floor.
           cross_config="$RUNNER_TEMP/baml-wrapper-cross.toml"
-          printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
+          printf '[build.env]\npassthrough = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "RUSTC_WRAPPER", "SCCACHE_BUCKET", "SCCACHE_ENDPOINT", "SCCACHE_ERROR_LOG", "SCCACHE_IDLE_TIMEOUT", "SCCACHE_REGION", "SCCACHE_S3_KEY_PREFIX"]\n[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = ["BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" > "$cross_config"
           {
             echo 'CARGO=cross'

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -126,8 +126,17 @@ jobs:
           WORKFLOW_REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
+          checked_out_sha="$(git rev-parse HEAD)"
           if [[ "$INPUT_DRY_RUN" != "false" ]]; then
-            echo "Dry run: a source CI attestation is not required."
+            requested_source_sha="${INPUT_SOURCE_SHA:-$WORKFLOW_SOURCE_SHA}"
+            if [[ "$requested_source_sha" != "$WORKFLOW_SOURCE_SHA" ||
+                  "$checked_out_sha" != "$WORKFLOW_SOURCE_SHA" ]]; then
+              echo "::error::dry-run source_sha must match the dispatched workflow revision"
+              echo "workflow_sha=$WORKFLOW_SOURCE_SHA checked_out_sha=$checked_out_sha"
+              exit 1
+            fi
+            echo "source_branch=$WORKFLOW_REF_NAME" >> "$GITHUB_OUTPUT"
+            echo "Dry run source matches the dispatched workflow revision."
             exit 0
           fi
           if [[ ! "$INPUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -151,7 +160,6 @@ jobs:
             exit 1
           fi
 
-          checked_out_sha="$(git rev-parse HEAD)"
           if [[ "$checked_out_sha" != "$INPUT_SOURCE_SHA" ]]; then
             echo "::error::checked-out SHA $checked_out_sha does not match source_sha $INPUT_SOURCE_SHA"
             exit 1

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -333,6 +333,9 @@ jobs:
     uses: ./.github/workflows/build2-toolchain.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       source_sha: ${{ needs.plan.outputs.source_sha }}
       version: ${{ needs.plan.outputs.version }}

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -404,6 +404,9 @@ jobs:
     uses: ./.github/workflows/build2-wrapper.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       source_sha: ${{ needs.plan.outputs.source_sha }}
       wrapper_version: ${{ needs.plan.outputs.wrapper_version }}
@@ -414,6 +417,9 @@ jobs:
     uses: ./.github/workflows/build2-python-sdk.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
@@ -424,6 +430,9 @@ jobs:
     uses: ./.github/workflows/build2-nodejs-sdk.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
@@ -434,6 +443,9 @@ jobs:
     uses: ./.github/workflows/build2-java-sdk.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
@@ -444,6 +456,9 @@ jobs:
     uses: ./.github/workflows/build2-web-sdk.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
@@ -467,6 +482,9 @@ jobs:
     uses: ./.github/workflows/build2-bridge-cffi.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}
@@ -659,6 +677,9 @@ jobs:
     uses: ./.github/workflows/build2-rust-sdk.reusable.yaml
     permissions:
       contents: read
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     with:
       release_plan_json: ${{ needs.plan.outputs.release_plan_json }}
       source_sha: ${{ needs.plan.outputs.source_sha }}

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -13,7 +13,7 @@
 passthrough = [
   "AWS_ACCESS_KEY_ID",
   "AWS_SECRET_ACCESS_KEY",
-  "RUSTC_WRAPPER=/project/target/sccache-host",
+  "RUSTC_WRAPPER=/target/sccache-host",
   "SCCACHE_BUCKET",
   "SCCACHE_ENDPOINT",
   "SCCACHE_ERROR_LOG",

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -9,6 +9,18 @@
 # `cross` runs the build inside a container and forwards only a curated set of
 # environment variables, so the source fingerprint and Rust/native remapping
 # flags must be listed here explicitly or they never reach the compilers.
+[build.env]
+passthrough = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "RUSTC_WRAPPER",
+  "SCCACHE_BUCKET",
+  "SCCACHE_ENDPOINT",
+  "SCCACHE_ERROR_LOG",
+  "SCCACHE_IDLE_TIMEOUT",
+  "SCCACHE_REGION",
+  "SCCACHE_S3_KEY_PREFIX",
+]
 [target.x86_64-unknown-linux-gnu.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -8,12 +8,15 @@
 #
 # `cross` runs the build inside a container and forwards only a curated set of
 # environment variables, so the source fingerprint and Rust/native remapping
-# flags must be listed here explicitly or they never reach the compilers.
+# listed here explicitly or they never reach the compilers. The wrapper and the
+# host-compatible sccache binary are copied into cross's shared /target mount by
+# `.github/actions/setup-r2-sccache`.
 [build.env]
 passthrough = [
-  "AWS_ACCESS_KEY_ID",
-  "AWS_SECRET_ACCESS_KEY",
-  "RUSTC_WRAPPER=/target/sccache-host",
+  "BAML_SCCACHE_BIN=/target/sccache-host",
+  "BAML_SCCACHE_R2_ACCESS_KEY_ID",
+  "BAML_SCCACHE_R2_SECRET_ACCESS_KEY",
+  "RUSTC_WRAPPER=/target/baml-sccache",
   "SCCACHE_BUCKET",
   "SCCACHE_ENDPOINT",
   "SCCACHE_ERROR_LOG",

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -13,7 +13,7 @@
 passthrough = [
   "AWS_ACCESS_KEY_ID",
   "AWS_SECRET_ACCESS_KEY",
-  "RUSTC_WRAPPER",
+  "RUSTC_WRAPPER=/project/target/sccache-host",
   "SCCACHE_BUCKET",
   "SCCACHE_ENDPOINT",
   "SCCACHE_ERROR_LOG",

--- a/tools/baml-sccache
+++ b/tools/baml-sccache
@@ -9,4 +9,6 @@ if [[ -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
     export AWS_SECRET_ACCESS_KEY="${BAML_SCCACHE_R2_SECRET_ACCESS_KEY}"
 fi
 
-exec sccache "$@"
+# Cross places the host-compatible sccache binary in its shared /target mount.
+# Native builds keep using the sccache resolved from PATH.
+exec "${BAML_SCCACHE_BIN:-sccache}" "$@"


### PR DESCRIPTION
## Summary

- stack on #4685 and extend its environment-only R2 sccache configuration to every Rust-producing `build2-*` workflow invoked by `release-baml-language.yml`
- configure native Linux, macOS, and Windows builds through a shared setup action
- configure maturin Linux containers without enabling its competing GitHub Actions cache backend
- mount the host sccache binary and explicitly forward only the required R2 settings into `cross` containers
- keep Swatinem caching for Cargo registry/git inputs while excluding compiled target directories that now belong to sccache

## Validation

- `git diff --check`
- `actionlint` on all seven changed `build2-*` reusable workflows and `release-baml-language.yml`
- YAML parsing for both changed composite actions
- verified all seven `build2-*` callers have explicit two-secret mappings and all seven Rust-producing jobs use `infisical-github-ci`

## Stack

- depends on #4685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added shared remote build caching to SDK and language release workflows.
  - Added optional cache credential forwarding across reusable release workflows.
  - Improved cache availability during cross-platform builds.
  - Added configurable Rust caching, including broader crate caching and target-cache control.
  - Standardized build-tool setup across workflows while retaining required Node.js, pnpm, wasm-pack, and related tooling.
  - Added validation to ensure dry-run releases use the intended source revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->