### PR TITLE
feat: load local sccache credentials from Infisical

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -33,8 +33,10 @@ else
     fi
 fi
 
-# Load local, machine-specific direnv settings outside the repo. This is where
-# local shells define BAML_SCCACHE_R2_* (CI passes them via the environment).
+# Load local, machine-specific direnv settings outside the repo. Local shells
+# may define explicit BAML_SCCACHE_R2_* overrides (CI passes them via the
+# environment). macOS developers normally use the Infisical flow documented in
+# tools/baml-sccache.md instead.
 if [ -f "$HOME/.envrc.baml" ]; then
     source_env "$HOME/.envrc.baml"
 fi
@@ -43,10 +45,11 @@ fi
 # ----------------------
 # .envrc is the single source of truth: every value below is set
 # unconditionally, so a RUSTC_WRAPPER / SCCACHE_* already in the environment
-# cannot override it. The R2 credentials (BAML_SCCACHE_R2_*) are the one input
-# we read from the environment; the RUSTC_WRAPPER maps them to the AWS_* names
-# sccache expects and then execs sccache. On POSIX that wrapper is the
-# tools/baml-sccache script. On Windows it's the native `tools_sccache` crate's
+# cannot override it. The RUSTC_WRAPPER decides whether remote credentials are
+# complete, maps them to the AWS_* names sccache expects, and removes this
+# remote configuration when falling back to the local cache. On most POSIX
+# hosts that wrapper is the tools/baml-sccache script. On macOS and Windows
+# it's the native `tools_sccache` crate's
 # binary: a .cmd wrapper would be run through cmd.exe, whose ~8191-char
 # command-line limit some crates exceed (e.g. windows-sys, with its enormous
 # `--check-cfg cfg(feature, values(...))` arg -> "The command line is too
@@ -57,27 +60,21 @@ case "$(uname -s 2>/dev/null || true)" in
     # Selected below (needs repo_root). Until the wrapper binary is built, leave
     # RUSTC_WRAPPER unset so the bootstrap `cargo build -p tools_sccache` runs
     # with plain rustc.
-    MINGW*|MSYS*|CYGWIN*|Windows_NT) unset RUSTC_WRAPPER ;;
-    *)                               export RUSTC_WRAPPER=baml-sccache ;;
+    Darwin|MINGW*|MSYS*|CYGWIN*|Windows_NT) unset RUSTC_WRAPPER ;;
+    *)                                      export RUSTC_WRAPPER=baml-sccache ;;
 esac
 export SCCACHE_IDLE_TIMEOUT=0
 # sccache needs a writable log file; some CI environments use a non-standard TMPDIR (for example, /var/folders/.../T/ on macOS).
 export SCCACHE_ERROR_LOG="${TMPDIR:-/tmp}/sccache-baml.log"
-
-if [ -n "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" ] && [ -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]; then
-    export SCCACHE_BUCKET=baml-build3
-    export SCCACHE_REGION=auto
-    export SCCACHE_ENDPOINT=https://c0bf62c013f607c849c6a50cdd627b7b.r2.cloudflarestorage.com
-    # Separate the cache namespaces so CI and local builds don't collide.
-    if [ "${CI:-}" = "true" ]; then
-        export SCCACHE_S3_KEY_PREFIX=baml/ci/
-    else
-        export SCCACHE_S3_KEY_PREFIX=baml/local/
-    fi
+export BAML_SCCACHE_DIRENV_LOADED=1
+export SCCACHE_BUCKET=baml-build3
+export SCCACHE_REGION=auto
+export SCCACHE_ENDPOINT=https://c0bf62c013f607c849c6a50cdd627b7b.r2.cloudflarestorage.com
+# Separate the cache namespaces so CI and local builds don't collide.
+if [ "${CI:-}" = "true" ]; then
+    export SCCACHE_S3_KEY_PREFIX=baml/ci/
 else
-    # No R2 credentials (fork-PR CI, or a local shell without ~/.envrc.baml):
-    # use sccache's host-local disk cache instead of R2.
-    unset SCCACHE_BUCKET SCCACHE_REGION SCCACHE_ENDPOINT SCCACHE_S3_KEY_PREFIX
+    export SCCACHE_S3_KEY_PREFIX=baml/local/
 fi
 
 repo_root=""
@@ -92,6 +89,28 @@ fi
 
 if [ -n "$repo_root" ]; then
     case "$(uname -s 2>/dev/null || true)" in
+        Darwin)
+            _wrapper="${repo_root}/baml_language/target/debug/baml-sccache"
+            _native_wrapper_build_ok=true
+            export SCCACHE_SERVER_UDS="${repo_root}/.baml-sccache.sock"
+            if [ "${CI:-}" != "true" ] && [ "${BAML_SCCACHE_INFISICAL:-}" != "0" ]; then
+                # Build before selecting the wrapper so this bootstrap cargo
+                # invocation cannot recursively call the binary being built.
+                if ! (
+                    cd "${repo_root}/baml_language" &&
+                    env -u RUSTC_WRAPPER -u RUSTC_WORKSPACE_WRAPPER cargo build --locked --quiet -p tools_sccache
+                ); then
+                    _native_wrapper_build_ok=false
+                    echo "baml-sccache: native wrapper build failed; using local shell wrapper" >&2
+                fi
+            fi
+            if [ "$_native_wrapper_build_ok" = true ] && [ -x "$_wrapper" ]; then
+                export RUSTC_WRAPPER="$_wrapper"
+            else
+                export RUSTC_WRAPPER=baml-sccache
+            fi
+            unset _wrapper _native_wrapper_build_ok
+            ;;
         MINGW*|MSYS*|CYGWIN*|Windows_NT)
             # Route rustc through the native sccache wrapper (tools_sccache)
             # once it's been compiled. Prefer a debug build, fall back to

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
  "anyhow",
  "baml_release",
  "console",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tempfile",
@@ -696,7 +696,7 @@ dependencies = [
  "mime_guess",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "sdkgen_cpp",
  "sdkgen_csharp",
  "sdkgen_go",
@@ -1047,7 +1047,7 @@ dependencies = [
  "notify",
  "num-bigint",
  "parking_lot",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
@@ -1123,7 +1123,7 @@ version = "0.0.0-beta"
 dependencies = [
  "anyhow",
  "flate2",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2",
@@ -1254,7 +1254,7 @@ dependencies = [
  "baml_version",
  "bex_vm_types",
  "borsh",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "sha2",
  "tempfile",
@@ -1742,7 +1742,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -3814,6 +3814,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4040,6 +4041,21 @@ dependencies = [
  "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "infisical"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf5b1e1089d886395e20cbe4f6ef6a8023c10313055581fce3bcc28598ec001"
+dependencies = [
+ "base64",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -5934,6 +5950,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -6515,6 +6572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6976,7 +7042,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "rustls-pemfile",
  "serde_json",
@@ -7258,6 +7324,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7432,6 +7499,15 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 [[package]]
 name = "tools_sccache"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "infisical",
+ "reqwest 0.12.28",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "tower"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -142,6 +142,7 @@ darwin-kperf-events = "0.1.0"
 anyhow = { version = "1" }
 async-trait = "0.1"
 askama = { version = "0.14.0" }
+infisical = "=0.0.3"
 # Slim, reqwest/serde-based replacements for the AWS SDK + Google Cloud auth
 # crates, living in `forks/`. They cover only what BAML needs (Bedrock Converse,
 # AWS credential sources, and Google Cloud OAuth2 tokens for Vertex AI) without
@@ -229,6 +230,11 @@ bytecount = "0.6"
 reqwest = { version = "0.13.1", default-features = false, features = [
   "stream",
 ] }
+# Infisical 0.0.3 exposes its reqwest 0.12 client as part of the public Client
+# API. Keep this alias until the SDK provides a documented access-token setter.
+reqwest_0_12 = { package = "reqwest", version = "0.12", default-features = false, features = [
+  "rustls-tls",
+] }
 mimalloc = { version = "0.1.52" }
 rowan = { version = "0.16" }
 rustls = { version = "0.23.37", default-features = false }
@@ -243,6 +249,7 @@ salsa = { version = "0.26", default-features = false, features = [
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde-wasm-bindgen = "0.6"
 serde_json = { version = "1.0.113", features = [ "arbitrary_precision", "preserve_order" ] }
+secrecy = "0.10"
 semver = { version = "1" }
 # The maintained fork of the archived serde_yaml, published by the YAML org;
 # package-renamed so `use serde_yaml::` imports stay unchanged.

--- a/baml_language/tools_sccache/Cargo.toml
+++ b/baml_language/tools_sccache/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
+readme = "README.md"
 
 # This is a CI/build helper, not part of the shipped product. It shells out to
 # spawn a child process, which has no meaning on wasm32-unknown-unknown, so keep
@@ -16,3 +17,15 @@ wasm_support = false
 [[bin]]
 name = "baml-sccache"
 path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+infisical = { workspace = true }
+reqwest_0_12 = { workspace = true }
+secrecy = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = [ "macros", "rt" ] }

--- a/baml_language/tools_sccache/README.md
+++ b/baml_language/tools_sccache/README.md
@@ -1,0 +1,38 @@
+# BAML sccache wrapper
+
+This crate builds the native `baml-sccache` `RUSTC_WRAPPER`. It maps BAML's explicit R2 credentials to the AWS environment names consumed by sccache and, for local macOS development, can retrieve those credentials from Infisical without writing them to disk or adding them to the parent process environment.
+
+The canonical explicit override names are `BAML_SCCACHE_R2_ACCESS_KEY_ID` and `BAML_SCCACHE_R2_SECRET_ACCESS_KEY`. `BAML_SCCACHE_R2_ACCESS_KEY` remains a deprecated compatibility alias for the first name. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are downstream sccache names, not the canonical BAML configuration interface. A complete explicit BAML pair always wins and prevents an Infisical request. A partial pair disables R2 rather than mixing credential sources. GitHub CI continues to pass the canonical BAML pair and only maps it to the sccache child; CI never performs Infisical lookup.
+
+The wrapper reads the project ID from the repository's checked-in `.infisical.json`, uses environment slug `gh-ci`, secret path `/`, and cloud base URL `https://app.infisical.com`, and requests only `BAML_SCCACHE_R2_ACCESS_KEY_ID` and `BAML_SCCACHE_R2_SECRET_ACCESS_KEY`, concurrently, through the official `infisical` Rust SDK 0.0.3. `.infisical.json` remains the project source of truth; its `defaultEnvironment` does not override the cache-specific `gh-ci` selection.
+
+`.envrc` is the source of truth for `SCCACHE_BUCKET`, region, endpoint, and the local-versus-CI key prefix. It marks loaded environments with `BAML_SCCACHE_DIRENV_LOADED=1`. When the native binary starts without that marker, it locates the repository and re-runs itself through `direnv exec`, which loads `.envrc` without serializing or printing the environment. The wrapper copies those non-secret settings to sccache only when it has a complete credential pair; local fallback removes them so a secretless build cannot accidentally attempt R2.
+
+## Human-session setup
+
+The official Rust SDK 0.0.3 supports Universal Auth but does not provide a documented API for consuming the human session stored by `infisical login`, and a CLI login is not automatically visible to the SDK. The wrapper deliberately does not read the CLI credential database or macOS Keychain and does not invoke `infisical export` or any token-printing command.
+
+Prefer a short-lived human token over a machine identity credential on a laptop. Allow the repository `.envrc` once, then after `infisical login`, use the CLI's documented token handoff in a one-command environment so the token is never exported into the long-lived development shell. The binary loads `.envrc` through direnv even when the calling shell has not loaded it:
+
+```bash
+direnv allow .envrc
+INFISICAL_TOKEN="$(infisical user get token --plain)" baml_language/target/debug/baml-sccache --start-server
+```
+
+The token exists only in the wrapper process. The wrapper removes `INFISICAL_TOKEN` before spawning sccache, fetches the R2 pair into redacting/zeroizing memory, maps it to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` only on that child, and starts the long-lived sccache server. Later rustc wrapper calls reuse the server without another Infisical request. If the human session expires, log in again and rerun the command after `sccache --stop-server`; logging out or revoking the session makes the next lookup fall back to local cache.
+
+Set `BAML_SCCACHE_INFISICAL=0` to opt out. Automatic lookup is limited to non-CI macOS processes. `BAML_SCCACHE_INFISICAL=1` opts another local platform into the same flow for testing, but never overrides CI detection. Missing CLI setup, a missing or expired token, network failure, missing project access, or an absent secret produces a concise cache-disabled reason and uses host-local sccache; no secret values are printed. A running sccache server is reused whether it was configured for R2 or local storage.
+
+The current SDK gap means a developer must explicitly bridge the already authenticated CLI session into the wrapper. The alternative documented SDK flow is Universal Auth, but that would place a machine identity client secret on each laptop, so this integration intentionally does not enable it.
+
+## Manual smoke test
+
+This smoke test is opt-in and must only be run when a valid human CLI session already exists:
+
+```bash
+sccache --stop-server >/dev/null 2>&1 || true
+INFISICAL_TOKEN="$(infisical user get token --plain)" baml_language/target/debug/baml-sccache --start-server
+baml_language/target/debug/baml-sccache --show-stats
+```
+
+Confirm that the command succeeds and that subsequent compilation increases cache activity. Neither command prints the R2 credentials. Do not add shell tracing, print the environment, or paste the token into a command argument.

--- a/baml_language/tools_sccache/src/main.rs
+++ b/baml_language/tools_sccache/src/main.rs
@@ -1,42 +1,599 @@
-//! Native `RUSTC_WRAPPER` shim — the compiled counterpart to the
-//! `tools/baml-sccache` shell script, used on Windows.
+//! Native `RUSTC_WRAPPER` shim for BAML's shared sccache R2 cache.
 //!
-//! cargo invokes `RUSTC_WRAPPER` once per crate, passing the full rustc command
-//! line through to it. A Windows `.cmd`/`.bat` wrapper is run through
-//! `cmd.exe`, whose ~8191-character command-line limit some crates exceed —
-//! e.g. `windows-sys`, with its enormous `--check-cfg cfg(feature,
-//! values(...))` argument — producing "The command line is too long". A real
-//! `.exe` is launched by cargo via `CreateProcess` directly (32767-character
-//! limit), so routing rustc through this binary avoids the cmd.exe hop and its
-//! tighter limit entirely.
-//!
-//! Its only job, like the shell script, is to map the `BAML_SCCACHE_R2_*`
-//! credentials to the `AWS_*` names sccache reads, then hand off to sccache
-//! with the same arguments.
+//! Explicit BAML-prefixed credentials are mapped to the AWS names sccache
+//! consumes. Local macOS developers can instead hand a short-lived Infisical
+//! human-session token to this process; the official Infisical Rust SDK then
+//! retrieves the R2 pair and only the spawned sccache process receives it.
 
-use std::process::{Command, exit};
+use std::{
+    ffi::OsString,
+    io::{self, Write},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream},
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus, exit},
+    time::Duration,
+};
 
-fn main() {
-    // sccache reads the R2 credentials under the AWS_* names. We run before any
-    // threads are spawned, so the set_var calls are sound.
-    for (from, to) in [
-        ("BAML_SCCACHE_R2_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID"),
-        ("BAML_SCCACHE_R2_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY"),
-    ] {
-        if let Some(value) = std::env::var_os(from) {
-            // SAFETY: single-threaded at this point; no concurrent env access.
-            unsafe { std::env::set_var(to, value) };
+use async_trait::async_trait;
+use infisical::{Client, InfisicalError, secrets::GetSecretRequest};
+use reqwest_0_12::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+const ACCESS_KEY_ID: &str = "BAML_SCCACHE_R2_ACCESS_KEY_ID";
+const LEGACY_ACCESS_KEY: &str = "BAML_SCCACHE_R2_ACCESS_KEY";
+const SECRET_ACCESS_KEY: &str = "BAML_SCCACHE_R2_SECRET_ACCESS_KEY";
+const INFISICAL_TOKEN: &str = "INFISICAL_TOKEN";
+const INFISICAL_CONTROL: &str = "BAML_SCCACHE_INFISICAL";
+const DIRENV_LOADED: &str = "BAML_SCCACHE_DIRENV_LOADED";
+
+const INFISICAL_BASE_URL: &str = "https://app.infisical.com";
+const INFISICAL_PROJECT_FILE: &str = ".infisical.json";
+const INFISICAL_ENVIRONMENT: &str = "gh-ci";
+const INFISICAL_SECRET_PATH: &str = "/";
+
+const SCCACHE_CONFIGURATION: [&str; 4] = [
+    "SCCACHE_BUCKET",
+    "SCCACHE_REGION",
+    "SCCACHE_ENDPOINT",
+    "SCCACHE_S3_KEY_PREFIX",
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SafeReason {
+    PartialExplicitCredentials,
+    MissingSessionToken,
+    AuthenticationExpiredOrRejected,
+    AccessDenied,
+    SecretMissing,
+    NetworkUnavailable,
+    InvalidResponse,
+    MissingProjectConfiguration,
+    MissingSccacheConfiguration,
+}
+
+impl SafeReason {
+    fn message(self) -> &'static str {
+        match self {
+            Self::PartialExplicitCredentials => {
+                "only one explicit R2 credential is set; set both canonical BAML_SCCACHE_R2_* names or unset both"
+            }
+            Self::MissingSessionToken => {
+                "no short-lived INFISICAL_TOKEN handoff; see tools/baml-sccache.md"
+            }
+            Self::AuthenticationExpiredOrRejected => {
+                "the Infisical session token is expired or rejected; refresh it and restart sccache"
+            }
+            Self::AccessDenied => {
+                "the Infisical session cannot access the gh-ci cache secrets for this repository's project"
+            }
+            Self::SecretMissing => {
+                "an R2 cache secret is missing from the configured project's gh-ci environment at /"
+            }
+            Self::NetworkUnavailable => {
+                "Infisical is unavailable; check the network and restart sccache to retry"
+            }
+            Self::InvalidResponse => {
+                "Infisical returned an unusable response; restart sccache to retry"
+            }
+            Self::MissingProjectConfiguration => {
+                "cannot read the Infisical project from .infisical.json"
+            }
+            Self::MissingSccacheConfiguration => {
+                "SCCACHE_BUCKET configuration is not loaded; install and allow direnv for this repository"
+            }
+        }
+    }
+}
+
+struct InfisicalConfiguration {
+    project_id: String,
+}
+
+#[derive(Deserialize)]
+struct InfisicalProjectFile {
+    #[serde(rename = "workspaceId", alias = "projectId")]
+    project_id: String,
+}
+
+impl InfisicalConfiguration {
+    fn from_repository_root(repository_root: &Path) -> Result<Self, SafeReason> {
+        let contents = std::fs::read_to_string(repository_root.join(INFISICAL_PROJECT_FILE))
+            .map_err(|_| SafeReason::MissingProjectConfiguration)?;
+        Self::from_json(&contents)
+    }
+
+    fn from_json(contents: &str) -> Result<Self, SafeReason> {
+        let project: InfisicalProjectFile =
+            serde_json::from_str(contents).map_err(|_| SafeReason::MissingProjectConfiguration)?;
+        if project.project_id.is_empty() {
+            return Err(SafeReason::MissingProjectConfiguration);
+        }
+        Ok(Self {
+            project_id: project.project_id,
+        })
+    }
+}
+
+struct SccacheConfiguration {
+    bucket: OsString,
+    region: OsString,
+    endpoint: OsString,
+    key_prefix: OsString,
+}
+
+impl SccacheConfiguration {
+    fn from_environment(environment: &impl Environment) -> Result<Self, SafeReason> {
+        let value = |name| {
+            environment
+                .var_os(name)
+                .filter(|value| !value.is_empty())
+                .ok_or(SafeReason::MissingSccacheConfiguration)
+        };
+        Ok(Self {
+            bucket: value("SCCACHE_BUCKET")?,
+            region: value("SCCACHE_REGION")?,
+            endpoint: value("SCCACHE_ENDPOINT")?,
+            key_prefix: value("SCCACHE_S3_KEY_PREFIX")?,
+        })
+    }
+}
+
+struct R2Credentials {
+    access_key_id: SecretString,
+    secret_access_key: SecretString,
+}
+
+impl R2Credentials {
+    fn new(access_key_id: String, secret_access_key: String) -> Self {
+        Self {
+            access_key_id: SecretString::from(access_key_id),
+            secret_access_key: SecretString::from(secret_access_key),
+        }
+    }
+}
+
+trait AuthenticationProvider {
+    fn access_token(&self) -> Result<&SecretString, SafeReason>;
+}
+
+struct EnvironmentTokenProvider {
+    token: Option<SecretString>,
+}
+
+impl EnvironmentTokenProvider {
+    fn from_environment(environment: &impl Environment) -> Self {
+        Self {
+            token: environment
+                .var_os(INFISICAL_TOKEN)
+                .and_then(|value| value.into_string().ok())
+                .filter(|value| !value.is_empty())
+                .map(SecretString::from),
+        }
+    }
+}
+
+impl std::fmt::Debug for EnvironmentTokenProvider {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EnvironmentTokenProvider")
+            .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+impl AuthenticationProvider for EnvironmentTokenProvider {
+    fn access_token(&self) -> Result<&SecretString, SafeReason> {
+        self.token.as_ref().ok_or(SafeReason::MissingSessionToken)
+    }
+}
+
+#[async_trait]
+trait CredentialProvider {
+    async fn fetch(&self) -> Result<R2Credentials, SafeReason>;
+}
+
+struct InfisicalCredentialProvider<A> {
+    authentication: A,
+    repository_root: Option<PathBuf>,
+}
+
+impl<A> InfisicalCredentialProvider<A> {
+    fn new(authentication: A, repository_root: Option<PathBuf>) -> Self {
+        Self {
+            authentication,
+            repository_root,
+        }
+    }
+}
+
+#[async_trait]
+impl<A> CredentialProvider for InfisicalCredentialProvider<A>
+where
+    A: AuthenticationProvider + Sync,
+{
+    async fn fetch(&self) -> Result<R2Credentials, SafeReason> {
+        let repository_root = self
+            .repository_root
+            .as_deref()
+            .ok_or(SafeReason::MissingProjectConfiguration)?;
+        let configuration = InfisicalConfiguration::from_repository_root(repository_root)?;
+        let token = self.authentication.access_token()?;
+        let mut client = Client::builder()
+            .base_url(INFISICAL_BASE_URL)
+            .user_agent(concat!("baml-sccache/", env!("CARGO_PKG_VERSION")))
+            .request_timeout(Duration::from_secs(5))
+            .build()
+            .await
+            .map_err(classify_infisical_error)?;
+
+        // Infisical's official Rust SDK 0.0.3 only documents Universal Auth.
+        // Its Client fields are public, so this is the narrowest available
+        // token handoff until the SDK adds a supported access-token setter.
+        // HeaderValue is marked sensitive and the SDK still performs both
+        // secret retrieval requests and response decoding.
+        authenticate_client(&mut client, token)?;
+
+        let access_key = fetch_secret(&client, ACCESS_KEY_ID, &configuration.project_id);
+        let secret_key = fetch_secret(&client, SECRET_ACCESS_KEY, &configuration.project_id);
+        let (access_key_id, secret_access_key) = tokio::try_join!(access_key, secret_key)?;
+
+        Ok(R2Credentials {
+            access_key_id,
+            secret_access_key,
+        })
+    }
+}
+
+fn authenticate_client(client: &mut Client, token: &SecretString) -> Result<(), SafeReason> {
+    let bearer = SecretString::from(format!("Bearer {}", token.expose_secret()));
+    let mut value = HeaderValue::from_str(bearer.expose_secret())
+        .map_err(|_| SafeReason::AuthenticationExpiredOrRejected)?;
+    value.set_sensitive(true);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, value);
+    client.http_client = reqwest_0_12::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .user_agent(concat!("baml-sccache/", env!("CARGO_PKG_VERSION")))
+        .use_rustls_tls()
+        .redirect(reqwest_0_12::redirect::Policy::none())
+        .default_headers(headers)
+        .build()
+        .map_err(|_| SafeReason::InvalidResponse)?;
+    client.logged_in = true;
+    Ok(())
+}
+
+async fn fetch_secret(
+    client: &Client,
+    name: &'static str,
+    project_id: &str,
+) -> Result<SecretString, SafeReason> {
+    let request = GetSecretRequest::builder(name, project_id, INFISICAL_ENVIRONMENT)
+        .path(INFISICAL_SECRET_PATH)
+        .expand_secret_references(false)
+        .build();
+    let secret = client
+        .secrets()
+        .get(request)
+        .await
+        .map_err(classify_infisical_error)?;
+    if secret.secret_value.is_empty() {
+        return Err(SafeReason::SecretMissing);
+    }
+    Ok(SecretString::from(secret.secret_value))
+}
+
+fn classify_infisical_error(error: InfisicalError) -> SafeReason {
+    match error {
+        InfisicalError::HttpError { status, .. } if status.as_u16() == 401 => {
+            SafeReason::AuthenticationExpiredOrRejected
+        }
+        InfisicalError::HttpError { status, .. } if status.as_u16() == 403 => {
+            SafeReason::AccessDenied
+        }
+        InfisicalError::HttpError { status, .. } if status.as_u16() == 404 => {
+            SafeReason::SecretMissing
+        }
+        InfisicalError::RequestError(error) if error.is_connect() || error.is_timeout() => {
+            SafeReason::NetworkUnavailable
+        }
+        InfisicalError::NotAuthenticated | InfisicalError::InvalidAuthMethod => {
+            SafeReason::AuthenticationExpiredOrRejected
+        }
+        _ => SafeReason::InvalidResponse,
+    }
+}
+
+trait Environment {
+    fn var_os(&self, name: &str) -> Option<OsString>;
+}
+
+struct ProcessEnvironment;
+
+impl Environment for ProcessEnvironment {
+    fn var_os(&self, name: &str) -> Option<OsString> {
+        std::env::var_os(name)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RuntimeContext {
+    is_macos: bool,
+    is_ci: bool,
+    server_running: bool,
+}
+
+enum Resolution {
+    Remote(R2Credentials, SccacheConfiguration),
+    Local,
+    LocalFallback(SafeReason),
+    Passthrough,
+}
+
+async fn resolve_credentials(
+    environment: &impl Environment,
+    context: RuntimeContext,
+    provider: &impl CredentialProvider,
+) -> Resolution {
+    match explicit_credentials(environment) {
+        ExplicitCredentials::Complete(credentials) => {
+            return match SccacheConfiguration::from_environment(environment) {
+                Ok(configuration) => Resolution::Remote(credentials, configuration),
+                Err(reason) => Resolution::LocalFallback(reason),
+            };
+        }
+        ExplicitCredentials::Partial => {
+            return Resolution::LocalFallback(SafeReason::PartialExplicitCredentials);
+        }
+        ExplicitCredentials::Absent => {}
+    }
+
+    if context.server_running {
+        return Resolution::Passthrough;
+    }
+    if context.is_ci || !automatic_lookup_enabled(environment, context) {
+        return Resolution::Local;
+    }
+
+    let configuration = match SccacheConfiguration::from_environment(environment) {
+        Ok(configuration) => configuration,
+        Err(reason) => return Resolution::LocalFallback(reason),
+    };
+
+    match provider.fetch().await {
+        Ok(credentials) => Resolution::Remote(credentials, configuration),
+        Err(reason) => Resolution::LocalFallback(reason),
+    }
+}
+
+enum ExplicitCredentials {
+    Complete(R2Credentials),
+    Partial,
+    Absent,
+}
+
+fn explicit_credentials(environment: &impl Environment) -> ExplicitCredentials {
+    let canonical_access_key = nonempty_utf8(environment.var_os(ACCESS_KEY_ID));
+    let legacy_access_key = nonempty_utf8(environment.var_os(LEGACY_ACCESS_KEY));
+    let secret_access_key = nonempty_utf8(environment.var_os(SECRET_ACCESS_KEY));
+    let access_key = canonical_access_key.or(legacy_access_key);
+
+    match (access_key, secret_access_key) {
+        (Some(access_key_id), Some(secret_access_key)) => {
+            ExplicitCredentials::Complete(R2Credentials::new(access_key_id, secret_access_key))
+        }
+        (None, None) => ExplicitCredentials::Absent,
+        _ => ExplicitCredentials::Partial,
+    }
+}
+
+fn nonempty_utf8(value: Option<OsString>) -> Option<String> {
+    value
+        .and_then(|value| value.into_string().ok())
+        .filter(|value| !value.is_empty())
+}
+
+fn automatic_lookup_enabled(environment: &impl Environment, context: RuntimeContext) -> bool {
+    match nonempty_utf8(environment.var_os(INFISICAL_CONTROL)).as_deref() {
+        Some("0" | "false" | "off") => false,
+        Some("1" | "true" | "on") => true,
+        _ => context.is_macos,
+    }
+}
+
+fn is_ci(environment: &impl Environment) -> bool {
+    ["CI", "GITHUB_ACTIONS"]
+        .into_iter()
+        .filter_map(|name| nonempty_utf8(environment.var_os(name)))
+        .any(|value| !matches!(value.as_str(), "0" | "false" | "off"))
+}
+
+#[cfg(unix)]
+fn server_running(environment: &impl Environment) -> bool {
+    use std::os::unix::net::UnixStream;
+
+    if let Some(path) = environment.var_os("SCCACHE_SERVER_UDS") {
+        return UnixStream::connect(path).is_ok();
+    }
+    tcp_server_running(environment)
+}
+
+#[cfg(not(unix))]
+fn server_running(environment: &impl Environment) -> bool {
+    tcp_server_running(environment)
+}
+
+fn tcp_server_address(environment: &impl Environment) -> SocketAddr {
+    let port = nonempty_utf8(environment.var_os("SCCACHE_SERVER_PORT"))
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(4226);
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+}
+
+fn tcp_server_running(environment: &impl Environment) -> bool {
+    tcp_endpoint_running(tcp_server_address(environment))
+}
+
+fn tcp_endpoint_running(address: SocketAddr) -> bool {
+    TcpStream::connect_timeout(&address, Duration::from_millis(50)).is_ok()
+}
+
+enum ChildEnvironment {
+    Remote(R2Credentials, SccacheConfiguration),
+    Local,
+    Passthrough,
+}
+
+impl ChildEnvironment {
+    fn from_resolution(resolution: Resolution) -> (Self, Option<SafeReason>) {
+        match resolution {
+            Resolution::Remote(credentials, configuration) => {
+                (Self::Remote(credentials, configuration), None)
+            }
+            Resolution::Local => (Self::Local, None),
+            Resolution::LocalFallback(reason) => (Self::Local, Some(reason)),
+            Resolution::Passthrough => (Self::Passthrough, None),
         }
     }
 
-    // argv[1..] is `<path-to-rustc> <args...>`; forward it verbatim to sccache.
-    // Use *_os to preserve non-UTF-8 paths/arguments.
-    let args = std::env::args_os().skip(1);
+    fn apply(&self, command: &mut Command, _environment: &impl Environment) {
+        command.env_remove(INFISICAL_TOKEN);
 
-    match Command::new("sccache").args(args).status() {
+        match self {
+            Self::Remote(credentials, configuration) => {
+                for name in [ACCESS_KEY_ID, LEGACY_ACCESS_KEY, SECRET_ACCESS_KEY] {
+                    command.env_remove(name);
+                }
+                command
+                    .env(
+                        "AWS_ACCESS_KEY_ID",
+                        credentials.access_key_id.expose_secret(),
+                    )
+                    .env(
+                        "AWS_SECRET_ACCESS_KEY",
+                        credentials.secret_access_key.expose_secret(),
+                    )
+                    .env("SCCACHE_BUCKET", &configuration.bucket)
+                    .env("SCCACHE_REGION", &configuration.region)
+                    .env("SCCACHE_ENDPOINT", &configuration.endpoint)
+                    .env("SCCACHE_S3_KEY_PREFIX", &configuration.key_prefix);
+            }
+            Self::Local => {
+                for name in [
+                    ACCESS_KEY_ID,
+                    LEGACY_ACCESS_KEY,
+                    SECRET_ACCESS_KEY,
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY",
+                ] {
+                    command.env_remove(name);
+                }
+                for name in SCCACHE_CONFIGURATION {
+                    command.env_remove(name);
+                }
+            }
+            Self::Passthrough => {}
+        }
+    }
+}
+
+fn repository_root_from(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|candidate| {
+            candidate.join(".envrc").is_file() && candidate.join(INFISICAL_PROJECT_FILE).is_file()
+        })
+        .map(Path::to_path_buf)
+}
+
+fn find_repository_root() -> Option<PathBuf> {
+    std::env::current_dir()
+        .ok()
+        .and_then(|path| repository_root_from(&path))
+        .or_else(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|path| repository_root_from(&path))
+        })
+}
+
+fn direnv_command(
+    repository_root: &Path,
+    executable: &Path,
+    arguments: impl IntoIterator<Item = OsString>,
+) -> Command {
+    let mut command = Command::new("direnv");
+    command
+        .arg("exec")
+        .arg(repository_root)
+        .arg(executable)
+        .args(arguments);
+    command
+}
+
+fn direnv_needs_loading(environment: &impl Environment) -> bool {
+    environment.var_os(DIRENV_LOADED).is_none()
+}
+
+fn run_through_direnv_if_needed(
+    environment: &impl Environment,
+    repository_root: Option<&Path>,
+) -> Result<Option<ExitStatus>, io::Error> {
+    if !direnv_needs_loading(environment) {
+        return Ok(None);
+    }
+    let Some(repository_root) = repository_root else {
+        return Ok(None);
+    };
+    let executable = std::env::current_exe()?;
+    let mut command = direnv_command(repository_root, &executable, std::env::args_os().skip(1));
+    match command.status() {
+        Ok(status) => Ok(Some(status)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+async fn run() -> Result<ExitStatus, io::Error> {
+    let environment = ProcessEnvironment;
+    let repository_root = find_repository_root();
+    if let Some(status) = run_through_direnv_if_needed(&environment, repository_root.as_deref())? {
+        return Ok(status);
+    }
+    let authentication = EnvironmentTokenProvider::from_environment(&environment);
+    let provider = InfisicalCredentialProvider::new(authentication, repository_root);
+    let context = RuntimeContext {
+        is_macos: cfg!(target_os = "macos"),
+        is_ci: is_ci(&environment),
+        server_running: server_running(&environment),
+    };
+    let resolution = resolve_credentials(&environment, context, &provider).await;
+    let (child_environment, fallback_reason) = ChildEnvironment::from_resolution(resolution);
+    if let Some(reason) = fallback_reason {
+        let _ = writeln!(
+            io::stderr().lock(),
+            "baml-sccache: R2 cache disabled: {}",
+            reason.message()
+        );
+    }
+
+    let mut command = Command::new("sccache");
+    command.args(std::env::args_os().skip(1));
+    child_environment.apply(&mut command, &environment);
+    command.status()
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    match run().await {
         Ok(status) => exit(status.code().unwrap_or(1)),
-        Err(err) => {
-            eprintln!("baml-sccache: failed to spawn sccache: {err}");
+        Err(error) => {
+            let _ = writeln!(
+                io::stderr().lock(),
+                "baml-sccache: failed to start direnv or sccache: {error}"
+            );
             exit(127);
         }
     }

--- a/tools/baml-sccache
+++ b/tools/baml-sccache
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -n "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" ]]; then
+if [[ -n "${BAML_SCCACHE_R2_ACCESS_KEY_ID:-}" && -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
     export AWS_ACCESS_KEY_ID="${BAML_SCCACHE_R2_ACCESS_KEY_ID}"
+    export AWS_SECRET_ACCESS_KEY="${BAML_SCCACHE_R2_SECRET_ACCESS_KEY}"
+elif [[ -n "${BAML_SCCACHE_R2_ACCESS_KEY:-}" && -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
+    # Deprecated compatibility alias. The canonical name includes `_ID`.
+    export AWS_ACCESS_KEY_ID="${BAML_SCCACHE_R2_ACCESS_KEY}"
+    export AWS_SECRET_ACCESS_KEY="${BAML_SCCACHE_R2_SECRET_ACCESS_KEY}"
+else
+    # .envrc exports the shared R2 configuration unconditionally so the native
+    # wrapper can retrieve local credentials. Secretless POSIX builds stay on
+    # the host-local cache.
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY SCCACHE_BUCKET SCCACHE_REGION SCCACHE_ENDPOINT SCCACHE_S3_KEY_PREFIX
 fi
 
-if [[ -n "${BAML_SCCACHE_R2_SECRET_ACCESS_KEY:-}" ]]; then
-    export AWS_SECRET_ACCESS_KEY="${BAML_SCCACHE_R2_SECRET_ACCESS_KEY}"
-fi
+# sccache only needs the mapped AWS names. In particular, never leak a
+# short-lived Infisical session token into the sccache server.
+unset BAML_SCCACHE_R2_ACCESS_KEY_ID BAML_SCCACHE_R2_ACCESS_KEY BAML_SCCACHE_R2_SECRET_ACCESS_KEY INFISICAL_TOKEN
 
 exec sccache "$@"

--- a/tools/baml-sccache.md
+++ b/tools/baml-sccache.md
@@ -1,0 +1,3 @@
+# Shared developer sccache
+
+The repository's Cargo builds use `tools/baml-sccache` on POSIX and the native `tools_sccache` crate on Windows and macOS. See [`baml_language/tools_sccache/README.md`](../baml_language/tools_sccache/README.md) for credential precedence, Infisical human-session setup, failure behavior, security properties, opt-out controls, and the manual smoke test.


### PR DESCRIPTION
## Summary

- Add Infisical-backed R2 credential retrieval to the native `baml-sccache` wrapper for local macOS developers.
- Keep GitHub CI unchanged at runtime: canonical `BAML_SCCACHE_R2_*` inputs are mapped directly to the AWS names for the sccache child, and CI never contacts Infisical.
- Read the Infisical project ID from `.infisical.json`, retrieve the two secrets from `gh-ci`, and load sccache's non-secret R2 configuration from `.envrc` even when the invoking shell has not already loaded direnv.
- Preserve local builds when credentials or configuration are unavailable by falling back to host-local sccache with concise, non-sensitive guidance.

## Architecture and precedence

The existing POSIX wrapper remains the lightweight path for Linux CI and other POSIX hosts. `.envrc` builds and selects the native `tools_sccache` binary on local macOS, while Windows keeps using the same native binary for its existing command-line-length workaround.

Credential precedence is: (1) the complete explicit canonical pair `BAML_SCCACHE_R2_ACCESS_KEY_ID` plus `BAML_SCCACHE_R2_SECRET_ACCESS_KEY`; (2) the deprecated compatibility alias `BAML_SCCACHE_R2_ACCESS_KEY` plus the canonical secret-key name; (3) eligible local Infisical lookup; (4) local-only behavior. A partial explicit pair disables R2 rather than mixing sources. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` remain downstream sccache names, not the canonical BAML input interface.

GitHub Actions and other detected CI processes never invoke the Infisical provider, including when `BAML_SCCACHE_INFISICAL=1`. A complete explicit BAML pair is still mapped in CI before that gate, preserving current CI behavior. `BAML_SCCACHE_INFISICAL=0` opts local developers out; `BAML_SCCACHE_INFISICAL=1` is a non-CI testing opt-in on another platform.

`.envrc` is the only source of truth for `SCCACHE_BUCKET`, `SCCACHE_REGION`, `SCCACHE_ENDPOINT`, and `SCCACHE_S3_KEY_PREFIX`. It exports `BAML_SCCACHE_DIRENV_LOADED=1`; if the native wrapper starts without that marker, it locates the repository and re-runs itself with `direnv exec`. This avoids `direnv export`, never serializes the environment, and ensures direct binary startup receives `.envrc` configuration. The wrappers remove remote configuration again when using local cache, so secretless builds do not attempt R2.

The wrapper checks the configured sccache Unix socket before lookup so an already running server is reused without another Infisical request. When retrieval is needed, it requests the two secrets concurrently and passes the resulting credentials only to the spawned sccache process. Starting the long-lived server once avoids a request per rustc invocation.

## Infisical authentication model and SDK limitation

This uses the official [`infisical` Rust SDK](https://infisical.com/docs/sdks/languages/rust) pinned to 0.0.3 and was checked against the [official SDK repository](https://github.com/Infisical/rust-sdk/tree/ba9025f8b90283c707112115c1399c0a59b651f5). The SDK documents Universal Auth and currently exposes no documented access-token setter or bridge to the human session stored by `infisical login`. A CLI login is therefore not automatically visible to the SDK.

The preferred laptop flow uses the CLI's documented short-lived human-session token handoff from [`infisical user get token --plain`](https://infisical.com/docs/cli/commands/user) in a one-command environment. The wrapper never invokes that command itself, never reads the CLI credential database or macOS Keychain, and does not use `infisical export`. The token is removed before sccache is spawned.

Because SDK 0.0.3 lacks an access-token setter, the implementation uses the SDK's public `Client` fields to install a sensitive bearer header, then uses the SDK for both secret retrieval calls and decoding. A small authentication-provider boundary isolates this workaround so it can be replaced when the SDK adds a documented setter. The alternative fully documented SDK flow would require a Universal Auth machine identity client secret on every laptop, so this PR intentionally prefers the short-lived human token despite the explicit handoff step.

Developer setup, token expiry/logout behavior, opt-out controls, direnv startup behavior, and the manual smoke procedure are documented in `baml_language/tools_sccache/README.md` and linked from `tools/baml-sccache.md`.

## Infisical configuration

The project ID is parsed at runtime from the checked-in `.infisical.json`; no project ID is duplicated in the binary. The cache-specific environment slug is `gh-ci`, the secret path is `/`, and the SDK base URL is `https://app.infisical.com`. The `.infisical.json` `defaultEnvironment` remains available to other repository tooling and does not override this cache-specific environment. Only `BAML_SCCACHE_R2_ACCESS_KEY_ID` and `BAML_SCCACHE_R2_SECRET_ACCESS_KEY` are requested.

## Security properties and failure behavior

Retrieved R2 values move immediately into `secrecy::SecretString`, are never written to disk or global process environment, and are exposed only while constructing the sccache child's `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment. BAML-prefixed values and `INFISICAL_TOKEN` are removed from that child. Credential-bearing structures do not implement `Debug`; the authentication provider has an explicit redacting `Debug`; raw SDK errors are collapsed into fieldless safe reasons before display; no values enter arguments, logs, telemetry, snapshots, fixtures, or panic messages.

Missing token/CLI setup, expired or rejected authentication, network unavailability, access denial, missing secrets, missing `.infisical.json`, missing direnv-provided sccache configuration, and unusable responses disable R2 for that server start and fall back to local sccache. The reason is concise and actionable without including response bodies or credentials. After login refresh, stop the local server and start it again with the one-command token handoff. Logging out or revocation causes the next attempted lookup to follow the same local fallback.

## Test evidence

- `cargo fmt --package tools_sccache -- --check`
- `cargo clippy --locked -p tools_sccache --all-targets -- -D warnings`
- `cargo check --locked -p tools_sccache --all-targets`
- `cargo build --locked -p tools_sccache`
- Isolated no-network direnv startup smoke using a synthetic `.envrc`, synthetic credentials, and a fake sccache child; it verified the bucket came from `.envrc` and BAML/Infisical variables were stripped.
- `bash -n` for `.envrc` and `tools/baml-sccache`.
- Direct license metadata: `infisical` MIT, reqwest 0.12 MIT OR Apache-2.0, and `secrecy` Apache-2.0 OR MIT, all allowed by `deny.toml`.

The installed Linux-musl Rust target could not complete because the host lacks `x86_64-linux-musl-gcc`; `cross` also lacks an arm64-host image for that target. Native macOS builds and all-target checking pass, and OS-specific socket code is cfg-gated.

`cargo deny check licenses bans sources` reports bans and sources as OK but the workspace license check fails on the existing `aws-lc-rs`/`aws-lc-sys` ISC/BSD-3-Clause/MIT-0 policy mismatch. Those packages are already present in the parent lockfile, and the new tool's resolved TLS graph uses `ring`; this PR does not broaden repository license policy.

## Manual smoke status

The live Infisical/R2 smoke was not run. Obtaining a token in this work session would require executing a command that emits it. In accordance with the security constraint, this work did not execute `infisical user get token`, `infisical export`, or any live secret retrieval. The opt-in procedure is documented for a developer to run without printing R2 values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native sccache support for macOS builds.
  - Added optional short-lived credential lookup for local macOS development.
  - Added support for credential precedence, legacy configuration, CI usage, and opt-out settings.
  - Added fallback to host-local caching when cloud credentials are unavailable or incomplete.
  - Improved credential isolation when launching sccache.

- **Documentation**
  - Added setup, credential, security, fallback, and smoke-test guidance for sccache usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

