### PR TITLE
fix(release): fix the x64 toolchain build, again

### DIFF
--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -94,9 +94,14 @@ jobs:
             # The glibc-2.17 image's target GCC is 4.8 and cannot compile
             # mimalloc v3's warning flags. Its host GCC is current; point that
             # compiler at the image's 2.17 sysroot so C dependencies retain the
-            # same compatibility floor as the Rust linker.
+            # same compatibility floor as the Rust linker. Cross sets TARGET_CC
+            # and TARGET_CXX to the old compilers, and native build scripts give
+            # those variables precedence over the target-specific overrides.
+            passthrough+=', "TARGET_CC=gcc", "TARGET_CXX=g++"'
             passthrough+=', "CC_x86_64_unknown_linux_gnu=gcc"'
+            passthrough+=', "CXX_x86_64_unknown_linux_gnu=g++"'
             passthrough+=', "CFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
+            passthrough+=', "CXXFLAGS_x86_64_unknown_linux_gnu=--sysroot=/usr/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot"'
           fi
           printf '[target.%s]\nimage = "%s"\n[target.%s.env]\npassthrough = [%s]\n' \
             "$TARGET" "$CROSS_IMAGE" "$TARGET" "$passthrough" > "$cross_config"


### PR DESCRIPTION
Nightly failed again: https://github.com/BoundaryML/baml/actions/runs/33603483285/attempts/1

This fixes that.

The x86_64 GNU nightly toolchain continued using the manylinux image's GCC 4.8 because Cross sets `TARGET_CC` and `TARGET_CXX`, which native build scripts prioritize over the target-specific compiler variables added in #4698. AWS-LC consequently failed to find `stdatomic.h`.

Override both higher-precedence variables with the image's GCC/G++ 11.4 while retaining the target-specific overrides and glibc 2.17 sysroot flags. Rust continues to use the existing backward-compatible linker.

Validation:
- `mise exec actionlint -- actionlint .github/workflows/build2-toolchain.reusable.yaml`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v`\n- In the exact manylinux2014-cross image, reproduced the `stdatomic.h` failure with GCC 4.8.5 and verified GCC 11.4 compiles the same C11 probe against the glibc 2.17 sysroot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GNU cross-compilation workflow to provide explicit C and C++ compiler settings for x86_64 Linux builds.
  * Improved compiler and sysroot configuration consistency for cross-build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->