### PR TITLE
chore: split BAML v1 setup actions from v0

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -5,7 +5,7 @@ This directory contains modular setup actions for the BAML project. Each action 
 ## Available Actions
 
 ### setup-all
-Sets up the complete development environment using all modular actions.
+Sets up the complete legacy engine development environment using the engine-specific modular actions.
 
 ```yaml
 - name: Setup All
@@ -41,7 +41,7 @@ Sets up the complete development environment using all modular actions.
 ```
 
 ### setup-node
-Sets up Node.js with pnpm package manager.
+Sets up Node.js with pnpm for BAML Language workflows.
 
 ```yaml
 - name: Setup Node.js
@@ -55,17 +55,55 @@ Sets up Node.js with pnpm package manager.
     turbo-cache-path: '.turbo'       # Optional, default: '.turbo'
 ```
 
+### engine-setup-node
+Sets up Node.js with pnpm for legacy engine workflows while preserving the same inputs and cache behavior as `setup-node`.
+
+```yaml
+- name: Setup Engine Node.js
+  uses: ./.github/actions/engine-setup-node
+  with:
+    node-version: '20'              # Optional, default: '20'
+    pnpm-version: '9.12.0'          # Optional, default: '9.12.0'
+    install-dependencies: 'true'     # Optional, default: 'true'
+    frozen-lockfile: 'true'          # Optional, default: 'true'
+    enable-turbo-cache: 'true'       # Optional, default: 'true'
+    turbo-cache-path: '.turbo'       # Optional, default: '.turbo'
+```
+
 ### setup-rust
-Sets up Rust toolchain with caching and optional WASM support.
+Sets up the BAML Language Rust toolchain with caching and optional WASM support.
 
 ```yaml
 - name: Setup Rust
   uses: ./.github/actions/setup-rust
   with:
-    toolchain: 'stable'                           # Optional, default: 'stable'
+    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
     enable-wasm: 'false'                         # Optional, default: 'false'
     targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
-    workspace: 'engine'                          # Optional, default: 'engine'
+    workspace: 'baml_language'                   # Optional, default: 'baml_language'
+```
+
+### engine-setup-rust
+Sets up the engine Rust toolchain with caching and optional WASM support.
+
+```yaml
+- name: Setup Engine Rust
+  uses: ./.github/actions/engine-setup-rust
+  with:
+    toolchain: '1.93.0'                          # Optional, default: '1.93.0'
+    enable-wasm: 'false'                         # Optional, default: 'false'
+    targets: 'x86_64-pc-windows-msvc'           # Optional, space-separated targets
+    workspace: 'engine'                         # Optional, default: 'engine'
+```
+
+### setup-ruby and engine-setup-ruby
+`setup-ruby` remains dedicated to BAML Language workflows, while `engine-setup-ruby` is the behavior-identical copy for legacy engine workflows.
+
+```yaml
+- name: Setup Engine Ruby
+  uses: ./.github/actions/engine-setup-ruby
+  with:
+    ruby-version: '3.4'                          # Optional, default: '3.4'
 ```
 
 ### setup-python
@@ -136,7 +174,7 @@ For jobs that don't need Python at all:
 Only needs Node.js and pnpm:
 ```yaml
 - name: Setup Node.js
-  uses: ./.github/actions/setup-node
+  uses: ./.github/actions/engine-setup-node
   with:
     node-version: ${{ env.NODE_VERSION }}
     pnpm-version: ${{ env.PNPM_VERSION }}
@@ -146,7 +184,7 @@ Only needs Node.js and pnpm:
 Only needs Rust toolchain:
 ```yaml
 - name: Setup Rust
-  uses: ./.github/actions/setup-rust
+  uses: ./.github/actions/engine-setup-rust
   with:
     toolchain: ${{ env.RUST_TOOLCHAIN }}
     targets: ${{ matrix.target }}
@@ -156,7 +194,7 @@ Only needs Rust toolchain:
 Needs Rust with WASM support:
 ```yaml
 - name: Setup Rust
-  uses: ./.github/actions/setup-rust
+  uses: ./.github/actions/engine-setup-rust
   with:
     toolchain: ${{ env.RUST_TOOLCHAIN }}
     enable-wasm: 'true'
@@ -166,12 +204,12 @@ Needs Rust with WASM support:
 Needs multiple technologies:
 ```yaml
 - name: Setup Rust
-  uses: ./.github/actions/setup-rust
+  uses: ./.github/actions/engine-setup-rust
   with:
     toolchain: ${{ env.RUST_TOOLCHAIN }}
 
 - name: Setup Node.js
-  uses: ./.github/actions/setup-node
+  uses: ./.github/actions/engine-setup-node
   with:
     node-version: ${{ env.NODE_VERSION }}
     pnpm-version: ${{ env.PNPM_VERSION }}

--- a/.github/actions/engine-setup-node/action.yml
+++ b/.github/actions/engine-setup-node/action.yml
@@ -1,0 +1,74 @@
+name: 'Setup Node.js and pnpm for engine'
+description: 'Setup Node.js with pnpm package manager for engine workflows'
+
+inputs:
+  node-version:
+    description: 'Node.js version to install'
+    required: false
+    default: '20'
+  pnpm-version:
+    description: 'pnpm version to install'
+    required: false
+    default: '9.12.0'
+  install-dependencies:
+    description: 'Whether to install dependencies with pnpm'
+    required: false
+    default: 'true'
+  frozen-lockfile:
+    description: 'Use frozen lockfile for installation'
+    required: false
+    default: 'true'
+  enable-turbo-cache:
+    description: 'Enable Turbo build cache using GitHub Actions cache'
+    required: false
+    default: 'true'
+  turbo-cache-path:
+    description: 'Path for Turbo cache directory'
+    required: false
+    default: '.turbo'
+  node-action-version:
+    description: 'Version of actions/setup-node to use (v4 or v6)'
+    required: false
+    # Default to v4 for backwards compatibility.
+    default: 'v4'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache Turbo build setup
+      if: inputs.enable-turbo-cache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.turbo-cache-path }}
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Setup Node.js (v4)
+      if: inputs.node-action-version == 'v4'
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+        registry-url: "https://registry.npmjs.org"
+
+    - name: Setup Node.js (v6)
+      if: inputs.node-action-version == 'v6'
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+        registry-url: "https://registry.npmjs.org"
+
+    - name: Install Node dependencies
+      if: inputs.install-dependencies == 'true'
+      run: pnpm install ${{ inputs.frozen-lockfile == 'true' && '--frozen-lockfile' || '' }}
+      shell: bash

--- a/.github/actions/engine-setup-ruby/action.yml
+++ b/.github/actions/engine-setup-ruby/action.yml
@@ -1,0 +1,16 @@
+name: "Setup Ruby for engine"
+description: "Setup Ruby with optional version selection for engine workflows"
+
+inputs:
+  ruby-version:
+    description: "Ruby version to install"
+    required: false
+    default: "3.4"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}

--- a/.github/actions/engine-setup-rust/action.yml
+++ b/.github/actions/engine-setup-rust/action.yml
@@ -1,5 +1,5 @@
-name: "Setup baml_language Rust"
-description: "Setup the baml_language Rust toolchain with caching and optional WASM support"
+name: "Setup Rust for engine"
+description: "Setup Rust toolchain with caching and optional WASM support for engine workflows"
 
 inputs:
   toolchain:
@@ -25,7 +25,7 @@ inputs:
   workspace:
     description: "Workspace path for Rust cache"
     required: false
-    default: "baml_language"
+    default: "engine"
   prefix-key:
     description: "Cache key prefix for Rust cache"
     required: false

--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -103,7 +103,7 @@ runs:
 
     - name: Setup Node.js
       if: inputs.setup-node == 'true'
-      uses: ./.github/actions/setup-node
+      uses: ./.github/actions/engine-setup-node
       with:
         node-version: ${{ inputs.node-version }}
         pnpm-version: ${{ inputs.pnpm-version }}
@@ -112,7 +112,7 @@ runs:
 
     - name: Setup Rust
       if: inputs.setup-rust == 'true'
-      uses: ./.github/actions/setup-rust
+      uses: ./.github/actions/engine-setup-rust
       with:
         toolchain: ${{ inputs.rust-toolchain }}
         enable-wasm: ${{ inputs.rust-enable-wasm }}

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: ${{ matrix._.target }}
           enable-cache: false

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -107,12 +107,12 @@ jobs:
 
       # Setup using standardized actions
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: v6
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: ${{ matrix._.target }}
           prefix-key: v5-rust-${{ matrix._.target }}

--- a/.github/workflows/build-vscode-release.reusable.yaml
+++ b/.github/workflows/build-vscode-release.reusable.yaml
@@ -55,12 +55,12 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: 'v6'
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: true
 

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -78,12 +78,12 @@ jobs:
           key: ollama-${{ matrix._.runs-on }}
 
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: 'v6'
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
 
       - name: Setup Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -177,7 +177,7 @@ jobs:
       # Setup Rust for Rust checks
       - name: Setup Rust
         if: contains(matrix.check, 'rust')
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: ${{ matrix.check == 'rust-lint-wasm' && 'true' || 'false' }}
 
@@ -228,13 +228,13 @@ jobs:
 
       # Setup Node.js for TypeScript lint
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: "v6"
 
       # Setup Rust for Rust checks
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: true
 
@@ -257,7 +257,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: wasm32-unknown-unknown
           enable-wasm: true
@@ -279,12 +279,12 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: "v6"
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           enable-wasm: false
           enable-cross: false
@@ -339,14 +339,14 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
       - name: Setup Node.js
         if: matrix.test-suite == 'python-integration'
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: "v6"
 
@@ -357,7 +357,7 @@ jobs:
 
       - name: Setup Ruby
         if: matrix.test-suite == 'rust-unit'
-        uses: ./.github/actions/setup-ruby
+        uses: ./.github/actions/engine-setup-ruby
 
       - name: Run Rust unit tests
         if: matrix.test-suite == 'rust-unit'
@@ -422,7 +422,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,7 +354,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: "v6"
           node-version: latest
@@ -452,7 +452,7 @@ jobs:
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: "v6"
           install-dependencies: false
@@ -480,7 +480,7 @@ jobs:
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
       - name: Setup Node.js
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/engine-setup-node
         with:
           node-action-version: "v6"
           install-dependencies: false

--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: ./.github/actions/engine-setup-rust
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -40,7 +40,7 @@ jobs:
           cache: "false"
 
       - name: Setup Ruby
-        uses: ./.github/actions/setup-ruby
+        uses: ./.github/actions/engine-setup-ruby
       
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/test-rust-sdk.yml
+++ b/.github/workflows/test-rust-sdk.yml
@@ -11,7 +11,6 @@ on:
       - "engine/**/*.rs"
       - "engine/**/*.proto"
       - ".github/actions/setup-protoc/**"
-      - ".github/actions/setup-rust/**"
       - ".github/workflows/test-rust-sdk.yml"
   push:
     branches: [canary]
@@ -20,7 +19,6 @@ on:
       - "engine/**/*.rs"
       - "engine/**/*.proto"
       - ".github/actions/setup-protoc/**"
-      - ".github/actions/setup-rust/**"
       - ".github/workflows/test-rust-sdk.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated setup actions for Node.js, Rust, and Ruby workflows.
  * Added configurable Rust support for WebAssembly, cross-compilation, caching, targets, and Protoc.
  * Added configurable Node.js and pnpm installation, dependency management, and caching options.

* **Documentation**
  * Updated setup action guidance and examples to distinguish language and legacy engine workflows.
  * Documented the new engine-specific actions and updated workflow configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->