### PR TITLE
Bind Java publish jobs to the Infisical-synced release environment

### DIFF
--- a/.github/workflows/publish-gradle-plugin-manual.yml
+++ b/.github/workflows/publish-gradle-plugin-manual.yml
@@ -11,8 +11,11 @@ name: Publish Gradle Plugin (manual)
 # canary/stable publishing is automated by the publish-gradle-plugin job there;
 # nightlies ride Maven Central instead (the Portal is stable-channels-only).
 #
-# Requires the org secrets GRADLE_PUBLISH_KEY / GRADLE_PUBLISH_SECRET (the Portal
-# API key + secret), which com.gradle.plugin-publish reads natively.
+# Requires GRADLE_PUBLISH_KEY / GRADLE_PUBLISH_SECRET (the Portal API key +
+# secret), which com.gradle.plugin-publish reads natively. They live in
+# Infisical (boundary-tools → gh-baml-language-release) and are synced into the
+# infisical-github-baml-language-release GitHub Environment, so the job binds
+# to that Environment rather than reading repository secrets.
 
 on:
   workflow_dispatch:
@@ -42,6 +45,7 @@ jobs:
   publish:
     name: Publish com.boundaryml.baml to the Portal
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -798,7 +798,13 @@ jobs:
     # dedicated publish-gradle-plugin job additionally pushes canary/stable cuts
     # to the Portal. Per-coordinate idempotency lets either family be (re)published
     # independently when only one is missing from Central.
+    #
+    # The MAVEN_CENTRAL_* secrets (Central Portal user token + the CI signing
+    # key/passphrase) live in Infisical (boundary-tools →
+    # gh-baml-language-release) and are synced into this GitHub Environment —
+    # they are not repository secrets, so the job must bind to it to see them.
     runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
     permissions:
       contents: read
     steps:
@@ -1020,6 +1026,9 @@ jobs:
     # mavenCentral() to pluginManagement to resolve the plugin from there).
     if: ${{ needs.plan.outputs.dry_run == 'false' && needs.plan.outputs.source_branch == 'canary' && needs.plan.outputs.channel != 'nightly' }}
     runs-on: ubuntu-latest
+    # GRADLE_PUBLISH_KEY / GRADLE_PUBLISH_SECRET are Infisical-synced Environment
+    # secrets (see publish-maven), not repository secrets.
+    environment: infisical-github-baml-language-release
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
The Maven Central and Gradle Plugin Portal secrets were among the repository secrets deleted in [B-1672](https://linear.app/boundaryml2/issue/B-1672/incident-reissue-accidentally-deleted-boundarymlbaml-actions-secrets). Their replacements live in Infisical (`boundary-tools` → `gh-baml-language-release`) and sync into the `infisical-github-baml-language-release` GitHub Environment, which jobs only see when they declare it ([B-1675](https://linear.app/boundaryml2/issue/B-1675/populate-maven-central-and-gradle-release-secrets-in-infisical)).

- `publish-maven`, `publish-gradle-plugin` (release-baml-language.yml) and the manual Gradle Portal publish now bind to that Environment, like the Go/Swift/Homebrew publishers already do.
- No secret names or Gradle-facing env vars change.

https://claude.ai/code/session_01UgZNNtK5bk4N5Vf2BuetfH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release publishing workflows to use the designated GitHub Environment for Maven Central and Gradle Plugin Portal credentials.
  * Documented the credential sources used during automated and manual plugin publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->