### PR TITLE
Let runtime-compiled code implement and call methods of mounted types

### DIFF
--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3790,7 +3790,11 @@ impl<'db> LoweringContext<'db> {
         method: &Name,
     ) -> Option<InterfaceTypeView> {
         // Only concrete receivers — interfaces/type-vars dispatch via the
-        // arms above. Containers are concrete too (`implements<T> I for T[]`).
+        // arms above. Containers are concrete too (`implements<T> I for T[]`),
+        // and so is a reflected type value (`reflect.Type` is its canonical
+        // class: `implement baml.ToString for reflect.Type` provides its
+        // `to_string`, and a runtime compile — with no stdlib source to
+        // devirtualize against — can reach that body only by dispatching).
         if !matches!(
             recv_ty,
             Tir2Ty::Class(..)
@@ -3802,6 +3806,7 @@ impl<'db> LoweringContext<'db> {
                 | Tir2Ty::Null { .. }
                 | Tir2Ty::Uint8Array { .. }
                 | Tir2Ty::Media(..)
+                | Tir2Ty::Type { .. }
                 | Tir2Ty::List(..)
                 | Tir2Ty::Map { .. }
                 | Tir2Ty::Future(..)

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_type_args_at_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_type_args_at_runtime/bytecode.snap
@@ -78,7 +78,11 @@ function class_type_args_at_runtime.$init_test_ns_class_type_args_at_runtime_cla
 
 function class_type_args_at_runtime.Box.describe(self: class_type_args_at_runtime.Box<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_frames/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_frames/bytecode.snap
@@ -29,13 +29,21 @@ function dispatch_frames.$init_test_ns_dispatch_frames_dispatch_frames(registry:
 
 function dispatch_frames.<(user.dispatch_frames.Box<#0> as user.dispatch_frames.Tagged)>.tag(self: dispatch_frames.Box<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
 function dispatch_frames.Conv.describe(self: dispatch_frames.Conv<#1>) -> string {
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_matrix/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_matrix/bytecode.snap
@@ -133,7 +133,9 @@ function dispatch_matrix.<(user.dispatch_matrix.Loud as user.dispatch_matrix.Spe
 
 function dispatch_matrix.<(user.dispatch_matrix.Pack<#0> as user.dispatch_matrix.Speaker)>.speak(self: dispatch_matrix.Pack<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _2
     load_const "pack of "
     load_var _2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
@@ -192,11 +192,15 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     store_var sig
     load_var sig
     load_field .returns
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_var sig
     load_field .errors
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _7
     load_var sig
     load_field .args
@@ -238,7 +242,9 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     store_var _19
     load_var arg
     load_field .type
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _22
     load_var2 11 12
     bin_op +
@@ -287,7 +293,9 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     store_var _41
     load_var opt
     load_field .1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _44
     load_var2 17 18
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/mir.snap
@@ -83,9 +83,9 @@ fn user.fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Ret
     let _3: string // parts
     let _4: string
     let _5: string
-    let _6: (reflect.Type) -> string throws never
+    let _6: reflect.Type
     let _7: string
-    let _8: (reflect.Type) -> string throws never
+    let _8: reflect.Type
     let _9: string
     let _10: int
     let _11: (reflect.Arg[]) -> int throws never
@@ -100,7 +100,7 @@ fn user.fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Ret
     let _20: string
     let _21: string
     let _22: string
-    let _23: (reflect.Type) -> string throws never
+    let _23: reflect.Type
     let _24: string[]
     let _25: (map<string, reflect.Arg>) -> string[] throws never
     let _26: reflect.Type
@@ -122,7 +122,7 @@ fn user.fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Ret
     let _42: string
     let _43: string
     let _44: string
-    let _45: (reflect.Type) -> string throws never
+    let _45: reflect.Type
 
     bb0: {
         _2 = call const fn reflect.signature(copy _1) -> [bb1];
@@ -130,12 +130,12 @@ fn user.fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Ret
 
     bb1: {
         _6 = copy _2.3;
-        _5 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _6) -> [bb2];
+        _5 = virtual_call to_string as baml.ToString(copy _6) -> [bb2];
     }
 
     bb2: {
         _8 = copy _2.4;
-        _7 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _8) -> [bb3];
+        _7 = virtual_call to_string as baml.ToString(copy _8) -> [bb3];
     }
 
     bb3: {
@@ -173,7 +173,7 @@ fn user.fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Ret
         _21 = copy _18.0;
         _19 = copy _20 + copy _21;
         _23 = copy _18.1;
-        _22 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _23) -> [bb9];
+        _22 = virtual_call to_string as baml.ToString(copy _23) -> [bb9];
     }
 
     bb9: {
@@ -227,7 +227,7 @@ fn user.fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Ret
         _43 = copy _32;
         _41 = copy _42 + copy _43;
         _45 = copy _33.1;
-        _44 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _45) -> [bb18];
+        _44 = virtual_call to_string as baml.ToString(copy _45) -> [bb18];
     }
 
     bb18: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/bytecode.snap
@@ -52,7 +52,11 @@ function fixtures.reflect_shadowing.package_still_reachable() -> string {
     load_const user.fixtures.reflect_shadowing.helper
     call reflect.signature
     load_field .returns
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/mir.snap
@@ -211,7 +211,7 @@ fn user.fixtures.reflect_shadowing.package_still_reachable() -> string {
     let _1: reflect.AnyFunction<Returns = unknown, Throws = unknown> // f
     let _2: reflect.Signature // sig
     let _3: reflect.AnyFunction<Returns = unknown, Throws = unknown>
-    let _4: (reflect.Type) -> string throws never
+    let _4: reflect.Type
 
     bb0: {
         _1 = const fn user.fixtures.reflect_shadowing.helper;
@@ -221,7 +221,7 @@ fn user.fixtures.reflect_shadowing.package_still_reachable() -> string {
 
     bb1: {
         _4 = copy _2.3;
-        _0 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _4) -> [bb2];
+        _0 = virtual_call to_string as baml.ToString(copy _4) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_inferred_generic_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_inferred_generic_type_args/bytecode.snap
@@ -219,7 +219,11 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.PlainThing
 
 function inferred_generic_type_args.<(user.inferred_generic_type_args.ProbeA as user.inferred_generic_type_args.TypeProbe)>.seen(self: inferred_generic_type_args.ProbeA, value: #0) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -249,7 +253,11 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.StrCounter
 
 function inferred_generic_type_args.<(user.inferred_generic_type_args.TypedBox<#0> as user.inferred_generic_type_args.Describable)>.describe(self: inferred_generic_type_args.TypedBox<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -279,7 +287,11 @@ function inferred_generic_type_args.ArrayCursor.of(items: #0[]) -> inferred_gene
 
 function inferred_generic_type_args.Counter.element_type(self: inferred_generic_type_args.Counter<#1>) -> string {
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -304,7 +316,11 @@ function inferred_generic_type_args.Dog.make(v: #0) -> inferred_generic_type_arg
 
 function inferred_generic_type_args.Named.tname(self: inferred_generic_type_args.Named<#1>) -> string {
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -407,7 +423,11 @@ function inferred_generic_type_args.default_method_typevar_name() -> string {
 
 function inferred_generic_type_args.echo_type(a: #0) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -424,7 +444,11 @@ function inferred_generic_type_args.free_fn_inferred_t() -> string {
 
 function inferred_generic_type_args.free_fn_tname(a: #0[]) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/bytecode.snap
@@ -108,7 +108,11 @@ function instantiation_expr.bound_method_value() -> int {
 
 function instantiation_expr.describe() -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/ns_qualified/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/ns_qualified/bytecode.snap
@@ -3,7 +3,11 @@ source: crates/baml_tests/src/corpus.rs
 ---
 function instantiation_expr.qualified.q_describe() -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
@@ -1795,10 +1795,14 @@ function interfaces.<(user.interfaces.GimpEchoer as user.interfaces.GimpEcho<int
 
 function interfaces.<(user.interfaces.GoopBox<#0> as user.interfaces.GoopDescriber<#0>)>.describe(self: interfaces.GoopBox<#0>, value: #1) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _4
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _6
     load_var _4
     load_const ":"
@@ -4698,7 +4702,11 @@ function interfaces.ritv_main() -> bool {
 
 function interfaces.rtit_main() -> string {
     load_type interfaces.RtitAnimal
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -5436,10 +5444,14 @@ function interfaces.w306_main() -> string {
 
 function interfaces.w306_names() -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var naked
     load_type interfaces.W306Box<#0>
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var wrapped
     load_const "naked="
     load_var naked

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_item_projections/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_item_projections/bytecode.snap
@@ -219,7 +219,9 @@ function item_projections.<(user.item_projections.Loud as user.item_projections.
 
 function item_projections.<(user.item_projections.Plate<#0> as user.item_projections.Embosser)>.emboss(u: #1) -> string {
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _2
     load_const "emboss "
     load_var _2
@@ -260,7 +262,9 @@ function item_projections.<(user.item_projections.Poly as user.item_projections.
 
 function item_projections.<(user.item_projections.Press as user.item_projections.Stamper)>.emboss(u: #0) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _2
     load_const "emboss "
     load_var _2
@@ -270,7 +274,9 @@ function item_projections.<(user.item_projections.Press as user.item_projections
 
 function item_projections.<(user.item_projections.Press as user.item_projections.Stamper)>.stamp(self: item_projections.Press, u: #0) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _3
     load_const "stamp "
     load_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_lambdas/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_lambdas/bytecode.snap
@@ -484,11 +484,15 @@ function lambdas.lambdas_inferred_signature() -> string {
     store_var sig
     load_var sig
     load_field .returns
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_var sig
     load_field .errors
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _7
     load_var _5
     load_const "/"
@@ -504,11 +508,15 @@ function lambdas.lambdas_inferred_throwing_signature() -> string {
     store_var sig
     load_var sig
     load_field .returns
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_var sig
     load_field .errors
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _7
     load_var _5
     load_const "/"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
@@ -106,7 +106,9 @@ function optional_chain_type_args.$init_test_ns_optional_chain_type_args_optiona
 
 function optional_chain_type_args.<(user.optional_chain_type_args.Cat as user.optional_chain_type_args.Speaker)>.speak(self: optional_chain_type_args.Cat) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _2
     load_const "cat:"
     load_var _2
@@ -116,16 +118,24 @@ function optional_chain_type_args.<(user.optional_chain_type_args.Cat as user.op
 
 function optional_chain_type_args.<(user.optional_chain_type_args.Dog as user.optional_chain_type_args.Speaker)>.speak(self: optional_chain_type_args.Dog) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
 function optional_chain_type_args.<(user.optional_chain_type_args.Pair<#0> as user.optional_chain_type_args.Tagged)>.tag(self: optional_chain_type_args.Pair<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _3
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_var _3
     load_const "/"
@@ -137,10 +147,14 @@ function optional_chain_type_args.<(user.optional_chain_type_args.Pair<#0> as us
 
 function optional_chain_type_args.Boxed.both(self: optional_chain_type_args.Boxed<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _3
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_var _3
     load_const "/"
@@ -152,7 +166,11 @@ function optional_chain_type_args.Boxed.both(self: optional_chain_type_args.Boxe
 
 function optional_chain_type_args.Boxed.describe(self: optional_chain_type_args.Boxed<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -169,7 +187,11 @@ function optional_chain_type_args.Callables.method(self: optional_chain_type_arg
 
 function optional_chain_type_args.Holder.ident(self: optional_chain_type_args.Holder, v: #0) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -193,7 +215,11 @@ function optional_chain_type_args.Holder.plain(self: optional_chain_type_args.Ho
 
 function optional_chain_type_args.Holder.value(self: optional_chain_type_args.Holder) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_projection_patterns/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_projection_patterns/bytecode.snap
@@ -207,7 +207,11 @@ function projection_patterns.Labeled.is_label(self: projection_patterns.Labeled,
 
 function projection_patterns.Labeled.label_name(self: projection_patterns.Labeled) -> string {
     load_type (#0 as projection_patterns.Labeled).Label
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_reflect_type_of_generic/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_reflect_type_of_generic/bytecode.snap
@@ -141,7 +141,11 @@ function reflect_type_of_generic.$init_test_ns_reflect_type_of_generic_reflect_t
 
 function reflect_type_of_generic.Box.describe(self: reflect_type_of_generic.Box<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -155,19 +159,31 @@ function reflect_type_of_generic.HolderStr.delegate(self: reflect_type_of_generi
 
 function reflect_type_of_generic.Inner.name(self: reflect_type_of_generic.Inner<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
 function reflect_type_of_generic.InnerShow.show(self: reflect_type_of_generic.InnerShow<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
 function reflect_type_of_generic.Leaf.describe(self: reflect_type_of_generic.Leaf<#0>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -187,14 +203,22 @@ function reflect_type_of_generic.array_of() -> reflect.Type {
 function reflect_type_of_generic.array_of_int_fn() -> string {
     load_type int
     call user.reflect_type_of_generic.array_of
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
 function reflect_type_of_generic.array_of_user_to_string_fn() -> string {
     load_type reflect_type_of_generic.User
     call user.reflect_type_of_generic.array_of
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -228,7 +252,11 @@ function reflect_type_of_generic.closure_captures_type_arg_user_fn() -> string {
 
 function reflect_type_of_generic.describe() -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -300,7 +328,11 @@ function reflect_type_of_generic.level1() -> reflect.Type {
 
 function reflect_type_of_generic.level1_str() -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_leaf_narrowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_leaf_narrowing/bytecode.snap
@@ -99,7 +99,9 @@ function runtime_leaf_narrowing.classify_type_runtime_value(value: reflect.Type 
 
   L1:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
 
   L2:
     return
@@ -119,7 +121,9 @@ function runtime_leaf_narrowing.if_let_binds_type_runtime_value() -> string {
 
   L1:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
 
   L2:
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_self_frame_slot/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_self_frame_slot/bytecode.snap
@@ -198,7 +198,11 @@ function self_frame_slot.<(#0[] as user.self_frame_slot.Marked)>.mark(self: #0[]
 
 function self_frame_slot.<(#0[] as user.self_frame_slot.Marked)>.type_name(self: #0[]) -> string {
     load_type #0[]
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -226,7 +230,11 @@ function self_frame_slot.<(int as user.self_frame_slot.Marked)>.mark(self: int) 
 
 function self_frame_slot.<(int as user.self_frame_slot.Marked)>.type_name(self: int) -> string {
     load_type int
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -254,7 +262,11 @@ function self_frame_slot.<(user.self_frame_slot.Crate<#0> as user.self_frame_slo
 
 function self_frame_slot.<(user.self_frame_slot.Crate<#0> as user.self_frame_slot.Marked)>.type_name(self: self_frame_slot.Crate<#0>) -> string {
     load_type self_frame_slot.Crate<#0>
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -282,7 +294,11 @@ function self_frame_slot.<(user.self_frame_slot.Croc as user.self_frame_slot.Mar
 
 function self_frame_slot.<(user.self_frame_slot.Croc as user.self_frame_slot.Marked)>.type_name(self: self_frame_slot.Croc) -> string {
     load_type self_frame_slot.Croc
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -300,7 +316,11 @@ function self_frame_slot.<(user.self_frame_slot.IntShelf as user.self_frame_slot
 
 function self_frame_slot.Kinded.kind_name(self: self_frame_slot.Kinded) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 
@@ -365,13 +385,19 @@ function self_frame_slot.Kinded.same_kind_of(self: self_frame_slot.Kinded, other
 
 function self_frame_slot.Store.describe(self: self_frame_slot.Store<#1>) -> string {
     load_type #0
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_type #1
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _7
     load_type (#0 as self_frame_slot.Store<#1>).Key
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _9
     load_var _5
     load_const "/"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_value_narrowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_value_narrowing/bytecode.snap
@@ -324,7 +324,9 @@ function type_value_narrowing.optional_type_absent() -> string {
     call baml.String.from
     store_var _7
     load_var t
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _11
     load_type string
     load_var _11
@@ -381,7 +383,9 @@ function type_value_narrowing.optional_type_present() -> string {
     call baml.String.from
     store_var _7
     load_var t
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _11
     load_type string
     load_var _11
@@ -441,7 +445,9 @@ function type_value_narrowing.render_mixed_list() -> string {
 
   L3:
     load_var _12
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _14
     load_type string
     load_var2 1 6
@@ -653,7 +659,9 @@ function type_value_narrowing.type_to_string_after_narrowing() -> string {
 
   L1:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
 
   L2:
     return
@@ -769,7 +777,9 @@ function type_value_narrowing.union_if_let_int() -> string {
 
   L1:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_type string
     load_var _5
@@ -797,7 +807,9 @@ function type_value_narrowing.union_if_let_type() -> string {
 
   L1:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_type string
     load_var _5
@@ -821,7 +833,9 @@ function type_value_narrowing.union_match_int_first(v: reflect.Type | int) -> st
 
   L0:
     load_var v
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _9
     load_type string
     load_var _9
@@ -865,7 +879,9 @@ function type_value_narrowing.union_match_type_first(v: reflect.Type | int) -> s
 
   L1:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_type string
     load_var _5
@@ -917,7 +933,9 @@ function type_value_narrowing.union_three_way(v: reflect.Type | int | string) ->
 
   L3:
     load_var _2
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _5
     load_type string
     load_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -969,7 +969,9 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     call baml.String.from
     store_var _83
     load_var t
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _87
     load_type string
     load_var _87
@@ -1073,7 +1075,9 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
 
   L16:
     load_var t
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _42
     load_type string
     load_var _42
@@ -1152,7 +1156,9 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     call baml.String.from
     store_var _111
     load_var t
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _115
     load_type string
     load_var _115
@@ -6648,7 +6654,9 @@ function ai.internal.validate_output_type(return_type: reflect.Type) -> void {
 
   L4:
     load_var return_type
-    call baml.<(reflect.Type as baml.ToString)>.to_string
+    load_type baml.ToString
+    load_const "to_string"
+    virtual_call nargs=1 ntypeargs=0
     store_var _11
     load_const "empty enum `"
     load_var _11

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
@@ -6086,7 +6086,7 @@ fn ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     }
 
     bb9: {
-        _11 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _1) -> [bb10];
+        _11 = virtual_call to_string as baml.ToString(copy _1) -> [bb10];
     }
 
     bb10: {
@@ -11977,7 +11977,7 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     bb24: {
         _82 = const "Expected zero or one " + copy _83;
         _81 = copy _82 + const " output for ";
-        _87 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _4) -> [bb25];
+        _87 = virtual_call to_string as baml.ToString(copy _4) -> [bb25];
     }
 
     bb25: {
@@ -12087,7 +12087,7 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     }
 
     bb44: {
-        _42 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _4) -> [bb45];
+        _42 = virtual_call to_string as baml.ToString(copy _4) -> [bb45];
     }
 
     bb45: {
@@ -12179,7 +12179,7 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     bb61: {
         _110 = const "the " + copy _111;
         _109 = copy _110 + const " output did not fit ";
-        _115 = call const fn baml.<(reflect.Type as baml.ToString)>.to_string(copy _4) -> [bb62];
+        _115 = virtual_call to_string as baml.ToString(copy _4) -> [bb62];
     }
 
     bb62: {

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -132,6 +132,144 @@ class Broken { value MissingType }
 }
 "####;
 
+/// A host contract crossing a `Package.compile` mount in every method shape:
+/// a method-bearing interface the runtime-compiled source implements, and
+/// the host's inherent, static, `implements`-block, out-of-body, and default
+/// methods called from the runtime-compiled source.
+const MOUNTED_METHODS_SOURCE: &str = r####"
+interface Describable {
+  function describe(self) -> string throws never
+  function shout(self) -> string throws never { self.describe().to_upper_case() }
+}
+
+class Host {
+  name string
+  function greet(self, punct: string) -> string throws never { "hi " + self.name + punct }
+  function make(name: string) -> Host throws never { Host { name: name } }
+  implements Describable {
+    function describe(self) -> string throws never { "host<" + self.name + ">" }
+  }
+}
+
+class Other { id int }
+implement Describable for Other {
+  function describe(self) -> string throws never { "other#" + self.id.to_string() }
+}
+
+function describe_all(items: Describable[]) -> string throws never {
+  let out = ""
+  for (let item in items) { out = out + item.describe() + ";" }
+  out
+}
+
+function compile_plugin() -> reflect.Package {
+  reflect.Package.compile(
+    { "plugin.baml": `
+class Widget { name string }
+
+implement app.Describable for Widget {
+  function describe(self) -> string throws never { "widget<" + self.name + ">" }
+}
+
+function make_widget(name: string) -> Widget throws never { Widget { name: name } }
+function call_host_inherent(h: app.Host) -> string throws never { h.greet("!") }
+function call_host_static(name: string) -> string throws never { app.Host.make(name).greet("?") }
+function call_host_impl_block(h: app.Host) -> string throws never { h.describe() }
+function call_host_default(h: app.Host) -> string throws never { h.shout() }
+function call_other_out_of_body(o: app.Other) -> string throws never { o.describe() }
+function existential(d: app.Describable) -> string throws never { d.describe() }
+function pass_through(items: app.Describable[]) -> string throws never { app.describe_all(items) }
+` },
+    packages = { "app": reflect.Package.current() },
+  )
+}
+
+function mount_is_clean() -> bool {
+  compile_plugin().diagnostics().length() == 0
+}
+
+function main() -> string {
+  let pkg = compile_plugin()
+  let make_widget = pkg.get_function<(string) -> Describable>("root.make_widget")
+    ?? throw "missing make_widget"
+  let inherent = pkg.get_function<(Host) -> string>("root.call_host_inherent")
+    ?? throw "missing call_host_inherent"
+  let static_ = pkg.get_function<(string) -> string>("root.call_host_static")
+    ?? throw "missing call_host_static"
+  let impl_block = pkg.get_function<(Host) -> string>("root.call_host_impl_block")
+    ?? throw "missing call_host_impl_block"
+  let dflt = pkg.get_function<(Host) -> string>("root.call_host_default")
+    ?? throw "missing call_host_default"
+  let out_of_body = pkg.get_function<(Other) -> string>("root.call_other_out_of_body")
+    ?? throw "missing call_other_out_of_body"
+  let existential = pkg.get_function<(Describable) -> string>("root.existential")
+    ?? throw "missing existential"
+  let pass_through = pkg.get_function<(Describable[]) -> string>("root.pass_through")
+    ?? throw "missing pass_through"
+  let w = make_widget("w1")
+  let h = Host { name: "h" }
+  let parts = [
+    w.describe(),
+    w.shout(),
+    describe_all([w, h, Other { id: 7 }]),
+    inherent(h),
+    static_("s"),
+    impl_block(h),
+    dflt(h),
+    out_of_body(Other { id: 3 }),
+    existential(w),
+    pass_through([w, h]),
+  ]
+  let out = ""
+  for (let part in parts) { out = out + part + "|" }
+  out
+}
+"####;
+
+/// A method-bearing host interface is implementable across a mount, and
+/// every host method shape is callable from the runtime-compiled source.
+#[tokio::test]
+async fn method_bearing_interface_crosses_a_mount() {
+    let output = baml_test!(baml: MOUNTED_METHODS_SOURCE);
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String(
+            "widget<w1>|WIDGET<W1>|widget<w1>;host<h>;other#7;|hi h!|hi s?|host<h>|HOST<H>|\
+             other#3|widget<w1>|widget<w1>;host<h>;|"
+                .into()
+        ))
+    );
+}
+
+/// The mount's link stubs spell methods inside their owner's body, so no
+/// `ns_<Type>/` stub namespace shadows the type it belongs to (E0099).
+#[tokio::test]
+async fn mounted_method_stubs_do_not_shadow_their_owner() {
+    let output = baml_test!(baml: MOUNTED_METHODS_SOURCE, entry: "mount_is_clean");
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// `baml.ToString` is implemented for `reflect.Type` out-of-body in the
+/// stdlib. A runtime compile has no stdlib source to devirtualize that call
+/// against, so it must dispatch — it used to reach the emitter as a static
+/// call to an interface body it could not name and panic the compiler.
+#[tokio::test]
+async fn runtime_compiled_to_string_on_a_reflected_type_dispatches() {
+    let output = baml_test!(
+        r####"
+function main() -> string {
+  let pkg = reflect.Package.compile({ "u.baml": `
+class C {}
+function render() -> string { reflect.Type.of_value(C {}).to_string() }
+` })
+  let render = pkg.get_function<() -> string>("root.render") ?? throw "missing render"
+  render()
+}
+"####
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::String("C".into())));
+}
+
 #[tokio::test]
 async fn package_finish_refuses_session_compile_artifact() {
     let output = baml_test!(

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -2472,7 +2472,7 @@ mod tests {
     fn runtime_mount_stubs_spell_methods_inside_their_owner() {
         use baml_compiler2_hir_ty::{
             callable::{ExternalCallTarget, ExternalLinkability},
-            package_interface::{ExportedFunction, ExportedType},
+            package_interface::{ExportedFieldAttrs, ExportedFunction, ExportedType},
         };
         use baml_type::{FunctionParamTy, ParamTy, Ty, TyAttr};
 
@@ -2511,7 +2511,11 @@ mod tests {
             Name::new("Host"),
             ExportedType::Class {
                 qtn: class_qtn,
-                fields: vec![(Name::new("name"), Ty::string(), Default::default())],
+                fields: vec![(
+                    Name::new("name"),
+                    Ty::string(),
+                    ExportedFieldAttrs::default(),
+                )],
                 methods: vec![
                     function(
                         "greet",
@@ -2537,7 +2541,7 @@ mod tests {
                         )],
                         None,
                         ExternalCallTarget::Method {
-                            package: app.clone(),
+                            package: app,
                             namespace: Vec::new(),
                             class: Name::new("Host"),
                             name: Name::new("make"),

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -178,9 +178,12 @@ fn enrich_runtime_mount(
     aliases: &[Name],
     mut package: RuntimePackageMount,
 ) -> Result<EnrichedRuntimeMount, RuntimeCompileDiagnostic> {
-    use baml_compiler2_hir_ty::package_interface::{
-        ExportedFieldAttrs, ExportedFunction, ExportedImpl, ExportedImplOrigin, ExportedType,
-        PackageInterface,
+    use baml_compiler2_hir_ty::{
+        callable::ExternalCallTarget,
+        package_interface::{
+            ExportedFieldAttrs, ExportedFunction, ExportedImpl, ExportedImplOrigin, ExportedType,
+            PackageInterface,
+        },
     };
 
     fn source_identifier(name: &Name) -> bool {
@@ -229,14 +232,7 @@ fn enrich_runtime_mount(
         }
     }
 
-    fn relocate_function(
-        function: &mut ExportedFunction,
-        alias: &Name,
-        viewpoint: &StubViewpoint<'_>,
-        stubs: &mut Vec<(Vec<Name>, Name, String)>,
-    ) {
-        use baml_compiler2_hir_ty::callable::{ExternalCallTarget, ExternalLinkability};
-
+    fn relocate_function(function: &mut ExportedFunction, alias: &Name) {
         for param in &mut function.params {
             *param = param.map_heads(&mut |name| relocated_name(name, alias));
         }
@@ -247,59 +243,128 @@ fn enrich_runtime_mount(
         relocate_ty(&mut function.callable_throws, alias);
         relocate_bounds(&mut function.generic_param_bounds, alias);
 
-        if !matches!(function.linkability, ExternalLinkability::Linkable) {
-            return;
-        }
-        let (namespace, name) = match &mut function.target {
-            ExternalCallTarget::Free {
-                package,
-                namespace,
-                name,
-            } => {
+        match &mut function.target {
+            ExternalCallTarget::Free { package, .. }
+            | ExternalCallTarget::Method { package, .. } => {
                 *package = alias.clone();
-                (namespace.clone(), name.clone())
             }
-            ExternalCallTarget::Method {
-                package,
-                namespace,
-                class,
-                name,
-            } => {
-                *package = alias.clone();
-                let mut target_namespace = namespace.clone();
-                target_namespace.push(class.clone());
-                (target_namespace, name.clone())
-            }
-            ExternalCallTarget::Interface { interface, method } => {
-                let mut target_namespace = interface.namespace().clone();
-                target_namespace.push(interface.name().clone());
+            ExternalCallTarget::Interface { interface, .. } => {
                 *interface = baml_type::QualifiedTypeName::new(
                     alias.clone(),
                     interface.namespace().clone(),
                     interface.name().clone(),
                 );
-                (target_namespace, method.clone())
             }
-        };
-        // Compiler-generated init/test helpers and callable companions are not
-        // authored declarations. The mounted interface already exports their
-        // exact callable identities; emitting either spelling as a source stub
-        // is invalid (`$init`) or would redeclare the authored function
-        // (`Extract@spec` is postfix syntax, not a declaration identifier).
-        if name.as_str().starts_with('$') || name.as_str().contains('@') {
-            return;
         }
-        let generic_params = function
+    }
+
+    /// Whether `function` is an authored, linkable declaration a source stub
+    /// may spell. Compiler-generated init/test helpers and callable
+    /// companions are not authored declarations: the mounted interface
+    /// already exports their exact callable identities; emitting either
+    /// spelling as a source stub is invalid (`$init`) or would redeclare the
+    /// authored function (`Extract@spec` is postfix syntax, not a declaration
+    /// identifier).
+    fn stubbable(function: &ExportedFunction) -> bool {
+        use baml_compiler2_hir_ty::callable::ExternalLinkability;
+
+        matches!(function.linkability, ExternalLinkability::Linkable)
+            && source_identifier(&function.name)
+    }
+
+    fn stub_type(ty: &baml_type::Ty, viewpoint: &StubViewpoint<'_>) -> String {
+        // Hide a type only when its source spelling would name a package this
+        // compile world cannot resolve and so produce diagnostics in a
+        // phantom `runtime_mount_*` file.
+        if viewpoint.hides_type(ty) {
+            "unknown".to_string()
+        } else {
+            ty.to_string()
+        }
+    }
+
+    /// `<T extends A & B, U>` for the function's own generic parameters, or
+    /// the empty string. Bounds are spelled only when `spell_bounds` (a bound
+    /// this world cannot name is dropped rather than widened).
+    fn stub_generics(
+        function: &ExportedFunction,
+        viewpoint: &StubViewpoint<'_>,
+        spell_bounds: bool,
+    ) -> String {
+        let generics = function
             .generic_params
             .iter()
-            .filter(|param| !baml_type::is_synthetic_effect_param(param.name()))
-            .map(ToString::to_string)
+            .enumerate()
+            .filter(|(_, param)| !baml_type::is_synthetic_effect_param(param.name()))
+            .map(|(index, param)| {
+                let bounds = if spell_bounds {
+                    function
+                        .generic_param_bounds
+                        .get(index)
+                        .map(|bounds| {
+                            bounds
+                                .iter()
+                                .filter(|bound| !viewpoint.hides_interface(bound))
+                                .map(|bound| {
+                                    baml_type::Ty::Interface(
+                                        bound.name.clone(),
+                                        bound.generics.clone(),
+                                        bound.associated_types.clone(),
+                                        baml_type::TyAttr::default(),
+                                    )
+                                    .to_string()
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+                if bounds.is_empty() {
+                    param.to_string()
+                } else {
+                    format!("{param} extends {}", bounds.join(" & "))
+                }
+            })
             .collect::<Vec<_>>();
-        let generic_suffix = if generic_params.is_empty() {
+        if generics.is_empty() {
             String::new()
         } else {
-            format!("<{}>", generic_params.join(", "))
+            format!("<{}>", generics.join(", "))
+        }
+    }
+
+    /// The link stub for a free function (or, when its owner has no source
+    /// stub, a method), spelled as a free `$rust_function` under the
+    /// namespace its call target names. The stub preserves only the callable
+    /// identity the emitter slots and the may-throw ABI bit: parameters are
+    /// `unknown`, and named error types retain the dependency package's
+    /// nominal identity in the mounted interface without necessarily being
+    /// source-spellable from this synthetic alias package.
+    fn free_function_stub(
+        function: &ExportedFunction,
+        viewpoint: &StubViewpoint<'_>,
+    ) -> Option<(Vec<Name>, Name, String)> {
+        if !stubbable(function) {
+            return None;
+        }
+        let name = function.name.clone();
+        let namespace = match &function.target {
+            ExternalCallTarget::Free { namespace, .. } => namespace.clone(),
+            ExternalCallTarget::Method {
+                namespace, class, ..
+            } => {
+                let mut namespace = namespace.clone();
+                namespace.push(class.clone());
+                namespace
+            }
+            ExternalCallTarget::Interface { interface, .. } => {
+                let mut namespace = interface.namespace().clone();
+                namespace.push(interface.name().clone());
+                namespace
+            }
         };
+        let generics = stub_generics(function, viewpoint, false);
         let params = function
             .params
             .iter()
@@ -321,25 +386,91 @@ fn enrich_runtime_mount(
         ) {
             String::new()
         } else {
-            // The link stub preserves only the may-throw ABI bit. Named error
-            // types retain the dependency package's nominal identity in the
-            // mounted interface and are not necessarily source-spellable from
-            // this synthetic alias package.
             " throws unknown".to_string()
         };
-        // Mounted inference owns the real return type. Hide it only when its
-        // source spelling would name a package this compile world cannot
-        // resolve and so produce diagnostics in a phantom `runtime_mount_*`
-        // file.
-        let return_type = if viewpoint.hides_type(&function.return_type) {
-            "unknown".to_string()
-        } else {
-            function.return_type.to_string()
-        };
+        // Mounted inference owns the real return type.
+        let return_type = stub_type(&function.return_type, viewpoint);
         let source = format!(
-            "function {name}{generic_suffix}({params}) -> {return_type}{throws} {{ $rust_function }}\n"
+            "function {name}{generics}({params}) -> {return_type}{throws} {{ $rust_function }}\n"
         );
-        stubs.push((namespace, name, source));
+        Some((namespace, name, source))
+    }
+
+    /// How a method stub is spelled inside its owner's stub body.
+    #[derive(Clone, Copy)]
+    enum MethodStubKind {
+        /// A class-inherent method: a `$rust_function` body the emitter slots
+        /// under the class-qualified name the runtime linker resolves.
+        ClassMethod,
+        /// An interface required method: signature only.
+        InterfaceRequired,
+        /// An interface default method: a `$rust_function` body, so a
+        /// consumer implementor that does not override it links to the
+        /// dependency's body.
+        InterfaceDefault,
+    }
+
+    /// The in-body stub line for a method of a mounted class or interface.
+    ///
+    /// Unlike a free link stub this spells the real signature (parameters,
+    /// bounds, declared throws) wherever this world can name it: source-backed
+    /// lookup wins before the mounted interface in HIR, so this stub is the
+    /// method the type checker sees — a consumer `implement` block is checked
+    /// for conformance against it, and a call on a mounted value is typed by
+    /// it.
+    fn method_stub(
+        function: &ExportedFunction,
+        viewpoint: &StubViewpoint<'_>,
+        kind: MethodStubKind,
+    ) -> Option<String> {
+        if !stubbable(function) {
+            return None;
+        }
+        let name = &function.name;
+        let generics = stub_generics(function, viewpoint, true);
+        let params = function
+            .params
+            .iter()
+            .enumerate()
+            .map(|(index, param)| {
+                if index == 0
+                    && param
+                        .name
+                        .as_ref()
+                        .is_some_and(|name| name.as_str() == "self")
+                {
+                    return "self".to_string();
+                }
+                let param_name = param
+                    .name
+                    .as_ref()
+                    .filter(|name| source_identifier(name))
+                    .map_or_else(|| format!("arg{index}"), ToString::to_string);
+                let ty = stub_type(&param.ty, viewpoint);
+                let default = if param.is_optional() { " = null" } else { "" };
+                format!("{param_name}: {ty}{default}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let return_type = stub_type(&function.return_type, viewpoint);
+        let throws = match &function.declared_throws {
+            Some(throws) => format!(" throws {}", stub_type(throws, viewpoint)),
+            None if matches!(
+                function.callable_throws,
+                baml_type::Ty::Never { .. } | baml_type::Ty::Void { .. }
+            ) =>
+            {
+                String::new()
+            }
+            None => " throws unknown".to_string(),
+        };
+        let body = match kind {
+            MethodStubKind::InterfaceRequired => "",
+            MethodStubKind::ClassMethod | MethodStubKind::InterfaceDefault => " { $rust_function }",
+        };
+        Some(format!(
+            "  function {name}{generics}({params}) -> {return_type}{throws}{body}\n"
+        ))
     }
 
     let mut interface = baml_artifact::decode::<PackageInterface>(
@@ -378,7 +509,8 @@ fn enrich_runtime_mount(
         .values_mut()
         .flat_map(|namespace| namespace.values_mut())
     {
-        relocate_function(function, &alias, &viewpoint, &mut stubs);
+        relocate_function(function, &alias);
+        stubs.extend(free_function_stub(function, &viewpoint));
     }
     for (export_namespace, exported_types) in &mut interface.types {
         for (export_name, exported) in exported_types {
@@ -395,16 +527,19 @@ fn enrich_runtime_mount(
                         relocate_ty(ty, &alias);
                     }
                     relocate_bounds(generic_param_bounds, &alias);
+                    for function in methods.iter_mut() {
+                        relocate_function(function, &alias);
+                    }
                     // The emitter needs a concrete class object in the mounted
                     // package's discarded source units so a consumer literal
                     // decomposes to an external object reference. At runtime
                     // that reference is resolved to the dependency's actual
                     // class object, preserving a mounted runtime mint instead
                     // of allocating a structurally-similar local class.
-                    if source_identifier(export_name)
+                    let class_stub = source_identifier(export_name)
                         && export_namespace.iter().all(source_identifier)
-                        && fields.iter().all(|(name, ..)| source_identifier(name))
-                    {
+                        && fields.iter().all(|(name, ..)| source_identifier(name));
+                    if class_stub {
                         let generics = generic_params
                             .iter()
                             .filter(|param| !baml_type::is_synthetic_effect_param(param.name()))
@@ -431,11 +566,28 @@ fn enrich_runtime_mount(
                             writeln!(&mut source, "  {field} {ty}")
                                 .expect("writing to String is infallible");
                         }
+                        // Inherent methods live in the class body: the stub is
+                        // the class the type checker sees, so this is where a
+                        // consumer's `value.method()` finds them, and the
+                        // emitter slots each under the same class-qualified
+                        // name a free stub in a `ns_<Class>/` namespace would
+                        // take — without that namespace shadowing the class.
+                        for method in methods.iter() {
+                            if let ExternalCallTarget::Method { .. } = method.target
+                                && let Some(stub) =
+                                    method_stub(method, &viewpoint, MethodStubKind::ClassMethod)
+                            {
+                                source.push_str(&stub);
+                            }
+                        }
                         source.push_str("}\n");
                         stubs.push((export_namespace.clone(), export_name.clone(), source));
-                    }
-                    for function in methods {
-                        relocate_function(function, &alias, &viewpoint, &mut stubs);
+                    } else {
+                        for method in methods.iter() {
+                            if let ExternalCallTarget::Method { .. } = method.target {
+                                stubs.extend(free_function_stub(method, &viewpoint));
+                            }
+                        }
                     }
                 }
                 ExportedType::Interface {
@@ -464,8 +616,11 @@ fn enrich_runtime_mount(
                     for (_, ty, _) in fields.iter_mut() {
                         relocate_ty(ty, &alias);
                     }
-                    for function in required_methods.iter_mut().chain(default_methods) {
-                        relocate_function(function, &alias, &viewpoint, &mut stubs);
+                    for function in required_methods
+                        .iter_mut()
+                        .chain(default_methods.iter_mut())
+                    {
+                        relocate_function(function, &alias);
                     }
                     let namespace = qtn.namespace().clone();
                     let name = qtn.name().clone();
@@ -500,6 +655,25 @@ fn enrich_runtime_mount(
                         write_docstring(&mut source, attrs.docstring.as_deref(), "  ");
                         writeln!(&mut source, "  {field}: {ty}")
                             .expect("writing to String is infallible");
+                    }
+                    // Methods live in the interface body: a consumer
+                    // `implement` block is checked against this stub, so it
+                    // must declare every required method, and a default body
+                    // is slotted under the interface-qualified name the
+                    // runtime linker resolves to the dependency's body.
+                    for method in required_methods.iter() {
+                        if let Some(stub) =
+                            method_stub(method, &viewpoint, MethodStubKind::InterfaceRequired)
+                        {
+                            source.push_str(&stub);
+                        }
+                    }
+                    for method in default_methods.iter() {
+                        if let Some(stub) =
+                            method_stub(method, &viewpoint, MethodStubKind::InterfaceDefault)
+                        {
+                            source.push_str(&stub);
+                        }
                     }
                     source.push_str("}\n");
                     stubs.push((namespace, name, source));
@@ -536,8 +710,12 @@ fn enrich_runtime_mount(
         if let ExportedImplOrigin::InBodyClass { class_qtn } = &mut implementation.origin {
             *class_qtn = relocated_name(class_qtn, &alias);
         }
+        // Implementation methods are reached by interface dispatch, which the
+        // consumer lowers as a virtual call on the receiver's runtime class:
+        // no source stub is needed, and a free stub under `ns_<Interface>/`
+        // would shadow the interface's own stub.
         for function in &mut implementation.methods {
-            relocate_function(function, &alias, &viewpoint, &mut stubs);
+            relocate_function(function, &alias);
         }
     }
     // Mounted runtime declarations are spelled `alias.<item name>` in this
@@ -2282,6 +2460,166 @@ mod tests {
         assert_eq!(
             runtime_relative_virtual_path(Path::new(RUNTIME_VIRTUAL_ROOT)),
             ""
+        );
+    }
+
+    /// Methods of a mounted class or interface are stubbed inside their
+    /// owner's body — never as free functions under a `ns_<Owner>/` namespace,
+    /// which would shadow the owner's own stub (E0099) and leave the source
+    /// stub the type checker sees without the methods the mounted interface
+    /// exports.
+    #[test]
+    fn runtime_mount_stubs_spell_methods_inside_their_owner() {
+        use baml_compiler2_hir_ty::{
+            callable::{ExternalCallTarget, ExternalLinkability},
+            package_interface::{ExportedFunction, ExportedType},
+        };
+        use baml_type::{FunctionParamTy, ParamTy, Ty, TyAttr};
+
+        let app = Name::new("app");
+        let class_qtn =
+            baml_type::QualifiedTypeName::new(app.clone(), Vec::new(), Name::new("Host"));
+        let iface_qtn =
+            baml_type::QualifiedTypeName::new(app.clone(), Vec::new(), Name::new("Describable"));
+        let self_param = ParamTy::new(0, Name::new("Self"));
+        let self_ty = Ty::TypeVar(self_param.clone(), TyAttr::default());
+        let function = |name: &str,
+                        params: Vec<FunctionParamTy>,
+                        declared_throws: Option<Ty>,
+                        target: ExternalCallTarget| ExportedFunction {
+            name: Name::new(name),
+            params,
+            return_type: Ty::string(),
+            declared_throws,
+            callable_throws: Ty::Never {
+                attr: TyAttr::default(),
+            },
+            generic_params: Vec::new(),
+            generic_param_bounds: Vec::new(),
+            builtin_kind: None,
+            target,
+            linkability: ExternalLinkability::Linkable,
+        };
+        let class_self = FunctionParamTy::required(
+            Some(Name::new("self")),
+            Ty::Class(class_qtn.clone(), Vec::new(), TyAttr::default()),
+        );
+        let interface_self = FunctionParamTy::required(Some(Name::new("self")), self_ty);
+        let mut types = IndexMap::new();
+        let mut root = IndexMap::new();
+        root.insert(
+            Name::new("Host"),
+            ExportedType::Class {
+                qtn: class_qtn,
+                fields: vec![(Name::new("name"), Ty::string(), Default::default())],
+                methods: vec![
+                    function(
+                        "greet",
+                        vec![
+                            class_self,
+                            FunctionParamTy::optional(Some(Name::new("punct")), Ty::string()),
+                        ],
+                        Some(Ty::Never {
+                            attr: TyAttr::default(),
+                        }),
+                        ExternalCallTarget::Method {
+                            package: app.clone(),
+                            namespace: Vec::new(),
+                            class: Name::new("Host"),
+                            name: Name::new("greet"),
+                        },
+                    ),
+                    function(
+                        "make",
+                        vec![FunctionParamTy::required(
+                            Some(Name::new("name")),
+                            Ty::string(),
+                        )],
+                        None,
+                        ExternalCallTarget::Method {
+                            package: app.clone(),
+                            namespace: Vec::new(),
+                            class: Name::new("Host"),
+                            name: Name::new("make"),
+                        },
+                    ),
+                ],
+                generic_params: Vec::new(),
+                generic_param_bounds: Vec::new(),
+            },
+        );
+        root.insert(
+            Name::new("Describable"),
+            ExportedType::Interface {
+                qtn: iface_qtn.clone(),
+                self_param,
+                generic_params: Vec::new(),
+                param_bounds: Vec::new(),
+                requires: Vec::new(),
+                associated_types: Vec::new(),
+                fields: Vec::new(),
+                required_methods: vec![function(
+                    "describe",
+                    vec![interface_self.clone()],
+                    Some(Ty::Never {
+                        attr: TyAttr::default(),
+                    }),
+                    ExternalCallTarget::Interface {
+                        interface: iface_qtn.clone(),
+                        method: Name::new("describe"),
+                    },
+                )],
+                default_methods: vec![function(
+                    "shout",
+                    vec![interface_self],
+                    None,
+                    ExternalCallTarget::Interface {
+                        interface: iface_qtn,
+                        method: Name::new("shout"),
+                    },
+                )],
+            },
+        );
+        types.insert(Vec::new(), root);
+        let interface = PackageInterface {
+            types,
+            functions: IndexMap::new(),
+            throw_sets: FunctionThrowSets::default(),
+            namespaces: std::collections::BTreeSet::default(),
+            impls: Vec::new(),
+        };
+        let interface_blob =
+            baml_artifact::encode(baml_artifact::ArtifactKind::PackageInterface, &interface)
+                .expect("package interface encodes");
+        let package = RuntimePackageMount {
+            interface_blob,
+            types: Vec::new(),
+        };
+
+        let (_, stubs) = enrich_runtime_mount("app", &[Name::new("app")], package)
+            .expect("runtime mount enriches");
+
+        assert!(
+            stubs.iter().all(|(namespace, ..)| namespace.is_empty()),
+            "no stub may open a namespace under the mount: {stubs:?}"
+        );
+        let source_of = |name: &str| {
+            &stubs
+                .iter()
+                .find(|(_, stub, _)| stub.as_str() == name)
+                .unwrap_or_else(|| panic!("missing stub for {name}: {stubs:?}"))
+                .2
+        };
+        assert_eq!(
+            source_of("Host"),
+            "class Host {\n  name string\n  function greet(self, punct: string = null) -> string \
+             throws never { $rust_function }\n  function make(name: string) -> string \
+             { $rust_function }\n}\n"
+        );
+        assert_eq!(
+            source_of("Describable"),
+            "interface Describable {\n  function describe(self) -> string throws never\n  \
+             function shout(self) -> string { $rust_function }\n}\n"
         );
     }
 

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -2463,16 +2463,20 @@ mod tests {
         );
     }
 
-    /// Methods of a mounted class or interface are stubbed inside their
-    /// owner's body — never as free functions under a `ns_<Owner>/` namespace,
-    /// which would shadow the owner's own stub (E0099) and leave the source
-    /// stub the type checker sees without the methods the mounted interface
-    /// exports.
-    #[test]
-    fn runtime_mount_stubs_spell_methods_inside_their_owner() {
+    /// The link stubs a mount emits for a package exporting a class `Host`
+    /// with the given fields and the inherent methods `greet(self, punct?)`
+    /// and `make(name)`, plus an interface `Describable` with the required
+    /// method `describe(self)` and the default method `shout(self)`.
+    fn host_and_describable_stubs(
+        fields: Vec<(
+            Name,
+            baml_type::Ty,
+            baml_compiler2_hir_ty::package_interface::ExportedFieldAttrs,
+        )>,
+    ) -> Vec<(Vec<Name>, Name, String)> {
         use baml_compiler2_hir_ty::{
             callable::{ExternalCallTarget, ExternalLinkability},
-            package_interface::{ExportedFieldAttrs, ExportedFunction, ExportedType},
+            package_interface::{ExportedFunction, ExportedType},
         };
         use baml_type::{FunctionParamTy, ParamTy, Ty, TyAttr};
 
@@ -2511,11 +2515,7 @@ mod tests {
             Name::new("Host"),
             ExportedType::Class {
                 qtn: class_qtn,
-                fields: vec![(
-                    Name::new("name"),
-                    Ty::string(),
-                    ExportedFieldAttrs::default(),
-                )],
+                fields,
                 methods: vec![
                     function(
                         "greet",
@@ -2599,9 +2599,25 @@ mod tests {
             interface_blob,
             types: Vec::new(),
         };
-
         let (_, stubs) = enrich_runtime_mount("app", &[Name::new("app")], package)
             .expect("runtime mount enriches");
+        stubs
+    }
+
+    /// Methods of a mounted class or interface are stubbed inside their
+    /// owner's body — never as free functions under a `ns_<Owner>/` namespace,
+    /// which would shadow the owner's own stub (E0099) and leave the source
+    /// stub the type checker sees without the methods the mounted interface
+    /// exports.
+    #[test]
+    fn runtime_mount_stubs_spell_methods_inside_their_owner() {
+        use baml_compiler2_hir_ty::package_interface::ExportedFieldAttrs;
+
+        let stubs = host_and_describable_stubs(vec![(
+            Name::new("name"),
+            baml_type::Ty::string(),
+            ExportedFieldAttrs::default(),
+        )]);
 
         assert!(
             stubs.iter().all(|(namespace, ..)| namespace.is_empty()),
@@ -2624,6 +2640,43 @@ mod tests {
             source_of("Describable"),
             "interface Describable {\n  function describe(self) -> string throws never\n  \
              function shout(self) -> string { $rust_function }\n}\n"
+        );
+    }
+
+    /// A class whose stub cannot be spelled (here: a field name that is not a
+    /// source identifier) still keeps its inherent methods slottable for the
+    /// emitter — as free link stubs under the class-named namespace, the
+    /// pre-existing form, which shadows nothing because there is no class
+    /// stub to shadow.
+    #[test]
+    fn runtime_mount_falls_back_to_free_method_stubs_without_a_class_stub() {
+        use baml_compiler2_hir_ty::package_interface::ExportedFieldAttrs;
+
+        let stubs = host_and_describable_stubs(vec![(
+            Name::new("0"),
+            baml_type::Ty::string(),
+            ExportedFieldAttrs::default(),
+        )]);
+
+        assert!(
+            stubs.iter().all(|(_, name, _)| name.as_str() != "Host"),
+            "an unspellable class must not get a class stub: {stubs:?}"
+        );
+        let host = vec![Name::new("Host")];
+        let free_stub = |name: &str| {
+            &stubs
+                .iter()
+                .find(|(namespace, stub, _)| *namespace == host && stub.as_str() == name)
+                .unwrap_or_else(|| panic!("missing free stub for Host.{name}: {stubs:?}"))
+                .2
+        };
+        assert_eq!(
+            free_stub("greet"),
+            "function greet(arg0: unknown, punct: unknown = null) -> string { $rust_function }\n"
+        );
+        assert_eq!(
+            free_stub("make"),
+            "function make(name: unknown) -> string { $rust_function }\n"
         );
     }
 

--- a/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_reflect/reflect.rs
@@ -506,8 +506,8 @@ fn check_function_contract(
     ))
 }
 
-fn dependency_object(vm: &BexVm, package: HeapPtr, local: &str) -> Option<HeapPtr> {
-    let Object::Package(package) = vm.get_object(package) else {
+fn dependency_object(vm: &BexVm, package_ptr: HeapPtr, local: &str) -> Option<HeapPtr> {
+    let Object::Package(package) = vm.get_object(package_ptr) else {
         return None;
     };
     let local_name = local_name(local)?;
@@ -519,6 +519,32 @@ fn dependency_object(vm: &BexVm, package: HeapPtr, local: &str) -> Option<HeapPt
         .or_else(|| package.functions.get(&local_name))
         .copied()
         .or_else(|| mounted_declaration(vm, package, local))
+        .or_else(|| dependency_named_object(vm, package_ptr, package, local))
+}
+
+/// Resolve `local` against a package's canonical object names: the lane for a
+/// declaration the package's item tables do not row under its own name. A
+/// class-inherent method is the case today — a consumer's static call imports
+/// it as `<alias>.<Class>.<method>`, the class-qualified spelling the emitter
+/// registered the function under — so it resolves exactly as the global lane
+/// resolves an alias-qualified global: `user.<local>` for a runtime image,
+/// `<canonical package>.<local>` for a static one.
+fn dependency_named_object(
+    vm: &BexVm,
+    package_ptr: HeapPtr,
+    package: &bex_vm_types::types::Package,
+    local: &str,
+) -> Option<HeapPtr> {
+    if let Some(runtime) = package.runtime() {
+        runtime
+            .object_names
+            .get(&format!("user.{local}"))
+            .or_else(|| runtime.object_names.get(local))
+            .copied()
+    } else {
+        let canonical = vm.packages.package_name(package_ptr)?;
+        vm.packages.object_by_name(&format!("{canonical}.{local}"))
+    }
 }
 
 /// Resolve `local` against a package's mount surface: the export name of a
@@ -1047,6 +1073,18 @@ impl BamlClassPackage for PackageReflectImpl {
             .filter(|(name, _)| name.starts_with("user."))
             .map(|(name, index)| (name.clone(), *index))
             .collect::<IndexMap<_, _>>();
+        // The object-lane twin of `global_names`: every named function this
+        // package compiled, under its canonical spelling. A consumer's static
+        // call to a class-inherent method imports the function object by that
+        // class-qualified name, which no item table rows (see
+        // `dependency_named_object`).
+        let object_names = plan
+            .program
+            .function_indices
+            .iter()
+            .filter(|(name, _)| name.starts_with("user."))
+            .map(|(name, index)| (name.clone(), objects[*index]))
+            .collect::<IndexMap<_, _>>();
         let init = plan
             .program
             .package_init_order
@@ -1070,6 +1108,7 @@ impl BamlClassPackage for PackageReflectImpl {
         package.test_init = test_init;
         let runtime = package.runtime_mut().expect("runtime package image");
         runtime.objects = objects.into_boxed_slice();
+        runtime.object_names = object_names;
         runtime.globals = globals.into_boxed_slice();
         runtime.global_names = global_names;
         runtime.type_values = type_values;


### PR DESCRIPTION
`Package.compile` stubbed every method of a mounted type as a free function under a `ns_<Owner>/` namespace. That namespace shadowed the owner (E0099), and the owner's own stub carried no methods, so a runtime-compiled `implement app.Describable for Widget` was checked against an empty interface (E0115) and `h.greet()` on a mounted class was "type `app.Host` has no member `greet`".

```baml
interface Describable {
  function describe(self) -> string throws never
}

function repro() -> null {
  reflect.Package.compile(
    { "plugin.baml": `
      class Widget { name string }
      implement app.Describable for Widget {
        function describe(self) -> string throws never { self.name }
      }
    ` },
    packages = { "app": reflect.Package.current() },
  )
}
```

Methods are now stubbed inside their owner's body: a class gets its inherent methods as `$rust_function` bodies, an interface gets required signatures and default bodies, all with real parameter types, bounds and declared throws. The runtime linker resolves a consumer's `app.Host.greet` import through the dependency's canonical function names, as the global lane already did.

Also fixes the adjacent compiler panic (`undefined function: baml.ToString.to_string`) on `reflect.Type.of_value(x).to_string()` inside runtime-compiled source: `reflect.Type` values are now concrete dispatch receivers, so the call goes through the interface as it does for classes.

https://claude.ai/code/session_01MYAMjHVrTzBmy8xrJznfJw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runtime packages now support cross-package method dispatch for interface, class, default, static, and implementation methods.
  - Mounted methods preserve signatures, generic constraints, return types, errors, and default values.
  - Reflected runtime types now support `to_string()` behavior.

- **Bug Fixes**
  - Fixed method resolution when compiling consumers of runtime packages.
  - Kept generated method declarations within their owning classes or interfaces.
  - Improved handling of nested types that cannot be represented directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->