### PR TITLE
fix(release): add ad-hoc nightly publication repair

### DIFF
--- a/.github/workflows/repair-nightly-20260901.yml
+++ b/.github/workflows/repair-nightly-20260901.yml
@@ -1,0 +1,403 @@
+name: Repair nightly 0.18.1-nightly.20260901.a
+
+run-name: Repair nightly 0.18.1-nightly.20260901.a publication
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: repair-nightly-0.18.1-nightly.20260901.a
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ROLE_ARN: arn:aws:iam::277707123528:role/pkg-boundaryml-com-github-release
+  PKG_BUCKET: pkgboundarymlcomstack-pkgboundarymlcomsitebucket4f-ybhvygkqittp
+  SOURCE_RUN_ID: "33621956905"
+  SOURCE_SHA: 5a29ca428e3a964d262506ed90d889b3ab4d01a7
+  VERSION: 0.18.1-nightly.20260901.a
+  CHANNEL: nightly
+  RELEASED_AT: "2026-09-02T10:14:35Z"
+  CRATES_IO_VERSION: 0.18.1-nightly.20260901.a
+  GO_VERSION: v0.18.1-nightly.20260901.a
+  NUGET_VERSION: 0.18.1-nightly.20260901.a
+  PYPI_VERSION: 0.18.1.dev2026090100
+  SWIFTPM_VERSION: 0.18.1-nightly.20260901.a
+  WRAPPER_VERSION: 0.2.4
+
+jobs:
+  verify-source:
+    name: Verify failed release source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source run and release identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")"
+          test "$(jq -r .head_sha <<<"$run")" = "$SOURCE_SHA"
+          test "$(jq -r .head_branch <<<"$run")" = "baml-language-source-$SOURCE_SHA"
+          test "$(jq -r .conclusion <<<"$run")" = failure
+
+          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/baml-language-$VERSION")"
+          test "$(jq -r .target_commitish <<<"$release")" = "$SOURCE_SHA"
+          echo "Repairing failed release run $SOURCE_RUN_ID from $SOURCE_SHA." >> "$GITHUB_STEP_SUMMARY"
+          echo "Java and C# publication success is intentionally assumed for this ad-hoc repair." >> "$GITHUB_STEP_SUMMARY"
+
+  publish-homebrew:
+    name: Publish Homebrew wrapper formula
+    needs: verify-source
+    runs-on: blacksmith-6vcpu-macos-latest
+    environment: infisical-github-baml-language-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wrapper-*
+          path: dist/wrapper
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - name: Generate Homebrew formula
+        run: |
+          set -euo pipefail
+          source_sha256="$(
+            curl --retry 5 --retry-all-errors -fsSL \
+              "https://github.com/BoundaryML/baml/archive/refs/tags/baml-wrapper-${WRAPPER_VERSION}.tar.gz" |
+              shasum -a 256 |
+              awk '{print $1}'
+          )"
+          scripts/baml-package-manager-artifacts \
+            --wrapper-dir dist/wrapper \
+            --version "$WRAPPER_VERSION" \
+            --source-sha256 "$source_sha256" \
+            --out package-manager
+      - name: Test Homebrew formula
+        run: |
+          set -euo pipefail
+          brew tap boundaryml/tap
+          tap="$(brew --repo boundaryml/tap)"
+          cp package-manager/homebrew/Formula/baml.rb "$tap/Formula/baml.rb"
+          brew audit --strict boundaryml/tap/baml
+          brew install --build-from-source boundaryml/tap/baml
+          brew test boundaryml/tap/baml
+          brew linkage --test boundaryml/tap/baml
+      - name: Push formula to BoundaryML/homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          tap="$(brew --repo boundaryml/tap)"
+          cd "$tap"
+          git config user.name "boundaryml-release-bot"
+          git config user.email "boundaryml-release-bot@users.noreply.github.com"
+          git remote set-url origin "https://github.com/BoundaryML/homebrew-tap.git"
+          git add Formula/baml.rb
+          git commit -m "Update baml wrapper to ${WRAPPER_VERSION}" || exit 0
+          git push origin HEAD
+
+  publish-pkg-boundaryml-com:
+    name: Publish pkg.boundaryml.com manifests
+    needs: verify-source
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-plan
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: toolchain-*
+          path: dist/toolchain
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bridge-cffi-*
+          path: dist/cffi
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wrapper-*
+          path: dist/wrapper
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: actions/download-artifact@v4
+        with:
+          name: baml-vscode-vsix
+          path: dist/vsix
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: actions/download-artifact@v4
+        with:
+          name: csharp-product-package
+          path: dist/csharp
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: actions/download-artifact@v4
+        with:
+          name: swift-xcframework
+          path: dist/swift
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: baml-language-repair-${{ github.run_id }}
+      - name: Generate release manifests
+        run: |
+          set -euo pipefail
+          (
+            cd dist/csharp
+            sha256sum -c product-package.sha256
+          )
+          csharp_digest="$(cut -d ' ' -f 1 dist/csharp/product-package.sha256)"
+          mapfile -t swift_packages < <(
+            find dist/swift -maxdepth 1 -type f \
+              -name 'BamlBridgeFFI-*.xcframework.zip' -print
+          )
+          if [[ "${#swift_packages[@]}" -ne 1 ]]; then
+            echo "::error::expected exactly one verified Swift XCFramework zip"
+            exit 1
+          fi
+          swift_digest="$(sha256sum "${swift_packages[0]}" | cut -d ' ' -f 1)"
+          scripts/baml-release-manifests \
+            --toolchain-dir dist/toolchain \
+            --cffi-dir dist/cffi \
+            --wrapper-dir dist/wrapper \
+            --vsix-dir dist/vsix \
+            --out manifests \
+            --channel "$CHANNEL" \
+            --version "$VERSION" \
+            --released-at "$RELEASED_AT" \
+            --pypi-version "$PYPI_VERSION" \
+            --wrapper-version "$WRAPPER_VERSION" \
+            --crates-io-version "$CRATES_IO_VERSION" \
+            --nuget-version "$NUGET_VERSION" \
+            --nuget-package-sha256 "$csharp_digest" \
+            --swiftpm-version "$SWIFTPM_VERSION" \
+            --swift-package-sha256 "$swift_digest"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-manifests
+          path: manifests
+          if-no-files-found: error
+      - name: Upload immutable manifest, install scripts, and index
+        run: |
+          set -euo pipefail
+          upload_immutable() {
+            local source="$1"
+            local dest="$2"
+            local tmp
+            local err
+            tmp="$(mktemp)"
+            err="$(mktemp)"
+            if aws s3api head-object --bucket "$PKG_BUCKET" --key "$dest" >/dev/null 2>"$err"; then
+              if ! aws s3 cp "s3://$PKG_BUCKET/$dest" "$tmp" >/dev/null 2>>"$err"; then
+                echo "::error::immutable object exists but could not be read: $dest"
+                cat "$err"
+                exit 1
+              fi
+              if cmp -s "$source" "$tmp"; then
+                echo "immutable object already exists and matches: $dest"
+              else
+                echo "::error::immutable object exists with different content: $dest"
+                exit 1
+              fi
+            elif grep -Eq '(\(404\)|Not Found|NoSuchKey)' "$err"; then
+              aws s3 cp "$source" "s3://$PKG_BUCKET/$dest" \
+                --content-type application/json \
+                --cache-control "public, max-age=86400, immutable"
+            else
+              echo "::error::failed to inspect immutable object before upload: $dest"
+              cat "$err"
+              exit 1
+            fi
+          }
+
+          upload_immutable "manifests/version/$VERSION.json" "manifest/v1/version/$VERSION.json"
+          if [[ -f manifests/wrapper.json ]]; then
+            aws s3 cp manifests/wrapper.json "s3://$PKG_BUCKET/manifest/v1/wrapper.json" \
+              --content-type application/json \
+              --cache-control "public, max-age=60, must-revalidate"
+          fi
+          aws s3 cp scripts/install.sh "s3://$PKG_BUCKET/install.sh" \
+            --content-type text/x-shellscript \
+            --cache-control "public, max-age=60, must-revalidate"
+          aws s3 cp scripts/install.ps1 "s3://$PKG_BUCKET/install.ps1" \
+            --content-type text/plain \
+            --cache-control "public, max-age=60, must-revalidate"
+          aws s3 cp tools/pkg_boundaryml_com/data/index.html "s3://$PKG_BUCKET/index.html" \
+            --content-type text/html \
+            --cache-control "public, max-age=300"
+
+  publish-go-sdk:
+    name: Publish Go SDK mirror
+    needs: [verify-source, publish-pkg-boundaryml-com]
+    runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: go-sdk-mirror
+          path: /tmp/go-sdk-package
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - name: Clone BoundaryML/baml-go
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          git clone https://github.com/BoundaryML/baml-go.git /tmp/baml-go
+          if ! git -C /tmp/baml-go rev-parse --verify HEAD >/dev/null 2>&1; then
+            git -C /tmp/baml-go switch --orphan main
+          fi
+      - name: Publish immutable module tag
+        env:
+          GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE2 }}
+        run: |
+          set -euo pipefail
+          manifest_url="https://pkg.boundaryml.com/manifest/v1/version/$VERSION.json"
+          manifest="$(mktemp)"
+          for attempt in $(seq 1 10); do
+            if curl -fsSL "$manifest_url" -o "$manifest"; then
+              break
+            fi
+            if [[ "$attempt" == 10 ]]; then
+              echo "::error::release manifest is unavailable: $manifest_url"
+              exit 1
+            fi
+            sleep "$attempt"
+          done
+          jq -e \
+            --arg version "$VERSION" \
+            --arg go_version "$GO_VERSION" \
+            --arg module "github.com/boundaryml/baml-go" \
+            '
+              .version == $version
+              and .baml_bridge_go == {
+                "module": $module,
+                "version": $go_version
+              }
+              and (.cffi | type == "object" and length > 0)
+            ' "$manifest" >/dev/null
+
+          rsync -a --checksum --delete --exclude .git /tmp/go-sdk-package/ /tmp/baml-go/
+          drift="$(
+            rsync -rcni --delete --exclude .git \
+              /tmp/go-sdk-package/ /tmp/baml-go/
+          )"
+          if [[ -n "$drift" ]]; then
+            echo "::error::mirror tree differs from the verified build artifact"
+            printf '%s\n' "$drift"
+            exit 1
+          fi
+
+          cd /tmp/baml-go
+          test "$(sed -n '1p' go.mod)" = "module github.com/boundaryml/baml-go"
+          if ! grep -qxF "const ToolchainVersion = \"$VERSION\"" version.go ||
+             ! grep -qxF "const BridgeRuntimeVersion = \"$GO_VERSION\"" version.go; then
+            echo "::error::version.go is not stamped for $VERSION / $GO_VERSION"
+            grep -n "ToolchainVersion\\|BridgeRuntimeVersion" version.go || true
+            exit 1
+          fi
+          git add -A
+
+          if git rev-parse --verify "refs/tags/$GO_VERSION" >/dev/null 2>&1; then
+            if git diff --cached --quiet "$GO_VERSION" --; then
+              echo "$GO_VERSION already exists with identical module content"
+              exit 0
+            fi
+            echo "::error::$GO_VERSION already exists with different module content"
+            exit 1
+          fi
+
+          if ! git diff --cached --quiet; then
+            git -c user.name="github-actions[bot]" \
+                -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+                commit -m "Sync BoundaryML/baml@$SOURCE_SHA for $GO_VERSION"
+          fi
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              tag -a "$GO_VERSION" -m "$GO_VERSION"
+          git push --atomic origin main "$GO_VERSION"
+
+  publish-pkg-channel:
+    name: Promote verified release channel manifest
+    needs: [publish-homebrew, publish-pkg-boundaryml-com, publish-go-sdk]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-manifests
+          path: manifests
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: baml-language-channel-repair-${{ github.run_id }}
+      - name: Verify repaired release state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          manifest="$(mktemp)"
+          curl --retry 5 --retry-all-errors -fsSL \
+            "https://pkg.boundaryml.com/manifest/v1/version/$VERSION.json" \
+            -o "$manifest"
+          jq -e \
+            --arg version "$VERSION" \
+            --arg go_version "$GO_VERSION" \
+            '.version == $version and .baml_bridge_go.version == $go_version' \
+            "$manifest" >/dev/null
+          gh api "repos/BoundaryML/baml-go/git/ref/tags/$GO_VERSION" >/dev/null
+      - name: Promote mutable channel manifest
+        run: |
+          set -euo pipefail
+          aws s3 cp "manifests/$CHANNEL.json" \
+            "s3://$PKG_BUCKET/manifest/v1/$CHANNEL.json" \
+            --content-type application/json \
+            --cache-control "public, max-age=60, must-revalidate"

--- a/.github/workflows/repair-nightly-20260901.yml
+++ b/.github/workflows/repair-nightly-20260901.yml
@@ -28,6 +28,7 @@ env:
   RELEASED_AT: "2026-09-02T10:14:35Z"
   CRATES_IO_VERSION: 0.18.1-nightly.20260901.a
   GO_VERSION: v0.18.1-nightly.20260901.a
+  GRADLE_PLUGIN_VERSION: 0.18.1-nightly.20260901.a
   NUGET_VERSION: 0.18.1-nightly.20260901.a
   PYPI_VERSION: 0.18.1.dev2026090100
   SWIFTPM_VERSION: 0.18.1-nightly.20260901.a
@@ -50,8 +51,258 @@ jobs:
 
           release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/baml-language-$VERSION")"
           test "$(jq -r .target_commitish <<<"$release")" = "$SOURCE_SHA"
+          nuget_url="https://api.nuget.org/v3-flatcontainer/baml-bridge/${NUGET_VERSION,,}/baml-bridge.${NUGET_VERSION,,}.nupkg"
+          curl --retry 5 --retry-all-errors -fsSI "$nuget_url" >/dev/null
           echo "Repairing failed release run $SOURCE_RUN_ID from $SOURCE_SHA." >> "$GITHUB_STEP_SUMMARY"
-          echo "Java and C# publication success is intentionally assumed for this ad-hoc repair." >> "$GITHUB_STEP_SUMMARY"
+          echo "Verified that C# $NUGET_VERSION is already available from NuGet; this workflow will not republish it." >> "$GITHUB_STEP_SUMMARY"
+
+  publish-maven:
+    name: Publish Java Maven Central
+    needs: verify-source
+    runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-plan
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - name: Verify and stamp release plan
+        run: |
+          set -euo pipefail
+          test "$(jq -r .canonical_version release-plan.json)" = "$VERSION"
+          test "$(jq -r .registry_versions.maven release-plan.json)" = "$VERSION"
+          test "$(jq -r .registry_versions.nuget release-plan.json)" = "$NUGET_VERSION"
+          scripts/baml-language-version stamp --plan release-plan.json
+      - name: Resolve Maven version
+        id: ver
+        run: |
+          set -euo pipefail
+          version="$(jq -r .registry_versions.maven release-plan.json)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Decide what to publish
+        id: exists
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          check() {
+            local url="https://repo1.maven.org/maven2/com/boundaryml/$1/${VERSION}/"
+            curl -s -o /dev/null -w '%{http_code}' -I "$url" || echo 000
+          }
+          bridge_code="$(check baml-bridge)"
+          plugin_code="$(check baml-gradle-plugin)"
+          kotlin_code="$(check baml-bridge-kotlin)"
+          bridge_publish=$([[ "$bridge_code" == "200" ]] && echo false || echo true)
+          plugin_publish=$([[ "$plugin_code" == "200" ]] && echo false || echo true)
+          kotlin_publish=$([[ "$kotlin_code" == "200" ]] && echo false || echo true)
+          any_publish=$([[ "$bridge_publish" == "true" || "$plugin_publish" == "true" || "$kotlin_publish" == "true" ]] && echo true || echo false)
+          {
+            echo "bridge_publish=$bridge_publish"
+            echo "plugin_publish=$plugin_publish"
+            echo "kotlin_publish=$kotlin_publish"
+            echo "any_publish=$any_publish"
+          } >> "$GITHUB_OUTPUT"
+          echo "baml-bridge ${VERSION}: HTTP ${bridge_code} -> publish=${bridge_publish}"
+          echo "baml-gradle-plugin ${VERSION}: HTTP ${plugin_code} -> publish=${plugin_publish}"
+          echo "baml-bridge-kotlin ${VERSION}: HTTP ${kotlin_code} -> publish=${kotlin_publish}"
+      - name: Setup mise (JDK + gradle)
+        if: ${{ steps.exists.outputs.any_publish == 'true' }}
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: java gradle
+      - name: Download native jars
+        if: ${{ steps.exists.outputs.bridge_publish == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          pattern: java-sdk-natives-*
+          path: dist/natives
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - name: Stage the signed baml-bridge Central layout
+        if: ${{ steps.exists.outputs.bridge_publish == 'true' }}
+        working-directory: baml_language/sdks/java/baml_bridge
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GPG_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
+            echo "::error::MAVEN_CENTRAL_GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
+            exit 1
+          fi
+          gradle --no-daemon publishMavenPublicationToStagingRepository \
+            -PbamlVersion="$VERSION" \
+            -PbamlNativeJarsDir="$GITHUB_WORKSPACE/dist/natives"
+      - name: Stage the signed gradle-plugin into the same Central layout
+        if: ${{ steps.exists.outputs.plugin_publish == 'true' }}
+        working-directory: baml_language/sdks/java/gradle-plugin
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GPG_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
+            echo "::error::MAVEN_CENTRAL_GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
+            exit 1
+          fi
+          gradle --no-daemon publishAllPublicationsToStagingRepository \
+            -PbamlVersion="$VERSION" \
+            -PbamlStagingDir="$GITHUB_WORKSPACE/baml_language/sdks/java/baml_bridge/build/staging-deploy"
+      - name: Stage the signed baml-bridge-kotlin into the same Central layout
+        if: ${{ steps.exists.outputs.kotlin_publish == 'true' }}
+        working-directory: baml_language/sdks/java/baml-bridge-kotlin
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          GPG_PRIVATE_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
+            echo "::error::MAVEN_CENTRAL_GPG_PRIVATE_KEY secret is empty; Central rejects unsigned bundles"
+            exit 1
+          fi
+          gradle --no-daemon publishMavenPublicationToStagingRepository \
+            -PbamlVersion="$VERSION" \
+            -PbamlStagingDir="$GITHUB_WORKSPACE/baml_language/sdks/java/baml_bridge/build/staging-deploy"
+      - name: Upload the Central bundle to the portal
+        if: ${{ steps.exists.outputs.any_publish == 'true' }}
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          BRIDGE_PUBLISH: ${{ steps.exists.outputs.bridge_publish }}
+          PLUGIN_PUBLISH: ${{ steps.exists.outputs.plugin_publish }}
+          KOTLIN_PUBLISH: ${{ steps.exists.outputs.kotlin_publish }}
+          CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          set -euo pipefail
+          staging="baml_language/sdks/java/baml_bridge/build/staging-deploy"
+          find "$staging" -name 'maven-metadata.xml*' -delete
+          if [[ "$BRIDGE_PUBLISH" == "true" && ! -d "$staging/com/boundaryml/baml-bridge/$VERSION" ]]; then
+            echo "::error::staging layout missing com/boundaryml/baml-bridge/$VERSION"
+            find "$staging" -maxdepth 4 -type d || true
+            exit 1
+          fi
+          if [[ "$PLUGIN_PUBLISH" == "true" && ! -d "$staging/com/boundaryml/baml-gradle-plugin/$VERSION" ]]; then
+            echo "::error::staging layout missing com/boundaryml/baml-gradle-plugin/$VERSION"
+            find "$staging" -maxdepth 4 -type d || true
+            exit 1
+          fi
+          if [[ "$KOTLIN_PUBLISH" == "true" && ! -d "$staging/com/boundaryml/baml-bridge-kotlin/$VERSION" ]]; then
+            echo "::error::staging layout missing com/boundaryml/baml-bridge-kotlin/$VERSION"
+            find "$staging" -maxdepth 4 -type d || true
+            exit 1
+          fi
+          ( cd "$staging" && zip -q -r "$GITHUB_WORKSPACE/central-bundle.zip" com )
+          echo "bundle contents:"
+          unzip -l "$GITHUB_WORKSPACE/central-bundle.zip"
+
+          if [[ -z "$CENTRAL_USERNAME" || -z "$CENTRAL_PASSWORD" ]]; then
+            echo "::error::MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD secrets are not set; cannot publish to Maven Central"
+            exit 1
+          fi
+          token="$(printf '%s:%s' "$CENTRAL_USERNAME" "$CENTRAL_PASSWORD" | base64 | tr -d '\n')"
+          deployment_id="$(curl -fsS -X POST \
+            -H "Authorization: Bearer $token" \
+            -F "bundle=@$GITHUB_WORKSPACE/central-bundle.zip" \
+            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=baml-java-$VERSION")"
+          echo "central deployment id: $deployment_id"
+
+          for attempt in $(seq 1 80); do
+            body="$(curl -fsS -X POST -H "Authorization: Bearer $token" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=$deployment_id")"
+            state="$(printf '%s' "$body" | jq -r '.deploymentState // empty')"
+            echo "attempt ${attempt}: deploymentState=${state:-<none>}"
+            case "$state" in
+              PUBLISHED|PUBLISHING)
+                echo "Java $VERSION accepted by Maven Central (state: $state)"
+                exit 0
+                ;;
+              FAILED)
+                echo "::error::Central deployment $deployment_id FAILED"
+                printf '%s\n' "$body" | jq . 2>/dev/null || printf '%s\n' "$body"
+                exit 1
+                ;;
+            esac
+            sleep 20
+          done
+          echo "::error::timed out waiting for deployment $deployment_id (last state: ${state:-<none>})"
+          exit 1
+
+  publish-gradle-plugin:
+    name: Publish Gradle Plugin Portal
+    needs: verify-source
+    runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-plan
+          github-token: ${{ github.token }}
+          repository: BoundaryML/baml
+          run-id: 33621956905
+      - name: Verify Gradle Plugin version
+        run: |
+          set -euo pipefail
+          test "$(jq -r .registry_versions.gradle_plugin release-plan.json)" = "$GRADLE_PLUGIN_VERSION"
+      - name: Skip if this version is already on the Gradle Plugin Portal
+        id: exists
+        run: |
+          set -euo pipefail
+          url="https://plugins.gradle.org/plugin/com.boundaryml.baml/${GRADLE_PLUGIN_VERSION}"
+          code="$(curl --retry 3 --retry-all-errors -sS -o /dev/null -w '%{http_code}' "$url")"
+          case "$code" in
+            200)
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "com.boundaryml.baml ${GRADLE_PLUGIN_VERSION} already on the Portal; skipping"
+              ;;
+            400|404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              echo "com.boundaryml.baml ${GRADLE_PLUGIN_VERSION} not on the Portal (HTTP ${code}); will publish"
+              ;;
+            *)
+              echo "::error::Gradle Plugin Portal version probe returned HTTP $code"
+              exit 1
+              ;;
+          esac
+      - name: Setup mise (JDK + gradle)
+        if: ${{ steps.exists.outputs.publish == 'true' }}
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: java gradle
+      - name: Publish to the Gradle Plugin Portal
+        if: ${{ steps.exists.outputs.publish == 'true' }}
+        working-directory: baml_language/sdks/java/gradle-plugin
+        env:
+          VERSION: ${{ env.GRADLE_PLUGIN_VERSION }}
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GRADLE_PUBLISH_KEY:-}" || -z "${GRADLE_PUBLISH_SECRET:-}" ]]; then
+            echo "::error::GRADLE_PUBLISH_KEY / GRADLE_PUBLISH_SECRET secret is empty"
+            exit 1
+          fi
+          gradle --no-daemon publishPlugins -PbamlVersion="$VERSION"
 
   publish-homebrew:
     name: Publish Homebrew wrapper formula
@@ -363,7 +614,7 @@ jobs:
 
   publish-pkg-channel:
     name: Promote verified release channel manifest
-    needs: [publish-homebrew, publish-pkg-boundaryml-com, publish-go-sdk]
+    needs: [publish-gradle-plugin, publish-homebrew, publish-maven, publish-pkg-boundaryml-com, publish-go-sdk]
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

- add a manual-only repair workflow pinned to failed nightly run 33621956905 and release 0.18.1-nightly.20260901.a
- verify the already-published C# package on NuGet without republishing it
- publish all three Java artifact families to Maven Central from the retained native-jar artifacts
- publish com.boundaryml.baml to the Gradle Plugin Portal
- publish the Homebrew formula, pkg.boundaryml.com immutable release data, and Go SDK mirror from the retained build artifacts
- promote the verified nightly channel manifest only after every repair publisher succeeds

The Maven Central, Gradle Plugin Portal, Homebrew, and Go jobs use the `infisical-github-baml-language-release` environment so their environment-scoped secrets are available. The workflow uses `workflow_dispatch` and does not run on push. It verifies the source run SHA, GitHub release identity, frozen release-plan versions, and existing NuGet package before publishing. Registry checks and immutable-output comparisons make retries safe.

## Validation

- `mise exec actionlint -- actionlint .github/workflows/repair-nightly-20260901.yml`
- `mise exec prek -- prek run --files .github/workflows/repair-nightly-20260901.yml --show-diff-on-failure`
- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -v` (23 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manually triggered workflow for repairing the `0.18.1-nightly.20260901.a` release.
  * Publishes Maven artifacts and the Gradle plugin when they are not already available.
  * Verifies existing C# package availability without republishing it.
  * Publishes the Homebrew formula, package release manifests and artifacts, and Go SDK mirror.
  * Validates release identity, checksums, tags, and manifest contents before promotion.
  * Waits for Maven and Gradle publication to complete before publishing the package channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->