### PR TITLE
chore: simplify c# sdk publication

### DIFF
--- a/.github/workflows/publish2-csharp-sdk.yaml
+++ b/.github/workflows/publish2-csharp-sdk.yaml
@@ -134,7 +134,7 @@ jobs:
         id: login
         uses: NuGet/login@v1.2.0
         with:
-          user: ${{ vars.NUGET_USER }}
+          user: rossir.paulo
 
       - name: Publish the already-verified package
         if: ${{ steps.existing.outputs.publish == 'true' }}


### PR DESCRIPTION
We don't need to encode this in github environment vars, simpler to just hardcode this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the NuGet publishing workflow to use a fixed login username for OIDC authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->