### PR TITLE
[B-1610] Require matching BAML skill in agent mode

### DIFF
--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -350,6 +350,13 @@ impl RuntimeCli {
             return args.run(crate::output::policy().stdout.color);
         }
 
+        // Resolve every output dial once, before any subcommand writes.
+        crate::output::init(self.output);
+
+        if self.command.requires_agent_skill() {
+            crate::skill_check::check()?;
+        }
+
         // Fire anonymous, best-effort telemetry for this invocation. The
         // event is appended to an on-disk queue (one atomic write); on drop
         // of the guard (after the match below returns) the queue file is
@@ -358,18 +365,6 @@ impl RuntimeCli {
         let _telemetry = crate::telemetry::record_invocation(
             self.invoked_subcommand.as_deref().unwrap_or("unknown"),
         );
-
-        // Resolve every output dial once, before any subcommand writes.
-        crate::output::init(self.output);
-
-        // Warn about a missing or stale embedded skill only on the core
-        // authoring commands, keeping machine-facing utilities quiet.
-        if matches!(
-            &self.command,
-            Commands::Init(_) | Commands::Run(_) | Commands::Generate(_) | Commands::Pack(_)
-        ) {
-            crate::skill_check::check();
-        }
 
         match &self.command {
             Commands::Init(args) => args.run(),
@@ -405,6 +400,23 @@ impl RuntimeCli {
 }
 
 impl Commands {
+    fn requires_agent_skill(&self) -> bool {
+        matches!(
+            self,
+            Self::Check(_)
+                | Self::Describe(_)
+                | Self::Query(_)
+                | Self::Format(_)
+                | Self::Generate(_)
+                | Self::Test(_)
+                | Self::Init(_)
+                | Self::New(_)
+                | Self::Run(_)
+                | Self::Pack(_)
+                | Self::Playground(_)
+        )
+    }
+
     fn has_legacy_project(&self) -> bool {
         match self {
             Self::Check(args) => args.from.is_some(),
@@ -658,6 +670,8 @@ mod tests {
             "always".into(),
             "--diagnostic-format".into(),
             "agent".into(),
+            "--agent-skill-check".into(),
+            "off".into(),
         ]);
 
         assert_eq!(cli.output.preset, crate::output::OutputPreset::Human);
@@ -670,6 +684,10 @@ mod tests {
             cli.output.diagnostic_format,
             Some(crate::output::DiagnosticFormatChoice::Agent)
         );
+        assert_eq!(
+            cli.output.agent_skill_check,
+            crate::output::AgentSkillCheckChoice::Off
+        );
     }
 
     #[test]
@@ -680,6 +698,7 @@ mod tests {
             ("color", "BAML_COLOR"),
             ("hyperlinks", "BAML_HYPERLINKS"),
             ("diagnostic_format", "BAML_DIAGNOSTIC_FORMAT"),
+            ("agent_skill_check", "BAML_AGENT_SKILL_CHECK"),
         ];
 
         for (id, env) in expected {
@@ -702,6 +721,7 @@ mod tests {
                     "--output-preset <PRESET>\n          Select output defaults [default: auto] [possible values: auto, human, agent]",
                     "--hyperlinks <WHEN>\n          Control terminal hyperlinks [possible values: auto, always, never]",
                     "--diagnostic-format <FORMAT>\n          Select the diagnostic format [possible values: human, agent, concise]",
+                    "--agent-skill-check <MODE>\n          Control BAML agent skill validation [default: auto] [possible values: auto, require, warn,\n          off]",
                 ],
             ),
             (

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -354,7 +354,7 @@ impl RuntimeCli {
         crate::output::init(self.output);
 
         if self.command.requires_agent_skill() {
-            crate::skill_check::check()?;
+            crate::skill_check::check(self.command.agent_skill_project_path())?;
         }
 
         // Fire anonymous, best-effort telemetry for this invocation. The
@@ -400,6 +400,24 @@ impl RuntimeCli {
 }
 
 impl Commands {
+    fn agent_skill_project_path(&self) -> Option<&Path> {
+        match self {
+            Self::Check(args) => args.from.as_deref(),
+            Self::Describe(args) => args.from.as_deref(),
+            Self::Query(args) => args.from.as_deref(),
+            Self::Format(args) => args.from.as_deref(),
+            Self::Generate(args) => match &args.command {
+                Some(crate::generate::GenerateCommand::Add(args)) => args.from.as_deref(),
+                None => args.from.as_deref(),
+            },
+            Self::Test(args) => args.from.as_deref(),
+            Self::Run(args) => args.from.as_deref(),
+            Self::Pack(args) => args.from.as_deref(),
+            Self::Playground(args) => args.from.as_deref(),
+            _ => None,
+        }
+    }
+
     fn requires_agent_skill(&self) -> bool {
         matches!(
             self,

--- a/baml_language/crates/baml_cli/src/output.rs
+++ b/baml_language/crates/baml_cli/src/output.rs
@@ -76,6 +76,22 @@ pub(crate) struct OutputArgs {
         display_order = 90
     )]
     pub diagnostic_format: Option<DiagnosticFormatChoice>,
+
+    #[arg(
+        long = "agent-skill-check",
+        env = "BAML_AGENT_SKILL_CHECK",
+        value_enum,
+        value_name = "MODE",
+        help = "Control BAML agent skill validation [default: auto] [possible values: auto, require, warn, off]",
+        hide_default_value = true,
+        hide_env = true,
+        hide_possible_values = true,
+        default_value_t = AgentSkillCheckChoice::Auto,
+        global = true,
+        help_heading = "Global options",
+        display_order = 95
+    )]
+    pub agent_skill_check: AgentSkillCheckChoice,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -119,12 +135,33 @@ pub(crate) enum DiagnosticFormatChoice {
     Concise,
 }
 
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum AgentSkillCheckChoice {
+    /// Require a matching skill for agents; warn for humans.
+    #[default]
+    Auto,
+    /// Fail when the matching skill is missing or outdated.
+    Require,
+    /// Warn when the matching skill is missing or outdated.
+    Warn,
+    /// Skip agent skill validation.
+    Off,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AgentSkillCheckPolicy {
+    Require,
+    Warn,
+    Off,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct OutputPolicy {
     pub stdout: StreamPolicy,
     pub stderr: StreamPolicy,
     pub diagnostics: DiagnosticPolicy,
     pub progress: bool,
+    pub agent_skill_check: AgentSkillCheckPolicy,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -163,6 +200,7 @@ const DEFAULT_POLICY: OutputPolicy = OutputPolicy {
         show_error_codes: true,
     },
     progress: true,
+    agent_skill_check: AgentSkillCheckPolicy::Warn,
 };
 
 static OUTPUT_POLICY: RwLock<OutputPolicy> = RwLock::new(DEFAULT_POLICY);
@@ -219,6 +257,12 @@ fn resolve(args: OutputArgs, signals: OutputSignals) -> OutputPolicy {
     if args.no_progress {
         policy.progress = false;
     }
+    policy.agent_skill_check = match args.agent_skill_check {
+        AgentSkillCheckChoice::Auto if signals.running_in_agent => AgentSkillCheckPolicy::Require,
+        AgentSkillCheckChoice::Auto | AgentSkillCheckChoice::Warn => AgentSkillCheckPolicy::Warn,
+        AgentSkillCheckChoice::Require => AgentSkillCheckPolicy::Require,
+        AgentSkillCheckChoice::Off => AgentSkillCheckPolicy::Off,
+    };
 
     policy
 }
@@ -240,6 +284,7 @@ impl OutputPreset {
                     show_error_codes: true,
                 },
                 progress: false,
+                agent_skill_check: AgentSkillCheckPolicy::Warn,
             },
             Self::Human | Self::Auto => OutputPolicy {
                 stdout: StreamPolicy {
@@ -255,6 +300,7 @@ impl OutputPreset {
                     show_error_codes: true,
                 },
                 progress: true,
+                agent_skill_check: AgentSkillCheckPolicy::Warn,
             },
         }
     }
@@ -336,6 +382,7 @@ mod tests {
             no_progress: false,
             hyperlinks: None,
             diagnostic_format: None,
+            agent_skill_check: AgentSkillCheckChoice::Auto,
         }
     }
 
@@ -355,6 +402,7 @@ mod tests {
         assert!(!policy.stderr.hyperlinks);
         assert_eq!(policy.diagnostics.format, DiagnosticFormat::Agent);
         assert!(!policy.progress);
+        assert_eq!(policy.agent_skill_check, AgentSkillCheckPolicy::Require);
     }
 
     #[test]
@@ -376,6 +424,7 @@ mod tests {
         assert!(policy.stderr.hyperlinks);
         assert_eq!(policy.diagnostics.format, DiagnosticFormat::Human);
         assert!(policy.progress);
+        assert_eq!(policy.agent_skill_check, AgentSkillCheckPolicy::Warn);
     }
 
     #[test]
@@ -420,5 +469,48 @@ mod tests {
         assert!(!policy.stdout.hyperlinks);
         assert!(!policy.stderr.hyperlinks);
         assert_eq!(policy.diagnostics.format, DiagnosticFormat::Agent);
+    }
+
+    #[test]
+    fn explicit_agent_skill_check_overrides_detection() {
+        for (choice, running_in_agent, expected) in [
+            (
+                AgentSkillCheckChoice::Require,
+                false,
+                AgentSkillCheckPolicy::Require,
+            ),
+            (
+                AgentSkillCheckChoice::Warn,
+                true,
+                AgentSkillCheckPolicy::Warn,
+            ),
+            (AgentSkillCheckChoice::Off, true, AgentSkillCheckPolicy::Off),
+        ] {
+            let mut output_args = args(OutputPreset::Auto);
+            output_args.agent_skill_check = choice;
+            let policy = resolve(
+                output_args,
+                OutputSignals {
+                    running_in_agent,
+                    ..INTERACTIVE
+                },
+            );
+
+            assert_eq!(policy.agent_skill_check, expected);
+        }
+    }
+
+    #[test]
+    fn explicit_human_output_does_not_disable_agent_skill_requirement() {
+        let policy = resolve(
+            args(OutputPreset::Human),
+            OutputSignals {
+                running_in_agent: true,
+                ..INTERACTIVE
+            },
+        );
+
+        assert_eq!(policy.diagnostics.format, DiagnosticFormat::Human);
+        assert_eq!(policy.agent_skill_check, AgentSkillCheckPolicy::Require);
     }
 }

--- a/baml_language/crates/baml_cli/src/skill_check.rs
+++ b/baml_language/crates/baml_cli/src/skill_check.rs
@@ -39,13 +39,13 @@ struct SkillMetadata {
     toolchain_version: String,
 }
 
-pub(crate) fn check() -> anyhow::Result<()> {
+pub(crate) fn check(project: Option<&Path>) -> anyhow::Result<()> {
     let policy = crate::output::policy().agent_skill_check;
     if policy == AgentSkillCheckPolicy::Off {
         return Ok(());
     }
 
-    let status = project_skill_status();
+    let status = project_skill_status(project)?;
     match (policy, status) {
         (_, SkillStatus::Current) => Ok(()),
         (AgentSkillCheckPolicy::Warn, status) => {
@@ -72,9 +72,16 @@ fn skill_warning_message(status: SkillStatus) -> Option<&'static str> {
     }
 }
 
-fn project_skill_status() -> SkillStatus {
-    let Ok(mut dir) = std::env::current_dir() else {
-        return SkillStatus::Missing;
+fn project_skill_status(project: Option<&Path>) -> anyhow::Result<SkillStatus> {
+    let mut dir = match project {
+        Some(project) => match crate::project_load::find_project_root_from(Some(project))? {
+            Some(root) => root,
+            None => return Ok(SkillStatus::Missing),
+        },
+        None => match std::env::current_dir() {
+            Ok(dir) => dir,
+            Err(_) => return Ok(SkillStatus::Missing),
+        },
     };
     let home = std::env::var_os("HOME").map(PathBuf::from);
 
@@ -82,17 +89,17 @@ fn project_skill_status() -> SkillStatus {
         let statuses = [".agents/skills", ".claude/skills"]
             .map(|relative| installed_skill_status(&dir.join(relative)));
         if statuses.contains(&SkillStatus::Outdated) {
-            return SkillStatus::Outdated;
+            return Ok(SkillStatus::Outdated);
         }
         if statuses.contains(&SkillStatus::Current) {
-            return SkillStatus::Current;
+            return Ok(SkillStatus::Current);
         }
         if home.as_ref().is_some_and(|home| dir == *home) || !dir.pop() {
             break;
         }
     }
 
-    SkillStatus::Missing
+    Ok(SkillStatus::Missing)
 }
 
 fn installed_skill_status(skills_dir: &Path) -> SkillStatus {

--- a/baml_language/crates/baml_cli/src/skill_check.rs
+++ b/baml_language/crates/baml_cli/src/skill_check.rs
@@ -1,4 +1,4 @@
-//! Passive warning for missing or stale BAML agent skills.
+//! Validation for missing or stale BAML agent skills.
 //!
 //! The active toolchain compares the installed skill's frontmatter version
 //! with its own version. This keeps skill freshness local and gives each
@@ -12,12 +12,14 @@ use std::{
 
 use serde::Deserialize;
 
-use crate::agent_command::SKILL_NAME;
+use crate::{agent_command::SKILL_NAME, output::AgentSkillCheckPolicy};
 
 const SKILL_OUTDATED_WARNING: &str =
     "your baml skill does not match this toolchain; use `baml agent install` to upgrade it";
 const SKILL_MISSING_WARNING: &str =
     "no baml skill is installed; set it up with `baml agent install`";
+const SKILL_OUTDATED_ERROR: &str = "the installed BAML agent skill does not match this toolchain; run `baml agent install`, restart the agent, then retry; set BAML_AGENT_SKILL_CHECK=off to bypass this check";
+const SKILL_MISSING_ERROR: &str = "the BAML agent skill is required but is not installed; run `baml agent install`, restart the agent, then retry; set BAML_AGENT_SKILL_CHECK=off to bypass this check";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SkillStatus {
@@ -37,9 +39,28 @@ struct SkillMetadata {
     toolchain_version: String,
 }
 
-pub(crate) fn check() {
-    if let Some(message) = skill_warning_message(project_skill_status()) {
-        crate::reporter::print_warning(format_args!("{message}"));
+pub(crate) fn check() -> anyhow::Result<()> {
+    let policy = crate::output::policy().agent_skill_check;
+    if policy == AgentSkillCheckPolicy::Off {
+        return Ok(());
+    }
+
+    let status = project_skill_status();
+    match (policy, status) {
+        (_, SkillStatus::Current) => Ok(()),
+        (AgentSkillCheckPolicy::Warn, status) => {
+            if let Some(message) = skill_warning_message(status) {
+                crate::reporter::print_warning(format_args!("{message}"));
+            }
+            Ok(())
+        }
+        (AgentSkillCheckPolicy::Require, SkillStatus::Missing) => {
+            anyhow::bail!(SKILL_MISSING_ERROR)
+        }
+        (AgentSkillCheckPolicy::Require, SkillStatus::Outdated) => {
+            anyhow::bail!(SKILL_OUTDATED_ERROR)
+        }
+        (AgentSkillCheckPolicy::Off, _) => Ok(()),
     }
 }
 

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__describe_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__describe_detailed_help.snap
@@ -106,5 +106,9 @@ Global options:
       --diagnostic-format <FORMAT>
           Select the diagnostic format [possible values: human, agent, concise]
 
+      --agent-skill-check <MODE>
+          Control BAML agent skill validation [default: auto] [possible values: auto, require, warn,
+          off]
+
   -h, --help
           Display concise help for this command

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
@@ -39,6 +39,8 @@ Global options:
                                     never]
       --diagnostic-format <FORMAT>  Select the diagnostic format [possible values: human, agent,
                                     concise]
+      --agent-skill-check <MODE>    Control BAML agent skill validation [default: auto] [possible
+                                    values: auto, require, warn, off]
   -h, --help                        Display concise help for this command
   -V, --version                     Print version
 

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__run_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__run_detailed_help.snap
@@ -108,6 +108,10 @@ Global options:
       --diagnostic-format <FORMAT>
           Select the diagnostic format [possible values: human, agent, concise]
 
+      --agent-skill-check <MODE>
+          Control BAML agent skill validation [default: auto] [possible values: auto, require, warn,
+          off]
+
   -h, --help
           Display concise help for this command
 

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
@@ -79,6 +79,10 @@ Global options:
       --diagnostic-format <FORMAT>
           Select the diagnostic format [possible values: human, agent, concise]
 
+      --agent-skill-check <MODE>
+          Control BAML agent skill validation [default: auto] [possible values: auto, require, warn,
+          off]
+
   -h, --help
           Display concise help for this command
 

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -713,6 +713,7 @@ impl TestArgs {
                     | "--no-profile"
                     | "--project"
                     | "--directory"
+                    | "--agent-skill-check"
                     | "--from"
                     | "--features"
                     | "--help"
@@ -720,11 +721,12 @@ impl TestArgs {
             ) || token.starts_with("--profile=")
                 || token.starts_with("--project=")
                 || token.starts_with("--directory=")
+                || token.starts_with("--agent-skill-check=")
                 || token.starts_with("--from=")
                 || token.starts_with("--features=");
             if bootstrap {
                 anyhow::bail!(
-                    "invalid argument `{token}` in test profile `{name}`: profile args cannot contain --profile, --no-profile, --project, --directory, --from, --features, or --help"
+                    "invalid argument `{token}` in test profile `{name}`: profile args cannot contain --profile, --no-profile, --project, --directory, --agent-skill-check, --from, --features, or --help"
                 );
             }
         }
@@ -1337,6 +1339,17 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("cannot contain --profile"), "{error}");
+
+        let error = TestArgs::parse_profile_args(
+            "bad_skill_check",
+            &["--agent-skill-check=off".to_string()],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("cannot contain") && error.contains("--agent-skill-check"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/tests/agent_install_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/agent_install_e2e.rs
@@ -10,6 +10,7 @@ fn run_from(project: &std::path::Path, args: &[&str]) -> std::process::Output {
         .current_dir(project)
         .env("HOME", project.parent().unwrap_or(project))
         .env("DO_NOT_TRACK", "1")
+        .env("BAML_AGENT_SKILL_CHECK", "warn")
         .env("HTTP_PROXY", "http://127.0.0.1:1")
         .env("HTTPS_PROXY", "http://127.0.0.1:1")
         .env("ALL_PROXY", "http://127.0.0.1:1")

--- a/baml_language/crates/baml_cli/tests/diagnostic_highlight_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/diagnostic_highlight_e2e.rs
@@ -45,6 +45,7 @@ fn forced_color_malformed_diagnostic_fragment_falls_back_and_reports() {
         .env("BAML_HOME", home)
         .env("BAML_NO_BYTECODE_CACHE", "1")
         .env("BAML_OUTPUT_PRESET", "human")
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .output()
         .expect("run baml check");
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -45,6 +45,7 @@ fn run_baml_cli_with_env(built: &Path, dir: &Path, args: &[&str], env: &[(&str, 
     // CLAUDECODE/AI_AGENT/… environment flips `--output-preset auto` to
     // `agent`, which disables the progress lines some assertions read.
     cmd.env("BAML_OUTPUT_PRESET", "human");
+    cmd.env("BAML_AGENT_SKILL_CHECK", "off");
     cmd.env("BAML_HOME", &home);
     // Tests are quiet unless they explicitly exercise the inherited log level.
     cmd.env_remove("BAML_LOG");
@@ -1216,6 +1217,7 @@ test "streams" {
         // Pin the human preset so inherited agent env (CLAUDECODE/AI_AGENT/…)
         // cannot flip `--output-preset auto` to `agent` and hide progress lines.
         .env("BAML_OUTPUT_PRESET", "human")
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .env("BAML_HOME", &home)
         .env("BAML_CACHE_DIR", common::shared_cache_dir())
         .stdout(Stdio::piped())
@@ -2196,6 +2198,7 @@ fn run_file_script_mode_passes_args_after_separator_as_argv() {
     let output = Command::new(&script)
         .args(["--", "alpha", "--beta", "gamma"])
         .current_dir(tmp.path())
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .env("BAML_CACHE_DIR", common::shared_cache_dir())
         .output()
         .expect("execute the shebang script directly");
@@ -2249,6 +2252,7 @@ fn shebang_can_name_a_specific_function() {
 
     let output = Command::new(&script)
         .current_dir(tmp.path())
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .env("BAML_CACHE_DIR", common::shared_cache_dir())
         .output()
         .expect("execute the shebang script directly");
@@ -2302,6 +2306,7 @@ fn executable_baml_script_runs_via_kernel_shebang() {
     // takes none. The kernel drives `#! … run --file <this script>`.
     let output = Command::new(&script)
         .current_dir(tmp.path())
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .env("BAML_CACHE_DIR", common::shared_cache_dir())
         .output()
         .expect("execute the shebang script directly");

--- a/baml_language/crates/baml_cli/tests/pack_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/pack_e2e.rs
@@ -178,6 +178,7 @@ fn pack_e2e_omits_compile_file_status() {
         // Pin the human preset so inherited agent env (CLAUDECODE/AI_AGENT/…)
         // cannot flip `--output-preset auto` to `agent` and hide progress lines.
         .env("BAML_OUTPUT_PRESET", "human")
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .env("BAML_CACHE_DIR", common::shared_cache_dir())
         .arg("pack")
         .arg("--from")

--- a/baml_language/crates/baml_cli/tests/query_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/query_e2e.rs
@@ -25,6 +25,7 @@ fn run_baml_cli(built: &Path, dir: &Path, args: &[&str]) -> Output {
     // outlives the test.
     cmd.env("BAML_PROFILE", "1");
     cmd.env("BAML_OUTPUT_PRESET", "human");
+    cmd.env("BAML_AGENT_SKILL_CHECK", "off");
     cmd.env("BAML_HOME", &home);
     cmd.env_remove("BAML_LOG");
     cmd.env("BAML_CACHE_DIR", common::shared_cache_dir());

--- a/baml_language/crates/baml_cli/tests/skill_warning_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/skill_warning_e2e.rs
@@ -12,6 +12,8 @@ const SKILL_OUTDATED_WARNING: &str =
     "your baml skill does not match this toolchain; use `baml agent install` to upgrade it";
 const SKILL_MISSING_WARNING: &str =
     "no baml skill is installed; set it up with `baml agent install`";
+const SKILL_OUTDATED_ERROR: &str = "the installed BAML agent skill does not match this toolchain";
+const SKILL_MISSING_ERROR: &str = "the BAML agent skill is required but is not installed";
 
 fn project_with_skill(content: &str) -> tempfile::TempDir {
     let dir = tempfile::tempdir().unwrap();
@@ -21,15 +23,39 @@ fn project_with_skill(content: &str) -> tempfile::TempDir {
     dir
 }
 
-fn run_args_from(args: &[&str], cwd: &Path) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_baml-cli"))
+fn command(args: &[&str], cwd: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_baml-cli"));
+    command
         .args(args)
         .current_dir(cwd)
         .env("HOME", cwd.parent().unwrap_or(cwd))
         .env("BAML_WRAPPER_EXEC", "1")
-        .env("DO_NOT_TRACK", "1")
+        .env("DO_NOT_TRACK", "1");
+    command
+}
+
+fn run_args_from(args: &[&str], cwd: &Path) -> Output {
+    command(args, cwd)
+        .env("BAML_AGENT_SKILL_CHECK", "warn")
         .output()
         .unwrap()
+}
+
+fn run_as_detected_agent(args: &[&str], cwd: &Path) -> Output {
+    let mut command = command(args, cwd);
+    for variable in [
+        "CLAUDECODE",
+        "CODEX_SANDBOX",
+        "PI_CODING_AGENT",
+        "OPENCODE_CLIENT",
+        "AI_AGENT",
+        "CURSOR_TRACE_ID",
+        "REPL_ID",
+        "AGENT",
+    ] {
+        command.env_remove(variable);
+    }
+    command.env("AGENT", "1").output().unwrap()
 }
 
 fn stderr_of(output: &Output) -> String {
@@ -37,13 +63,62 @@ fn stderr_of(output: &Output) -> String {
 }
 
 #[test]
-fn non_authoring_commands_never_warn() {
+fn exempt_commands_never_warn() {
     let empty = tempfile::tempdir().unwrap();
 
-    for command in [["check"].as_slice(), ["fmt"].as_slice()] {
-        let stderr = stderr_of(&run_args_from(command, empty.path()));
+    for args in [["clean"].as_slice(), ["telemetry"].as_slice()] {
+        let stderr = stderr_of(&run_args_from(args, empty.path()));
         assert!(!stderr.contains(SKILL_MISSING_WARNING), "{stderr}");
     }
+}
+
+#[test]
+fn detected_agent_cannot_run_without_skill() {
+    let project = tempfile::tempdir().unwrap();
+    let output = run_as_detected_agent(&["init"], project.path());
+    let stderr = stderr_of(&output);
+
+    assert_eq!(output.status.code(), Some(4), "{stderr}");
+    assert!(stderr.contains(SKILL_MISSING_ERROR), "{stderr}");
+    assert!(!project.path().join("baml.toml").exists());
+}
+
+#[test]
+fn require_rejects_outdated_skill() {
+    let project = project_with_skill("old");
+    let output = command(&["init"], project.path())
+        .env("BAML_AGENT_SKILL_CHECK", "require")
+        .output()
+        .unwrap();
+    let stderr = stderr_of(&output);
+
+    assert_eq!(output.status.code(), Some(4), "{stderr}");
+    assert!(stderr.contains(SKILL_OUTDATED_ERROR), "{stderr}");
+    assert!(!project.path().join("baml.toml").exists());
+}
+
+#[test]
+fn matching_skill_allows_detected_agent() {
+    let project = project_with_skill(&common::installed_skill_content());
+    let output = run_as_detected_agent(&["init"], project.path());
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert!(project.path().join("baml.toml").is_file());
+}
+
+#[test]
+fn off_bypasses_agent_skill_validation() {
+    let project = tempfile::tempdir().unwrap();
+    let output = command(&["init"], project.path())
+        .env("AGENT", "1")
+        .env("BAML_AGENT_SKILL_CHECK", "off")
+        .output()
+        .unwrap();
+    let stderr = stderr_of(&output);
+
+    assert!(output.status.success(), "{stderr}");
+    assert!(!stderr.contains("baml skill"), "{stderr}");
+    assert!(project.path().join("baml.toml").is_file());
 }
 
 #[test]
@@ -123,7 +198,13 @@ fn stale_copy_in_either_agent_directory_prompts_upgrade() {
 #[test]
 fn agent_command_never_nags() {
     let empty = tempfile::tempdir().unwrap();
-    let stderr = stderr_of(&run_args_from(&["agent", "install"], empty.path()));
+    let output = command(&["agent", "install"], empty.path())
+        .env("AGENT", "1")
+        .env("BAML_AGENT_SKILL_CHECK", "require")
+        .output()
+        .unwrap();
+    let stderr = stderr_of(&output);
 
+    assert!(output.status.success(), "{stderr}");
     assert!(!stderr.contains(SKILL_MISSING_WARNING), "{stderr}");
 }

--- a/baml_language/crates/baml_cli/tests/skill_warning_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/skill_warning_e2e.rs
@@ -55,7 +55,11 @@ fn run_as_detected_agent(args: &[&str], cwd: &Path) -> Output {
     ] {
         command.env_remove(variable);
     }
-    command.env("AGENT", "1").output().unwrap()
+    command
+        .env("AGENT", "1")
+        .env("BAML_AGENT_SKILL_CHECK", "auto")
+        .output()
+        .unwrap()
 }
 
 fn stderr_of(output: &Output) -> String {
@@ -104,6 +108,48 @@ fn matching_skill_allows_detected_agent() {
 
     assert!(output.status.success(), "{}", stderr_of(&output));
     assert!(project.path().join("baml.toml").is_file());
+}
+
+#[test]
+fn selected_project_uses_its_skill() {
+    let cwd = tempfile::tempdir().unwrap();
+    let project = project_with_skill(&common::installed_skill_content());
+    let source_dir = project.path().join("baml_src");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(
+        source_dir.join("main.baml"),
+        "function main() -> string { \"hello\" }\n",
+    )
+    .unwrap();
+
+    let output = run_as_detected_agent(
+        &["check", "--project", project.path().to_str().unwrap()],
+        cwd.path(),
+    );
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+}
+
+#[test]
+fn selected_project_does_not_use_cwd_skill() {
+    let cwd = project_with_skill(&common::installed_skill_content());
+    let project = tempfile::tempdir().unwrap();
+    let source_dir = project.path().join("baml_src");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(
+        source_dir.join("main.baml"),
+        "function main() -> string { \"hello\" }\n",
+    )
+    .unwrap();
+
+    let output = run_as_detected_agent(
+        &["check", "--project", project.path().to_str().unwrap()],
+        cwd.path(),
+    );
+    let stderr = stderr_of(&output);
+
+    assert_eq!(output.status.code(), Some(4), "{stderr}");
+    assert!(stderr.contains(SKILL_MISSING_ERROR), "{stderr}");
 }
 
 #[test]

--- a/baml_language/crates/baml_cli/tests/test_list_discovery_cache_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/test_list_discovery_cache_e2e.rs
@@ -36,6 +36,7 @@ fn run_list(
     // CLAUDECODE/AI_AGENT/… environment flips `--output-preset auto` to
     // `agent`, which disables the progress lines some assertions read.
     cmd.env("BAML_OUTPUT_PRESET", "human");
+    cmd.env("BAML_AGENT_SKILL_CHECK", "off");
     cmd.env("BAML_HOME", &home);
     cmd.env("BAML_CACHE_DIR", cache_dir);
     cmd.env("BAML_CACHE_DEBUG", "1");

--- a/baml_language/crates/baml_cli/tests/test_profiles_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/test_profiles_e2e.rs
@@ -57,6 +57,7 @@ fn run_with_env(dir: &Path, args: &[&str], env: Option<(&str, &str)>) -> std::pr
         // Pin the human preset so inherited agent env (CLAUDECODE/AI_AGENT/…)
         // cannot flip `--output-preset auto` to `agent` and hide progress lines.
         .env("BAML_OUTPUT_PRESET", "human")
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .env("BAML_HOME", home)
         .env("BAML_CACHE_DIR", dir.join(".baml-cache"));
     if let Some((name, value)) = env {

--- a/baml_language/crates/baml_cli/tests/update_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/update_e2e.rs
@@ -8,6 +8,7 @@ fn update_suggests_the_toolchain_and_wrapper_commands() {
         // Pin the human preset so inherited agent env (CLAUDECODE/AI_AGENT/…)
         // cannot flip `--output-preset auto` to `agent` and hide progress lines.
         .env("BAML_OUTPUT_PRESET", "human")
+        .env("BAML_AGENT_SKILL_CHECK", "off")
         .output()
         .unwrap();
 


### PR DESCRIPTION
## Summary

- require the toolchain-matched BAML skill for detected coding agents before authoring commands run
- add `--agent-skill-check` / `BAML_AGENT_SKILL_CHECK` with `auto`, `require`, `warn`, and `off` policies
- exempt install, help, and internal/management commands and keep human-mode warnings
- add deterministic unit, end-to-end, and help snapshot coverage

## Testing

- all `baml_cli` unit and integration tests
- `cargo clippy -p baml_cli --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable agent skill validation for CLI commands.
  - Added `--agent-skill-check` modes: `auto`, `require`, `warn`, and `off`.
  - Added equivalent `BAML_AGENT_SKILL_CHECK` environment variable support.
  - Detected coding agents can receive warnings or blocking errors for missing or outdated skills.
  - Added support for selecting the project directory used for skill validation.

- **Bug Fixes**
  - Skill-check validation errors are now surfaced correctly.
  - Profile arguments now reject agent skill-check settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->