### PR TITLE
feat(docs): validate and render BAML snippets

### DIFF
--- a/typescript2/app-developer-docs/app/baml/book/foundations/functions/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/book/foundations/functions/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { BamlSnippet } from '@/components/baml-snippet';
 import { DocsShell } from '@/components/docs-shell';
 
 export const metadata = {
@@ -35,11 +36,7 @@ export default function FunctionsChapterPage() {
 
       <h2 id="anatomy">Anatomy of a function</h2>
       <p>The smallest useful function returns a typed value directly.</p>
-      <pre>
-        <code>{`function ReturnNumber(value: int) -> int {
-  value
-}`}</code>
-      </pre>
+      <BamlSnippet id="functions/return-number" />
       <p>
         <code>ReturnNumber</code> is the function name, <code>value</code> is a
         named parameter, and the arrow introduces the return type. The final
@@ -70,6 +67,12 @@ class Receipt {
           the application can genuinely handle a missing value.
         </p>
       </blockquote>
+      <p>
+        The compiler rejects a body whose value does not match the declared
+        return type. This deliberately invalid example is checked for the
+        expected <code>E0001</code> diagnostic during documentation validation.
+      </p>
+      <BamlSnippet id="errors/invalid-return-type" />
 
       <h2 id="model-backed">Model-backed functions</h2>
       <p>

--- a/typescript2/app-developer-docs/app/baml/book/foundations/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/book/foundations/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { BamlProject } from '@/components/baml-snippet';
 import { DocsCard } from '@/components/docs-card';
 import { DocsShell } from '@/components/docs-shell';
 
@@ -38,6 +39,11 @@ export default function FoundationsPage() {
           relying on the new shape in application code.
         </p>
       </blockquote>
+      <p>
+        A project can split related types and functions across files while the
+        compiler checks them as one unit.
+      </p>
+      <BamlProject id="cross-file-types" />
       <h2 id="chapters">Chapters</h2>
       <div className="docs-card-grid">
         <DocsCard

--- a/typescript2/app-developer-docs/app/globals.css
+++ b/typescript2/app-developer-docs/app/globals.css
@@ -305,3 +305,56 @@ body:has([data-slot="docs"]) footer {
 .button-secondary:hover {
   opacity: 0.82;
 }
+
+.baml-snippet,
+.baml-project {
+  margin-block: 1.25rem;
+}
+
+.baml-project {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.baml-code {
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0.7rem;
+}
+
+.baml-code figcaption {
+  padding: 0.5rem 0.85rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.baml-code pre {
+  padding: 1rem;
+  margin: 0;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  background: var(--background) !important;
+  border: 0;
+  border-radius: 0;
+}
+
+.baml-code code {
+  font-family: var(--font-mono);
+}
+
+.baml-code-dark {
+  display: none;
+}
+
+.dark .baml-code-light {
+  display: none;
+}
+
+.dark .baml-code-dark {
+  display: block;
+}

--- a/typescript2/app-developer-docs/components/baml-snippet.tsx
+++ b/typescript2/app-developer-docs/components/baml-snippet.tsx
@@ -1,0 +1,95 @@
+import {
+  loadProjectSnippet,
+  loadStandaloneSnippet,
+} from '@/lib/snippets/discovery';
+import { highlightCode } from '@/lib/snippets/highlighter';
+
+function TokenizedCode({
+  className,
+  lines,
+}: {
+  className: string;
+  lines: Awaited<ReturnType<typeof highlightCode>>['light'];
+}) {
+  let nextLineOffset = 0;
+  const keyedLines = lines.map((line) => {
+    const offset = nextLineOffset;
+    nextLineOffset +=
+      line.reduce((length, token) => length + token.content.length, 0) + 1;
+    return { line, offset };
+  });
+  return (
+    <pre className={className}>
+      <code>
+        {keyedLines.map(({ line, offset }, lineIndex) => (
+          <span key={offset}>
+            {line.map((token) => (
+              <span key={token.offset} style={{ color: token.color }}>
+                {token.content}
+              </span>
+            ))}
+            {lineIndex === keyedLines.length - 1 ? null : '\n'}
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}
+
+async function HighlightedCode({
+  code,
+  filename,
+  language,
+}: {
+  code: string;
+  filename: string;
+  language: 'baml' | 'toml';
+}) {
+  const tokens = await highlightCode(code, language);
+  return (
+    <figure className="baml-code" data-language={language}>
+      <figcaption>{filename}</figcaption>
+      <TokenizedCode className="baml-code-light" lines={tokens.light} />
+      <TokenizedCode className="baml-code-dark" lines={tokens.dark} />
+    </figure>
+  );
+}
+
+export async function BamlSnippet({
+  id,
+  region = 'example',
+}: {
+  id: string;
+  region?: string;
+}) {
+  const snippet = await loadStandaloneSnippet(id);
+  const code = snippet.parsed.regions.get(region);
+  if (code === undefined) {
+    const available = [...snippet.parsed.regions.keys()].join(', ');
+    throw new Error(
+      `BAML snippet ${id} has no region ${region}. Available regions: ${available}`,
+    );
+  }
+
+  return (
+    <div className="baml-snippet" data-snippet-id={id}>
+      <HighlightedCode code={code} filename={`${id}.baml`} language="baml" />
+    </div>
+  );
+}
+
+export async function BamlProject({ id }: { id: string }) {
+  const project = await loadProjectSnippet(id);
+  return (
+    <div className="baml-project" data-project-id={id}>
+      {project.files.map((file) => (
+        <HighlightedCode
+          code={file.displaySource}
+          filename={file.projectPath}
+          key={file.projectPath}
+          language={file.projectPath.endsWith('.toml') ? 'toml' : 'baml'}
+        />
+      ))}
+    </div>
+  );
+}

--- a/typescript2/app-developer-docs/content/code/projects/cross-file-types/baml.toml
+++ b/typescript2/app-developer-docs/content/code/projects/cross-file-types/baml.toml
@@ -1,0 +1,2 @@
+[package]
+name = "docs_cross_file_types"

--- a/typescript2/app-developer-docs/content/code/projects/cross-file-types/baml_src/functions.baml
+++ b/typescript2/app-developer-docs/content/code/projects/cross-file-types/baml_src/functions.baml
@@ -1,0 +1,3 @@
+function FirstItem(receipt: Receipt) -> ReceiptItem? {
+  receipt.items[0]
+}

--- a/typescript2/app-developer-docs/content/code/projects/cross-file-types/baml_src/types.baml
+++ b/typescript2/app-developer-docs/content/code/projects/cross-file-types/baml_src/types.baml
@@ -1,0 +1,8 @@
+class ReceiptItem {
+  name string
+  quantity int
+}
+
+class Receipt {
+  items ReceiptItem[]
+}

--- a/typescript2/app-developer-docs/content/code/standalone/errors/invalid-return-type.baml
+++ b/typescript2/app-developer-docs/content/code/standalone/errors/invalid-return-type.baml
@@ -1,0 +1,13 @@
+// docs:meta
+// expect:
+//   status: failure
+//   diagnostics:
+//     - code: E0001
+//       messageContains: mismatched types
+// docs:endmeta
+
+// docs:start example
+function ReturnNumber(value: int) -> string {
+  value
+}
+// docs:end example

--- a/typescript2/app-developer-docs/content/code/standalone/functions/return-number.baml
+++ b/typescript2/app-developer-docs/content/code/standalone/functions/return-number.baml
@@ -1,0 +1,5 @@
+// docs:start example
+function ReturnNumber(value: int) -> int {
+  value
+}
+// docs:end example

--- a/typescript2/app-developer-docs/lib/snippets/checker.ts
+++ b/typescript2/app-developer-docs/lib/snippets/checker.ts
@@ -1,0 +1,299 @@
+import { spawn } from 'node:child_process';
+import { copyFile, mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, relative, resolve, sep } from 'node:path';
+
+import {
+  discoverProjectSnippets,
+  discoverStandaloneSnippets,
+  type ProjectSnippet,
+  type StandaloneSnippet,
+} from './discovery';
+import type { ExpectedDiagnostic, SnippetExpectation } from './schema';
+
+export interface CompilerDiagnostic {
+  code: string;
+  message: string;
+  output: string;
+}
+
+export interface CompilerCheckResult {
+  diagnostics: CompilerDiagnostic[];
+  exitCode: number | null;
+  output: string;
+}
+
+export interface SnippetValidationResult {
+  id: string;
+  kind: 'project' | 'standalone';
+  pageSources: string[];
+  sourcePath: string;
+}
+
+const diagnosticStartPattern = /^.*? error\[([^\]]+)\]: (.*)$/gm;
+
+function runProcess(
+  binary: string,
+  argumentsToPass: readonly string[],
+): Promise<{
+  exitCode: number | null;
+  output: string;
+}> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(binary, argumentsToPass, {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      output += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      output += chunk;
+    });
+    child.on('error', rejectPromise);
+    child.on('close', (exitCode) => resolvePromise({ exitCode, output }));
+  });
+}
+
+export function parseCompilerDiagnostics(output: string): CompilerDiagnostic[] {
+  const matches = [...output.matchAll(diagnosticStartPattern)];
+  return matches.map((match, index) => {
+    const start = match.index ?? 0;
+    const end = matches[index + 1]?.index ?? output.length;
+    return {
+      code: match[1],
+      message: match[2],
+      output: output.slice(start, end).trim(),
+    };
+  });
+}
+
+async function checkProject(
+  binary: string,
+  projectPath: string,
+): Promise<CompilerCheckResult> {
+  const result = await runProcess(binary, [
+    '--output-preset',
+    'agent',
+    '--color',
+    'never',
+    '--no-progress',
+    '--diagnostic-format',
+    'agent',
+    'check',
+    '--project',
+    projectPath,
+  ]);
+  return { ...result, diagnostics: parseCompilerDiagnostics(result.output) };
+}
+
+function diagnosticMatches(
+  actual: CompilerDiagnostic,
+  expected: ExpectedDiagnostic,
+): boolean {
+  return (
+    actual.code === expected.code &&
+    (expected.messageContains === undefined ||
+      actual.output.includes(expected.messageContains))
+  );
+}
+
+export function expectationFailure(
+  expectation: SnippetExpectation,
+  result: CompilerCheckResult,
+): string | null {
+  if (result.exitCode !== 0 && result.diagnostics.length === 0) {
+    return `compiler exited ${result.exitCode} without a typed diagnostic`;
+  }
+  if (expectation.status === 'success') {
+    return result.diagnostics.length === 0
+      ? null
+      : `expected success but received ${result.diagnostics.length} error diagnostic(s)`;
+  }
+  if (result.diagnostics.length === 0) {
+    return 'expected failure but received no error diagnostics';
+  }
+  const missing = expectation.diagnostics?.filter(
+    (expected) =>
+      !result.diagnostics.some((actual) => diagnosticMatches(actual, expected)),
+  );
+  if (missing && missing.length > 0) {
+    return `missing expected diagnostics: ${missing
+      .map(
+        (diagnostic) =>
+          `${diagnostic.code}${
+            diagnostic.messageContains
+              ? ` containing ${JSON.stringify(diagnostic.messageContains)}`
+              : ''
+          }`,
+      )
+      .join(', ')}`;
+  }
+  return null;
+}
+
+async function listSourceFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(root, entry.name);
+      if (entry.isDirectory()) return listSourceFiles(path);
+      return /\.(mdx|tsx)$/.test(entry.name) ? [path] : [];
+    }),
+  );
+  return files.flat();
+}
+
+async function findPageSources(
+  appRoot: string,
+  component: 'BamlProject' | 'BamlSnippet',
+  id: string,
+): Promise<string[]> {
+  const roots = [resolve(appRoot, 'app'), resolve(appRoot, 'content')];
+  const files = (await Promise.all(roots.map(listSourceFiles))).flat();
+  const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const usagePattern = new RegExp(
+    `<${component}\\s+[^>]*id=["']${escapedId}["']`,
+  );
+  const matched = await Promise.all(
+    files.map(async (path) =>
+      usagePattern.test(await readFile(path, 'utf8'))
+        ? relative(appRoot, path).split(sep).join('/')
+        : null,
+    ),
+  );
+  return matched.filter((path): path is string => path !== null).sort();
+}
+
+function formatFailure(
+  toolchainVersion: string,
+  kind: 'project' | 'standalone',
+  id: string,
+  sourcePath: string,
+  pageSources: readonly string[],
+  expectation: SnippetExpectation,
+  reason: string,
+  result: CompilerCheckResult,
+): Error {
+  return new Error(
+    [
+      `BAML ${kind} snippet validation failed`,
+      `id: ${id}`,
+      `page: ${pageSources.join(', ') || '<unreferenced>'}`,
+      `source: content/code/${sourcePath}`,
+      `toolchain: ${toolchainVersion}`,
+      `expectation: ${JSON.stringify(expectation)}`,
+      `actual: ${reason}`,
+      result.output.trim() || '<no compiler output>',
+    ].join('\n'),
+  );
+}
+
+async function validateStandalone(
+  binary: string,
+  toolchainVersion: string,
+  appRoot: string,
+  snippet: StandaloneSnippet,
+): Promise<SnippetValidationResult> {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'baml-docs-snippet-'));
+  const expectedPrefix = join(tmpdir(), 'baml-docs-snippet-');
+  if (!temporaryRoot.startsWith(expectedPrefix)) {
+    throw new Error(`Unexpected temporary path: ${temporaryRoot}`);
+  }
+  try {
+    await copyFile(
+      snippet.absolutePath,
+      join(temporaryRoot, basename(snippet.absolutePath)),
+    );
+    const result = await checkProject(binary, temporaryRoot);
+    const pageSources = await findPageSources(
+      appRoot,
+      'BamlSnippet',
+      snippet.id,
+    );
+    const reason = expectationFailure(snippet.parsed.expectation, result);
+    if (reason) {
+      throw formatFailure(
+        toolchainVersion,
+        'standalone',
+        snippet.id,
+        snippet.sourcePath,
+        pageSources,
+        snippet.parsed.expectation,
+        reason,
+        result,
+      );
+    }
+    return {
+      id: snippet.id,
+      kind: 'standalone',
+      pageSources,
+      sourcePath: snippet.sourcePath,
+    };
+  } finally {
+    await rm(temporaryRoot, { force: true, recursive: true });
+  }
+}
+
+async function validateProject(
+  binary: string,
+  toolchainVersion: string,
+  appRoot: string,
+  project: ProjectSnippet,
+): Promise<SnippetValidationResult> {
+  const result = await checkProject(binary, project.absolutePath);
+  const pageSources = await findPageSources(appRoot, 'BamlProject', project.id);
+  const reason = expectationFailure(project.expectation, result);
+  if (reason) {
+    throw formatFailure(
+      toolchainVersion,
+      'project',
+      project.id,
+      project.sourcePath,
+      pageSources,
+      project.expectation,
+      reason,
+      result,
+    );
+  }
+  return {
+    id: project.id,
+    kind: 'project',
+    pageSources,
+    sourcePath: project.sourcePath,
+  };
+}
+
+export async function validateSnippetCatalog(
+  binary: string,
+  appRoot: string,
+): Promise<{ results: SnippetValidationResult[]; toolchainVersion: string }> {
+  const versionResult = await runProcess(binary, ['--version']);
+  if (versionResult.exitCode !== 0) {
+    throw new Error(
+      `Unable to read BAML toolchain version from ${binary}: ${versionResult.output}`,
+    );
+  }
+  const toolchainVersion = versionResult.output.trim();
+  const standaloneSnippets = await discoverStandaloneSnippets();
+  const projects = await discoverProjectSnippets();
+  const standaloneResults: SnippetValidationResult[] = [];
+  for (const snippet of standaloneSnippets) {
+    standaloneResults.push(
+      await validateStandalone(binary, toolchainVersion, appRoot, snippet),
+    );
+  }
+  const projectResults: SnippetValidationResult[] = [];
+  for (const project of projects) {
+    projectResults.push(
+      await validateProject(binary, toolchainVersion, appRoot, project),
+    );
+  }
+  return {
+    results: [...standaloneResults, ...projectResults],
+    toolchainVersion,
+  };
+}

--- a/typescript2/app-developer-docs/lib/snippets/discovery.ts
+++ b/typescript2/app-developer-docs/lib/snippets/discovery.ts
@@ -1,0 +1,183 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { extname, relative, resolve, sep } from 'node:path';
+
+import { type ParsedBamlSource, parseBamlSource } from './parser';
+import {
+  type SnippetExpectation,
+  successfulSnippetExpectation,
+} from './schema';
+
+export const snippetContentRoot = resolve(process.cwd(), 'content/code');
+
+export interface StandaloneSnippet {
+  absolutePath: string;
+  id: string;
+  parsed: ParsedBamlSource;
+  sourcePath: string;
+}
+
+export interface ProjectSnippetFile {
+  absolutePath: string;
+  displaySource: string;
+  projectPath: string;
+  sourcePath: string;
+}
+
+export interface ProjectSnippet {
+  absolutePath: string;
+  expectation: SnippetExpectation;
+  files: ProjectSnippetFile[];
+  id: string;
+  sourcePath: string;
+}
+
+function posixPath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function resolveContained(root: string, requestedPath: string): string {
+  if (
+    !requestedPath ||
+    requestedPath.startsWith('/') ||
+    requestedPath.includes('\\')
+  ) {
+    throw new Error(`Invalid snippet path: ${requestedPath}`);
+  }
+  const absolutePath = resolve(root, requestedPath);
+  const relativePath = relative(root, absolutePath);
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    relativePath === ''
+  ) {
+    throw new Error(
+      `Snippet path escapes its canonical root: ${requestedPath}`,
+    );
+  }
+  return absolutePath;
+}
+
+async function listFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(root, entry.name);
+      return entry.isDirectory() ? listFiles(path) : [path];
+    }),
+  );
+  return nested.flat().sort();
+}
+
+async function requireFile(path: string, label: string): Promise<void> {
+  const details = await stat(path).catch(() => null);
+  if (!details?.isFile()) {
+    throw new Error(`${label} does not exist: ${path}`);
+  }
+}
+
+async function requireDirectory(path: string, label: string): Promise<void> {
+  const details = await stat(path).catch(() => null);
+  if (!details?.isDirectory()) {
+    throw new Error(`${label} does not exist: ${path}`);
+  }
+}
+
+export async function loadStandaloneSnippet(
+  id: string,
+): Promise<StandaloneSnippet> {
+  if (extname(id)) {
+    throw new Error(`Standalone snippet IDs must omit the extension: ${id}`);
+  }
+  const standaloneRoot = resolve(snippetContentRoot, 'standalone');
+  const absolutePath = resolveContained(standaloneRoot, `${id}.baml`);
+  await requireFile(absolutePath, 'Standalone snippet');
+  const sourcePath = posixPath(relative(snippetContentRoot, absolutePath));
+  const rawSource = await readFile(absolutePath, 'utf8');
+  return {
+    absolutePath,
+    id,
+    parsed: parseBamlSource(rawSource, sourcePath),
+    sourcePath,
+  };
+}
+
+export async function discoverStandaloneSnippets(): Promise<
+  StandaloneSnippet[]
+> {
+  const standaloneRoot = resolve(snippetContentRoot, 'standalone');
+  const files = (await listFiles(standaloneRoot)).filter(
+    (path) => extname(path) === '.baml',
+  );
+  return Promise.all(
+    files.map((path) =>
+      loadStandaloneSnippet(
+        posixPath(relative(standaloneRoot, path)).replace(/\.baml$/, ''),
+      ),
+    ),
+  );
+}
+
+export async function loadProjectSnippet(id: string): Promise<ProjectSnippet> {
+  const projectsRoot = resolve(snippetContentRoot, 'projects');
+  const absolutePath = resolveContained(projectsRoot, id);
+  await requireDirectory(absolutePath, 'Snippet project');
+
+  const manifestPath = resolveContained(absolutePath, 'baml.toml');
+  const sourceRoot = resolveContained(absolutePath, 'baml_src');
+  await requireFile(manifestPath, 'Snippet project manifest');
+  await requireDirectory(sourceRoot, 'Snippet project source directory');
+
+  const bamlFiles = (await listFiles(sourceRoot)).filter(
+    (path) => extname(path) === '.baml',
+  );
+  if (bamlFiles.length === 0) {
+    throw new Error(`Snippet project has no BAML source files: ${id}`);
+  }
+
+  const parsedFiles = await Promise.all(
+    bamlFiles.map(async (path) => {
+      const projectPath = posixPath(relative(absolutePath, path));
+      const sourcePath = posixPath(relative(snippetContentRoot, path));
+      const parsed = parseBamlSource(await readFile(path, 'utf8'), sourcePath);
+      return { parsed, path, projectPath, sourcePath };
+    }),
+  );
+  const metadataFiles = parsedFiles.filter(({ parsed }) => parsed.hasMetadata);
+  if (metadataFiles.length > 1) {
+    throw new Error(`Snippet project ${id} has metadata in more than one file`);
+  }
+
+  const files: ProjectSnippetFile[] = [
+    {
+      absolutePath: manifestPath,
+      displaySource: (await readFile(manifestPath, 'utf8')).trim(),
+      projectPath: 'baml.toml',
+      sourcePath: posixPath(relative(snippetContentRoot, manifestPath)),
+    },
+    ...parsedFiles.map(({ path, parsed, projectPath, sourcePath }) => ({
+      absolutePath: path,
+      displaySource: parsed.source,
+      projectPath,
+      sourcePath,
+    })),
+  ];
+
+  return {
+    absolutePath,
+    expectation:
+      metadataFiles[0]?.parsed.expectation ?? successfulSnippetExpectation,
+    files,
+    id,
+    sourcePath: posixPath(relative(snippetContentRoot, absolutePath)),
+  };
+}
+
+export async function discoverProjectSnippets(): Promise<ProjectSnippet[]> {
+  const projectsRoot = resolve(snippetContentRoot, 'projects');
+  const entries = await readdir(projectsRoot, { withFileTypes: true });
+  return Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => loadProjectSnippet(entry.name)),
+  );
+}

--- a/typescript2/app-developer-docs/lib/snippets/highlighter.ts
+++ b/typescript2/app-developer-docs/lib/snippets/highlighter.ts
@@ -1,0 +1,44 @@
+import bamlGrammar from '@b/pkg-grammar';
+import {
+  type BundledLanguage,
+  createHighlighter,
+  type ThemedToken,
+} from 'shiki';
+
+function createDocsHighlighter() {
+  return createHighlighter({
+    langs: [bamlGrammar, 'toml'],
+    themes: ['github-light', 'github-dark'],
+  });
+}
+
+let highlighterPromise: ReturnType<typeof createDocsHighlighter> | null = null;
+
+function getHighlighter(): ReturnType<typeof createDocsHighlighter> {
+  highlighterPromise ??= createDocsHighlighter();
+  return highlighterPromise;
+}
+
+function registeredLanguage(language: 'baml' | 'toml'): BundledLanguage {
+  if (language === 'toml') return language;
+  // SAFETY: createDocsHighlighter registers the canonical custom grammar named baml.
+  return language as BundledLanguage;
+}
+
+export async function highlightCode(
+  code: string,
+  language: 'baml' | 'toml',
+): Promise<{ dark: ThemedToken[][]; light: ThemedToken[][] }> {
+  const highlighter = await getHighlighter();
+  const registered = registeredLanguage(language);
+  return {
+    dark: highlighter.codeToTokensBase(code, {
+      lang: registered,
+      theme: 'github-dark',
+    }),
+    light: highlighter.codeToTokensBase(code, {
+      lang: registered,
+      theme: 'github-light',
+    }),
+  };
+}

--- a/typescript2/app-developer-docs/lib/snippets/parser.ts
+++ b/typescript2/app-developer-docs/lib/snippets/parser.ts
@@ -1,0 +1,194 @@
+import { load } from 'js-yaml';
+
+import {
+  type SnippetExpectation,
+  snippetMetadataSchema,
+  successfulSnippetExpectation,
+} from './schema';
+
+const metadataStartPattern = /^\s*\/\/ docs:meta\s*$/;
+const metadataEndPattern = /^\s*\/\/ docs:endmeta\s*$/;
+const regionStartPattern =
+  /^\s*\/\/ docs:start ([A-Za-z0-9][A-Za-z0-9._-]*)\s*$/;
+const regionEndPattern = /^\s*\/\/ docs:end ([A-Za-z0-9][A-Za-z0-9._-]*)\s*$/;
+const docsDirectivePattern = /^\s*\/\/ docs:/;
+
+export interface ParsedBamlSource {
+  expectation: SnippetExpectation;
+  hasMetadata: boolean;
+  regions: ReadonlyMap<string, string>;
+  source: string;
+}
+
+interface ParsedMetadataBlock {
+  expectation: SnippetExpectation;
+  hasMetadata: boolean;
+  sourceLines: string[];
+}
+
+function fail(sourceName: string, lineNumber: number, message: string): never {
+  throw new Error(`${sourceName}:${lineNumber}: ${message}`);
+}
+
+function parseMetadata(
+  lines: readonly string[],
+  sourceName: string,
+): ParsedMetadataBlock {
+  let metadataStart = -1;
+  let metadataEnd = -1;
+
+  for (const [index, line] of lines.entries()) {
+    if (metadataStartPattern.test(line)) {
+      if (metadataStart !== -1) {
+        fail(sourceName, index + 1, 'only one docs metadata block is allowed');
+      }
+      metadataStart = index;
+      continue;
+    }
+    if (metadataEndPattern.test(line)) {
+      if (metadataStart === -1) {
+        fail(sourceName, index + 1, 'docs:endmeta has no matching docs:meta');
+      }
+      if (metadataEnd !== -1) {
+        fail(sourceName, index + 1, 'docs metadata block has multiple endings');
+      }
+      metadataEnd = index;
+    }
+  }
+
+  if (metadataStart === -1) {
+    return {
+      expectation: successfulSnippetExpectation,
+      hasMetadata: false,
+      sourceLines: [...lines],
+    };
+  }
+  if (metadataEnd === -1) {
+    fail(
+      sourceName,
+      metadataStart + 1,
+      'docs:meta has no matching docs:endmeta',
+    );
+  }
+  if (metadataEnd < metadataStart) {
+    fail(sourceName, metadataEnd + 1, 'docs:endmeta appears before docs:meta');
+  }
+
+  const yamlLines = lines
+    .slice(metadataStart + 1, metadataEnd)
+    .map((line, offset) => {
+      const match = line.match(/^\s*\/\/( ?)(.*)$/);
+      if (!match) {
+        fail(
+          sourceName,
+          metadataStart + offset + 2,
+          'every docs metadata line must begin with //',
+        );
+      }
+      return match[2];
+    });
+
+  let expectation: SnippetExpectation;
+  try {
+    const metadata = snippetMetadataSchema.parse(load(yamlLines.join('\n')));
+    expectation = metadata.expect;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(sourceName, metadataStart + 1, `invalid docs metadata: ${detail}`);
+  }
+
+  return {
+    expectation,
+    hasMetadata: true,
+    sourceLines: lines.filter(
+      (_line, index) => index < metadataStart || index > metadataEnd,
+    ),
+  };
+}
+
+export function parseBamlSource(
+  rawSource: string,
+  sourceName: string,
+): ParsedBamlSource {
+  const normalizedSource = rawSource.replaceAll('\r\n', '\n');
+  const { expectation, hasMetadata, sourceLines } = parseMetadata(
+    normalizedSource.split('\n'),
+    sourceName,
+  );
+  const regionLines = new Map<string, string[]>();
+  const cleanedLines: string[] = [];
+  let activeRegion: { name: string; startLine: number } | null = null;
+
+  for (const [index, line] of sourceLines.entries()) {
+    const startMatch = line.match(regionStartPattern);
+    if (startMatch) {
+      if (activeRegion) {
+        fail(
+          sourceName,
+          index + 1,
+          `region ${startMatch[1]} is nested inside ${activeRegion.name}`,
+        );
+      }
+      if (regionLines.has(startMatch[1])) {
+        fail(sourceName, index + 1, `duplicate region ${startMatch[1]}`);
+      }
+      activeRegion = { name: startMatch[1], startLine: index + 1 };
+      regionLines.set(startMatch[1], []);
+      continue;
+    }
+
+    const endMatch = line.match(regionEndPattern);
+    if (endMatch) {
+      if (!activeRegion) {
+        fail(sourceName, index + 1, `region ${endMatch[1]} has no start`);
+      }
+      if (endMatch[1] !== activeRegion.name) {
+        fail(
+          sourceName,
+          index + 1,
+          `region ${endMatch[1]} closes active region ${activeRegion.name}`,
+        );
+      }
+      activeRegion = null;
+      continue;
+    }
+
+    if (docsDirectivePattern.test(line)) {
+      fail(
+        sourceName,
+        index + 1,
+        `malformed or unknown docs directive: ${line.trim()}`,
+      );
+    }
+
+    cleanedLines.push(line);
+    if (activeRegion) {
+      regionLines.get(activeRegion.name)?.push(line);
+    }
+  }
+
+  if (activeRegion) {
+    fail(
+      sourceName,
+      activeRegion.startLine,
+      `region ${activeRegion.name} has no matching end`,
+    );
+  }
+
+  const source = cleanedLines.join('\n').trim();
+  if (regionLines.size === 0) {
+    regionLines.set('example', source.split('\n'));
+  }
+
+  return {
+    expectation,
+    hasMetadata,
+    regions: new Map(
+      [...regionLines].map(([name, content]) => [
+        name,
+        content.join('\n').trim(),
+      ]),
+    ),
+    source,
+  };
+}

--- a/typescript2/app-developer-docs/lib/snippets/schema.ts
+++ b/typescript2/app-developer-docs/lib/snippets/schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const expectedDiagnosticSchema = z
+  .object({
+    code: z.string().regex(/^E\d{4}$/),
+    messageContains: z.string().min(1).optional(),
+  })
+  .strict();
+
+const successExpectationSchema = z
+  .object({
+    status: z.literal('success'),
+  })
+  .strict();
+
+const failureExpectationSchema = z
+  .object({
+    diagnostics: z.array(expectedDiagnosticSchema).min(1).optional(),
+    status: z.literal('failure'),
+  })
+  .strict();
+
+export const snippetExpectationSchema = z.discriminatedUnion('status', [
+  successExpectationSchema,
+  failureExpectationSchema,
+]);
+
+export const snippetMetadataSchema = z
+  .object({
+    expect: snippetExpectationSchema,
+  })
+  .strict();
+
+export type ExpectedDiagnostic = z.output<typeof expectedDiagnosticSchema>;
+export type SnippetExpectation = z.output<typeof snippetExpectationSchema>;
+export type SnippetMetadata = z.output<typeof snippetMetadataSchema>;
+
+export const successfulSnippetExpectation: SnippetExpectation = {
+  status: 'success',
+};

--- a/typescript2/app-developer-docs/mdx-components.tsx
+++ b/typescript2/app-developer-docs/mdx-components.tsx
@@ -1,9 +1,13 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 
+import { BamlProject, BamlSnippet } from '@/components/baml-snippet';
+
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    BamlProject,
+    BamlSnippet,
     ...components,
   };
 }

--- a/typescript2/app-developer-docs/package.json
+++ b/typescript2/app-developer-docs/package.json
@@ -39,8 +39,13 @@
     "docs:db:migrate": "tsx scripts/migrate-generated-content.ts",
     "docs:db:populate": "tsx scripts/populate-generated-content.ts",
     "docs:db:verify": "tsx scripts/verify-generated-content.ts",
+    "docs:grammar:build": "pnpm --filter @b/pkg-grammar build",
+    "docs:snippets:validate": "tsx scripts/validate-snippets.ts",
     "lint": "biome check . && tsx node_modules/oxlint/bin/oxlint --config .oxlintrc.json .",
     "postinstall": "fumadocs-mdx",
+    "prebuild": "pnpm docs:grammar:build",
+    "pretest": "pnpm docs:grammar:build",
+    "pretypecheck": "pnpm docs:grammar:build",
     "start": "next start",
     "test": "tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"

--- a/typescript2/app-developer-docs/scripts/validate-snippets.ts
+++ b/typescript2/app-developer-docs/scripts/validate-snippets.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path';
+
+import { validateSnippetCatalog } from '../lib/snippets/checker';
+import { parseOperatorArguments } from './operator-arguments';
+
+const argumentsToUse = parseOperatorArguments(
+  process.argv.slice(2),
+  ['baml-bin'],
+  [],
+);
+const binary =
+  argumentsToUse.values.get('baml-bin') ?? process.env.BAML_BINARY ?? 'baml';
+const appRoot = resolve(import.meta.dirname, '..');
+const validation = await validateSnippetCatalog(binary, appRoot);
+
+console.log(
+  `Validated ${validation.results.length} BAML snippets with ${validation.toolchainVersion}.`,
+);
+for (const result of validation.results) {
+  console.log(
+    `- ${result.kind} ${result.id} (${result.pageSources.join(', ') || 'unreferenced'})`,
+  );
+}

--- a/typescript2/app-developer-docs/tests/snippets.test.ts
+++ b/typescript2/app-developer-docs/tests/snippets.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  type CompilerCheckResult,
+  expectationFailure,
+  parseCompilerDiagnostics,
+} from '../lib/snippets/checker';
+import {
+  loadProjectSnippet,
+  loadStandaloneSnippet,
+} from '../lib/snippets/discovery';
+import { highlightCode } from '../lib/snippets/highlighter';
+import { parseBamlSource } from '../lib/snippets/parser';
+
+test('snippet metadata and named regions are parsed and removed from display source', () => {
+  const parsed = parseBamlSource(
+    `// docs:meta
+// expect:
+//   status: failure
+//   diagnostics:
+//     - code: E0001
+//       messageContains: expected string
+// docs:endmeta
+// docs:start example
+function Broken(value: int) -> string {
+  value
+}
+// docs:end example`,
+    'fixture.baml',
+  );
+
+  assert.deepEqual(parsed.expectation, {
+    diagnostics: [{ code: 'E0001', messageContains: 'expected string' }],
+    status: 'failure',
+  });
+  assert.equal(parsed.hasMetadata, true);
+  assert.match(parsed.regions.get('example') ?? '', /function Broken/);
+  assert.doesNotMatch(parsed.source, /docs:/);
+});
+
+test('a source without markers exposes the whole file as the example region', () => {
+  const parsed = parseBamlSource(
+    'function Identity(value: int) -> int {\n  value\n}',
+    'identity.baml',
+  );
+  assert.equal(parsed.regions.get('example'), parsed.source);
+  assert.deepEqual(parsed.expectation, { status: 'success' });
+});
+
+test('snippet directives and metadata fail closed', () => {
+  assert.throws(
+    () =>
+      parseBamlSource(
+        '// docs:start first\n// docs:start second\n// docs:end second',
+        'nested.baml',
+      ),
+    /nested inside/,
+  );
+  assert.throws(
+    () =>
+      parseBamlSource(
+        '// docs:meta\n// expect:\n//   status: success\n//   surprise: true\n// docs:endmeta',
+        'unknown.baml',
+      ),
+    /invalid docs metadata/,
+  );
+  assert.throws(
+    () =>
+      parseBamlSource(
+        '// docs:meta\n// expect:\n//   status: success\n//   diagnostics: []\n// docs:endmeta',
+        'contradictory.baml',
+      ),
+    /invalid docs metadata/,
+  );
+});
+
+test('compiler diagnostics are parsed even when the compiler exits successfully', () => {
+  const output = [
+    'example.baml:1:1-1:2 error[E0001]: mismatched types',
+    '  primary: expected `string`, found `int`',
+    'example.baml:2:1-2:2 error[E0003]: unresolved name: `missing`',
+  ].join('\n');
+  const diagnostics = parseCompilerDiagnostics(output);
+  assert.deepEqual(
+    diagnostics.map(({ code, message }) => ({ code, message })),
+    [
+      { code: 'E0001', message: 'mismatched types' },
+      { code: 'E0003', message: 'unresolved name: `missing`' },
+    ],
+  );
+
+  const result: CompilerCheckResult = {
+    diagnostics,
+    exitCode: 0,
+    output,
+  };
+  assert.equal(
+    expectationFailure({ status: 'success' }, result),
+    'expected success but received 2 error diagnostic(s)',
+  );
+  assert.equal(
+    expectationFailure(
+      {
+        diagnostics: [{ code: 'E0001', messageContains: 'expected `string`' }],
+        status: 'failure',
+      },
+      result,
+    ),
+    null,
+  );
+  assert.equal(
+    expectationFailure(
+      { diagnostics: [{ code: 'E0001' }], status: 'failure' },
+      { ...result, exitCode: 2 },
+    ),
+    null,
+  );
+});
+
+test('canonical standalone and project IDs resolve to checked source trees', async () => {
+  const standalone = await loadStandaloneSnippet('functions/return-number');
+  assert.equal(
+    standalone.sourcePath,
+    'standalone/functions/return-number.baml',
+  );
+  await assert.rejects(loadStandaloneSnippet('../outside'), /escapes/);
+
+  const project = await loadProjectSnippet('cross-file-types');
+  assert.deepEqual(
+    project.files.map(({ projectPath }) => projectPath),
+    ['baml.toml', 'baml_src/functions.baml', 'baml_src/types.baml'],
+  );
+  assert.deepEqual(project.expectation, { status: 'success' });
+});
+
+test('the canonical BAML grammar produces highlighted light and dark tokens', async () => {
+  const highlighted = await highlightCode(
+    'function Identity(value: int) -> int { value }',
+    'baml',
+  );
+  for (const tokens of [highlighted.light, highlighted.dark]) {
+    assert.equal(
+      tokens
+        .flat()
+        .map(({ content }) => content)
+        .join(''),
+      'function Identity(value: int) -> int { value }',
+    );
+    assert.ok(tokens.flat().some(({ color }) => color !== undefined));
+  }
+});


### PR DESCRIPTION
## Why

Before this layer, BAML examples in the portal were copied directly into page components. They could drift from compilable source, could not express expected failures, and did not use the canonical BAML grammar.

After this layer, rendered BAML examples come from canonical files under `content/code`, and the same files are checked with one explicitly selected compiler binary. Standalone examples are isolated from one another; proper projects retain their real manifest and source tree.

## End-user behavior

A page can render a checked standalone region with:

```mdx
<BamlSnippet id="functions/return-number" />
```

A page can render a complete checked project with:

```mdx
<BamlProject id="cross-file-types" />
```

Intentionally invalid examples declare strict YAML expectations beside the source. The validator requires the requested diagnostic code and optional message fragment, even though the current compiler uses a nonzero exit status for typed errors.

## Review map

- `lib/snippets/parser.ts` owns strict metadata and region parsing. Unknown keys, malformed directives, duplicate metadata, nested regions, and contradictory success metadata fail closed.
- `lib/snippets/discovery.ts` derives IDs from canonical paths and requires real `baml.toml` plus `baml_src/` project structure.
- `lib/snippets/checker.ts` copies each standalone file into its own operating-system temporary directory, checks proper projects directly, parses typed diagnostics, and emits page, snippet, source, toolchain, expectation, actual-result context.
- `components/baml-snippet.tsx` renders escaped token trees from Shiki rather than injecting HTML. Both themes use the canonical `@b/pkg-grammar` TextMate grammar.
- `content/code` contains the architecture-proof fixtures: one valid standalone file, one expected `E0001` failure, and one proper two-file project.
- The Functions and Foundations pages demonstrate both components with actual user-visible examples.
- The implementation plan and status ledger record Phase 2B completion and the separate authorization-dependent CI credential work for Phase 2F.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 25 tests passed
- `pnpm docs:snippets:validate --baml-bin /opt/homebrew/bin/baml` — 3 examples passed with wrapper 0.2.4 and toolchain `0.18.1-nightly.20260901.a`
- Next.js development-runtime browser review of both book pages
- Light/dark token view switch verified in the browser

A full remote/static production build remains an explicit Phase 2F item: dependent PR #4730 currently has no `GENERATED_CONTENT_DATABASE_URL` in GitHub Actions or Vercel Preview. No persistent external credential was created in this layer.

## Stack

Depends on #4730. This is the third layer in stack #4731.