### PR TITLE
ci: disable Windows SDK tests

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -729,6 +729,9 @@ jobs:
                 "rust-cache-key": "macos-cargo",
                 "timeout": 40,
               },
+              /*
+               * Windows SDK tests are intentionally disabled because their compute cost is too high for the value they provide.
+               * Restore them by removing this block comment.
               {
                 "sdk-label": "go",
                 "sdk-dir": "go",
@@ -817,6 +820,7 @@ jobs:
                 "rust-cache-key": "windows-cargo",
                 "timeout": 60,
               },
+              */
             ];
 
             // TODO(B-1545): Re-enable macOS SDK tests after the SIGABRT flakiness is fixed: https://linear.app/boundaryml2/issue/B-1545/investigate-flakiness-in-cargo-test-aarch64-apple-darwin-ci-job


### PR DESCRIPTION
Disable SDK tests on windows, save money on CI.

Only `.github/workflows/cargo-tests.reusable.yaml` changes. Its `sdk-tests` matrix no longer schedules these Windows variants:

- `go:windows`
- `python-pydantic2:windows`
- `ruby-sorbet:windows`
- `typescript:windows`
- `typescript-web:windows`
- `csharp:windows`
- `rust:windows`
- `java:windows`

The complete Windows matrix configuration remains inline inside a JavaScript block comment with a nearby cost/value explanation. Re-enable all eight variants by removing the opening and closing block-comment markers.