### PR TITLE
ci: use repository secrets for sccache

### DIFF
--- a/.github/workflows/canary-cache-refresh.yml
+++ b/.github/workflows/canary-cache-refresh.yml
@@ -46,8 +46,7 @@ jobs:
   cargo-tests:
     needs: purge
     uses: ./.github/workflows/cargo-tests.reusable.yaml
-    # Structural mapping only: the called jobs get the values from their
-    # infisical-github-ci Environment, not from repository secrets.
+    # Map repository Actions secrets into the reusable-workflow contract.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -19,11 +19,11 @@
 #
 # mise installs sccache and direnv, then each cargo job loads .envrc via
 # `direnv export gha` so CI uses the exact same sccache config as local shells:
-# .envrc is the single source of truth. The R2 credentials come from the
-# infisical-github-ci GitHub Environment using the same BAML_SCCACHE_R2_* names that the
-# RUSTC_WRAPPER maps to AWS_* before exec'ing sccache — the `tools/baml-sccache`
-# script on POSIX, and the native `tools_sccache` crate's binary on Windows
-# (built per-job; see the "Build native sccache wrapper" step).
+# .envrc is the single source of truth. The R2 credentials come from repository
+# Actions secrets using the same BAML_SCCACHE_R2_* names that the RUSTC_WRAPPER
+# maps to AWS_* before exec'ing sccache — the `tools/baml-sccache` script on
+# POSIX, and the native `tools_sccache` crate's binary on Windows (built per-job;
+# see the "Build native sccache wrapper" step).
 #
 # Secretless runs (e.g. fork PRs) still install sccache, but .envrc sees no R2
 # credentials and falls back to the runner-local cache.
@@ -31,18 +31,14 @@ name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
-    # Callers intentionally map these names even though the values exist only
-    # in the GitHub Environment. The mapping establishes the reusable-workflow
-    # secret contract; each job's environment supplies the actual value.
-    # Keep them optional so fork PRs retain the secretless local-cache path.
+    # Optional so secretless fork PRs can use the local cache.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
         required: false
 
-# Read-only by design: these jobs run PR-controlled cargo build/test code, so
-# they should not need elevated repository permissions.
+# Jobs run PR-controlled code with read-only repository access.
 permissions:
   contents: read
 
@@ -51,9 +47,9 @@ defaults:
     shell: bash
 
 env:
-  # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
-  # .envrc itself so it stays the single source of truth across CI and local.
-  # Native Cargo linker overrides live in baml_language/.cargo/config.toml.
+  # .envrc supplies the remaining sccache configuration.
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -75,11 +71,7 @@ jobs:
   cargo-test-linux:
     name: "cargo test (x86_64-unknown-linux-gnu)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 25
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -182,11 +174,8 @@ jobs:
   cargo-test-linux-musl:
     name: "cargo test (x86_64-unknown-linux-musl)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 35
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
     steps:
       - uses: useblacksmith/checkout@v1
@@ -379,10 +368,7 @@ jobs:
     # 8-vCPU + CARGO_BUILD_JOBS=16 (2x cores) was the value sweet spot for the
     # native Windows Rust builds (build-caching/04 Exp 7/9).
     runs-on: blacksmith-8vcpu-windows-2025
-    environment: infisical-github-ci
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_JOBS: "16"
       # Windows debug builds emit very large PDBs; full debuginfo across the
       # whole `--all-features` test build overruns the runner's ~130 GB disk
@@ -921,11 +907,8 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
-    environment: infisical-github-ci
     timeout-minutes: ${{ matrix.timeout }}
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       # MSBuild reads environment variables as global properties. The .NET
       # SDK embeds the git commit into every build by default (SourceLink
       # json + SourceRevisionId in InformationalVersion), which changes a
@@ -1244,11 +1227,7 @@ jobs:
   cargo-test-wasm:
     name: "cargo test (wasm32-unknown-unknown)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 45
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -1358,11 +1337,7 @@ jobs:
   cargo-build-msrv:
     name: "cargo build (msrv)"
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 25
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -1449,11 +1424,7 @@ jobs:
   cargo-doc:
     name: "cargo doc"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 25
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -1528,11 +1499,7 @@ jobs:
   snapshot-tests:
     name: "snapshot tests"
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 30
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -589,8 +589,7 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/cargo-tests.reusable.yaml
-    # Structural mapping only: the called jobs get the values from their
-    # infisical-github-ci Environment, not from repository secrets.
+    # Map repository Actions secrets into the reusable-workflow contract.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -5,51 +5,21 @@
 # nothing about how the original runs. Promote or delete after the
 # trial; do not evolve both copies.
 #
-# sccache strategy
-# ================
-#
-# This workflow uses sccache for Rust compilation artifacts and
-# Swatinem/rust-cache for Cargo registry/git state — i.e. everything cargo
-# downloads before it compiles: the crates.io index, the `.crate` tarballs, and
-# the git checkouts of our forks (minijinja, aws-sdk-rust, google-cloud-rust).
-# `cache-all-crates: true` keeps all of those (the git forks in particular,
-# which are large and otherwise re-cloned on every runner); `cache-targets:
-# false` leaves the compiled `target/` tree to sccache so the two caches don't
-# compete.
-#
-# Because `target/` is excluded, rust-cache's payload is small (registry + git,
-# no build output). This copy never SAVES cache entries (save-if: false on
-# every step): the env pins below shift rust-cache's keys, so saving here
-# would write a parallel set of entries into the repo's shared cache quota
-# and evict the gating workflow's. On ix, warmth comes from the seed disk,
-# not the Actions cache.
-#
-# mise installs sccache and direnv, then each cargo job loads .envrc via
-# `direnv export gha` so CI uses the exact same sccache config as local shells:
-# .envrc is the single source of truth. The R2 credentials come from the
-# infisical-github-ci GitHub Environment using the same BAML_SCCACHE_R2_* names that the
-# RUSTC_WRAPPER maps to AWS_* before exec'ing sccache — the `tools/baml-sccache`
-# script on POSIX, and the native `tools_sccache` crate's binary on Windows
-# (built per-job; see the "Build native sccache wrapper" step).
-#
-# Secretless runs (e.g. fork PRs) still install sccache, but .envrc sees no R2
-# credentials and falls back to the runner-local cache.
+# sccache stores Rust compilation artifacts in R2. This preview never writes
+# rust-cache entries; ix warmth comes from the seed disk. .envrc configures
+# sccache, with secretless fork PRs falling back to local cache.
 name: Cargo Tests (Reusable)
 
 on:
   workflow_call:
-    # Callers intentionally map these names even though the values exist only
-    # in the GitHub Environment. The mapping establishes the reusable-workflow
-    # secret contract; each job's environment supplies the actual value.
-    # Keep them optional so fork PRs retain the secretless local-cache path.
+    # Optional so secretless fork PRs can use the local cache.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
         required: false
 
-# Read-only by design: these jobs run PR-controlled cargo build/test code, so
-# they should not need elevated repository permissions.
+# Jobs run PR-controlled code with read-only repository access.
 permissions:
   contents: read
 
@@ -58,9 +28,9 @@ defaults:
     shell: bash
 
 env:
-  # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
-  # .envrc itself so it stays the single source of truth across CI and local.
-  # Native Cargo linker overrides live in baml_language/.cargo/config.toml.
+  # .envrc supplies the remaining sccache configuration.
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
@@ -92,13 +62,9 @@ jobs:
     name: "cargo test (x86_64-unknown-linux-gnu)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     # 40, not 25: a machine without a warm seed compiles cold and can
     # exceed 25 minutes; the cap is a hang backstop, not a perf gate.
     timeout-minutes: 40
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -197,12 +163,9 @@ jobs:
     name: "cargo test (x86_64-unknown-linux-musl)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-musl"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     # 45, not 35: same reasoning as the gnu lane above.
     timeout-minutes: 45
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_TARGET: x86_64-unknown-linux-musl
       # The ix machine image ships musl-gcc; setup-musl-cross is skipped
       # there, so wire the same env the action would export.
@@ -827,11 +790,8 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
-    environment: infisical-github-ci
     timeout-minutes: ${{ matrix.timeout }}
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       # The machine image defaults these to 16; 32 runs clean on the
       # 64-vCPU machines.
       NEXTEST_TEST_THREADS: "32"
@@ -1054,11 +1014,7 @@ jobs:
     name: "cargo test (wasm32-unknown-unknown)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-wasm"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     timeout-minutes: 45
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1172,14 +1128,10 @@ jobs:
     name: "cargo build (msrv)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-msrv"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     # 40, not 25: the MSRV toolchain is unique to this job, so a machine
     # without a warm seed rebuilds everything from cold and can exceed 25
     # minutes. Warm runs sit far inside the old budget.
     timeout-minutes: 40
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1270,11 +1222,7 @@ jobs:
     name: "cargo doc"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     timeout-minutes: 25
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1353,12 +1301,8 @@ jobs:
     name: "snapshot tests"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-16vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     # 45, not 30: cold headroom, same reasoning as the gnu lane above.
     timeout-minutes: 45
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -114,8 +114,7 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
-    # Structural mapping only: the called jobs get the values from their
-    # infisical-github-ci Environment, not from repository secrets.
+    # Map repository Actions secrets into the reusable-workflow contract.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ix-size-gate.reusable.yaml
+++ b/.github/workflows/ix-size-gate.reusable.yaml
@@ -6,35 +6,20 @@
 # nothing about how the original runs. Promote or delete after the
 # trial; do not evolve both copies.
 #
-# sccache strategy
-# ================
-#
-# These jobs compile the same release artifacts the cargo tests do, so they
-# share the sccache + Swatinem/rust-cache setup documented at the top of
-# cargo-tests.reusable.yaml: sccache holds the compiled `target/` tree (R2
-# backend), while rust-cache keeps the registry/git state (`cache-all-crates:
-# true`, `cache-targets: false`). They are read-only consumers of the shared
-# rust-cache entries written by canary in cargo-tests.reusable.yaml, and read
-# the same sccache R2 cache via .envrc.
-#
-# Secretless runs (e.g. fork PRs) still install sccache, but .envrc sees no R2
-# credentials and falls back to the runner-local cache.
+# Size-gate jobs share cargo tests' R2 sccache. This preview relies on ix seed
+# disks rather than writing rust-cache entries. Secretless fork PRs use local cache.
 name: Size Gate (Reusable)
 
 on:
   workflow_call:
-    # Callers intentionally map these names even though the values exist only
-    # in the GitHub Environment. The mapping establishes the reusable-workflow
-    # secret contract; each job's environment supplies the actual value.
-    # Keep them optional so fork PRs retain the secretless local-cache path.
+    # Optional so secretless fork PRs can use the local cache.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false
       BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
         required: false
 
-# Read-only: these jobs run PR-controlled code and only upload artifacts,
-# so they must not inherit whatever the caller grants.
+# Jobs run PR-controlled code with read-only repository access.
 permissions:
   contents: read
 
@@ -43,31 +28,23 @@ defaults:
     shell: bash
 
 env:
-  # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
-  # .envrc itself so it stays the single source of truth across CI and local.
+  # .envrc supplies the remaining sccache configuration.
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
-# Individual measure-baml-size jobs are intentionally never allowed to fail.
-# Each platform job has `continue-on-error: true` so a violation, runner
-# death, or build hiccup does not fail the calling workflow. The
-# enforce-baml-size job aggregates all available reports and is the one
-# place where a real failure (policy violation or a missing platform
-# report) can block CI.
+# Measure jobs collect reports without failing early; the report job enforces policy.
 
 jobs:
   size-gate-linux:
     name: "measure-baml-size (linux)"
     # Fork PRs stay on the hosted runner; untrusted code never lands on ix.
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-gnu"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     timeout-minutes: 20
     continue-on-error: true
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -155,12 +132,8 @@ jobs:
   size-gate-wasm:
     name: "measure-baml-size (wasm)"
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-wasm"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     timeout-minutes: 25
     continue-on-error: true
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -250,14 +223,10 @@ jobs:
   size-gate-report:
     name: "enforce-baml-size"
     runs-on: ${{ (((github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["ix", "ix-light"]')) || 'blacksmith-4vcpu-ubuntu-2404' }}
-    environment: infisical-github-ci
     if: ${{ always() && !cancelled() }}
     needs: [size-gate-linux, size-gate-wasm]
     permissions:
       contents: read
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -1,24 +1,10 @@
-# sccache strategy
-# ================
-#
-# These jobs compile the same release artifacts the cargo tests do, so they
-# share the sccache + Swatinem/rust-cache setup documented at the top of
-# cargo-tests.reusable.yaml: sccache holds the compiled `target/` tree (R2
-# backend), while rust-cache keeps the registry/git state (`cache-all-crates:
-# true`, `cache-targets: false`). They are read-only consumers of the shared
-# rust-cache entries written by canary in cargo-tests.reusable.yaml, and read
-# the same sccache R2 cache via .envrc.
-#
-# Secretless runs (e.g. fork PRs) still install sccache, but .envrc sees no R2
-# credentials and falls back to the runner-local cache.
+# Size-gate jobs share cargo tests' R2 sccache and read-only rust-cache entries.
+# .envrc configures sccache, with secretless fork PRs falling back to local cache.
 name: Size Gate (Reusable)
 
 on:
   workflow_call:
-    # Callers intentionally map these names even though the values exist only
-    # in the GitHub Environment. The mapping establishes the reusable-workflow
-    # secret contract; each job's environment supplies the actual value.
-    # Keep them optional so fork PRs retain the secretless local-cache path.
+    # Optional so secretless fork PRs can use the local cache.
     secrets:
       BAML_SCCACHE_R2_ACCESS_KEY_ID:
         required: false
@@ -30,30 +16,22 @@ defaults:
     shell: bash
 
 env:
-  # Inputs read by .envrc; everything else (RUSTC_WRAPPER, SCCACHE_*) is set by
-  # .envrc itself so it stays the single source of truth across CI and local.
+  # .envrc supplies the remaining sccache configuration.
+  BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+  BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
-# Individual measure-baml-size jobs are intentionally never allowed to fail.
-# Each platform job has `continue-on-error: true` so a violation, runner
-# death, or build hiccup does not fail the calling workflow. The
-# enforce-baml-size job aggregates all available reports and is the one
-# place where a real failure (policy violation or a missing platform
-# report) can block CI.
+# Measure jobs collect reports without failing early; the report job enforces policy.
 
 jobs:
   size-gate-linux:
     name: "measure-baml-size (linux)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 30
     continue-on-error: true
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -138,12 +116,8 @@ jobs:
   size-gate-macos:
     name: "measure-baml-size (macos)"
     runs-on: blacksmith-6vcpu-macos-latest
-    environment: infisical-github-ci
     timeout-minutes: 20
     continue-on-error: true
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -228,14 +202,11 @@ jobs:
   size-gate-windows:
     name: "measure-baml-size (windows)"
     runs-on: blacksmith-8vcpu-windows-2025
-    environment: infisical-github-ci
     # TODO: Reduce this once our changes to aws-sdk-rust are upstreamed
     # Right now it needs to download our repo every time which is very slow
     timeout-minutes: 45
     continue-on-error: true
     env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
       CARGO_BUILD_JOBS: "16"
     steps:
       - uses: actions/checkout@v7
@@ -339,12 +310,8 @@ jobs:
   size-gate-wasm:
     name: "measure-baml-size (wasm)"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment: infisical-github-ci
     timeout-minutes: 25
     continue-on-error: true
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:
@@ -431,15 +398,11 @@ jobs:
   size-gate-report:
     name: "enforce-baml-size"
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    environment: infisical-github-ci
     if: ${{ always() && !cancelled() }}
     needs: [size-gate-linux, size-gate-macos, size-gate-windows, size-gate-wasm]
     permissions:
       contents: read
       pull-requests: write
-    env:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     steps:
       - uses: useblacksmith/checkout@v1
         with:


### PR DESCRIPTION
Move the sccache secrets from being in a github environment into the shared GHA secrets for the repo. Keeping them in an environment was a nice idea, but it means that every PR push becomes a "deployment".