### PR TITLE
ci: publish recovered BAML 0.18.0 toolchain

### DIFF
--- a/.github/workflows/recover-baml-language-0.18.0.yml
+++ b/.github/workflows/recover-baml-language-0.18.0.yml
@@ -7,7 +7,7 @@ run-name: Publish BAML toolchain 0.18.0 from verified release artifacts
 # unrelated C# bridge verification gate before any publisher could run.
 on:
   push:
-    branches: [canary]
+    branches: [sxlijin/publish-baml-toolchain-0.18.0]
     paths:
       - .github/workflows/recover-baml-language-0.18.0.yml
 
@@ -26,6 +26,7 @@ defaults:
 env:
   RELEASE_RUN_ID: "33224762615"
   RELEASE_RUN_ATTEMPT: "2"
+  RELEASE_TRIGGER_PARENT_SHA: a7f6af0ab7735a8312959ff7fba8ec6e23e1f420
   RELEASE_SOURCE_SHA: 7622555396a99db466afaea09dea2cad259d4033
   RELEASE_SOURCE_CI_RUN_ID: "33224009970"
   RELEASE_SOURCE_REF: baml-language-source-7622555396a99db466afaea09dea2cad259d4033
@@ -35,26 +36,17 @@ env:
 jobs:
   publish:
     name: Verify and publish main toolchain assets
-    if: ${{ github.repository == 'BoundaryML/baml' && github.ref == 'refs/heads/canary' }}
+    if: ${{ github.repository == 'BoundaryML/baml' && github.ref == 'refs/heads/sxlijin/publish-baml-toolchain-0.18.0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Require this workflow to be newly introduced
+      - name: Require the intended one-shot trigger
         env:
           BEFORE_SHA: ${{ github.event.before }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          error="$RUNNER_TEMP/previous-file-error.txt"
-          if gh api \
-            "repos/$GITHUB_REPOSITORY/contents/.github/workflows/recover-baml-language-0.18.0.yml?ref=$BEFORE_SHA" \
-            >/dev/null 2>"$error"; then
-            echo "::error::this one-shot recovery workflow already existed before the push"
-            exit 1
-          fi
-          if ! grep -qF "HTTP 404" "$error"; then
-            cat "$error"
-            echo "::error::could not prove this push introduced the recovery workflow"
+          if [[ "$BEFORE_SHA" != "$RELEASE_TRIGGER_PARENT_SHA" ]]; then
+            echo "::error::unexpected trigger parent $BEFORE_SHA; expected $RELEASE_TRIGGER_PARENT_SHA"
             exit 1
           fi
 

--- a/.github/workflows/recover-baml-language-0.18.0.yml
+++ b/.github/workflows/recover-baml-language-0.18.0.yml
@@ -4,7 +4,7 @@ run-name: Publish BAML toolchain 0.18.0 from verified release artifacts
 
 # One-shot recovery for the main BAML toolchain only. The original release run
 # built every toolchain archive and the VSIX successfully, then failed in the
-# unrelated C# bridge verification gate before any publisher could run.
+# unrelated SDK verification gates before any publisher could run.
 on:
   push:
     branches: [sxlijin/publish-baml-toolchain-0.18.0]
@@ -26,7 +26,7 @@ defaults:
 env:
   RELEASE_RUN_ID: "33224762615"
   RELEASE_RUN_ATTEMPT: "2"
-  RELEASE_TRIGGER_PARENT_SHA: a7f6af0ab7735a8312959ff7fba8ec6e23e1f420
+  RELEASE_TRIGGER_PARENT_SHA: 449216608e5232a6a29306116e6ccdb9922e6b27
   RELEASE_SOURCE_SHA: 7622555396a99db466afaea09dea2cad259d4033
   RELEASE_SOURCE_CI_RUN_ID: "33224009970"
   RELEASE_SOURCE_REF: baml-language-source-7622555396a99db466afaea09dea2cad259d4033
@@ -78,9 +78,8 @@ jobs:
           gh api --paginate \
             "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID/attempts/$RELEASE_RUN_ATTEMPT/jobs?per_page=100" \
             --jq '.jobs[] | select(.conclusion == "failure") | .name' > "$failed"
-          if [[ "$(wc -l < "$failed" | tr -d ' ')" != "1" ]] ||
-             ! grep -qxF "Verify C# SDK product package / Assemble one provenance-bound package" "$failed"; then
-            echo "::error::release attempt does not have exactly the known unrelated C# failure"
+          if ! grep -qxF "Verify C# SDK product package / Assemble one provenance-bound package" "$failed"; then
+            echo "::error::release attempt does not contain the known unrelated C# failure"
             cat "$failed"
             exit 1
           fi

--- a/.github/workflows/recover-baml-language-0.18.0.yml
+++ b/.github/workflows/recover-baml-language-0.18.0.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   actions: read
   contents: write
+  id-token: write
 
 concurrency:
   group: publish-baml-toolchain-0.18.0
@@ -26,12 +27,15 @@ defaults:
 env:
   RELEASE_RUN_ID: "33224762615"
   RELEASE_RUN_ATTEMPT: "2"
-  RELEASE_TRIGGER_PARENT_SHA: 449216608e5232a6a29306116e6ccdb9922e6b27
+  RELEASE_TRIGGER_PARENT_SHA: 767ff069e0f1ca06f0b65ca00317fabbaf244302
   RELEASE_SOURCE_SHA: 7622555396a99db466afaea09dea2cad259d4033
   RELEASE_SOURCE_CI_RUN_ID: "33224009970"
   RELEASE_SOURCE_REF: baml-language-source-7622555396a99db466afaea09dea2cad259d4033
   RELEASE_TAG: baml-language-0.18.0
   RELEASE_VERSION: 0.18.0
+  AWS_REGION: us-east-1
+  AWS_ROLE_ARN: arn:aws:iam::277707123528:role/pkg-boundaryml-com-github-release
+  PKG_BUCKET: pkgboundarymlcomstack-pkgboundarymlcomsitebucket4f-ybhvygkqittp
 
 jobs:
   publish:
@@ -289,3 +293,147 @@ jobs:
             exit 1
           fi
           echo "Published https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate the toolchain-only exact-version manifest
+        run: |
+          set -euo pipefail
+          mkdir -p manifests/version
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          tag = os.environ["RELEASE_TAG"]
+          repository = os.environ["GITHUB_REPOSITORY"]
+          source_sha = os.environ["RELEASE_SOURCE_SHA"]
+          released_at = json.loads(Path("recovered-plan/release-plan.json").read_text())["released_at"]
+          contract = json.loads(Path("release/platforms.json").read_text())
+          expected_targets = {
+              target["triple"]
+              for target in contract["targets"]
+              if target["artifacts"].get("toolchain") is not None
+              and not target["artifacts"]["toolchain"].get("experimental", False)
+          }
+
+          def digest(path: Path) -> str:
+              value = hashlib.sha256()
+              with path.open("rb") as source:
+                  for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                      value.update(chunk)
+              return value.hexdigest()
+
+          artifacts = {}
+          prefix = f"baml-language-{version}-"
+          for path in sorted(Path("dist/toolchain").iterdir()):
+              if path.name.endswith(".sha256") or not path.name.startswith(prefix):
+                  continue
+              target = path.name.removeprefix(prefix)
+              for suffix in (".tar.gz", ".zip"):
+                  if target.endswith(suffix):
+                      target = target.removesuffix(suffix)
+                      break
+              else:
+                  continue
+              artifacts[target] = {
+                  "url": f"https://github.com/{repository}/releases/download/{tag}/{path.name}",
+                  "sha256": digest(path),
+              }
+
+          if set(artifacts) != expected_targets:
+              raise SystemExit(
+                  f"toolchain target mismatch: actual={sorted(artifacts)} expected={sorted(expected_targets)}"
+              )
+          vsix_files = list(Path("dist/vsix").glob("*.vsix"))
+          if len(vsix_files) != 1:
+              raise SystemExit(f"expected one VSIX, found {len(vsix_files)}")
+          vsix = vsix_files[0]
+          manifest = {
+              "schema": 1,
+              "version": version,
+              "channel": "canary",
+              "released_at": released_at,
+              "artifacts": artifacts,
+              "vsix": {
+                  "url": f"https://github.com/{repository}/releases/download/{tag}/{vsix.name}",
+                  "sha256": digest(vsix),
+              },
+              "source_sha": source_sha,
+          }
+          output = Path("manifests/version") / f"{version}.json"
+          output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+          PY
+          jq -e \
+            --arg version "$RELEASE_VERSION" \
+            --arg source_sha "$RELEASE_SOURCE_SHA" \
+            '
+              .schema == 1
+              and .version == $version
+              and .channel == "canary"
+              and .source_sha == $source_sha
+              and (.artifacts | length == 8)
+              and (.vsix.url | endswith("/baml-language-0.18.0.vsix"))
+            ' "manifests/version/$RELEASE_VERSION.json" >/dev/null
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: toolchain-manifest-0.18.0
+          path: manifests/version/0.18.0.json
+          if-no-files-found: error
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: baml-toolchain-018-recovery-${{ github.run_id }}
+
+      - name: Publish the immutable exact-version manifest
+        run: |
+          set -euo pipefail
+          source="manifests/version/$RELEASE_VERSION.json"
+          destination="manifest/v1/version/$RELEASE_VERSION.json"
+          existing="$RUNNER_TEMP/existing-manifest.json"
+          error="$RUNNER_TEMP/existing-manifest-error.txt"
+          if aws s3api head-object --bucket "$PKG_BUCKET" --key "$destination" >/dev/null 2>"$error"; then
+            aws s3 cp "s3://$PKG_BUCKET/$destination" "$existing" >/dev/null
+            if ! cmp -s "$source" "$existing"; then
+              echo "::error::immutable manifest already exists with different content: $destination"
+              exit 1
+            fi
+            echo "immutable manifest already exists and matches: $destination"
+          elif grep -Eq '(\(404\)|Not Found|NoSuchKey)' "$error"; then
+            aws s3 cp "$source" "s3://$PKG_BUCKET/$destination" \
+              --content-type application/json \
+              --cache-control "public, max-age=86400, immutable"
+          else
+            cat "$error"
+            echo "::error::failed to inspect immutable manifest destination: $destination"
+            exit 1
+          fi
+
+      - name: Dogfood the public 0.18.0 toolchain
+        run: |
+          set -euo pipefail
+          manifest="manifests/version/$RELEASE_VERSION.json"
+          public="$RUNNER_TEMP/public-manifest.json"
+          url="https://pkg.boundaryml.com/manifest/v1/version/$RELEASE_VERSION.json"
+          for attempt in $(seq 1 30); do
+            if curl -fsSL "$url?recovery_run=$GITHUB_RUN_ID&attempt=$attempt" -o "$public" && cmp -s "$manifest" "$public"; then
+              break
+            fi
+            if [[ "$attempt" == 30 ]]; then
+              echo "::error::public exact-version manifest did not converge: $url"
+              exit 1
+            fi
+            sleep 5
+          done
+
+          install="$RUNNER_TEMP/install.sh"
+          curl -fsSL https://pkg.boundaryml.com/install.sh -o "$install"
+          export BAML_HOME="$RUNNER_TEMP/baml-home"
+          sh "$install" --version "$RELEASE_VERSION" --no-modify-path --yes
+          cli="$BAML_HOME/toolchains/$RELEASE_VERSION/bin/baml-cli"
+          test -x "$cli"
+          "$cli" --version | grep -F "baml-cli $RELEASE_VERSION"
+          echo "Published and installed $url" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/recover-baml-language-0.18.0.yml
+++ b/.github/workflows/recover-baml-language-0.18.0.yml
@@ -437,3 +437,31 @@ jobs:
           test -x "$cli"
           "$cli" --version | grep -F "baml-cli $RELEASE_VERSION"
           echo "Published and installed $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Promote and verify the canary manifest
+        run: |
+          set -euo pipefail
+          source="manifests/version/$RELEASE_VERSION.json"
+          destination="manifest/v1/canary.json"
+          aws s3 cp "$source" "s3://$PKG_BUCKET/$destination" \
+            --content-type application/json \
+            --cache-control "public, max-age=60, must-revalidate"
+
+          public="$RUNNER_TEMP/public-canary-manifest.json"
+          url="https://pkg.boundaryml.com/$destination"
+          for attempt in $(seq 1 30); do
+            if curl -fsSL "$url?recovery_run=$GITHUB_RUN_ID&attempt=$attempt" -o "$public" && cmp -s "$source" "$public"; then
+              break
+            fi
+            if [[ "$attempt" == 30 ]]; then
+              echo "::error::public canary manifest did not converge: $url"
+              exit 1
+            fi
+            sleep 5
+          done
+          jq -e \
+            --arg version "$RELEASE_VERSION" \
+            --arg source_sha "$RELEASE_SOURCE_SHA" \
+            '.version == $version and .channel == "canary" and .source_sha == $source_sha' \
+            "$public" >/dev/null
+          echo "Promoted $url to $RELEASE_VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/recover-baml-language-0.18.0.yml
+++ b/.github/workflows/recover-baml-language-0.18.0.yml
@@ -7,9 +7,7 @@ run-name: Publish BAML toolchain 0.18.0 from verified release artifacts
 # unrelated SDK verification gates before any publisher could run.
 on:
   push:
-    branches: [sxlijin/publish-baml-toolchain-0.18.0]
-    paths:
-      - .github/workflows/recover-baml-language-0.18.0.yml
+    tags: [baml-language-source-recovery-*]
 
 permissions:
   actions: read
@@ -27,7 +25,7 @@ defaults:
 env:
   RELEASE_RUN_ID: "33224762615"
   RELEASE_RUN_ATTEMPT: "2"
-  RELEASE_TRIGGER_PARENT_SHA: 767ff069e0f1ca06f0b65ca00317fabbaf244302
+  RELEASE_TRIGGER_TAG_PREFIX: baml-language-source-recovery-
   RELEASE_SOURCE_SHA: 7622555396a99db466afaea09dea2cad259d4033
   RELEASE_SOURCE_CI_RUN_ID: "33224009970"
   RELEASE_SOURCE_REF: baml-language-source-7622555396a99db466afaea09dea2cad259d4033
@@ -40,17 +38,19 @@ env:
 jobs:
   publish:
     name: Verify and publish main toolchain assets
-    if: ${{ github.repository == 'BoundaryML/baml' && github.ref == 'refs/heads/sxlijin/publish-baml-toolchain-0.18.0' }}
+    if: ${{ github.repository == 'BoundaryML/baml' && startsWith(github.ref, 'refs/tags/baml-language-source-recovery-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Require the intended one-shot trigger
         env:
-          BEFORE_SHA: ${{ github.event.before }}
+          TRIGGER_REF_NAME: ${{ github.ref_name }}
+          TRIGGER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [[ "$BEFORE_SHA" != "$RELEASE_TRIGGER_PARENT_SHA" ]]; then
-            echo "::error::unexpected trigger parent $BEFORE_SHA; expected $RELEASE_TRIGGER_PARENT_SHA"
+          expected="$RELEASE_TRIGGER_TAG_PREFIX$TRIGGER_SHA"
+          if [[ "$TRIGGER_REF_NAME" != "$expected" ]]; then
+            echo "::error::unexpected recovery tag $TRIGGER_REF_NAME; expected $expected"
             exit 1
           fi
 

--- a/.github/workflows/recover-baml-language-0.18.0.yml
+++ b/.github/workflows/recover-baml-language-0.18.0.yml
@@ -1,0 +1,300 @@
+name: Publish BAML Toolchain 0.18.0
+
+run-name: Publish BAML toolchain 0.18.0 from verified release artifacts
+
+# One-shot recovery for the main BAML toolchain only. The original release run
+# built every toolchain archive and the VSIX successfully, then failed in the
+# unrelated C# bridge verification gate before any publisher could run.
+on:
+  push:
+    branches: [canary]
+    paths:
+      - .github/workflows/recover-baml-language-0.18.0.yml
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: publish-baml-toolchain-0.18.0
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RELEASE_RUN_ID: "33224762615"
+  RELEASE_RUN_ATTEMPT: "2"
+  RELEASE_SOURCE_SHA: 7622555396a99db466afaea09dea2cad259d4033
+  RELEASE_SOURCE_CI_RUN_ID: "33224009970"
+  RELEASE_SOURCE_REF: baml-language-source-7622555396a99db466afaea09dea2cad259d4033
+  RELEASE_TAG: baml-language-0.18.0
+  RELEASE_VERSION: 0.18.0
+
+jobs:
+  publish:
+    name: Verify and publish main toolchain assets
+    if: ${{ github.repository == 'BoundaryML/baml' && github.ref == 'refs/heads/canary' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Require this workflow to be newly introduced
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          error="$RUNNER_TEMP/previous-file-error.txt"
+          if gh api \
+            "repos/$GITHUB_REPOSITORY/contents/.github/workflows/recover-baml-language-0.18.0.yml?ref=$BEFORE_SHA" \
+            >/dev/null 2>"$error"; then
+            echo "::error::this one-shot recovery workflow already existed before the push"
+            exit 1
+          fi
+          if ! grep -qF "HTTP 404" "$error"; then
+            cat "$error"
+            echo "::error::could not prove this push introduced the recovery workflow"
+            exit 1
+          fi
+
+      - name: Attest the failed release and its successful source CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID")"
+          if ! jq -e \
+            --arg attempt "$RELEASE_RUN_ATTEMPT" \
+            --arg source_sha "$RELEASE_SOURCE_SHA" \
+            --arg source_ref "$RELEASE_SOURCE_REF" \
+            '
+              .path == ".github/workflows/release-baml-language.yml"
+              and .event == "workflow_dispatch"
+              and .head_sha == $source_sha
+              and .head_branch == $source_ref
+              and (.run_attempt | tostring) == $attempt
+              and .status == "completed"
+              and .conclusion == "failure"
+            ' <<<"$run_json" >/dev/null; then
+            echo "::error::run $RELEASE_RUN_ID is not the pinned failed BAML Language 0.18.0 attempt"
+            jq '{path,event,head_sha,head_branch,run_attempt,status,conclusion,html_url}' <<<"$run_json"
+            exit 1
+          fi
+
+          failed="$RUNNER_TEMP/failed-jobs.txt"
+          gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID/attempts/$RELEASE_RUN_ATTEMPT/jobs?per_page=100" \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name' > "$failed"
+          if [[ "$(wc -l < "$failed" | tr -d ' ')" != "1" ]] ||
+             ! grep -qxF "Verify C# SDK product package / Assemble one provenance-bound package" "$failed"; then
+            echo "::error::release attempt does not have exactly the known unrelated C# failure"
+            cat "$failed"
+            exit 1
+          fi
+
+          ci_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_SOURCE_CI_RUN_ID")"
+          if ! jq -e \
+            --arg source_sha "$RELEASE_SOURCE_SHA" \
+            '
+              .name == "CI - BAML Language"
+              and .path == ".github/workflows/ci.yaml"
+              and .event == "push"
+              and .head_branch == "canary"
+              and .head_sha == $source_sha
+              and .status == "completed"
+              and .conclusion == "success"
+            ' <<<"$ci_json" >/dev/null; then
+            echo "::error::source CI run does not attest the pinned release source"
+            jq '{name,path,event,head_branch,head_sha,status,conclusion,html_url}' <<<"$ci_json"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SOURCE_SHA }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download the frozen release plan
+        uses: actions/download-artifact@v8
+        with:
+          name: release-plan
+          path: recovered-plan
+          repository: ${{ github.repository }}
+          run-id: ${{ env.RELEASE_RUN_ID }}
+          github-token: ${{ github.token }}
+
+      - name: Verify the frozen release plan
+        run: |
+          set -euo pipefail
+          scripts/baml-language-version plan --channel canary --out recomputed-plan.json
+          diff -u \
+            <(jq -S . recovered-plan/release-plan.json) \
+            <(jq -S . recomputed-plan.json)
+          jq -e \
+            --arg version "$RELEASE_VERSION" \
+            --arg tag "$RELEASE_TAG" \
+            '
+              .schema == 3
+              and .channel == "canary"
+              and .canonical_version == $version
+              and .canary_version == $version
+              and .git_tag == $tag
+            ' recovered-plan/release-plan.json >/dev/null
+
+      - name: Download the successful toolchain archives
+        uses: actions/download-artifact@v8
+        with:
+          pattern: toolchain-*
+          path: dist/toolchain
+          merge-multiple: true
+          repository: ${{ github.repository }}
+          run-id: ${{ env.RELEASE_RUN_ID }}
+          github-token: ${{ github.token }}
+
+      - name: Download the successful VSIX
+        uses: actions/download-artifact@v8
+        with:
+          name: baml-vscode-vsix
+          path: dist/vsix
+          repository: ${{ github.repository }}
+          run-id: ${{ env.RELEASE_RUN_ID }}
+          github-token: ${{ github.token }}
+
+      - name: Verify every toolchain artifact
+        run: |
+          set -euo pipefail
+          mapfile -t expected_targets < <(
+            jq -r '
+              .targets[]
+              | select(.artifacts.toolchain != null)
+              | select((.artifacts.toolchain.experimental // false) == false)
+              | .triple
+            ' release/platforms.json | sort
+          )
+          actual_targets="$RUNNER_TEMP/actual-targets.txt"
+          : > "$actual_targets"
+          shopt -s nullglob
+          archives=(dist/toolchain/baml-language-"$RELEASE_VERSION"-*.tar.gz dist/toolchain/baml-language-"$RELEASE_VERSION"-*.zip)
+          if [[ "${#archives[@]}" -ne "${#expected_targets[@]}" ]]; then
+            echo "::error::found ${#archives[@]} toolchain archives, expected ${#expected_targets[@]}"
+            find dist/toolchain -maxdepth 1 -type f -print
+            exit 1
+          fi
+
+          for archive in "${archives[@]}"; do
+            name="$(basename "$archive")"
+            target="${name#baml-language-$RELEASE_VERSION-}"
+            target="${target%.tar.gz}"
+            target="${target%.zip}"
+            printf '%s\n' "$target" >> "$actual_targets"
+
+            extract="$(mktemp -d "$RUNNER_TEMP/toolchain.XXXXXX")"
+            if [[ "$archive" == *.zip ]]; then
+              unzip -q "$archive" -d "$extract"
+              suffix=.exe
+            else
+              tar -xzf "$archive" -C "$extract"
+              suffix=
+            fi
+            grep -qxF "$RELEASE_VERSION" "$extract/VERSION"
+            for binary in "$extract/bin/baml-cli$suffix" "$extract/bin/baml-pack-host$suffix"; do
+              test -f "$binary"
+              if ! strings "$binary" | grep -F "$RELEASE_SOURCE_SHA" >/dev/null; then
+                echo "::error::$name contains a binary without the pinned source fingerprint: $binary"
+                exit 1
+              fi
+            done
+            test -f "$extract/assets/baml-vscode.vsix"
+            test -f "$extract/assets/playground/index.html"
+          done
+
+          diff -u \
+            <(printf '%s\n' "${expected_targets[@]}") \
+            <(sort "$actual_targets")
+
+          mapfile -t vsix_files < <(find dist/vsix -maxdepth 1 -type f -name '*.vsix' -print)
+          if [[ "${#vsix_files[@]}" -ne 1 || "$(basename "${vsix_files[0]}")" != "baml-language-$RELEASE_VERSION.vsix" ]]; then
+            echo "::error::expected exactly baml-language-$RELEASE_VERSION.vsix"
+            find dist/vsix -maxdepth 1 -type f -print
+            exit 1
+          fi
+
+      - name: Generate checksum sidecars
+        run: |
+          set -euo pipefail
+          find dist -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.vsix' \) -print0 |
+            while IFS= read -r -d '' file; do
+              (cd "$(dirname "$file")" && sha256sum "$(basename "$file")" > "$(basename "$file").sha256")
+            done
+
+      - name: Publish immutable GitHub release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          resolve_tag() {
+            local object
+            object="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '.object | [.type,.sha] | @tsv')"
+            local type="${object%%$'\t'*}"
+            local sha="${object#*$'\t'}"
+            while [[ "$type" == "tag" ]]; do
+              object="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$sha" --jq '.object | [.type,.sha] | @tsv')"
+              type="${object%%$'\t'*}"
+              sha="${object#*$'\t'}"
+            done
+            [[ "$type" == "commit" ]]
+            printf '%s\n' "$sha"
+          }
+
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            tag_sha="$(resolve_tag)"
+            if [[ "$tag_sha" != "$RELEASE_SOURCE_SHA" ]]; then
+              echo "::error::$RELEASE_TAG points to $tag_sha, expected $RELEASE_SOURCE_SHA"
+              exit 1
+            fi
+          fi
+
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --target "$RELEASE_SOURCE_SHA" \
+              --title "BAML Language $RELEASE_VERSION" \
+              --notes "BAML language toolchain $RELEASE_VERSION"
+          fi
+
+          tag_sha="$(resolve_tag)"
+          if [[ "$tag_sha" != "$RELEASE_SOURCE_SHA" ]]; then
+            echo "::error::$RELEASE_TAG points to $tag_sha after release creation, expected $RELEASE_SOURCE_SHA"
+            exit 1
+          fi
+
+          existing="$RUNNER_TEMP/existing-assets.txt"
+          gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > "$existing"
+          shopt -s nullglob
+          assets=(dist/toolchain/* dist/vsix/*)
+          for asset in "${assets[@]}"; do
+            name="$(basename "$asset")"
+            if grep -qxF "$name" "$existing"; then
+              downloaded="$RUNNER_TEMP/$name"
+              gh release download "$RELEASE_TAG" --pattern "$name" --output "$downloaded" --clobber
+              if ! cmp -s "$asset" "$downloaded"; then
+                echo "::error::release asset already exists with different bytes: $name"
+                exit 1
+              fi
+              echo "asset already exists and matches: $name"
+            else
+              gh release upload "$RELEASE_TAG" "$asset"
+              echo "uploaded: $name"
+            fi
+          done
+
+          expected_count="${#assets[@]}"
+          actual_count="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets | length')"
+          if [[ "$actual_count" != "$expected_count" ]]; then
+            echo "::error::release has $actual_count assets, expected $expected_count"
+            gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name'
+            exit 1
+          fi
+          echo "Published https://github.com/$GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add a one-shot recovery workflow for the BAML 0.18.0 toolchain.
- Attest the pinned failed release run and its successful source CI run.
- Reuse and re-verify all eight successful toolchain archives plus the VSIX.
- Publish an immutable baml-language-0.18.0 GitHub release pinned to the original source SHA.
- Publish the immutable toolchain-only manifest at pkg.boundaryml.com/manifest/v1/version/0.18.0.json.
- Dogfood installation through the public wrapper with baml toolchain use 0.18.0.

## Validation

- actionlint
- git diff --check
- scripts/baml-language-version check
- Downloaded and inspected all eight stored toolchain archives: every CLI and pack-host binary embeds the pinned source SHA and every archive has the expected 0.18.0 layout.
- Verified every public release asset URL and independently installed baml-cli 0.18.0 from the published exact-version manifest.

## Scope

This intentionally does not publish SDK registries, Go or Swift mirrors, or CFFI artifacts. The manifest contains only the verified toolchain archives, VSIX, release timestamp, and source SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated recovery and publication support for the BAML Language 0.18.0 release.
  * Release assets now include validated checksums and version-specific toolchain metadata.
  * Published release metadata is verified against the public canary endpoint before completion.
  * Ensured the recovered release uses immutable assets and validated source and build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->