### PR TITLE
style(web): apply inline code styling globally

### DIFF
--- a/typescript2/app-website/app/blog/[slug]/content.tsx
+++ b/typescript2/app-website/app/blog/[slug]/content.tsx
@@ -84,25 +84,8 @@ export async function PostBody({ children }: { children: string }) {
   });
 
   return (
-    <>
-      <div className="blog-post-body prose flex flex-col flex-1 mx-auto container-sm max-w-screen-md">
-        {content}
-      </div>
-      <style>{`
-        .blog-post-body :not(pre) > code {
-          background: #eeeeee;
-          border: 1px solid #dedede;
-          border-radius: 0.45em;
-          color: inherit;
-          font-size: 0.875em;
-          font-weight: 500;
-          padding: 0.12em 0.35em;
-        }
-        .blog-post-body :not(pre) > code::before,
-        .blog-post-body :not(pre) > code::after {
-          content: none;
-        }
-      `}</style>
-    </>
+    <div className="inline-code-content prose flex flex-col flex-1 mx-auto container-sm max-w-screen-md">
+      {content}
+    </div>
   );
 }

--- a/typescript2/app-website/app/blog/[slug]/content.tsx
+++ b/typescript2/app-website/app/blog/[slug]/content.tsx
@@ -84,8 +84,25 @@ export async function PostBody({ children }: { children: string }) {
   });
 
   return (
-    <div className="prose flex flex-col flex-1 mx-auto container-sm max-w-screen-md">
-      {content}
-    </div>
+    <>
+      <div className="blog-post-body prose flex flex-col flex-1 mx-auto container-sm max-w-screen-md">
+        {content}
+      </div>
+      <style>{`
+        .blog-post-body :not(pre) > code {
+          background: #eeeeee;
+          border: 1px solid #dedede;
+          border-radius: 0.45em;
+          color: inherit;
+          font-size: 0.875em;
+          font-weight: 500;
+          padding: 0.12em 0.35em;
+        }
+        .blog-post-body :not(pre) > code::before,
+        .blog-post-body :not(pre) > code::after {
+          content: none;
+        }
+      `}</style>
+    </>
   );
 }

--- a/typescript2/app-website/app/blog/[slug]/content.tsx
+++ b/typescript2/app-website/app/blog/[slug]/content.tsx
@@ -84,7 +84,7 @@ export async function PostBody({ children }: { children: string }) {
   });
 
   return (
-    <div className="inline-code-content prose flex flex-col flex-1 mx-auto container-sm max-w-screen-md">
+    <div className="prose flex flex-col flex-1 mx-auto container-sm max-w-screen-md">
       {content}
     </div>
   );

--- a/typescript2/app-website/app/globals.css
+++ b/typescript2/app-website/app/globals.css
@@ -695,6 +695,22 @@ pre > code {
   counter-reset: line;
 }
 
+/* Shared inline code treatment for long-form prose. */
+.inline-code-content :not(pre) > code {
+  padding: 2px 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.86em;
+  font-weight: inherit;
+  color: inherit;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 4px;
+}
+
+.inline-code-content :not(pre) > code::before,
+.inline-code-content :not(pre) > code::after {
+  content: none;
+}
+
 @media (prefers-color-scheme: dark) {
   .dark code[data-theme*=" "],
   .dark code[data-theme*=" "] span {

--- a/typescript2/app-website/app/globals.css
+++ b/typescript2/app-website/app/globals.css
@@ -25,9 +25,9 @@
  * ::-webkit-scrollbar for Safari/older Chromium (ignored when the standard
  * properties are supported). */
 * {
-  scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--foreground) 26%, transparent)
     transparent;
+  scrollbar-width: thin;
 }
 ::-webkit-scrollbar {
   width: 10px;
@@ -39,10 +39,10 @@
 }
 ::-webkit-scrollbar-thumb {
   background-color: color-mix(in srgb, var(--foreground) 26%, transparent);
-  border-radius: 999px;
+  background-clip: padding-box;
   /* Transparent border + padding-box clip = inset pill thumb. */
   border: 3px solid transparent;
-  background-clip: padding-box;
+  border-radius: 999px;
 }
 ::-webkit-scrollbar-thumb:hover {
   background-color: color-mix(in srgb, var(--foreground) 42%, transparent);
@@ -479,9 +479,6 @@
  * text-foreground, vsc-* utilities, etc.) inherit local values without
  * leaking back into the marketing-site theme. */
 .baml-playground-root {
-  color-scheme: light;
-
-  /* vsc-* token defaults */
   --vsc-bg: #fffdf6;
   --vsc-bg-secondary: #f4eee2;
   --vsc-surface: #f7f0e4;
@@ -530,9 +527,10 @@
   --border: #d8cfbd;
   --input: #d8cfbd;
   --ring: #6d28d9;
+  color: var(--vsc-text);
+  color-scheme: light;
 
   background-color: var(--vsc-bg);
-  color: var(--vsc-text);
 }
 
 /* Dark variant of the playground surface. Activated when the page's code
@@ -542,8 +540,6 @@
  * brand purple as the accent, but lightened so it reads on a dark panel
  * (the old #6d28d9 codelens/link was nearly invisible on dark). */
 .baml-playground-root[data-theme="dark"] {
-  color-scheme: dark;
-
   --vsc-bg: #1e1e1e;
   --vsc-bg-secondary: #252526;
   --vsc-surface: #252526;
@@ -586,9 +582,10 @@
   --border: #333333;
   --input: #3c3c3c;
   --ring: #8b5cf6;
+  color: var(--vsc-text);
+  color-scheme: dark;
 
   background-color: var(--vsc-bg);
-  color: var(--vsc-text);
 }
 
 .dark {
@@ -631,7 +628,11 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    font-family:
+      "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
+    font-size: 14px;
+    line-height: 1.5;
     background-image:
       radial-gradient(
         circle at 1px 1px,
@@ -646,11 +647,7 @@
     background-size:
       18px 18px,
       100% 100%;
-    font-family:
-      "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      "Liberation Mono", "Courier New", monospace;
-    font-size: 14px;
-    line-height: 1.5;
+    @apply bg-background text-foreground;
   }
 }
 

--- a/typescript2/app-website/app/globals.css
+++ b/typescript2/app-website/app/globals.css
@@ -530,7 +530,6 @@
 
   color: var(--vsc-text);
   color-scheme: light;
-
   background-color: var(--vsc-bg);
 }
 
@@ -586,7 +585,6 @@
 
   color: var(--vsc-text);
   color-scheme: dark;
-
   background-color: var(--vsc-bg);
 }
 

--- a/typescript2/app-website/app/globals.css
+++ b/typescript2/app-website/app/globals.css
@@ -695,8 +695,8 @@ pre > code {
   counter-reset: line;
 }
 
-/* Shared inline code treatment for long-form prose. */
-.inline-code-content :not(pre) > code {
+/* Inline code treatment across the website. */
+:not(pre) > code {
   padding: 2px 5px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.86em;
@@ -706,8 +706,8 @@ pre > code {
   border-radius: 4px;
 }
 
-.inline-code-content :not(pre) > code::before,
-.inline-code-content :not(pre) > code::after {
+:not(pre) > code::before,
+:not(pre) > code::after {
   content: none;
 }
 

--- a/typescript2/app-website/app/globals.css
+++ b/typescript2/app-website/app/globals.css
@@ -527,6 +527,7 @@
   --border: #d8cfbd;
   --input: #d8cfbd;
   --ring: #6d28d9;
+
   color: var(--vsc-text);
   color-scheme: light;
 
@@ -582,6 +583,7 @@
   --border: #333333;
   --input: #3c3c3c;
   --ring: #8b5cf6;
+
   color: var(--vsc-text);
   color-scheme: dark;
 
@@ -699,7 +701,7 @@ pre > code {
   font-size: 0.86em;
   font-weight: inherit;
   color: inherit;
-  background: rgba(0, 0, 0, 0.06);
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
   border-radius: 4px;
 }
 

--- a/typescript2/app-website/app/quickstart/page.tsx
+++ b/typescript2/app-website/app/quickstart/page.tsx
@@ -59,7 +59,7 @@ export default function QuickstartPage() {
       {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static page CSS */}
       <style dangerouslySetInnerHTML={{ __html: CSS }} />
       <Navbar />
-      <main className="qs-wrap inline-code-content">
+      <main className="qs-wrap">
         <div className="qs-head">
           <h1 className="qs-h1">Quickstart</h1>
           <p className="qs-lead">

--- a/typescript2/app-website/app/quickstart/page.tsx
+++ b/typescript2/app-website/app/quickstart/page.tsx
@@ -33,8 +33,6 @@ const CSS = `
 /* the install unit spans the column so it lines up with the cards below */
 .qs-try > div { max-width: none; }
 .qs-ctas { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.qs-wrap :not(pre) > code { background: rgba(0,0,0,0.06); border-radius: 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.86em; padding: 2px 5px; }
 .qs-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
 .qs-card { position: relative; display: flex; flex-direction: column; gap: 4px; padding: 13px 16px;
   border: 1px solid #e7e2d6; border-radius: 11px; background: #fffdf7; text-decoration: none;
@@ -61,7 +59,7 @@ export default function QuickstartPage() {
       {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static page CSS */}
       <style dangerouslySetInnerHTML={{ __html: CSS }} />
       <Navbar />
-      <main className="qs-wrap">
+      <main className="qs-wrap inline-code-content">
         <div className="qs-head">
           <h1 className="qs-h1">Quickstart</h1>
           <p className="qs-lead">


### PR DESCRIPTION
## Stack

Built on top of #4743. Review and merge that PR first.

## Summary

- apply the website’s existing inline-code treatment globally with `:not(pre) > code`
- remove the Blog and Quickstart opt-in classes and all blog-only inline-code styling
- remove the literal backticks added by the Typography plugin
- leave fenced code blocks unchanged

## Validation

- targeted Biome check passes
- home, Quickstart, and BAML 0.18.0 routes return 200 locally
- browser verification on an article containing both inline and fenced code confirms that only inline code receives the global treatment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined scrollbar and playground styling for a more consistent appearance across themes.
  - Improved theme behavior by reorganizing color-scheme, typography, background, and foreground styling.
  - Enhanced inline code presentation with spacing, monospace text, rounded corners, inherited colors, and subtle theme-aware backgrounds.
  - Removed Quickstart-specific inline code styling so code text follows the broader styling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->