### PR TITLE
ai.events.UserContent: journal user turns that carry media

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
@@ -46,25 +46,17 @@ class Media {
     // `baml.media.Image.from_base64` and its siblings return the `image` /
     // `audio` / `video` / `pdf` primitives, which are distinct static types
     // from the `baml.media.*` wrapper classes `MediaPart` is a union of, so
-    // the value bridges through its BEP-038 `{kind, source, value, mime}`
-    // envelope. The decode discriminates on the envelope's `kind`, so the
-    // union lands on the wrapper for the value's own media kind.
+    // the value bridges through `root.internal.media_part`.
     function new(
         value: image | audio | video | pdf,
         provider_id: string? = null,
         revised_prompt: string? = null,
     ) -> Media {
-        let envelope = baml.json.to_json(value) catch_all (e) {
-            _ => {
-                throw baml.errors.InvalidArgument { message: `media output could not be encoded: ${e.to_string()}` }
-            },
-        };
-        let part: root.MediaPart = baml.json.from_json<root.MediaPart>(envelope) catch_all (e) {
-            _ => {
-                throw baml.errors.InvalidArgument { message: `media output could not be decoded: ${e.to_string()}` }
-            },
-        };
-        Media { media: part, provider_id: provider_id, revised_prompt: revised_prompt }
+        Media {
+            media: root.internal.media_part(value),
+            provider_id: provider_id,
+            revised_prompt: revised_prompt,
+        }
     }
 }
 

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_events/events.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_events/events.baml
@@ -1,7 +1,5 @@
 // The event catalog: the typed things that can appear in a root.Journal.
 // Only the runner produces events — clients and tools never append.
-//
-// Mirrors _planv2/pages/04_reference/02_events.md.
 
 class RunStarted {
     spec_name: string,
@@ -10,6 +8,34 @@ class RunStarted {
 
 class UserMessage {
     content: string,
+}
+
+/// A user turn carrying prompt parts: text and media, in order. A runner
+/// appends it imperatively mid-run — a screenshot after a tool ran, a
+/// document the host attaches — and every client lowers it to a user
+/// message at its position in the journal. `UserMessage` stays text-only.
+class UserContent {
+    parts: root.PromptPart[],
+
+    /// Build a turn from ordinary values: text, and the `image` / `audio` /
+    /// `video` / `pdf` primitives `baml.media.*.from_base64` and friends
+    /// return. Those primitives are distinct static types from the
+    /// `baml.media.*` wrapper classes `root.PromptPart` is a union of, so a
+    /// media value bridges through `root.internal.media_part` (exactly as
+    /// `root.content.Media.new` does); text passes straight through. Parts
+    /// that are already `root.PromptPart` — a rendered prompt's, a
+    /// `root.content.Media`'s — go in the plain constructor instead.
+    function new(parts: (string | image | audio | video | pdf)[]) -> UserContent {
+        let out: root.PromptPart[] = [];
+        for (let part in parts) {
+            if let text: string = part {
+                out.push(text);
+            } else {
+                out.push(root.internal.media_part(part));
+            }
+        }
+        UserContent { parts: out }
+    }
 }
 
 class AssistantMessage {
@@ -93,6 +119,7 @@ class LLMCall {
 
 type Event = RunStarted
     | UserMessage
+    | UserContent
     | AssistantMessage
     | ToolRequested
     | ToolCompleted

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_internal/media_resolve.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_internal/media_resolve.baml
@@ -202,3 +202,25 @@ function _resolve_media_preview_content(
         detail: "request preview received media without inline data, a file, or a URL",
     }
 }
+
+/// A primitive media value as the `root.MediaPart` wrapper for its kind.
+///
+/// `baml.media.Image.from_base64` and its siblings return the `image` /
+/// `audio` / `video` / `pdf` primitives, which are distinct static types from
+/// the `baml.media.*` wrapper classes `MediaPart` is a union of, so the value
+/// bridges through its BEP-038 `{kind, source, value, mime}` envelope. The
+/// decode discriminates on the envelope's `kind`, so the union lands on the
+/// wrapper for the value's own media kind. Shared by `root.content.Media.new`
+/// and `root.events.UserContent.new`.
+function media_part(value: image | audio | video | pdf) -> root.MediaPart {
+    let envelope = baml.json.to_json(value) catch_all (e) {
+        _ => {
+            throw baml.errors.InvalidArgument { message: `media value could not be encoded: ${e.to_string()}` }
+        },
+    };
+    baml.json.from_json<root.MediaPart>(envelope) catch_all (e) {
+        _ => {
+            throw baml.errors.InvalidArgument { message: `media value could not be decoded: ${e.to_string()}` }
+        },
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
@@ -418,6 +418,41 @@ function merge_request_body(base: baml.json.json, overrides: baml.json.json?) ->
 // model switch inside one provider counts as a different client, exactly like
 // pi's provider+api+model comparison.
 
+/// The `root.PromptMessage` a `root.events.UserContent` event stands for: a
+/// `user` message whose `parts` are the event's parts verbatim, so a client
+/// hands it to the SAME helper that lowers rendered prompt messages and media
+/// takes the same wire shape whether it came from the template or the journal.
+/// `content` is the text rendering the CLI-style clients want: text parts as
+/// written, media parts as a readable placeholder.
+function user_content_message(event: root.events.UserContent) -> root.PromptMessage {
+    let text: string[] = [];
+    for (let part in event.parts) {
+        match (part) {
+            let s: string => {
+                text.push(s);
+                null
+            },
+            let image: baml.media.Image => {
+                text.push("[image]");
+                null
+            },
+            let audio: baml.media.Audio => {
+                text.push("[audio]");
+                null
+            },
+            let video: baml.media.Video => {
+                text.push("[video]");
+                null
+            },
+            let pdf: baml.media.Pdf => {
+                text.push("[pdf]");
+                null
+            },
+        };
+    }
+    root.PromptMessage { role: "user", content: text.join(""), parts: event.parts, metadata: {} }
+}
+
 /// Make one run's journal safe to replay to `client_id`, and return the
 /// sanitized copy. Every client should lower
 /// `ai.wire.sanitize_for_client(input.journal, self.id())` instead of
@@ -433,7 +468,8 @@ function merge_request_body(base: baml.json.json, overrides: baml.json.json?) ->
 ///     Anthropic 400, and the same shape an aborted turn leaves behind.
 ///     Such a turn never has tool calls, so nothing is orphaned by dropping it.
 ///  4. A tool call with no `ToolCompleted`/`ToolFailed` before the next
-///     assistant or user message (or before the end of the journal) gets a
+///     assistant or user turn (`UserMessage` or `UserContent`; or before the
+///     end of the journal) gets a
 ///     synthesized `ToolFailed { message: "No result provided" }`, because
 ///     most APIs reject a tool call that was never answered.
 ///
@@ -471,6 +507,11 @@ function sanitize_for_client(j: root.Journal, client_id: string) -> root.Journal
             let user: root.events.UserMessage => {
                 root.internal._flush_orphaned_calls(out, pending);
                 out.push(user);
+                null
+            },
+            let content: root.events.UserContent => {
+                root.internal._flush_orphaned_calls(out, pending);
+                out.push(content);
                 null
             },
             let completed: root.events.ToolCompleted => {

--- a/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
@@ -485,7 +485,7 @@ function _anthropic_push_tool_result(
 
 // ai.RunStarted/ai.ToolRequested/ai.Usage/ai.FinalProduced are not promptable and skip;
 // skipped events never close an open tool_result group.
-function _anthropic_lower_journal(j: ai.Journal) -> AnthropicMessage[] {
+function _anthropic_lower_journal(j: ai.Journal, preview: bool = false) -> AnthropicMessage[] {
     let msgs: AnthropicMessage[] = [];
     for (let e in j.entries()) {
         match (e) {
@@ -497,6 +497,20 @@ function _anthropic_lower_journal(j: ai.Journal) -> AnthropicMessage[] {
                         blocks: [AnthTextBlock { type: "text", text: m.content, cache_control: null }],
                     },
                 );
+                null
+            },
+            // A parts-bearing user turn lowers through the same helper as a
+            // rendered prompt message, so a mid-run screenshot takes exactly
+            // the wire shape the template's media would.
+            let m: ai.events.UserContent => {
+                let blocks = _anthropic_prompt_blocks(
+                    ai.wire.user_content_message(m),
+                    "user",
+                    preview = preview,
+                );
+                if (blocks.length() > 0) {
+                    msgs.push(AnthropicMessage { role: "user", tool_results: false, blocks: blocks });
+                }
                 null
             },
             let m: ai.events.AssistantMessage => {
@@ -639,7 +653,10 @@ function anthropic_messages_request(
     // Sanitize BEFORE lowering: foreign-client reasoning, empty turns and
     // orphaned tool calls are repaired once, in ai.wire, for every provider.
     for (
-        let message in _anthropic_lower_journal(ai.wire.sanitize_for_client(input.journal, params.client_id))
+        let message in _anthropic_lower_journal(
+            ai.wire.sanitize_for_client(input.journal, params.client_id),
+            preview = preview,
+        )
     ) {
         lowered.push(message);
     }

--- a/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
@@ -785,7 +785,11 @@ function _push_tool_result(
 
 // `ai.RunStarted` / `ai.ToolRequested` / `ai.Usage` / `ai.FinalProduced` are
 // journal-only and skip; skipping never closes an open tool-result group.
-function _lower_journal(journal: ai.Journal, with_status: bool) -> Message[] {
+function _lower_journal(
+    journal: ai.Journal,
+    with_status: bool,
+    preview: bool = false,
+) -> Message[] {
     let pending: PendingMessage[] = [];
     for (let event in journal.entries()) {
         match (event) {
@@ -799,6 +803,21 @@ function _lower_journal(journal: ai.Journal, with_status: bool) -> Message[] {
                         tool_results: false,
                     },
                 );
+                null
+            },
+            // A parts-bearing user turn lowers through the same helper as a
+            // rendered prompt message, so a mid-run screenshot takes exactly
+            // the wire shape the template's media would.
+            let user: ai.events.UserContent => {
+                let blocks = _prompt_content(ai.wire.user_content_message(user), preview = preview);
+                if (blocks.length() > 0) {
+                    pending.push(
+                        PendingMessage {
+                            message: Message { role: "user", content: blocks },
+                            tool_results: false,
+                        },
+                    );
+                }
                 null
             },
             let assistant: ai.events.AssistantMessage => {
@@ -987,6 +1006,7 @@ function converse_request(
     let journal_messages = _lower_journal(
         ai.wire.sanitize_for_client(input.journal, client.id()),
         _supports_tool_result_status(client.model),
+        preview = preview,
     );
     for (let message in journal_messages) {
         messages.push(message);

--- a/baml_language/crates/baml_builtins2/baml_std/claude_code/ns_internal/cli.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/claude_code/ns_internal/cli.baml
@@ -10,6 +10,11 @@ function transcript_text(j: ai.Journal) -> string {
             let u: ai.events.UserMessage => {
                 lines.push(`user: ${u.content}`);
             },
+            // The CLI takes text only: text parts as written, media as the
+            // readable placeholder `ai.wire.user_content_message` renders.
+            let u: ai.events.UserContent => {
+                lines.push(`user: ${ai.wire.user_content_message(u).content}`);
+            },
             let a: ai.events.AssistantMessage => {
                 for (let b in a.content) {
                     match (b) {

--- a/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
@@ -608,7 +608,11 @@ function _gm_tool_name_for(j: ai.Journal, id: string) -> string {
 // ai.RunStarted, ai.ToolRequested, ai.Usage, and ai.FinalProduced are journal-only.
 // Consecutive tool results merge into ONE user content of functionResponse
 // parts, matching how Gemini expects results for a multi-call turn.
-function google_lower_journal(j: ai.Journal) -> GmContent[] {
+function google_lower_journal(
+    j: ai.Journal,
+    fetch_url: bool = true,
+    preview: bool = false,
+) -> GmContent[] {
     let contents: GmContent[] = [];
     let pending: GmPart[] = []; // functionResponse parts awaiting flush
     for (let e in j.entries()) {
@@ -622,6 +626,27 @@ function google_lower_journal(j: ai.Journal) -> GmContent[] {
                     null
                 };
                 contents.push(GmContent { role: "user", parts: [GmPart.of_text(u.content)] });
+                null
+            },
+            // A parts-bearing user turn lowers through the same helper as a
+            // rendered prompt message, so a mid-run screenshot takes exactly
+            // the wire shape the template's media would.
+            let u: ai.events.UserContent => {
+                if (pending.length() > 0) {
+                    contents.push(GmContent { role: "user", parts: pending });
+                    pending = [];
+                    null
+                } else {
+                    null
+                };
+                let parts = _gm_prompt_parts(
+                    ai.wire.user_content_message(u),
+                    fetch_url = fetch_url,
+                    preview = preview,
+                );
+                if (parts.length() > 0) {
+                    contents.push(GmContent { role: "user", parts: parts });
+                }
                 null
             },
             let a: ai.events.AssistantMessage => {
@@ -722,7 +747,7 @@ function gemini_build_body(
     let lowered = google_lower_prompt(prompt, fetch_url = fetch_url, preview = preview);
     let contents = lowered.contents;
     let journal = ai.wire.sanitize_for_client(input.journal, client_id);
-    for (let item in google_lower_journal(journal)) {
+    for (let item in google_lower_journal(journal, fetch_url = fetch_url, preview = preview)) {
         contents.push(item);
     }
 

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
@@ -757,7 +757,11 @@ function chat_lower_prompt(
 ///
 /// Callers pass the journal through `ai.wire.sanitize_for_client` first, so
 /// foreign reasoning, empty turns and unanswered tool calls are already handled.
-function chat_lower_journal(j: ai.Journal) -> ChatMessage[] {
+function chat_lower_journal(
+    j: ai.Journal,
+    compat: ChatCompat,
+    preview: bool = false,
+) -> ChatMessage[] {
     let out: ChatMessage[] = [];
     for (let event in j.entries()) {
         match (event) {
@@ -770,6 +774,27 @@ function chat_lower_journal(j: ai.Journal) -> ChatMessage[] {
                         tool_call_id: null,
                     },
                 );
+                null
+            },
+            // A parts-bearing user turn lowers through the same helper as a
+            // rendered prompt message, so a mid-run screenshot takes exactly
+            // the wire shape the template's media would.
+            let user: ai.events.UserContent => {
+                let parts = _chat_prompt_parts(
+                    ai.wire.user_content_message(user),
+                    compat,
+                    preview = preview,
+                );
+                if (parts.length() > 0) {
+                    out.push(
+                        ChatMessage {
+                            role: "user",
+                            content: _chat_content(parts, compat.collapse_text_content),
+                            tool_calls: null,
+                            tool_call_id: null,
+                        },
+                    );
+                }
                 null
             },
             let assistant: ai.events.AssistantMessage => {
@@ -1060,7 +1085,7 @@ function chat_build_request(
     let prompt = input.prompt(ai.internal.build_output_format(input.output_type));
     let messages = chat_lower_prompt(prompt, compat, preview = preview);
     let journal = ai.wire.sanitize_for_client(input.journal, chat_client_id(compat, params));
-    for (let message in chat_lower_journal(journal)) {
+    for (let message in chat_lower_journal(journal, compat, preview = preview)) {
         messages.push(message);
     }
 

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/images.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/images.baml
@@ -172,6 +172,31 @@ function _oai_images_prompt_text(prompt: ai.Prompt, journal: ai.Journal) -> stri
                 parts.push(trimmed);
             }
         }
+        if let content: ai.events.UserContent = event {
+            for (let part in content.parts) {
+                match (part) {
+                    let text: string => {
+                        let trimmed = text.trim();
+                        if (trimmed != "") {
+                            parts.push(trimmed);
+                        }
+                        null
+                    },
+                    let image: baml.media.Image => {
+                        throw _oai_images_media_rejected("image")
+                    },
+                    let audio: baml.media.Audio => {
+                        throw _oai_images_media_rejected("audio")
+                    },
+                    let video: baml.media.Video => {
+                        throw _oai_images_media_rejected("video")
+                    },
+                    let pdf: baml.media.Pdf => {
+                        throw _oai_images_media_rejected("pdf")
+                    },
+                };
+            }
+        }
     }
     let joined = parts.join("\n\n");
     if (joined == "") {

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
@@ -555,7 +555,7 @@ function _openai_apply_message_metadata(
 // ai.Journal -> Responses API input items. Only promptable events lower;
 // ai.RunStarted, ai.ToolRequested, ai.Usage, and ai.FinalProduced are
 // journal-only. Callers pass the SANITIZED journal (see _openai_request).
-function openai_lower_journal(j: ai.Journal) -> OaInputItem[] {
+function openai_lower_journal(j: ai.Journal, preview: bool = false) -> OaInputItem[] {
     let items: OaInputItem[] = [];
     for (let e in j.entries()) {
         match (e) {
@@ -566,6 +566,20 @@ function openai_lower_journal(j: ai.Journal) -> OaInputItem[] {
                         content: [OaInputText { type: "input_text", text: u.content }],
                     },
                 );
+                null
+            },
+            // A parts-bearing user turn lowers through the same helper as a
+            // rendered prompt message, so a mid-run screenshot takes exactly
+            // the wire shape the template's media would.
+            let u: ai.events.UserContent => {
+                let content = _openai_prompt_content(
+                    ai.wire.user_content_message(u),
+                    "user",
+                    preview = preview,
+                );
+                if (content.length() > 0) {
+                    items.push(OaMessageItem { role: "user", content: content });
+                }
                 null
             },
             let a: ai.events.AssistantMessage => {
@@ -753,7 +767,7 @@ function _openai_request(
     // sanitize BEFORE lowering: foreign reasoning, empty turns and orphaned
     // tool calls are everyone's problem, fixed once in ai.wire.
     let journal = ai.wire.sanitize_for_client(input.journal, c.id());
-    for (let item in openai_lower_journal(journal)) {
+    for (let item in openai_lower_journal(journal, preview = preview)) {
         items.push(item);
     }
     let wants_image = _openai_wants_image(input.output_type);

--- a/baml_language/crates/baml_builtins2/baml_std/vercel/ns_internal/images.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/vercel/ns_internal/images.baml
@@ -206,6 +206,31 @@ function _gw_images_input(
                 parts.push(trimmed);
             }
         }
+        if let content: ai.events.UserContent = event {
+            for (let part in content.parts) {
+                match (part) {
+                    let text: string => {
+                        let trimmed = text.trim();
+                        if (trimmed != "") {
+                            parts.push(trimmed);
+                        }
+                        null
+                    },
+                    let image: baml.media.Image => {
+                        throw _gw_images_media_rejected("image")
+                    },
+                    let audio: baml.media.Audio => {
+                        throw _gw_images_media_rejected("audio")
+                    },
+                    let video: baml.media.Video => {
+                        throw _gw_images_media_rejected("video")
+                    },
+                    let pdf: baml.media.Pdf => {
+                        throw _gw_images_media_rejected("pdf")
+                    },
+                };
+            }
+        }
     }
     let joined = parts.join("\n\n");
     if (joined == "") {

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_anthropic/anthropic_client.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_anthropic/anthropic_client.baml
@@ -1160,3 +1160,94 @@ testset "live" with testing.Sequential() {
         log.warn("live::anthropic not registered: ANTHROPIC_API_KEY is unset")
     }
 }
+
+// ─── journal UserContent: media after a tool result ──────────────────────────
+
+// A runner that screenshots after every tool call appends an
+// `ai.events.UserContent` carrying the image AFTER the tool result. Anthropic
+// wants the tool_result blocks first in the user turn that answers a tool_use,
+// so the parts-bearing user turn merges into that same message, after the
+// results: [tool_result, text, image] — the image lowered exactly as prompt
+// media is (`_anthropic_prompt_blocks`).
+function anthropic_user_content_after_tool_result() -> string {
+    let cl = anthropic.AnthropicClient.new(model = "claude-haiku-4-5", api_key = "test-key");
+    let journal = ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [
+                    ai.content.ToolUse { id: "toolu_a", name: "anth_weather", args: { "city": "SF" } },
+                ],
+                client_id: "anthropic/claude-haiku-4-5",
+            },
+            ai.events.ToolCompleted { id: "toolu_a", output: "sunny in SF" },
+            ai.events.UserContent.new(
+                [
+                    "Screenshot after the tool ran:",
+                    baml.media.Image.from_base64("SGVsbG8=", "image/png"),
+                ],
+            ),
+        ],
+    };
+    let body = anth_render_body(cl, AnthMockTools@spec("weather?"), journal);
+    [
+        `role1=${baml.json.path_or<string>(body, ".messages[1].role", "-")}`,
+        `use0=${baml.json.path_or<string>(body, ".messages[1].content[0].type", "-")}`,
+        `role2=${baml.json.path_or<string>(body, ".messages[2].role", "-")}`,
+        `res0=${baml.json.path_or<string>(body, ".messages[2].content[0].type", "-")}`,
+        `id0=${baml.json.path_or<string>(body, ".messages[2].content[0].tool_use_id", "-")}`,
+        `type1=${baml.json.path_or<string>(body, ".messages[2].content[1].type", "-")}`,
+        `text1=${baml.json.path_or<string>(body, ".messages[2].content[1].text", "-")}`,
+        `type2=${baml.json.path_or<string>(body, ".messages[2].content[2].type", "-")}`,
+        `mime2=${baml.json.path_or<string>(body, ".messages[2].content[2].source.media_type", "-")}`,
+        `data2=${baml.json.path_or<string>(body, ".messages[2].content[2].source.data", "-")}`,
+        `role3=${baml.json.path_or<string>(body, ".messages[3].role", "-")}`,
+    ].join("|")
+}
+
+test "anthropic_user_content_after_tool_result" {
+    let got = anthropic_user_content_after_tool_result();
+    assert.contains(got, "role1=assistant|");
+    assert.contains(got, "use0=tool_use|");
+    assert.contains(got, "role2=user|");
+    assert.contains(got, "res0=tool_result|");
+    assert.contains(got, "id0=toolu_a|");
+    assert.contains(got, "type1=text|");
+    assert.contains(got, "text1=Screenshot after the tool ran:|");
+    assert.contains(got, "type2=image|");
+    assert.contains(got, "mime2=image/png|");
+    assert.contains(got, "data2=SGVsbG8=|");
+    // the screenshot rode in the tool-result user turn: no fourth message
+    assert.contains(got, "role3=-")
+}
+
+// `ai.wire.sanitize_for_client` treats a UserContent turn like a UserMessage:
+// a tool call still unanswered when it arrives is closed first.
+function anthropic_orphaned_tool_call_closed_before_user_content() -> string {
+    let cl = anthropic.AnthropicClient.new(model = "claude-haiku-4-5", api_key = "test-key");
+    let journal = ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [
+                    ai.content.ToolUse { id: "t1", name: "anth_weather", args: { "city": "SF" } },
+                ],
+                client_id: "anthropic/claude-haiku-4-5",
+            },
+            ai.events.UserContent.new(["never mind, look at this instead"]),
+        ],
+    };
+    let body = anth_render_body(cl, AnthMockPlain@spec(), journal);
+    [
+        `type=${baml.json.path_or<string>(body, ".messages[2].content[0].type", "-")}`,
+        `id=${baml.json.path_or<string>(body, ".messages[2].content[0].tool_use_id", "-")}`,
+        `is_error=${baml.json.path_or<bool>(body, ".messages[2].content[0].is_error", false)}`,
+        `text=${baml.json.path_or<string>(body, ".messages[2].content[1].text", "-")}`,
+    ].join("|")
+}
+
+test "anthropic_orphaned_tool_call_closed_before_user_content" {
+    let got = anthropic_orphaned_tool_call_closed_before_user_content();
+    assert.contains(got, "type=tool_result|");
+    assert.contains(got, "id=t1|");
+    assert.contains(got, "is_error=true|");
+    assert.contains(got, "text=never mind, look at this instead")
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_bedrock/bedrock.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_bedrock/bedrock.baml
@@ -1267,3 +1267,48 @@ testset "live" with testing.Sequential() {
         log.warn("live::bedrock not registered: AWS_PROFILE is unset (local SSO session required)")
     }
 }
+
+// ─── journal UserContent: media after a tool result ──────────────────────────
+
+// A runner that screenshots after every tool call appends an
+// `ai.events.UserContent` AFTER the tool result. Converse wants the toolResult
+// blocks in the user message that follows the toolUse, and two user messages
+// back to back are rejected, so the parts-bearing turn merges into that same
+// message after the result: [toolResult, text, image] — the image lowered
+// exactly as prompt media is (`_prompt_content`).
+function bedrock_user_content_after_tool_result() -> string {
+    let args: map<string, unknown> = { "city": "SF" };
+    let log: ai.events.Event[] = [
+        ai.events.AssistantMessage {
+            content: [ai.content.ToolUse { id: "tu_1", name: "get_weather", args: args }],
+            client_id: `bedrock/${_model()}`,
+        },
+        ai.events.ToolCompleted { id: "tu_1", output: "sunny" },
+        ai.events.UserContent.new(
+                [
+                    "Screenshot after the tool ran:",
+                    baml.media.Image.from_base64("SGVsbG8=", "image/png"),
+                ],
+            ),
+    ];
+    let journal = ai.Journal { log: log };
+    let body = _body(_client(null), _turn_input(BedrockUserOnly@spec("go"), journal, _weather_tools()));
+    [
+        baml.json.path<string>(body, ".messages[1].role"),
+        baml.json.path<string>(body, ".messages[1].content[0].toolUse.toolUseId"),
+        baml.json.path<string>(body, ".messages[2].role"),
+        baml.json.path<string>(body, ".messages[2].content[0].toolResult.toolUseId"),
+        baml.json.path<string>(body, ".messages[2].content[1].text"),
+        baml.json.path<string>(body, ".messages[2].content[2].image.format"),
+        baml.json.path<string>(body, ".messages[2].content[2].image.source.bytes"),
+        _array_len(body, ".messages").to_string(),
+        _array_len(body, ".messages[2].content").to_string(),
+    ].join("|")
+}
+
+test "bedrock_user_content_after_tool_result" {
+    assert.equal(
+        bedrock_user_content_after_tool_result(),
+        "assistant|tu_1|user|tu_1|Screenshot after the tool ran:|png|SGVsbG8=|3|3",
+    )
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_google/google_client.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_google/google_client.baml
@@ -1127,3 +1127,90 @@ testset "live" with testing.Sequential() {
         )
     }
 }
+
+// ─── journal UserContent: media after a tool result ──────────────────────────
+//
+// A runner that screenshots after every tool call appends an
+// `ai.events.UserContent` carrying the image AFTER the tool result. It lowers
+// to a `user` content at that position — after the flushed functionResponse —
+// with its text and inlineData parts in order, on both backends.
+
+function _google_journal_with_screenshot() -> ai.Journal {
+    let args: map<string, unknown> = { "city": "NYC" };
+    ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [ai.content.ToolUse { id: "call_1", name: "weather_lookup", args: args }],
+                client_id: "google/gemini-2.5-flash",
+            },
+            ai.events.ToolCompleted { id: "call_1", output: "sunny in NYC" },
+            ai.events.UserContent.new(
+                [
+                    "Screenshot after the tool ran:",
+                    baml.media.Image.from_base64("SGVsbG8=", "image/png"),
+                ],
+            ),
+        ],
+    }
+}
+
+function _google_user_content_shape(body: json) -> string {
+    [
+        baml.json.path<string>(body, ".contents[1].role"),
+        baml.json.path<string>(body, ".contents[1].parts[0].functionCall.name"),
+        baml.json.path<string>(body, ".contents[2].role"),
+        baml.json.path<string>(body, ".contents[2].parts[0].functionResponse.name"),
+        baml.json.path<string>(body, ".contents[3].role"),
+        baml.json.path<string>(body, ".contents[3].parts[0].text"),
+        baml.json.path<string>(body, ".contents[3].parts[1].inlineData.mimeType"),
+        baml.json.path<string>(body, ".contents[3].parts[1].inlineData.data"),
+        baml.json.path_or<string>(body, ".contents[4].role", "absent"),
+    ].join("|")
+}
+
+function google_user_content_after_tool_result() -> string {
+    let spec = GoogleToolEcho@spec("Weather in NYC?");
+    let input = ai.ModelTurnInput {
+        prompt: spec.prompt_template,
+        journal: _google_journal_with_screenshot(),
+        toolbox: spec.tools(),
+        output_type: spec.output_type(),
+    };
+    let cl = google.GoogleClient.new(
+        model = "gemini-2.5-flash",
+        api_key = "test-key",
+        base_url = "https://example.test",
+    );
+    _google_user_content_shape(baml.json.parse(google.internal.google_render(cl, input).body))
+}
+
+test "google_user_content_after_tool_result" {
+    assert.equal(
+        google_user_content_after_tool_result(),
+        "model|weather_lookup|user|weather_lookup|user|Screenshot after the tool ran:|image/png|SGVsbG8=|absent",
+    )
+}
+
+function vertex_user_content_after_tool_result() -> string {
+    let spec = GoogleToolEcho@spec("Weather in NYC?");
+    let input = ai.ModelTurnInput {
+        prompt: spec.prompt_template,
+        journal: _google_journal_with_screenshot(),
+        toolbox: spec.tools(),
+        output_type: spec.output_type(),
+    };
+    let cl = google.VertexClient.new(
+        model = "gemini-2.5-flash",
+        project_id = "my-project",
+        location = "us-central1",
+        api_key = "express-key",
+    );
+    _google_user_content_shape(baml.json.parse(google.internal.vertex_render(cl, input).body))
+}
+
+test "vertex_user_content_after_tool_result" {
+    assert.equal(
+        vertex_user_content_after_tool_result(),
+        "model|weather_lookup|user|weather_lookup|user|Screenshot after the tool ran:|image/png|SGVsbG8=|absent",
+    )
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_on_event/llm_on_event.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_on_event/llm_on_event.baml
@@ -46,6 +46,7 @@ function label_of(e: ai.events.Event) -> string {
     match (e) {
         let x: ai.events.RunStarted => "RunStarted",
         let x: ai.events.UserMessage => "UserMessage",
+        let x: ai.events.UserContent => "UserContent",
         let x: ai.events.AssistantMessage => "AssistantMessage",
         let x: ai.events.ToolRequested => "ToolRequested",
         let x: ai.events.ToolCompleted => "ToolCompleted",
@@ -84,4 +85,32 @@ test "explicit Agent accepts and swallows a throwing listener" {
     let out = agent.run(Greet@spec("world"));
     assert.equal(out.value.message, "hi");
     assert.equal(probe.labels, ["RunStarted", "AssistantMessage", "Usage", "FinalProduced"])
+}
+
+// The Claude Code CLI folds the journal into one text prompt: a UserContent
+// turn renders its text parts as written and its media as a readable
+// placeholder, in order, after the tool result it follows.
+function claude_code_transcript_with_user_content() -> string {
+    let args: map<string, unknown> = { };
+    let journal = ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [ai.content.ToolUse { id: "c1", name: "look", args: args }],
+                client_id: "claude-code/opus",
+            },
+            ai.events.ToolCompleted { id: "c1", output: "done" },
+            ai.events.UserContent.new(
+                [
+                    "Screenshot after the tool ran: ",
+                    baml.media.Image.from_base64("SGVsbG8=", "image/png"),
+                ],
+            ),
+        ],
+    };
+    claude_code.internal.transcript_text(journal)
+}
+
+test "claude_code_transcript_with_user_content" {
+    let got = claude_code_transcript_with_user_content();
+    assert.contains(got, "tool result id=c1 is_error=false: done\nuser: Screenshot after the tool ran: [image]")
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
@@ -1780,3 +1780,68 @@ testset "live" with testing.Sequential() {
         log.warn("live::openrouter not registered: OPENROUTER_API_KEY is unset")
     }
 }
+
+// ─── journal UserContent: media after a tool result ──────────────────────────
+
+// `_chat_input_with_history` plus the screenshot a runner appends after the
+// tool result: an `ai.events.UserContent` with a text part and a base64 image.
+function _chat_input_with_screenshot() -> ai.ModelTurnInput {
+    let spec = ChatEcho@spec("and tomorrow?");
+    let args: map<string, unknown> = { "city": "SF" };
+    let journal = ai.Journal {
+        log: [
+            ai.events.UserMessage { content: "weather in SF?" },
+            ai.events.AssistantMessage {
+                content: [
+                    ai.content.Text { text: "checking" },
+                    ai.content.ToolUse { id: "call_1", name: "chat_get_weather", args: args },
+                ],
+                client_id: "openai-chat/gpt-4o-mini",
+            },
+            ai.events.ToolCompleted { id: "call_1", output: "sunny in SF" },
+            ai.events.UserContent.new(
+                [
+                    "Screenshot after the tool ran:",
+                    baml.media.Image.from_base64("SGVsbG8=", "image/png"),
+                ],
+            ),
+        ],
+    };
+    ai.ModelTurnInput {
+        prompt: spec.prompt_template,
+        journal: journal,
+        toolbox: ai.tools.Toolbox.new([ai.tools.tool(chat_get_weather)]),
+        output_type: spec.output_type(),
+    }
+}
+
+// The screenshot lowers to a `user` message AFTER the `tool` message, with a
+// text part and an `image_url` data-URL part — the same shape prompt media
+// takes (`_chat_prompt_parts`).
+function chat_user_content_after_tool_result() -> string {
+    root.llm_mock.mock_json_serve(
+        [root.llm_mock.MockResponse.ok(_chat_ok_body())],
+        (mock: root.llm_mock.MockJsonServer) -> {
+            let cl = openai.ChatClient.new(api_key = "k", base_url = mock.base_url());
+            let _ = cl.invoke(_chat_input_with_screenshot());
+            let body = mock.last_request().json();
+            [
+                baml.json.path<string>(body, ".messages[4].role"),
+                baml.json.path<string>(body, ".messages[4].tool_call_id"),
+                baml.json.path<string>(body, ".messages[5].role"),
+                baml.json.path<string>(body, ".messages[5].content[0].type"),
+                baml.json.path<string>(body, ".messages[5].content[0].text"),
+                baml.json.path<string>(body, ".messages[5].content[1].type"),
+                baml.json.path<string>(body, ".messages[5].content[1].image_url.url"),
+                baml.json.path_or<string>(body, ".messages[6].role", "absent"),
+            ].join("|")
+        },
+    )
+}
+
+test "chat_user_content_after_tool_result" {
+    assert.equal(
+        chat_user_content_after_tool_result(),
+        "tool|call_1|user|text|Screenshot after the tool ran:|image_url|data:image/png;base64,SGVsbG8=|absent",
+    )
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_openai_responses/responses.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_openai_responses/responses.baml
@@ -1113,3 +1113,61 @@ testset "live" with testing.Sequential() {
         log.warn("live::openai_responses not registered: OPENAI_API_KEY is unset")
     }
 }
+
+// ─── journal UserContent: media after a tool result ──────────────────────────
+
+// A runner that screenshots after every tool call appends an
+// `ai.events.UserContent` AFTER the tool result. It lowers to a user message
+// item right after the `function_call_output`, its text and image as the same
+// typed parts prompt media takes (`_openai_prompt_content`).
+function oai_user_content_after_tool_result() -> string {
+    let spec = OaiEcho@spec("Say pong.");
+    let properties: map<string, unknown> = { };
+    let required: string[] = [];
+    let schema: map<string, unknown> = {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+    };
+    let toolbox = ai.tools.Toolbox.new(
+        [
+            ai.tools.raw_tool(
+                "lookup",
+                "Look something up",
+                schema,
+                (args: map<string, unknown>) -> {
+                    let out = "ok";
+                    out
+                },
+            ),
+        ],
+    );
+    let args: map<string, unknown> = { };
+    let journal = ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [ai.content.ToolUse { id: "call_1", name: "lookup", args: args }],
+                client_id: "openai/gpt-4o-mini",
+            },
+            ai.events.ToolCompleted { id: "call_1", output: "ok" },
+            ai.events.UserContent.new(
+                [
+                    "Screenshot after the tool ran:",
+                    baml.media.Image.from_base64("SGVsbG8=", "image/png"),
+                ],
+            ),
+        ],
+    };
+    let cl = openai.ResponsesClient.new(model = "gpt-4o-mini", api_key = "test-key");
+    let req = openai.internal.openai_render(cl, _oai_input(spec, journal, toolbox));
+    req.body
+}
+
+test "oai_user_content_after_tool_result" {
+    let got = oai_user_content_after_tool_result();
+    // the user turn with the image sits immediately after the tool result
+    assert.contains(
+        got,
+        `{"type":"function_call_output","call_id":"call_1","output":"ok"},{"role":"user","content":[{"type":"input_text","text":"Screenshot after the tool ran:"},{"type":"input_image","image_url":"data:image/png;base64,SGVsbG8=","detail":"auto"}]}`,
+    )
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
@@ -155,7 +155,7 @@ function env_ref_clients.$init_test_ns_env_ref_clients_env_ref_clients(registry:
     return
 }
 
-function env_ref_clients.EnvRefDynamicEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_clients.EnvRefDynamicEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -265,7 +265,7 @@ function env_ref_clients.EnvRefDynamicEcho@spec(question: string) -> ai.Function
     return
 }
 
-function env_ref_clients.EnvRefDynamicEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_clients.EnvRefDynamicEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -293,7 +293,7 @@ function env_ref_clients.EnvRefDynamicEcho@stream(question: string, client: ai.s
     return
 }
 
-function env_ref_clients.EnvRefEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_clients.EnvRefEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -408,7 +408,7 @@ function env_ref_clients.EnvRefEcho@spec(question: string) -> ai.FunctionSpec<st
     return
 }
 
-function env_ref_clients.EnvRefEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_clients.EnvRefEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -436,7 +436,7 @@ function env_ref_clients.EnvRefEcho@stream(question: string, client: ai.stream.S
     return
 }
 
-function env_ref_clients.EnvRefResolvedEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_clients.EnvRefResolvedEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -536,7 +536,7 @@ function env_ref_clients.EnvRefResolvedEcho@spec(question: string) -> ai.Functio
     return
 }
 
-function env_ref_clients.EnvRefResolvedEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_clients.EnvRefResolvedEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -564,7 +564,7 @@ function env_ref_clients.EnvRefResolvedEcho@stream(question: string, client: ai.
     return
 }
 
-function env_ref_clients.LiveEnvRefEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_clients.LiveEnvRefEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -663,7 +663,7 @@ function env_ref_clients.LiveEnvRefEcho@spec(question: string) -> ai.FunctionSpe
     return
 }
 
-function env_ref_clients.LiveEnvRefEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_clients.LiveEnvRefEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -691,7 +691,7 @@ function env_ref_clients.LiveEnvRefEcho@stream(question: string, client: ai.stre
     return
 }
 
-function env_ref_clients.LiveEnvRefFallbackEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_clients.LiveEnvRefFallbackEcho(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -801,7 +801,7 @@ function env_ref_clients.LiveEnvRefFallbackEcho@spec(question: string) -> ai.Fun
     return
 }
 
-function env_ref_clients.LiveEnvRefFallbackEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_clients.LiveEnvRefFallbackEcho@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_desugar/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_desugar/bytecode.snap
@@ -76,7 +76,7 @@ function env_ref_desugar.$init_test_ns_env_ref_desugar_env_ref_desugar(registry:
     return
 }
 
-function env_ref_desugar.EnvRefBadClientFn(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_desugar.EnvRefBadClientFn(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -166,7 +166,7 @@ function env_ref_desugar.EnvRefBadClientFn@spec() -> ai.FunctionSpec<string> {
     return
 }
 
-function env_ref_desugar.EnvRefBadClientFn@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_desugar.EnvRefBadClientFn@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -232,7 +232,7 @@ function env_ref_desugar.EnvRefClientId() -> string {
     return
 }
 
-function env_ref_desugar.EnvRefDesugarFn(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_desugar.EnvRefDesugarFn(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -322,7 +322,7 @@ function env_ref_desugar.EnvRefDesugarFn@spec() -> ai.FunctionSpec<string> {
     return
 }
 
-function env_ref_desugar.EnvRefDesugarFn@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_desugar.EnvRefDesugarFn@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -360,7 +360,7 @@ function env_ref_desugar.EnvRefDesugarFnClientId() -> string {
     return
 }
 
-function env_ref_desugar.EnvRefDynClientFn(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function env_ref_desugar.EnvRefDynClientFn(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -450,7 +450,7 @@ function env_ref_desugar.EnvRefDynClientFn@spec() -> ai.FunctionSpec<string> {
     return
 }
 
-function env_ref_desugar.EnvRefDynClientFn@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function env_ref_desugar.EnvRefDynClientFn@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.anyfunction_reflect.RuntimeClassify(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> #0 {
+function fixtures.anyfunction_reflect.RuntimeClassify(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> #0 {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -104,7 +104,7 @@ function fixtures.anyfunction_reflect.RuntimeClassify@spec(input: string) -> ai.
     return
 }
 
-function fixtures.anyfunction_reflect.RuntimeClassify@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0 | null, #0> {
+function fixtures.anyfunction_reflect.RuntimeClassify@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0 | null, #0> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/mir.snap
@@ -346,12 +346,12 @@ fn user.fixtures.anyfunction_reflect.typed_dispatch(name: string, args: map<stri
     }
 }
 
-fn user.fixtures.anyfunction_reflect.RuntimeClassify(input: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> T {
+fn user.fixtures.anyfunction_reflect.RuntimeClassify(input: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> T {
     // Locals:
     let _0: T // _0 // return
     let _1: string // input // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<T>
@@ -625,12 +625,12 @@ fn .<lambda(RuntimeClassify@spec, 0)>( __spec_output_format: ai.OutputFormat) ->
     }
 }
 
-fn user.fixtures.anyfunction_reflect.RuntimeClassify@stream(input: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<null | T, T> {
+fn user.fixtures.anyfunction_reflect.RuntimeClassify@stream(input: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<null | T, T> {
     // Locals:
     let _0: ai.stream.Stream<null | T, T> // _0 // return
     let _1: string // input // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<T>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.backtick_decl_slots.Greet(name: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.backtick_decl_slots.Greet(name: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function fixtures.backtick_decl_slots.Greet@spec(name: string) -> ai.FunctionSpe
     return
 }
 
-function fixtures.backtick_decl_slots.Greet@stream(name: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.backtick_decl_slots.Greet@stream(name: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.backtick_decl_slots.Greet(name: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.backtick_decl_slots.Greet(name: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // name // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -247,12 +247,12 @@ fn .<lambda(Greet@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     }
 }
 
-fn user.fixtures.backtick_decl_slots.Greet@stream(name: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.backtick_decl_slots.Greet@stream(name: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // name // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.comment_in_type.CommentAfterArrow(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.comment_in_type.CommentAfterArrow(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -91,7 +91,7 @@ function fixtures.comment_in_type.CommentAfterArrow@spec() -> ai.FunctionSpec<st
     return
 }
 
-function fixtures.comment_in_type.CommentAfterArrow@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.comment_in_type.CommentAfterArrow@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -118,7 +118,7 @@ function fixtures.comment_in_type.CommentAfterArrow@stream(client: ai.stream.Str
     return
 }
 
-function fixtures.comment_in_type.FunctionWithComments(a: string, b: int, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.comment_in_type.FunctionWithComments(a: string, b: int, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -214,7 +214,7 @@ function fixtures.comment_in_type.FunctionWithComments@spec(a: string, b: int) -
     return
 }
 
-function fixtures.comment_in_type.FunctionWithComments@stream(a: string, b: int, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.comment_in_type.FunctionWithComments@stream(a: string, b: int, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/mir.snap
@@ -2,13 +2,13 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.comment_in_type.FunctionWithComments(a: string, b: int, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.comment_in_type.FunctionWithComments(a: string, b: int, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // a // param
     let _2: int // b // param
     let _3: null | ai.Client // client // param
-    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _5: bool
     let _6: bool
     let _7: ai.RunResult<string>
@@ -227,13 +227,13 @@ fn .<lambda(FunctionWithComments@spec, 0)>( __spec_output_format: ai.OutputForma
     }
 }
 
-fn user.fixtures.comment_in_type.FunctionWithComments@stream(a: string, b: int, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.comment_in_type.FunctionWithComments@stream(a: string, b: int, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // a // param
     let _2: int // b // param
     let _3: null | ai.stream.StreamingClient // client // param
-    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _5: bool
     let _6: bool
     let _7: ai.FunctionSpec<string>
@@ -275,11 +275,11 @@ fn user.fixtures.comment_in_type.FunctionWithComments@stream(a: string, b: int, 
     }
 }
 
-fn user.fixtures.comment_in_type.CommentAfterArrow(client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.comment_in_type.CommentAfterArrow(client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: null | ai.Client // client // param
-    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _3: bool
     let _4: bool
     let _5: ai.RunResult<string>
@@ -492,11 +492,11 @@ fn .<lambda(CommentAfterArrow@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     }
 }
 
-fn user.fixtures.comment_in_type.CommentAfterArrow@stream(client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.comment_in_type.CommentAfterArrow@stream(client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: null | ai.stream.StreamingClient // client // param
-    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _3: bool
     let _4: bool
     let _5: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_llm_return_type/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_llm_return_type/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.json_llm_return_type.ExtractAny(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> baml.json.json {
+function fixtures.json_llm_return_type.ExtractAny(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> baml.json.json {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -91,7 +91,7 @@ function fixtures.json_llm_return_type.ExtractAny@spec() -> ai.FunctionSpec<baml
     return
 }
 
-function fixtures.json_llm_return_type.ExtractAny@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<baml.json.json$stream | null, baml.json.json> {
+function fixtures.json_llm_return_type.ExtractAny@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<baml.json.json$stream | null, baml.json.json> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_llm_return_type/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_llm_return_type/mir.snap
@@ -2,11 +2,11 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.json_llm_return_type.ExtractAny(client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> {
+fn user.fixtures.json_llm_return_type.ExtractAny(client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> {
     // Locals:
     let _0: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // _0 // return
     let _1: null | ai.Client // client // param
-    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _3: bool
     let _4: bool
     let _5: ai.RunResult<baml.json.json>
@@ -247,11 +247,11 @@ fn .<lambda(ExtractAny@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.P
     }
 }
 
-fn user.fixtures.json_llm_return_type.ExtractAny@stream(client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<baml.json.json, baml.json.json> {
+fn user.fixtures.json_llm_return_type.ExtractAny@stream(client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<baml.json.json, baml.json.json> {
     // Locals:
     let _0: ai.stream.Stream<baml.json.json, baml.json.json> // _0 // return
     let _1: null | ai.stream.StreamingClient // client // param
-    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _3: bool
     let _4: bool
     let _5: ai.FunctionSpec<baml.json.json>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.llm_image_outputs.GenerateImage(prompt: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> image {
+function fixtures.llm_image_outputs.GenerateImage(prompt: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> image {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -116,7 +116,7 @@ function fixtures.llm_image_outputs.GenerateImage@spec(prompt: string) -> ai.Fun
     return
 }
 
-function fixtures.llm_image_outputs.GenerateImage@stream(prompt: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<image, image> {
+function fixtures.llm_image_outputs.GenerateImage@stream(prompt: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<image, image> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -144,7 +144,7 @@ function fixtures.llm_image_outputs.GenerateImage@stream(prompt: string, client:
     return
 }
 
-function fixtures.llm_image_outputs.GenerateImageSet(prompt: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> image[] {
+function fixtures.llm_image_outputs.GenerateImageSet(prompt: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> image[] {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -259,7 +259,7 @@ function fixtures.llm_image_outputs.GenerateImageSet@spec(prompt: string) -> ai.
     return
 }
 
-function fixtures.llm_image_outputs.GenerateImageSet@stream(prompt: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<image[], image[]> {
+function fixtures.llm_image_outputs.GenerateImageSet@stream(prompt: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<image[], image[]> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -287,7 +287,7 @@ function fixtures.llm_image_outputs.GenerateImageSet@stream(prompt: string, clie
     return
 }
 
-function fixtures.llm_image_outputs.GenerateMixedImageNarrative(prompt: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> (image | string)[] {
+function fixtures.llm_image_outputs.GenerateMixedImageNarrative(prompt: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> (image | string)[] {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -402,7 +402,7 @@ function fixtures.llm_image_outputs.GenerateMixedImageNarrative@spec(prompt: str
     return
 }
 
-function fixtures.llm_image_outputs.GenerateMixedImageNarrative@stream(prompt: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<(image | string)[], (image | string)[]> {
+function fixtures.llm_image_outputs.GenerateMixedImageNarrative@stream(prompt: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<(image | string)[], (image | string)[]> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.llm_image_outputs.GenerateImage(prompt: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> image {
+fn user.fixtures.llm_image_outputs.GenerateImage(prompt: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> image {
     // Locals:
     let _0: image // _0 // return
     let _1: string // prompt // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<image>
@@ -246,12 +246,12 @@ fn .<lambda(GenerateImage@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     }
 }
 
-fn user.fixtures.llm_image_outputs.GenerateImage@stream(prompt: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<image, image> {
+fn user.fixtures.llm_image_outputs.GenerateImage@stream(prompt: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<image, image> {
     // Locals:
     let _0: ai.stream.Stream<image, image> // _0 // return
     let _1: string // prompt // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<image>
@@ -293,12 +293,12 @@ fn user.fixtures.llm_image_outputs.GenerateImage@stream(prompt: string, client: 
     }
 }
 
-fn user.fixtures.llm_image_outputs.GenerateImageSet(prompt: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> image[] {
+fn user.fixtures.llm_image_outputs.GenerateImageSet(prompt: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> image[] {
     // Locals:
     let _0: image[] // _0 // return
     let _1: string // prompt // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<image[]>
@@ -537,12 +537,12 @@ fn .<lambda(GenerateImageSet@spec, 0)>( __spec_output_format: ai.OutputFormat) -
     }
 }
 
-fn user.fixtures.llm_image_outputs.GenerateImageSet@stream(prompt: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<image[], image[]> {
+fn user.fixtures.llm_image_outputs.GenerateImageSet@stream(prompt: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<image[], image[]> {
     // Locals:
     let _0: ai.stream.Stream<image[], image[]> // _0 // return
     let _1: string // prompt // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<image[]>
@@ -584,12 +584,12 @@ fn user.fixtures.llm_image_outputs.GenerateImageSet@stream(prompt: string, clien
     }
 }
 
-fn user.fixtures.llm_image_outputs.GenerateMixedImageNarrative(prompt: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> (string | image)[] {
+fn user.fixtures.llm_image_outputs.GenerateMixedImageNarrative(prompt: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> (string | image)[] {
     // Locals:
     let _0: (string | image)[] // _0 // return
     let _1: string // prompt // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<(string | image)[]>
@@ -857,12 +857,12 @@ fn .<lambda(GenerateMixedImageNarrative@spec, 0)>( __spec_output_format: ai.Outp
     }
 }
 
-fn user.fixtures.llm_image_outputs.GenerateMixedImageNarrative@stream(prompt: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<(string | image)[], (string | image)[]> {
+fn user.fixtures.llm_image_outputs.GenerateMixedImageNarrative@stream(prompt: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<(string | image)[], (string | image)[]> {
     // Locals:
     let _0: ai.stream.Stream<(string | image)[], (string | image)[]> // _0 // return
     let _1: string // prompt // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<(string | image)[]>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.llm_parse_catchable_parse_error.ExtractInvoice(text: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.llm_parse_catchable_parse_error.Invoice {
+function fixtures.llm_parse_catchable_parse_error.ExtractInvoice(text: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.llm_parse_catchable_parse_error.Invoice {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function fixtures.llm_parse_catchable_parse_error.ExtractInvoice@spec(text: stri
     return
 }
 
-function fixtures.llm_parse_catchable_parse_error.ExtractInvoice@stream(text: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<fixtures.llm_parse_catchable_parse_error.Invoice$stream | null, fixtures.llm_parse_catchable_parse_error.Invoice> {
+function fixtures.llm_parse_catchable_parse_error.ExtractInvoice@stream(text: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<fixtures.llm_parse_catchable_parse_error.Invoice$stream | null, fixtures.llm_parse_catchable_parse_error.Invoice> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice(text: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> fixtures.llm_parse_catchable_parse_error.Invoice {
+fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice(text: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> fixtures.llm_parse_catchable_parse_error.Invoice {
     // Locals:
     let _0: fixtures.llm_parse_catchable_parse_error.Invoice // _0 // return
     let _1: string // text // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<fixtures.llm_parse_catchable_parse_error.Invoice>
@@ -246,12 +246,12 @@ fn .<lambda(ExtractInvoice@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 }
 
-fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@stream(text: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<null | fixtures.llm_parse_catchable_parse_error.Invoice$stream, fixtures.llm_parse_catchable_parse_error.Invoice> {
+fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@stream(text: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<null | fixtures.llm_parse_catchable_parse_error.Invoice$stream, fixtures.llm_parse_catchable_parse_error.Invoice> {
     // Locals:
     let _0: ai.stream.Stream<null | fixtures.llm_parse_catchable_parse_error.Invoice$stream, fixtures.llm_parse_catchable_parse_error.Invoice> // _0 // return
     let _1: string // text // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<fixtures.llm_parse_catchable_parse_error.Invoice>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.llm_quoted_prompt.BacktickPrompt(topic: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.llm_quoted_prompt.BacktickPrompt(topic: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function fixtures.llm_quoted_prompt.BacktickPrompt@spec(topic: string) -> ai.Fun
     return
 }
 
-function fixtures.llm_quoted_prompt.BacktickPrompt@stream(topic: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.llm_quoted_prompt.BacktickPrompt@stream(topic: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -128,7 +128,7 @@ function fixtures.llm_quoted_prompt.BacktickPrompt@stream(topic: string, client:
     return
 }
 
-function fixtures.llm_quoted_prompt.QuotedPrompt(topic: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.llm_quoted_prompt.QuotedPrompt(topic: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -223,7 +223,7 @@ function fixtures.llm_quoted_prompt.QuotedPrompt@spec(topic: string) -> ai.Funct
     return
 }
 
-function fixtures.llm_quoted_prompt.QuotedPrompt@stream(topic: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.llm_quoted_prompt.QuotedPrompt@stream(topic: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.llm_quoted_prompt.QuotedPrompt(topic: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.llm_quoted_prompt.QuotedPrompt(topic: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // topic // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -223,12 +223,12 @@ fn .<lambda(QuotedPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai
     }
 }
 
-fn user.fixtures.llm_quoted_prompt.QuotedPrompt@stream(topic: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.llm_quoted_prompt.QuotedPrompt@stream(topic: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // topic // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>
@@ -270,12 +270,12 @@ fn user.fixtures.llm_quoted_prompt.QuotedPrompt@stream(topic: string, client: nu
     }
 }
 
-fn user.fixtures.llm_quoted_prompt.BacktickPrompt(topic: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.llm_quoted_prompt.BacktickPrompt(topic: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // topic // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -543,12 +543,12 @@ fn .<lambda(BacktickPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 }
 
-fn user.fixtures.llm_quoted_prompt.BacktickPrompt@stream(topic: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.llm_quoted_prompt.BacktickPrompt@stream(topic: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // topic // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.llm_spec_mode.NamedTools(q: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.llm_spec_mode.Answer {
+function fixtures.llm_spec_mode.NamedTools(q: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.llm_spec_mode.Answer {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -114,7 +114,7 @@ function fixtures.llm_spec_mode.NamedTools@spec(q: string) -> ai.FunctionSpec<fi
     return
 }
 
-function fixtures.llm_spec_mode.PlainChat(q: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.llm_spec_mode.PlainChat(q: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -229,7 +229,7 @@ function fixtures.llm_spec_mode.PlainChat@spec(q: string) -> ai.FunctionSpec<str
     return
 }
 
-function fixtures.llm_spec_mode.PlainChat@stream(q: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.llm_spec_mode.PlainChat@stream(q: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -257,7 +257,7 @@ function fixtures.llm_spec_mode.PlainChat@stream(q: string, client: ai.stream.St
     return
 }
 
-function fixtures.llm_spec_mode.SpecAgent(q: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.llm_spec_mode.Answer {
+function fixtures.llm_spec_mode.SpecAgent(q: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.llm_spec_mode.Answer {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/mir.snap
@@ -36,12 +36,12 @@ fn user.fixtures.llm_spec_mode.more_tools() -> ai.tools.Tool[] {
     }
 }
 
-fn user.fixtures.llm_spec_mode.PlainChat(q: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.llm_spec_mode.PlainChat(q: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // q // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -309,12 +309,12 @@ fn .<lambda(PlainChat@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pr
     }
 }
 
-fn user.fixtures.llm_spec_mode.PlainChat@stream(q: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.llm_spec_mode.PlainChat@stream(q: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // q // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>
@@ -356,12 +356,12 @@ fn user.fixtures.llm_spec_mode.PlainChat@stream(q: string, client: null | ai.str
     }
 }
 
-fn user.fixtures.llm_spec_mode.SpecAgent(q: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> fixtures.llm_spec_mode.Answer {
+fn user.fixtures.llm_spec_mode.SpecAgent(q: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> fixtures.llm_spec_mode.Answer {
     // Locals:
     let _0: fixtures.llm_spec_mode.Answer // _0 // return
     let _1: string // q // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<fixtures.llm_spec_mode.Answer>
@@ -631,12 +631,12 @@ fn .<lambda(SpecAgent@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pr
     }
 }
 
-fn user.fixtures.llm_spec_mode.NamedTools(q: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> fixtures.llm_spec_mode.Answer {
+fn user.fixtures.llm_spec_mode.NamedTools(q: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> fixtures.llm_spec_mode.Answer {
     // Locals:
     let _0: fixtures.llm_spec_mode.Answer // _0 // return
     let _1: string // q // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<fixtures.llm_spec_mode.Answer>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.o1_allowed_roles.AskGpt4o(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.o1_allowed_roles.AskGpt4o(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function fixtures.o1_allowed_roles.AskGpt4o@spec(question: string) -> ai.Functio
     return
 }
 
-function fixtures.o1_allowed_roles.AskGpt4o@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.o1_allowed_roles.AskGpt4o@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -128,7 +128,7 @@ function fixtures.o1_allowed_roles.AskGpt4o@stream(question: string, client: ai.
     return
 }
 
-function fixtures.o1_allowed_roles.AskO1(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.o1_allowed_roles.AskO1(question: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -227,7 +227,7 @@ function fixtures.o1_allowed_roles.AskO1@spec(question: string) -> ai.FunctionSp
     return
 }
 
-function fixtures.o1_allowed_roles.AskO1@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.o1_allowed_roles.AskO1@stream(question: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.o1_allowed_roles.AskO1(question: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.o1_allowed_roles.AskO1(question: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // question // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -243,12 +243,12 @@ fn .<lambda(AskO1@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     }
 }
 
-fn user.fixtures.o1_allowed_roles.AskO1@stream(question: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.o1_allowed_roles.AskO1@stream(question: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // question // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>
@@ -290,12 +290,12 @@ fn user.fixtures.o1_allowed_roles.AskO1@stream(question: string, client: null | 
     }
 }
 
-fn user.fixtures.o1_allowed_roles.AskGpt4o(question: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.o1_allowed_roles.AskGpt4o(question: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // question // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -531,12 +531,12 @@ fn .<lambda(AskGpt4o@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     }
 }
 
-fn user.fixtures.o1_allowed_roles.AskGpt4o@stream(question: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.o1_allowed_roles.AskGpt4o@stream(question: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // question // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.optional_function_parameters.AskDocs(query: string, max_results: int, filter: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.optional_function_parameters.AskDocs(query: string, max_results: int, filter: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -114,7 +114,7 @@ function fixtures.optional_function_parameters.AskDocs@spec(query: string, max_r
     return
 }
 
-function fixtures.optional_function_parameters.AskDocs@stream(query: string, max_results: int, filter: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.optional_function_parameters.AskDocs@stream(query: string, max_results: int, filter: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/mir.snap
@@ -232,14 +232,14 @@ fn user.fixtures.optional_function_parameters.HostEntry(query: string, max_resul
     }
 }
 
-fn user.fixtures.optional_function_parameters.AskDocs(query: string, max_results: int, filter: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.optional_function_parameters.AskDocs(query: string, max_results: int, filter: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // query // param
     let _2: int // max_results // param
     let _3: string // filter // param
     let _4: null | ai.Client // client // param
-    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _6: bool
     let _7: bool
     let _8: ai.RunResult<string>
@@ -529,14 +529,14 @@ fn .<lambda(AskDocs@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prom
     }
 }
 
-fn user.fixtures.optional_function_parameters.AskDocs@stream(query: string, max_results: int, filter: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.optional_function_parameters.AskDocs@stream(query: string, max_results: int, filter: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // query // param
     let _2: int // max_results // param
     let _3: string // filter // param
     let _4: null | ai.stream.StreamingClient // client // param
-    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _6: bool
     let _7: bool
     let _8: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.retry_policy.UseRetryClient(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.retry_policy.UseRetryClient(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function fixtures.retry_policy.UseRetryClient@spec(input: string) -> ai.Function
     return
 }
 
-function fixtures.retry_policy.UseRetryClient@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.retry_policy.UseRetryClient@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.retry_policy.UseRetryClient(input: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.retry_policy.UseRetryClient(input: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // input // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -246,12 +246,12 @@ fn .<lambda(UseRetryClient@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 }
 
-fn user.fixtures.retry_policy.UseRetryClient@stream(input: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.retry_policy.UseRetryClient@stream(input: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // input // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function fixtures.stream_llm_inferred_typeargs.TestFunc(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.stream_llm_inferred_typeargs.TestFunc(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function fixtures.stream_llm_inferred_typeargs.TestFunc@spec(input: string) -> a
     return
 }
 
-function fixtures.stream_llm_inferred_typeargs.TestFunc@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.stream_llm_inferred_typeargs.TestFunc@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/mir.snap
@@ -2,12 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 === MIR2 ===
-fn user.fixtures.stream_llm_inferred_typeargs.TestFunc(input: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.stream_llm_inferred_typeargs.TestFunc(input: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // input // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -246,12 +246,12 @@ fn .<lambda(TestFunc@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     }
 }
 
-fn user.fixtures.stream_llm_inferred_typeargs.TestFunc@stream(input: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.stream_llm_inferred_typeargs.TestFunc@stream(input: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // input // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/bytecode.snap
@@ -13,7 +13,7 @@ function fixtures.testset_vibes_nested.$init_test_ns_fixtures_ns_testset_vibes_n
     return
 }
 
-function fixtures.testset_vibes_nested.ClassifySentiment(text: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.testset_vibes_nested.Sentiment {
+function fixtures.testset_vibes_nested.ClassifySentiment(text: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> fixtures.testset_vibes_nested.Sentiment {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -52,7 +52,7 @@ function fixtures.testset_vibes_nested.ClassifySentiment(text: string, client: a
     return
 }
 
-function fixtures.testset_vibes_nested.ClassifySentiment2(text: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function fixtures.testset_vibes_nested.ClassifySentiment2(text: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -151,7 +151,7 @@ function fixtures.testset_vibes_nested.ClassifySentiment2@spec(text: string) -> 
     return
 }
 
-function fixtures.testset_vibes_nested.ClassifySentiment2@stream(text: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function fixtures.testset_vibes_nested.ClassifySentiment2@stream(text: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -239,7 +239,7 @@ function fixtures.testset_vibes_nested.ClassifySentiment@spec(text: string) -> a
     return
 }
 
-function fixtures.testset_vibes_nested.ClassifySentiment@stream(text: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<fixtures.testset_vibes_nested.Sentiment$stream | null, fixtures.testset_vibes_nested.Sentiment> {
+function fixtures.testset_vibes_nested.ClassifySentiment@stream(text: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<fixtures.testset_vibes_nested.Sentiment$stream | null, fixtures.testset_vibes_nested.Sentiment> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -296,7 +296,7 @@ function fixtures.testset_vibes_nested.Foo() -> string | image {
     jump L0
 }
 
-function fixtures.testset_vibes_nested.GenerateTests(count: int, topic: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string[] {
+function fixtures.testset_vibes_nested.GenerateTests(count: int, topic: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string[] {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -400,7 +400,7 @@ function fixtures.testset_vibes_nested.GenerateTests@spec(count: int, topic: str
     return
 }
 
-function fixtures.testset_vibes_nested.GenerateTests@stream(count: int, topic: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string[], string[]> {
+function fixtures.testset_vibes_nested.GenerateTests@stream(count: int, topic: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string[], string[]> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/mir.snap
@@ -315,12 +315,12 @@ fn .<lambda(<lambda(<lambda(<lambda($init_test_ns_fixtures_ns_testset_vibes_nest
     }
 }
 
-fn user.fixtures.testset_vibes_nested.ClassifySentiment(text: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> fixtures.testset_vibes_nested.Sentiment {
+fn user.fixtures.testset_vibes_nested.ClassifySentiment(text: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> fixtures.testset_vibes_nested.Sentiment {
     // Locals:
     let _0: fixtures.testset_vibes_nested.Sentiment // _0 // return
     let _1: string // text // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<fixtures.testset_vibes_nested.Sentiment>
@@ -559,12 +559,12 @@ fn .<lambda(ClassifySentiment@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     }
 }
 
-fn user.fixtures.testset_vibes_nested.ClassifySentiment@stream(text: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<null | fixtures.testset_vibes_nested.Sentiment$stream, fixtures.testset_vibes_nested.Sentiment> {
+fn user.fixtures.testset_vibes_nested.ClassifySentiment@stream(text: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<null | fixtures.testset_vibes_nested.Sentiment$stream, fixtures.testset_vibes_nested.Sentiment> {
     // Locals:
     let _0: ai.stream.Stream<null | fixtures.testset_vibes_nested.Sentiment$stream, fixtures.testset_vibes_nested.Sentiment> // _0 // return
     let _1: string // text // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<fixtures.testset_vibes_nested.Sentiment>
@@ -606,13 +606,13 @@ fn user.fixtures.testset_vibes_nested.ClassifySentiment@stream(text: string, cli
     }
 }
 
-fn user.fixtures.testset_vibes_nested.GenerateTests(count: int, topic: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string[] {
+fn user.fixtures.testset_vibes_nested.GenerateTests(count: int, topic: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string[] {
     // Locals:
     let _0: string[] // _0 // return
     let _1: int // count // param
     let _2: string // topic // param
     let _3: null | ai.Client // client // param
-    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _5: bool
     let _6: bool
     let _7: ai.RunResult<string[]>
@@ -878,13 +878,13 @@ fn .<lambda(GenerateTests@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     }
 }
 
-fn user.fixtures.testset_vibes_nested.GenerateTests@stream(count: int, topic: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string[], string[]> {
+fn user.fixtures.testset_vibes_nested.GenerateTests@stream(count: int, topic: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string[], string[]> {
     // Locals:
     let _0: ai.stream.Stream<string[], string[]> // _0 // return
     let _1: int // count // param
     let _2: string // topic // param
     let _3: null | ai.stream.StreamingClient // client // param
-    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _4: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _5: bool
     let _6: bool
     let _7: ai.FunctionSpec<string[]>
@@ -972,12 +972,12 @@ fn user.fixtures.testset_vibes_nested.Foo() -> string | image {
     }
 }
 
-fn user.fixtures.testset_vibes_nested.ClassifySentiment2(text: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> string {
+fn user.fixtures.testset_vibes_nested.ClassifySentiment2(text: string, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // text // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<string>
@@ -1216,12 +1216,12 @@ fn .<lambda(ClassifySentiment2@spec, 0)>( __spec_output_format: ai.OutputFormat)
     }
 }
 
-fn user.fixtures.testset_vibes_nested.ClassifySentiment2@stream(text: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
+fn user.fixtures.testset_vibes_nested.ClassifySentiment2@stream(text: string, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<string | null, string> {
     // Locals:
     let _0: ai.stream.Stream<string | null, string> // _0 // return
     let _1: string // text // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.FunctionSpec<string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_invoke_error_normalization/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_invoke_error_normalization/bytecode.snap
@@ -85,7 +85,7 @@ function invoke_error_normalization.<(user.invoke_error_normalization.TimeoutInv
     return
 }
 
-function invoke_error_normalization.TimeoutSpec(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function invoke_error_normalization.TimeoutSpec(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -191,7 +191,7 @@ function invoke_error_normalization.TimeoutSpec@spec() -> ai.FunctionSpec<string
     return
 }
 
-function invoke_error_normalization.TimeoutSpec@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function invoke_error_normalization.TimeoutSpec@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_output_format_options/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_output_format_options/bytecode.snap
@@ -27,7 +27,7 @@ function output_format_options.$init_test_ns_output_format_options_output_format
     return
 }
 
-function output_format_options.OfAllLegacyOptions(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> output_format_options.OfOptionResult {
+function output_format_options.OfAllLegacyOptions(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> output_format_options.OfOptionResult {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -133,7 +133,7 @@ function output_format_options.OfAllLegacyOptions@spec() -> ai.FunctionSpec<outp
     return
 }
 
-function output_format_options.OfAllLegacyOptions@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<output_format_options.OfOptionResult$stream | null, output_format_options.OfOptionResult> {
+function output_format_options.OfAllLegacyOptions@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<output_format_options.OfOptionResult$stream | null, output_format_options.OfOptionResult> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_parse_companions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_parse_companions/bytecode.snap
@@ -20,7 +20,7 @@ function parse_companions.$init_test_ns_parse_companions_parse_companions(regist
     return
 }
 
-function parse_companions.ParseCompanionsParseAliasPayload(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> parse_companions.ParseCompanionsAliasPayload {
+function parse_companions.ParseCompanionsParseAliasPayload(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> parse_companions.ParseCompanionsAliasPayload {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -110,7 +110,7 @@ function parse_companions.ParseCompanionsParseAliasPayload@spec() -> ai.Function
     return
 }
 
-function parse_companions.ParseCompanionsParseAliasPayload@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<parse_companions.ParseCompanionsAliasPayload$stream | null, parse_companions.ParseCompanionsAliasPayload> {
+function parse_companions.ParseCompanionsParseAliasPayload@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<parse_companions.ParseCompanionsAliasPayload$stream | null, parse_companions.ParseCompanionsAliasPayload> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -137,7 +137,7 @@ function parse_companions.ParseCompanionsParseAliasPayload@stream(client: ai.str
     return
 }
 
-function parse_companions.ParseCompanionsParseOptPayload(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> parse_companions.ParseCompanionsOptPayload {
+function parse_companions.ParseCompanionsParseOptPayload(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> parse_companions.ParseCompanionsOptPayload {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -227,7 +227,7 @@ function parse_companions.ParseCompanionsParseOptPayload@spec() -> ai.FunctionSp
     return
 }
 
-function parse_companions.ParseCompanionsParseOptPayload@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<parse_companions.ParseCompanionsOptPayload$stream | null, parse_companions.ParseCompanionsOptPayload> {
+function parse_companions.ParseCompanionsParseOptPayload@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<parse_companions.ParseCompanionsOptPayload$stream | null, parse_companions.ParseCompanionsOptPayload> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_prompt_tag_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_prompt_tag_runtime/bytecode.snap
@@ -140,7 +140,7 @@ function prompt_tag_runtime.<(user.prompt_tag_runtime.RedactedMedia as baml.ToSt
     return
 }
 
-function prompt_tag_runtime.PtRenderPerson(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> prompt_tag_runtime.Person {
+function prompt_tag_runtime.PtRenderPerson(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> prompt_tag_runtime.Person {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -246,7 +246,7 @@ function prompt_tag_runtime.PtRenderPerson@spec() -> ai.FunctionSpec<prompt_tag_
     return
 }
 
-function prompt_tag_runtime.PtRenderPerson@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<prompt_tag_runtime.Person$stream | null, prompt_tag_runtime.Person> {
+function prompt_tag_runtime.PtRenderPerson@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<prompt_tag_runtime.Person$stream | null, prompt_tag_runtime.Person> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -273,7 +273,7 @@ function prompt_tag_runtime.PtRenderPerson@stream(client: ai.stream.StreamingCli
     return
 }
 
-function prompt_tag_runtime.PtStructuredGreeting(name: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function prompt_tag_runtime.PtStructuredGreeting(name: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -388,7 +388,7 @@ function prompt_tag_runtime.PtStructuredGreeting@spec(name: string) -> ai.Functi
     return
 }
 
-function prompt_tag_runtime.PtStructuredGreeting@stream(name: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function prompt_tag_runtime.PtStructuredGreeting@stream(name: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -416,7 +416,7 @@ function prompt_tag_runtime.PtStructuredGreeting@stream(name: string, client: ai
     return
 }
 
-function prompt_tag_runtime.PtStructuredImage(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function prompt_tag_runtime.PtStructuredImage(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -531,7 +531,7 @@ function prompt_tag_runtime.PtStructuredImage@spec(photo: image) -> ai.FunctionS
     return
 }
 
-function prompt_tag_runtime.PtStructuredImage@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function prompt_tag_runtime.PtStructuredImage@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_request_preview_credentials/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_request_preview_credentials/bytecode.snap
@@ -41,7 +41,7 @@ function request_preview_credentials.$init_test_ns_request_preview_credentials_r
     return
 }
 
-function request_preview_credentials.PreviewShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function request_preview_credentials.PreviewShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -147,7 +147,7 @@ function request_preview_credentials.PreviewShape@spec() -> ai.FunctionSpec<stri
     return
 }
 
-function request_preview_credentials.PreviewShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function request_preview_credentials.PreviewShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_render_identity/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_render_identity/bytecode.snap
@@ -62,7 +62,7 @@ function runtime_render_identity.$init_test_ns_runtime_render_identity_runtime_r
     return
 }
 
-function runtime_render_identity.Render(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> #0 {
+function runtime_render_identity.Render(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> #0 {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -156,7 +156,7 @@ function runtime_render_identity.Render@spec() -> ai.FunctionSpec<#0> {
     return
 }
 
-function runtime_render_identity.Render@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0 | null, #0> {
+function runtime_render_identity.Render@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0 | null, #0> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -184,7 +184,7 @@ function runtime_render_identity.Render@stream(client: ai.stream.StreamingClient
     return
 }
 
-function runtime_render_identity.RenderPair(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> runtime_render_identity.BoxRec<#0> | runtime_render_identity.BoxRec<#1> {
+function runtime_render_identity.RenderPair(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> runtime_render_identity.BoxRec<#0> | runtime_render_identity.BoxRec<#1> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -282,7 +282,7 @@ function runtime_render_identity.RenderPair@spec() -> ai.FunctionSpec<runtime_re
     return
 }
 
-function runtime_render_identity.RenderPair@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<runtime_render_identity.BoxRec$stream<#0> | runtime_render_identity.BoxRec$stream<#1> | null, runtime_render_identity.BoxRec<#0> | runtime_render_identity.BoxRec<#1>> {
+function runtime_render_identity.RenderPair@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<runtime_render_identity.BoxRec$stream<#0> | runtime_render_identity.BoxRec$stream<#1> | null, runtime_render_identity.BoxRec<#0> | runtime_render_identity.BoxRec<#1>> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
@@ -393,7 +393,7 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Syntheti
     return
 }
 
-function streaming_composite_clients.CompositeStreamSpec(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function streaming_composite_clients.CompositeStreamSpec(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -499,7 +499,7 @@ function streaming_composite_clients.CompositeStreamSpec@spec() -> ai.FunctionSp
     return
 }
 
-function streaming_composite_clients.CompositeStreamSpec@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function streaming_composite_clients.CompositeStreamSpec@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -541,7 +541,7 @@ function streaming_composite_clients.composite_input() -> ai.ModelTurnInput {
     call ai.FunctionSpec.output_type
     store_var _7
     load_var _2
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 0
     init_instance ai.Journal .log
     load_var2 3 4

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_parsing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_parsing/bytecode.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/baml_tests/src/corpus.rs
 ---
-function streaming_parsing.ExtractDoc(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> streaming_parsing.Doc {
+function streaming_parsing.ExtractDoc(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> streaming_parsing.Doc {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -100,7 +100,7 @@ function streaming_parsing.ExtractDoc@spec(input: string) -> ai.FunctionSpec<str
     return
 }
 
-function streaming_parsing.ExtractDoc@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<streaming_parsing.Doc$stream | null, streaming_parsing.Doc> {
+function streaming_parsing.ExtractDoc@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<streaming_parsing.Doc$stream | null, streaming_parsing.Doc> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -128,7 +128,7 @@ function streaming_parsing.ExtractDoc@stream(input: string, client: ai.stream.St
     return
 }
 
-function streaming_parsing.SayHello(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function streaming_parsing.SayHello(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -227,7 +227,7 @@ function streaming_parsing.SayHello@spec(input: string) -> ai.FunctionSpec<strin
     return
 }
 
-function streaming_parsing.SayHello@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function streaming_parsing.SayHello@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_structured_prompt_requests/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_structured_prompt_requests/bytecode.snap
@@ -153,7 +153,7 @@ function structured_prompt_requests.$init_test_ns_structured_prompt_requests_str
     return
 }
 
-function structured_prompt_requests.AudioShape(sound: audio, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.AudioShape(sound: audio, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -265,7 +265,7 @@ function structured_prompt_requests.AudioShape@spec(sound: audio) -> ai.Function
     return
 }
 
-function structured_prompt_requests.AudioShape@stream(sound: audio, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.AudioShape@stream(sound: audio, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -293,7 +293,7 @@ function structured_prompt_requests.AudioShape@stream(sound: audio, client: ai.s
     return
 }
 
-function structured_prompt_requests.ChatMediaShape(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.ChatMediaShape(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -392,7 +392,7 @@ function structured_prompt_requests.ChatMediaShape@spec(photo: image) -> ai.Func
     return
 }
 
-function structured_prompt_requests.ChatMediaShape@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.ChatMediaShape@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -420,7 +420,7 @@ function structured_prompt_requests.ChatMediaShape@stream(photo: image, client: 
     return
 }
 
-function structured_prompt_requests.ExplicitRolesShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.ExplicitRolesShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -510,7 +510,7 @@ function structured_prompt_requests.ExplicitRolesShape@spec() -> ai.FunctionSpec
     return
 }
 
-function structured_prompt_requests.ExplicitRolesShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.ExplicitRolesShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -537,7 +537,7 @@ function structured_prompt_requests.ExplicitRolesShape@stream(client: ai.stream.
     return
 }
 
-function structured_prompt_requests.FirstShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.FirstShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -627,7 +627,7 @@ function structured_prompt_requests.FirstShape@spec() -> ai.FunctionSpec<string>
     return
 }
 
-function structured_prompt_requests.FirstShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.FirstShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -654,7 +654,7 @@ function structured_prompt_requests.FirstShape@stream(client: ai.stream.Streamin
     return
 }
 
-function structured_prompt_requests.GenericShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> structured_prompt_requests.Outer<#0> {
+function structured_prompt_requests.GenericShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> structured_prompt_requests.Outer<#0> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -748,7 +748,7 @@ function structured_prompt_requests.GenericShape@spec() -> ai.FunctionSpec<struc
     return
 }
 
-function structured_prompt_requests.GenericShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<structured_prompt_requests.Outer$stream<#0> | null, structured_prompt_requests.Outer<#0>> {
+function structured_prompt_requests.GenericShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<structured_prompt_requests.Outer$stream<#0> | null, structured_prompt_requests.Outer<#0>> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -776,7 +776,7 @@ function structured_prompt_requests.GenericShape@stream(client: ai.stream.Stream
     return
 }
 
-function structured_prompt_requests.Greet(name: string, suffix: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.Greet(name: string, suffix: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var suffix
     load_const <omitted>
     cmp_op ==
@@ -915,7 +915,7 @@ function structured_prompt_requests.Greet@spec(name: string, suffix: string) -> 
     return
 }
 
-function structured_prompt_requests.Greet@stream(name: string, suffix: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.Greet@stream(name: string, suffix: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var suffix
     load_const <omitted>
     cmp_op ==
@@ -951,7 +951,7 @@ function structured_prompt_requests.Greet@stream(name: string, suffix: string, c
     return
 }
 
-function structured_prompt_requests.MediaAll(photo: image, sound: audio, document: pdf, movie: video, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.MediaAll(photo: image, sound: audio, document: pdf, movie: video, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1082,7 +1082,7 @@ function structured_prompt_requests.MediaAll@spec(photo: image, sound: audio, do
     return
 }
 
-function structured_prompt_requests.MediaAll@stream(photo: image, sound: audio, document: pdf, movie: video, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.MediaAll@stream(photo: image, sound: audio, document: pdf, movie: video, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1111,7 +1111,7 @@ function structured_prompt_requests.MediaAll@stream(photo: image, sound: audio, 
     return
 }
 
-function structured_prompt_requests.MediaImageAudioPdf(photo: image, sound: audio, document: pdf, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.MediaImageAudioPdf(photo: image, sound: audio, document: pdf, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1237,7 +1237,7 @@ function structured_prompt_requests.MediaImageAudioPdf@spec(photo: image, sound:
     return
 }
 
-function structured_prompt_requests.MediaImageAudioPdf@stream(photo: image, sound: audio, document: pdf, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.MediaImageAudioPdf@stream(photo: image, sound: audio, document: pdf, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1266,7 +1266,7 @@ function structured_prompt_requests.MediaImageAudioPdf@stream(photo: image, soun
     return
 }
 
-function structured_prompt_requests.MediaImagePdf(photo: image, document: pdf, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.MediaImagePdf(photo: image, document: pdf, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1383,7 +1383,7 @@ function structured_prompt_requests.MediaImagePdf@spec(photo: image, document: p
     return
 }
 
-function structured_prompt_requests.MediaImagePdf@stream(photo: image, document: pdf, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.MediaImagePdf@stream(photo: image, document: pdf, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1411,7 +1411,7 @@ function structured_prompt_requests.MediaImagePdf@stream(photo: image, document:
     return
 }
 
-function structured_prompt_requests.MediaShape(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.MediaShape(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1510,7 +1510,7 @@ function structured_prompt_requests.MediaShape@spec(photo: image) -> ai.Function
     return
 }
 
-function structured_prompt_requests.MediaShape@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.MediaShape@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1538,7 +1538,7 @@ function structured_prompt_requests.MediaShape@stream(photo: image, client: ai.s
     return
 }
 
-function structured_prompt_requests.PreludeShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.PreludeShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1628,7 +1628,7 @@ function structured_prompt_requests.PreludeShape@spec() -> ai.FunctionSpec<strin
     return
 }
 
-function structured_prompt_requests.PreludeShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.PreludeShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1655,7 +1655,7 @@ function structured_prompt_requests.PreludeShape@stream(client: ai.stream.Stream
     return
 }
 
-function structured_prompt_requests.RequestShape(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.RequestShape(input: string, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1770,7 +1770,7 @@ function structured_prompt_requests.RequestShape@spec(input: string) -> ai.Funct
     return
 }
 
-function structured_prompt_requests.RequestShape@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.RequestShape@stream(input: string, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1798,7 +1798,7 @@ function structured_prompt_requests.RequestShape@stream(input: string, client: a
     return
 }
 
-function structured_prompt_requests.RoledShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.RoledShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1904,7 +1904,7 @@ function structured_prompt_requests.RoledShape@spec() -> ai.FunctionSpec<string>
     return
 }
 
-function structured_prompt_requests.RoledShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.RoledShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1931,7 +1931,7 @@ function structured_prompt_requests.RoledShape@stream(client: ai.stream.Streamin
     return
 }
 
-function structured_prompt_requests.RolelessImageShape(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.RolelessImageShape(photo: image, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -2030,7 +2030,7 @@ function structured_prompt_requests.RolelessImageShape@spec(photo: image) -> ai.
     return
 }
 
-function structured_prompt_requests.RolelessImageShape@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.RolelessImageShape@stream(photo: image, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -2058,7 +2058,7 @@ function structured_prompt_requests.RolelessImageShape@stream(photo: image, clie
     return
 }
 
-function structured_prompt_requests.RolelessShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.RolelessShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -2148,7 +2148,7 @@ function structured_prompt_requests.RolelessShape@spec() -> ai.FunctionSpec<stri
     return
 }
 
-function structured_prompt_requests.RolelessShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.RolelessShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -2175,7 +2175,7 @@ function structured_prompt_requests.RolelessShape@stream(client: ai.stream.Strea
     return
 }
 
-function structured_prompt_requests.WhitespaceShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
+function structured_prompt_requests.WhitespaceShape(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> string {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -2265,7 +2265,7 @@ function structured_prompt_requests.WhitespaceShape@spec() -> ai.FunctionSpec<st
     return
 }
 
-function structured_prompt_requests.WhitespaceShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
+function structured_prompt_requests.WhitespaceShape@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<string | null, string> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -2301,7 +2301,7 @@ function structured_prompt_requests._input_for(spec: ai.FunctionSpec<string>) ->
     call ai.tools.Toolbox.new
     store_var _5
     load_var _2
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 0
     init_instance ai.Journal .log
     load_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_reflection/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_reflection/bytecode.snap
@@ -48,7 +48,7 @@ function type_reflection.$init_test_ns_type_reflection_type_reflection(registry:
     return
 }
 
-function type_reflection.GetBar(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> type_reflection.Bar {
+function type_reflection.GetBar(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> type_reflection.Bar {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -138,7 +138,7 @@ function type_reflection.GetBar@spec() -> ai.FunctionSpec<type_reflection.Bar> {
     return
 }
 
-function type_reflection.GetBar@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<type_reflection.Bar$stream | null, type_reflection.Bar> {
+function type_reflection.GetBar@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<type_reflection.Bar$stream | null, type_reflection.Bar> {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -165,7 +165,7 @@ function type_reflection.GetBar@stream(client: ai.stream.StreamingClient | null,
     return
 }
 
-function type_reflection.GetFoo(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> type_reflection.Foo {
+function type_reflection.GetFoo(client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> type_reflection.Foo {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -255,7 +255,7 @@ function type_reflection.GetFoo@spec() -> ai.FunctionSpec<type_reflection.Foo> {
     return
 }
 
-function type_reflection.GetFoo@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<type_reflection.Foo$stream | null, type_reflection.Foo> {
+function type_reflection.GetFoo@stream(client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<type_reflection.Foo$stream | null, type_reflection.Foo> {
     load_var client
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -162,7 +162,7 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     load_deref ?6
     load_var _125
     init_instance ai.events.FinalProduced .value_json
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
     pop 1
@@ -231,7 +231,7 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     load_var2 19 20
     cmp_int_op <
     pop_jump_if_false L1
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 17 18
     call baml.Array.at
     store_var _55
@@ -439,7 +439,7 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     store_var _38
     load_var2 20 21
     init_instance ai.events.AssistantMessage .content, .client_id
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     store_var batch
     load_var turn
@@ -461,7 +461,7 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     jump L6
 
   L5:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 19 23
     call baml.Array.push
     pop 1
@@ -489,7 +489,7 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
   L8:
     load_var _50
     store_var u
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 19 26
     load_field .id
     load_var u
@@ -508,7 +508,7 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     load_var _61
     narrow_bind ai.events.Usage, slot=27
     pop_jump_if_false L10
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 19 27
     call baml.Array.push
     pop 1
@@ -592,7 +592,7 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     throw
 
   L20:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var batch
     load_const "The reply did not match the required schema. Answer again with only the corrected value."
     init_instance ai.events.UserMessage .content
@@ -670,7 +670,7 @@ function ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
     load_field .on_event
     store_var _6
     load_var _6
-    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never, slot=5
+    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never, slot=5
     pop_jump_if_false L1
     load_var _6
     store_var cb
@@ -694,68 +694,74 @@ function ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
     return
 
   L2:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 4 7
     call baml.Array.at
     store_var _15
     load_var _15
     narrow_bind ai.events.RunStarted, slot=10
     pop_jump_if_false L3
-    jump L11
+    jump L12
 
   L3:
     load_var _15
     narrow_bind ai.events.UserMessage, slot=10
     pop_jump_if_false L4
-    jump L11
+    jump L12
 
   L4:
     load_var _15
-    narrow_bind ai.events.AssistantMessage, slot=10
+    narrow_bind ai.events.UserContent, slot=10
     pop_jump_if_false L5
-    jump L11
+    jump L12
 
   L5:
     load_var _15
-    narrow_bind ai.events.ToolRequested, slot=10
+    narrow_bind ai.events.AssistantMessage, slot=10
     pop_jump_if_false L6
-    jump L11
+    jump L12
 
   L6:
     load_var _15
-    narrow_bind ai.events.ToolCompleted, slot=10
+    narrow_bind ai.events.ToolRequested, slot=10
     pop_jump_if_false L7
-    jump L11
+    jump L12
 
   L7:
     load_var _15
-    narrow_bind ai.events.ToolFailed, slot=10
+    narrow_bind ai.events.ToolCompleted, slot=10
     pop_jump_if_false L8
-    jump L11
+    jump L12
 
   L8:
     load_var _15
-    narrow_bind ai.events.Usage, slot=10
+    narrow_bind ai.events.ToolFailed, slot=10
     pop_jump_if_false L9
-    jump L11
+    jump L12
 
   L9:
     load_var _15
-    narrow_bind ai.events.LLMCall, slot=10
+    narrow_bind ai.events.Usage, slot=10
     pop_jump_if_false L10
-    jump L11
+    jump L12
 
   L10:
     load_var _15
-    narrow_bind ai.events.FinalProduced, slot=10
-    pop_jump_if_false L12
+    narrow_bind ai.events.LLMCall, slot=10
+    pop_jump_if_false L11
+    jump L12
 
   L11:
+    load_var _15
+    narrow_bind ai.events.FinalProduced, slot=10
+    pop_jump_if_false L13
+
+  L12:
     load_var2 10 6
     call_indirect
     pop 1
 
-  L12:
+  L13:
     load_var i
     load_const 1
     add_int
@@ -1238,7 +1244,7 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     load_var _44
     bin_op +
     init_instance ai.events.ToolFailed .id, .message
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
     pop 1
@@ -1264,7 +1270,7 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     load_var2 4 8
     load_var _16
     init_instance ai.events.ToolFailed .id, .message
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
     pop 1
@@ -1332,7 +1338,7 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     load_field .id
     load_var _32
     init_instance ai.events.ToolCompleted .id, .output
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
     pop 1
@@ -1363,7 +1369,7 @@ function ai.Agent._validated_schema_attempts(self: ai.Agent) -> int {
     throw
 }
 
-function ai.Agent.new(max_steps: int, schema_attempts: int, client: ai.Client | null, tool_errors: ai.tools.ErrorMode, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.Agent {
+function ai.Agent.new(max_steps: int, schema_attempts: int, client: ai.Client | null, tool_errors: ai.tools.ErrorMode, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.Agent {
     load_var max_steps
     load_const <omitted>
     cmp_op ==
@@ -1575,7 +1581,7 @@ function ai.FunctionSpec.build_request(self: ai.FunctionSpec<#0>, client: ai.Cli
     return
 }
 
-function ai.FunctionSpec.call(self: ai.FunctionSpec<#0>, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> #0 {
+function ai.FunctionSpec.call(self: ai.FunctionSpec<#0>, client: ai.Client | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> #0 {
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -1664,16 +1670,16 @@ function ai.FunctionSpec.tools(self: ai.FunctionSpec<#0>) -> ai.tools.Toolbox {
     return
 }
 
-function ai.Journal.append_all(self: ai.Journal, events: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced)[]) -> void {
+function ai.Journal.append_all(self: ai.Journal, events: (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced)[]) -> void {
     load_var events
-    load_type baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_type baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_type baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1683,7 +1689,7 @@ function ai.Journal.append_all(self: ai.Journal, events: (ai.events.RunStarted |
     jump L2
 
   L1:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var self
     load_field .log
     load_var _4
@@ -1696,7 +1702,7 @@ function ai.Journal.append_all(self: ai.Journal, events: (ai.events.RunStarted |
     return
 }
 
-function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced)[] {
+function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced)[] {
     load_var self
     load_field .log
     return
@@ -1713,7 +1719,7 @@ function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
     store_var _6
     load_var2 2 3
     init_instance ai.events.RunStarted .spec_name, .arguments
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     init_instance ai.Journal .log
     return
@@ -3668,50 +3674,8 @@ function ai.content.Media.new(value: image | audio | video | pdf, provider_id: s
 
   L1:
     load_var value
-    call baml.json.to_json
-    store_var envelope
-    jump L2
-    load_var e
-    throw_if_panic
-    load_type baml.json.JsonSerializationError
-    load_var e
-    call baml.String.from
-    store_var _11
-    load_type string
-    load_var _11
-    call baml.String.from
-    store_var _10
-    load_const "media output could not be encoded: "
-    load_var _10
-    bin_op +
-    init_instance baml.errors.InvalidArgument .message
-    throw
-
-  L2:
-    load_type baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
-    load_var envelope
-    call baml.json.from_json
-    store_var part
-    jump L3
-    load_var e
-    throw_if_panic
-    load_type baml.json.JsonDecodeError
-    load_var e
-    call baml.String.from
-    store_var _21
-    load_type string
-    load_var _21
-    call baml.String.from
-    store_var _20
-    load_const "media output could not be decoded: "
-    load_var _20
-    bin_op +
-    init_instance baml.errors.InvalidArgument .message
-    throw
-
-  L3:
-    load_var2 8 2
-    load_var revised_prompt
+    call ai.internal.media_part
+    load_var2 2 3
     init_instance ai.content.Media .media, .provider_id, .revised_prompt
     return
 }
@@ -4051,14 +4015,68 @@ function ai.errors.normalize_invoke(error: ai.errors.Failure | baml.errors.Timeo
     return
 }
 
-function ai.events.guard(listener: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws #0) | null) -> ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null {
+function ai.events.UserContent.new(parts: (string | image | audio | video | pdf)[]) -> ai.events.UserContent {
+    load_type string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+    alloc_array 0
+    store_var out
+    load_var parts
+    load_type baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+
+  L0:
+    load_var _3
+    load_type baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L4
+
+  L1:
+    load_var _4
+    store_var part
+    load_var part
+    store_var _8
+    load_var _8
+    narrow_bind string, slot=6
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_var part
+    call ai.internal.media_part
+    store_var _14
+    load_type string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+    load_var2 2 7
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L3:
+    load_type string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+    load_var2 2 6
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L4:
+    load_var out
+    init_instance ai.events.UserContent .parts
+    return
+}
+
+function ai.events.guard(listener: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws #0) | null) -> ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null {
     load_var ?3
     make_cell
     store_var ?3
     load_var listener
     store_var _2
     load_var _2
-    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws #0, slot=2
+    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws #0, slot=2
     pop_jump_if_false L0
     jump L1
 
@@ -4195,7 +4213,7 @@ function ai.internal._configured(value: string) -> string | null {
     return
 }
 
-function ai.internal._flush_orphaned_calls(out: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced)[], pending: string[]) -> void {
+function ai.internal._flush_orphaned_calls(out: (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced)[], pending: string[]) -> void {
     load_var pending
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
@@ -4214,7 +4232,7 @@ function ai.internal._flush_orphaned_calls(out: (ai.events.RunStarted | ai.event
     jump L2
 
   L1:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 1 4
     load_const "No result provided"
     init_instance ai.events.ToolFailed .id, .message
@@ -6610,6 +6628,52 @@ function ai.internal.make_role(name: string) -> ai.Role {
     return
 }
 
+function ai.internal.media_part(value: image | audio | video | pdf) -> baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf {
+    load_var value
+    call baml.json.to_json
+    store_var envelope
+    jump L0
+    load_var e
+    throw_if_panic
+    load_type baml.json.JsonSerializationError
+    load_var e
+    call baml.String.from
+    store_var _7
+    load_type string
+    load_var _7
+    call baml.String.from
+    store_var _6
+    load_const "media value could not be encoded: "
+    load_var _6
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L0:
+    load_type baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+    load_var envelope
+    call baml.json.from_json
+    jump L1
+    load_var e
+    throw_if_panic
+    load_type baml.json.JsonDecodeError
+    load_var e
+    call baml.String.from
+    store_var _16
+    load_type string
+    load_var _16
+    call baml.String.from
+    store_var _15
+    load_const "media value could not be decoded: "
+    load_var _15
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L1:
+    return
+}
+
 function ai.internal.render_output_format(return_type: reflect.Type) -> string {
 }
 
@@ -8035,7 +8099,7 @@ function ai.stream.decode_sse_batch(batch: string) -> ai.stream.SseEvent[] {
     return
 }
 
-function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0, #1> {
+function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0, #1> {
     load_var ?10
     make_cell
     store_var ?10
@@ -8124,7 +8188,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
     load_deref ?11
     store_var _31
     load_var _31
-    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never, slot=13
+    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never, slot=13
     pop_jump_if_false L8
     load_var _31
     store_var _34
@@ -9211,7 +9275,7 @@ function ai.wire.resolve_media_preview(media: baml.media.Image | baml.media.Audi
 }
 
 function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Journal {
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 0
     store_var out
     load_type string
@@ -9219,21 +9283,21 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     store_var pending
     load_var j
     call ai.Journal.entries
-    load_type baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_type baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L0:
     load_var _6
-    load_type baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_type baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
     load_var _7
     is_type baml.iter.Done
     pop_jump_if_false L1
-    jump L12
+    jump L14
 
   L1:
     load_var _7
@@ -9243,7 +9307,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     load_var _11
     narrow_bind ai.events.AssistantMessage, slot=8
     pop_jump_if_false L2
-    jump L9
+    jump L11
 
   L2:
     load_var event
@@ -9251,70 +9315,90 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     load_var _38
     narrow_bind ai.events.UserMessage, slot=15
     pop_jump_if_false L3
-    jump L8
+    jump L10
 
   L3:
     load_var event
     store_var _46
     load_var _46
-    narrow_bind ai.events.ToolCompleted, slot=17
+    narrow_bind ai.events.UserContent, slot=17
     pop_jump_if_false L4
-    jump L7
+    jump L9
 
   L4:
     load_var event
     store_var _54
     load_var _54
-    narrow_bind ai.events.ToolFailed, slot=19
+    narrow_bind ai.events.ToolCompleted, slot=19
     pop_jump_if_false L5
-    jump L6
+    jump L8
 
   L5:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var event
+    store_var _62
+    load_var _62
+    narrow_bind ai.events.ToolFailed, slot=21
+    pop_jump_if_false L6
+    jump L7
+
+  L6:
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 3 7
     call baml.Array.push
     pop 1
     jump L0
 
-  L6:
-    load_var _54
-    store_var failed
-    load_var2 4 20
-    load_field .id
-    call ai.internal._resolve_pending_call
-    pop 1
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
-    load_var2 3 20
-    call baml.Array.push
-    pop 1
-    jump L0
-
   L7:
-    load_var _46
-    store_var completed
-    load_var2 4 18
+    load_var _62
+    store_var failed
+    load_var2 4 22
     load_field .id
     call ai.internal._resolve_pending_call
     pop 1
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
-    load_var2 3 18
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 22
     call baml.Array.push
     pop 1
     jump L0
 
   L8:
-    load_var _38
-    store_var user
-    load_var2 3 4
-    call ai.internal._flush_orphaned_calls
+    load_var _54
+    store_var completed
+    load_var2 4 20
+    load_field .id
+    call ai.internal._resolve_pending_call
     pop 1
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
-    load_var2 3 16
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 20
     call baml.Array.push
     pop 1
     jump L0
 
   L9:
+    load_var _46
+    store_var content
+    load_var2 3 4
+    call ai.internal._flush_orphaned_calls
+    pop 1
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 18
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L10:
+    load_var _38
+    store_var user
+    load_var2 3 4
+    call ai.internal._flush_orphaned_calls
+    pop 1
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 16
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L11:
     load_var _11
     store_var assistant
     load_var2 3 4
@@ -9335,7 +9419,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     load_const 0
     cmp_int_op >
     pop_jump_if_false L0
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 3 10
     load_var assistant
     load_field .client_id
@@ -9348,7 +9432,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     virtual_call nargs=1 ntypeargs=0
     store_var _28
 
-  L10:
+  L12:
     load_var _28
     load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>
     load_const "next"
@@ -9356,23 +9440,23 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     store_var _29
     load_var _29
     is_type baml.iter.Done
-    pop_jump_if_false L11
+    pop_jump_if_false L13
     jump L0
 
-  L11:
+  L13:
     load_var _29
     store_var _33
     load_var _33
     narrow_bind ai.content.ToolUse, slot=14
-    pop_jump_if_false L10
+    pop_jump_if_false L12
     load_type string
     load_var2 4 14
     load_field .id
     call baml.Array.push
     pop 1
-    jump L10
+    jump L12
 
-  L12:
+  L14:
     load_var2 3 4
     call ai.internal._flush_orphaned_calls
     pop 1
@@ -9698,4 +9782,115 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
     load_field .headers
     call ai.errors.classify_http
     throw
+}
+
+function ai.wire.user_content_message(event: ai.events.UserContent) -> ai.PromptMessage {
+    load_type string
+    alloc_array 0
+    store_var text
+    load_var event
+    load_field .parts
+    load_type baml.iter.Iterable<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+
+  L0:
+    load_var _4
+    load_type baml.iter.Iterator<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_var _5
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L10
+
+  L1:
+    load_var _5
+    store_var part
+    load_var part
+    store_var _9
+    load_var _9
+    narrow_bind string, slot=6
+    pop_jump_if_false L2
+    jump L9
+
+  L2:
+    load_var part
+    store_var _14
+    load_var _14
+    narrow_bind baml.media.Image, slot=7
+    pop_jump_if_false L3
+    jump L8
+
+  L3:
+    load_var part
+    store_var _17
+    load_var _17
+    narrow_bind baml.media.Audio, slot=8
+    pop_jump_if_false L4
+    jump L7
+
+  L4:
+    load_var part
+    store_var _20
+    load_var _20
+    narrow_bind baml.media.Video, slot=9
+    pop_jump_if_false L5
+    jump L6
+
+  L5:
+    load_type string
+    load_var text
+    load_const "[pdf]"
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L6:
+    load_type string
+    load_var text
+    load_const "[video]"
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L7:
+    load_type string
+    load_var text
+    load_const "[audio]"
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L8:
+    load_type string
+    load_var text
+    load_const "[image]"
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L9:
+    load_type string
+    load_var2 2 6
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L10:
+    load_type string
+    load_var text
+    load_const ""
+    call baml.Array.join
+    store_var _25
+    load_const "user"
+    load_var2 10 1
+    load_field .parts
+    load_type string
+    load_type baml.json.json
+    alloc_map 0
+    init_instance ai.PromptMessage .role, .content, .parts, .metadata
+    return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
@@ -128,9 +128,9 @@ fn ai.Context.output_format(self: ai.Context, prefix: string | null | ai.interna
     }
 }
 
-fn ai.Journal.entries(self: ai.Journal) -> (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] {
+fn ai.Journal.entries(self: ai.Journal) -> (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] {
     // Locals:
-    let _0: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // _0 // return
+    let _0: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // _0 // return
     let _1: ai.Journal // self // param
 
     bb0: {
@@ -147,7 +147,7 @@ fn ai.Journal.new(spec: ai.FunctionSpec<Out>) -> ai.Journal {
     // Locals:
     let _0: ai.Journal // _0 // return
     let _1: ai.FunctionSpec<Out> // spec // param
-    let _2: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _2: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _3: ai.events.RunStarted
     let _4: string
     let _5: reflect.Type
@@ -166,7 +166,7 @@ fn ai.Journal.new(spec: ai.FunctionSpec<Out>) -> ai.Journal {
 
     bb2: {
         _3 = ai.events.RunStarted { copy _4, copy _6 };
-        _2 = [copy _3]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _2 = [copy _3]: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _0 = ai.Journal { copy _2 };
         goto -> bb3;
     }
@@ -176,27 +176,27 @@ fn ai.Journal.new(spec: ai.FunctionSpec<Out>) -> ai.Journal {
     }
 }
 
-fn ai.Journal.append_all(self: ai.Journal, events: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]) -> void {
+fn ai.Journal.append_all(self: ai.Journal, events: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]) -> void {
     // Locals:
     let _0: void // _0 // return
     let _1: ai.Journal // self // param
-    let _2: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // events // param
-    let _3: baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    let _2: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // events // param
+    let _3: baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>
     let _4: unknown
     let _5: bool
-    let _6: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _7: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage // e
+    let _6: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
+    let _7: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage // e
     let _8: int
-    let _9: ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[], ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> int throws never
-    let _10: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _9: ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[], ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> int throws never
+    let _10: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _11: reflect.Type
 
     bb0: {
-        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -210,7 +210,7 @@ fn ai.Journal.append_all(self: ai.Journal, events: (ai.events.AssistantMessage |
         _7 = copy _6;
         _9 = copy _1.0;
         _10 = copy _7;
-        _11 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _11 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1];
     }
 
@@ -2747,25 +2747,7 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
     let _3: string | null // revised_prompt // param
     let _4: bool
     let _5: bool
-    let _6: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // envelope
-    let _7: unknown // e
-    let _8: baml.errors.InvalidArgument
-    let _9: string
-    let _10: string
-    let _11: string
-    let _12: reflect.Type
-    let _13: reflect.Type
-    let _14: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // part
-    let _15: unknown // e
-    let _16: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _17: reflect.Type
-    let _18: baml.errors.InvalidArgument
-    let _19: string
-    let _20: string
-    let _21: string
-    let _22: reflect.Type
-    let _23: reflect.Type
-    let _24: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _6: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
 
     bb0: {
         _4 = copy _2 == const <omitted>;
@@ -2788,63 +2770,16 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
     }
 
     bb4: {
-        _6 = call const fn baml.json.to_json(copy _1) -> [bb5, unwind: bb8];
+        _6 = call const fn ai.internal.media_part(copy _1) -> [bb5];
     }
 
     bb5: {
-        _16 = copy _6;
-        _17 = load_type(baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf);
-        _14 = call const fn baml.json.from_json<copy _17>(copy _16) -> [bb6, unwind: bb12];
+        _0 = ai.content.Media { copy _6, copy _2, copy _3 };
+        goto -> bb6;
     }
 
     bb6: {
-        _24 = copy _14;
-        _0 = ai.content.Media { copy _24, copy _2, copy _3 };
-        goto -> bb7;
-    }
-
-    bb7: {
         return;
-    }
-
-    bb8: {
-        throw_if_panic copy _7 -> bb9;
-    }
-
-    bb9: {
-        _12 = load_type(baml.json.JsonSerializationError);
-        _11 = call const fn baml.String.from<copy _12>(copy _7) -> [bb10];
-    }
-
-    bb10: {
-        _13 = load_type(string);
-        _10 = call const fn baml.String.from<copy _13>(copy _11) -> [bb11];
-    }
-
-    bb11: {
-        _9 = const "media output could not be encoded: " + copy _10;
-        _8 = baml.errors.InvalidArgument { copy _9 };
-        throw copy _8;
-    }
-
-    bb12: {
-        throw_if_panic copy _15 -> bb13;
-    }
-
-    bb13: {
-        _22 = load_type(baml.json.JsonDecodeError);
-        _21 = call const fn baml.String.from<copy _22>(copy _15) -> [bb14];
-    }
-
-    bb14: {
-        _23 = load_type(string);
-        _20 = call const fn baml.String.from<copy _23>(copy _21) -> [bb15];
-    }
-
-    bb15: {
-        _19 = const "media output could not be decoded: " + copy _20;
-        _18 = baml.errors.InvalidArgument { copy _19 };
-        throw copy _18;
     }
 }
 
@@ -3313,16 +3248,87 @@ fn ai.errors.classify_http(provider: string, status_code: int, body: string, hea
     }
 }
 
-fn ai.events.guard(listener: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws E)) -> null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) {
+fn ai.events.UserContent.new(parts: (string | image | audio | video | pdf)[]) -> ai.events.UserContent {
     // Locals:
-    let _0: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // _0 // return
-    let _1: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws E) // listener // param
-    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws E)
-    let _3: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws E // cb [captured]
+    let _0: ai.events.UserContent // _0 // return
+    let _1: (string | image | audio | video | pdf)[] // parts // param
+    let _2: (string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[] // out
+    let _3: baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>
+    let _4: unknown
+    let _5: bool
+    let _6: string | image | audio | video | pdf
+    let _7: string | image | audio | video | pdf // part
+    let _8: string | image | audio | video | pdf
+    let _9: string // text
+    let _10: int
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _15: image | audio | video | pdf
+    let _16: reflect.Type
+    let _17: (string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[]
+
+    bb0: {
+        _2 = []: string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf[];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>(copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _5 = is_type(copy _4, baml.iter.Done);
+        branch copy _5 -> [bb7, bb3];
+    }
+
+    bb3: {
+        _6 = copy _4;
+        fresh_cell(_7);
+        _7 = copy _6;
+        _8 = copy _7;
+        _8 = narrow_bind copy _8 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb6, bb4];
+    }
+
+    bb4: {
+        _15 = copy _7;
+        _14 = call const fn ai.internal.media_part(copy _15) -> [bb5];
+    }
+
+    bb5: {
+        _16 = load_type(string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf);
+        _13 = call const fn baml.Array.push<copy _16>(copy _2, copy _14) -> [bb1];
+    }
+
+    bb6: {
+        _9 = copy _8;
+        _11 = copy _9;
+        _12 = load_type(string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf);
+        _10 = call const fn baml.Array.push<copy _12>(copy _2, copy _11) -> [bb1];
+    }
+
+    bb7: {
+        _17 = copy _2;
+        _0 = ai.events.UserContent { copy _17 };
+        goto -> bb8;
+    }
+
+    bb8: {
+        return;
+    }
+}
+
+fn ai.events.guard(listener: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws E)) -> null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) {
+    // Locals:
+    let _0: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // _0 // return
+    let _1: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws E) // listener // param
+    let _2: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws E)
+    let _3: (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws E // cb [captured]
 
     bb0: {
         _2 = copy _1;
-        _2 = narrow_bind copy _2 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: TypeArgRef(0), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb2, bb1];
+        _2 = narrow_bind copy _2 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserContent" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: TypeArgRef(0), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb2, bb1];
     }
 
     bb1: {
@@ -3342,12 +3348,12 @@ fn ai.events.guard(listener: null | ((ai.events.AssistantMessage | ai.events.Fin
 }
 
 // lambda[0]
-fn .<lambda(guard, 0)>(e: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void {
+fn .<lambda(guard, 0)>(e: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void {
     // Locals:
     let _0: void // _0 // return
-    let _1: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage // e // param
+    let _1: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage // e // param
     let _2: unknown // err
-    let _3: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws E
+    let _3: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws E
 
     bb0: {
         _3 = copy capture[0];
@@ -6023,6 +6029,83 @@ fn ai.internal._resolve_media_preview_content(url: string | null, file: string |
     }
 }
 
+fn ai.internal.media_part(value: image | audio | video | pdf) -> baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video {
+    // Locals:
+    let _0: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // _0 // return
+    let _1: image | audio | video | pdf // value // param
+    let _2: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // envelope
+    let _3: unknown // e
+    let _4: baml.errors.InvalidArgument
+    let _5: string
+    let _6: string
+    let _7: string
+    let _8: reflect.Type
+    let _9: reflect.Type
+    let _10: unknown // e
+    let _11: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _12: reflect.Type
+    let _13: baml.errors.InvalidArgument
+    let _14: string
+    let _15: string
+    let _16: string
+    let _17: reflect.Type
+    let _18: reflect.Type
+
+    bb0: {
+        _2 = call const fn baml.json.to_json(copy _1) -> [bb1, unwind: bb3];
+    }
+
+    bb1: {
+        _11 = copy _2;
+        _12 = load_type(baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf);
+        _0 = call const fn baml.json.from_json<copy _12>(copy _11) -> [bb2, unwind: bb7];
+    }
+
+    bb2: {
+        return;
+    }
+
+    bb3: {
+        throw_if_panic copy _3 -> bb4;
+    }
+
+    bb4: {
+        _8 = load_type(baml.json.JsonSerializationError);
+        _7 = call const fn baml.String.from<copy _8>(copy _3) -> [bb5];
+    }
+
+    bb5: {
+        _9 = load_type(string);
+        _6 = call const fn baml.String.from<copy _9>(copy _7) -> [bb6];
+    }
+
+    bb6: {
+        _5 = const "media value could not be encoded: " + copy _6;
+        _4 = baml.errors.InvalidArgument { copy _5 };
+        throw copy _4;
+    }
+
+    bb7: {
+        throw_if_panic copy _10 -> bb8;
+    }
+
+    bb8: {
+        _17 = load_type(baml.json.JsonDecodeError);
+        _16 = call const fn baml.String.from<copy _17>(copy _10) -> [bb9];
+    }
+
+    bb9: {
+        _18 = load_type(string);
+        _15 = call const fn baml.String.from<copy _18>(copy _16) -> [bb10];
+    }
+
+    bb10: {
+        _14 = const "media value could not be decoded: " + copy _15;
+        _13 = baml.errors.InvalidArgument { copy _14 };
+        throw copy _13;
+    }
+}
+
 fn ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     // Locals:
     let _0: void // _0 // return
@@ -6609,10 +6692,10 @@ fn ai.internal._wire_blocks(content: (ai.content.Media | ai.content.Reasoning | 
     }
 }
 
-fn ai.internal._flush_orphaned_calls(out: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[], pending: string[]) -> void {
+fn ai.internal._flush_orphaned_calls(out: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[], pending: string[]) -> void {
     // Locals:
     let _0: void // _0 // return
-    let _1: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // out // param
+    let _1: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // out // param
     let _2: string[] // pending // param
     let _3: baml.iter.Iterator<Error = never, Item = string>
     let _4: unknown
@@ -6645,7 +6728,7 @@ fn ai.internal._flush_orphaned_calls(out: (ai.events.AssistantMessage | ai.event
         _7 = copy _6;
         _10 = copy _7;
         _9 = ai.events.ToolFailed { copy _10, const "No result provided" };
-        _11 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _11 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _8 = call const fn baml.Array.push<copy _11>(copy _1, copy _9) -> [bb1];
     }
 
@@ -8753,12 +8836,12 @@ fn ai.stream.Stream.final(self: ai.stream.Stream) -> TFinal {
     }
 }
 
-fn ai.stream.from_spec(spec: ai.FunctionSpec<TFinal>, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<TStream, TFinal> {
+fn ai.stream.from_spec(spec: ai.FunctionSpec<TFinal>, client: null | ai.stream.StreamingClient, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.stream.Stream<TStream, TFinal> {
     // Locals:
     let _0: ai.stream.Stream<TStream, TFinal> // _0 // return
     let _1: ai.FunctionSpec<TFinal> // spec // param
     let _2: null | ai.stream.StreamingClient // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: bool
@@ -8783,13 +8866,13 @@ fn ai.stream.from_spec(spec: ai.FunctionSpec<TFinal>, client: null | ai.stream.S
     let _25: ai.Client
     let _26: string // provider [captured]
     let _27: ai.Client // c
-    let _28: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // emit [captured]
+    let _28: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // emit [captured]
     let _29: reflect.Type
     let _30: bool // settled [captured]
-    let _31: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _32: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
+    let _31: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)
+    let _32: (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
     let _33: void
-    let _34: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _34: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never
     let _35: ai.events.RunStarted
     let _36: string
     let _37: reflect.Type
@@ -8889,7 +8972,7 @@ fn ai.stream.from_spec(spec: ai.FunctionSpec<TFinal>, client: null | ai.stream.S
     bb15: {
         _30 = const false;
         _31 = copy _28;
-        _31 = narrow_bind copy _31 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb16, bb19];
+        _31 = narrow_bind copy _31 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserContent" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb16, bb19];
     }
 
     bb16: {
@@ -8973,12 +9056,12 @@ fn .<lambda(from_spec, 0)>() -> string | null {
     let _3: ai.stream.Done | string[]
     let _4: bool
     let _5: bool
-    let _6: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _7: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _8: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
+    let _6: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)
+    let _7: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)
+    let _8: (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
     let _9: ai.ModelTurn // turn
     let _10: void
-    let _11: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _11: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never
     let _12: ai.events.AssistantMessage
     let _13: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
     let _14: string
@@ -8986,7 +9069,7 @@ fn .<lambda(from_spec, 0)>() -> string | null {
     let _16: null | ai.events.Usage
     let _17: ai.events.Usage // u
     let _18: void
-    let _19: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _19: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never
     let _20: ai.events.Usage
     let _21: ai.events.LLMCall[]
     let _22: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
@@ -8995,7 +9078,7 @@ fn .<lambda(from_spec, 0)>() -> string | null {
     let _25: ai.events.LLMCall
     let _26: ai.events.LLMCall // call
     let _27: void
-    let _28: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _28: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never
     let _29: ai.events.LLMCall
     let _30: string[] // batch
     let _31: reflect.Type
@@ -9027,7 +9110,7 @@ fn .<lambda(from_spec, 0)>() -> string | null {
         capture[1] = const true;
         _6 = copy capture[2];
         _7 = copy _6;
-        _7 = narrow_bind copy _7 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb5, bb13];
+        _7 = narrow_bind copy _7 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserContent" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb5, bb13];
     }
 
     bb5: {
@@ -11032,23 +11115,137 @@ fn ai.wire.merge_request_body(base: int | float | string | bool | null | baml.js
     }
 }
 
+fn ai.wire.user_content_message(event: ai.events.UserContent) -> ai.PromptMessage {
+    // Locals:
+    let _0: ai.PromptMessage // _0 // return
+    let _1: ai.events.UserContent // event // param
+    let _2: string[] // text
+    let _3: (string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[]
+    let _4: baml.iter.Iterator<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>
+    let _5: unknown
+    let _6: bool
+    let _7: string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _8: string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // part
+    let _9: string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _10: string // s
+    let _11: int
+    let _12: string
+    let _13: reflect.Type
+    let _14: string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _15: int
+    let _16: reflect.Type
+    let _17: string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _18: int
+    let _19: reflect.Type
+    let _20: string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _21: int
+    let _22: reflect.Type
+    let _23: int
+    let _24: reflect.Type
+    let _25: string
+    let _26: reflect.Type
+    let _27: (string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[]
+    let _28: map<string, baml.json.json>
+
+    bb0: {
+        _2 = []: string[];
+        _3 = copy _1.0;
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>(copy _3) -> [bb1];
+    }
+
+    bb1: {
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>(copy _4) -> [bb2];
+    }
+
+    bb2: {
+        _6 = is_type(copy _5, baml.iter.Done);
+        branch copy _6 -> [bb12, bb3];
+    }
+
+    bb3: {
+        _7 = copy _5;
+        fresh_cell(_8);
+        _8 = copy _7;
+        _9 = copy _8;
+        _9 = narrow_bind copy _9 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb4];
+    }
+
+    bb4: {
+        _14 = copy _8;
+        _14 = narrow_bind copy _14 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Image" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb10, bb5];
+    }
+
+    bb5: {
+        _17 = copy _8;
+        _17 = narrow_bind copy _17 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb6];
+    }
+
+    bb6: {
+        _20 = copy _8;
+        _20 = narrow_bind copy _20 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb7];
+    }
+
+    bb7: {
+        _24 = load_type(string);
+        _23 = call const fn baml.Array.push<copy _24>(copy _2, const "[pdf]") -> [bb1];
+    }
+
+    bb8: {
+        _22 = load_type(string);
+        _21 = call const fn baml.Array.push<copy _22>(copy _2, const "[video]") -> [bb1];
+    }
+
+    bb9: {
+        _19 = load_type(string);
+        _18 = call const fn baml.Array.push<copy _19>(copy _2, const "[audio]") -> [bb1];
+    }
+
+    bb10: {
+        _16 = load_type(string);
+        _15 = call const fn baml.Array.push<copy _16>(copy _2, const "[image]") -> [bb1];
+    }
+
+    bb11: {
+        _10 = copy _9;
+        _12 = copy _10;
+        _13 = load_type(string);
+        _11 = call const fn baml.Array.push<copy _13>(copy _2, copy _12) -> [bb1];
+    }
+
+    bb12: {
+        _26 = load_type(string);
+        _25 = call const fn baml.Array.join<copy _26>(copy _2, const "") -> [bb13];
+    }
+
+    bb13: {
+        _27 = copy _1.0;
+        _28 = {  }: map<string, baml.json.json>;
+        _0 = ai.PromptMessage { const "user", copy _25, copy _27, copy _28 };
+        goto -> bb14;
+    }
+
+    bb14: {
+        return;
+    }
+}
+
 fn ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Journal {
     // Locals:
     let _0: ai.Journal // _0 // return
     let _1: ai.Journal // j // param
     let _2: string // client_id // param
-    let _3: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // out
+    let _3: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // out
     let _4: string[] // pending
-    let _5: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _6: baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    let _5: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
+    let _6: baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>
     let _7: unknown
     let _8: bool
-    let _9: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _10: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage // event
-    let _11: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _9: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
+    let _10: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage // event
+    let _11: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _12: ai.events.AssistantMessage // assistant
     let _13: void
-    let _14: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _14: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _15: string[]
     let _16: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[] // blocks
     let _17: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
@@ -11072,55 +11269,63 @@ fn ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Journal {
     let _35: int
     let _36: string
     let _37: reflect.Type
-    let _38: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _38: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _39: ai.events.UserMessage // user
     let _40: void
-    let _41: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _41: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _42: string[]
     let _43: int
     let _44: ai.events.UserMessage
     let _45: reflect.Type
-    let _46: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _47: ai.events.ToolCompleted // completed
+    let _46: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
+    let _47: ai.events.UserContent // content
     let _48: void
-    let _49: string[]
-    let _50: string
+    let _49: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
+    let _50: string[]
     let _51: int
-    let _52: ai.events.ToolCompleted
+    let _52: ai.events.UserContent
     let _53: reflect.Type
-    let _54: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _55: ai.events.ToolFailed // failed
+    let _54: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
+    let _55: ai.events.ToolCompleted // completed
     let _56: void
     let _57: string[]
     let _58: string
     let _59: int
-    let _60: ai.events.ToolFailed
+    let _60: ai.events.ToolCompleted
     let _61: reflect.Type
-    let _62: int
-    let _63: ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolRequested | ai.events.Usage
-    let _64: reflect.Type
-    let _65: void
-    let _66: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _67: string[]
-    let _68: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _62: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
+    let _63: ai.events.ToolFailed // failed
+    let _64: void
+    let _65: string[]
+    let _66: string
+    let _67: int
+    let _68: ai.events.ToolFailed
+    let _69: reflect.Type
+    let _70: int
+    let _71: ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolRequested | ai.events.Usage
+    let _72: reflect.Type
+    let _73: void
+    let _74: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
+    let _75: string[]
+    let _76: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
 
     bb0: {
-        _3 = []: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _3 = []: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _4 = []: string[];
         _5 = call const fn ai.Journal.entries(copy _1) -> [bb1];
     }
 
     bb1: {
-        _6 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _5) -> [bb2];
+        _6 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>(copy _5) -> [bb2];
     }
 
     bb2: {
-        _7 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _6) -> [bb3];
+        _7 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage>(copy _6) -> [bb3];
     }
 
     bb3: {
         _8 = is_type(copy _7, baml.iter.Done);
-        branch copy _8 -> [bb25, bb4];
+        branch copy _8 -> [bb28, bb4];
     }
 
     bb4: {
@@ -11128,143 +11333,161 @@ fn ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Journal {
         fresh_cell(_10);
         _10 = copy _9;
         _11 = copy _10;
-        _11 = narrow_bind copy _11 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb15, bb5];
+        _11 = narrow_bind copy _11 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb5];
     }
 
     bb5: {
         _38 = copy _10;
-        _38 = narrow_bind copy _38 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb13, bb6];
+        _38 = narrow_bind copy _38 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb16, bb6];
     }
 
     bb6: {
         _46 = copy _10;
-        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb11, bb7];
+        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserContent" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb7];
     }
 
     bb7: {
         _54 = copy _10;
-        _54 = narrow_bind copy _54 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb8];
+        _54 = narrow_bind copy _54 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb12, bb8];
     }
 
     bb8: {
-        _63 = copy _10;
-        _64 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _62 = call const fn baml.Array.push<copy _64>(copy _3, copy _63) -> [bb2];
+        _62 = copy _10;
+        _62 = narrow_bind copy _62 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb10, bb9];
     }
 
     bb9: {
-        _55 = copy _54;
-        _57 = copy _4;
-        _58 = copy _55.0;
-        _56 = call const fn ai.internal._resolve_pending_call(copy _57, copy _58) -> [bb10];
+        _71 = copy _10;
+        _72 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _70 = call const fn baml.Array.push<copy _72>(copy _3, copy _71) -> [bb2];
     }
 
     bb10: {
-        _60 = copy _55;
-        _61 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _59 = call const fn baml.Array.push<copy _61>(copy _3, copy _60) -> [bb2];
+        _63 = copy _62;
+        _65 = copy _4;
+        _66 = copy _63.0;
+        _64 = call const fn ai.internal._resolve_pending_call(copy _65, copy _66) -> [bb11];
     }
 
     bb11: {
-        _47 = copy _46;
-        _49 = copy _4;
-        _50 = copy _47.0;
-        _48 = call const fn ai.internal._resolve_pending_call(copy _49, copy _50) -> [bb12];
+        _68 = copy _63;
+        _69 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _67 = call const fn baml.Array.push<copy _69>(copy _3, copy _68) -> [bb2];
     }
 
     bb12: {
-        _52 = copy _47;
-        _53 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _51 = call const fn baml.Array.push<copy _53>(copy _3, copy _52) -> [bb2];
+        _55 = copy _54;
+        _57 = copy _4;
+        _58 = copy _55.0;
+        _56 = call const fn ai.internal._resolve_pending_call(copy _57, copy _58) -> [bb13];
     }
 
     bb13: {
-        _39 = copy _38;
-        _41 = copy _3;
-        _42 = copy _4;
-        _40 = call const fn ai.internal._flush_orphaned_calls(copy _41, copy _42) -> [bb14];
+        _60 = copy _55;
+        _61 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _59 = call const fn baml.Array.push<copy _61>(copy _3, copy _60) -> [bb2];
     }
 
     bb14: {
-        _44 = copy _39;
-        _45 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _43 = call const fn baml.Array.push<copy _45>(copy _3, copy _44) -> [bb2];
+        _47 = copy _46;
+        _49 = copy _3;
+        _50 = copy _4;
+        _48 = call const fn ai.internal._flush_orphaned_calls(copy _49, copy _50) -> [bb15];
     }
 
     bb15: {
-        _12 = copy _11;
-        _14 = copy _3;
-        _15 = copy _4;
-        _13 = call const fn ai.internal._flush_orphaned_calls(copy _14, copy _15) -> [bb16];
+        _52 = copy _47;
+        _53 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _51 = call const fn baml.Array.push<copy _53>(copy _3, copy _52) -> [bb2];
     }
 
     bb16: {
-        _17 = copy _12.0;
-        _19 = copy _12.1;
-        _18 = copy _19 == copy _2;
-        _16 = call const fn ai.internal._wire_blocks(copy _17, copy _18) -> [bb17];
+        _39 = copy _38;
+        _41 = copy _3;
+        _42 = copy _4;
+        _40 = call const fn ai.internal._flush_orphaned_calls(copy _41, copy _42) -> [bb17];
     }
 
     bb17: {
-        _21 = len(_16);
-        goto -> bb18;
+        _44 = copy _39;
+        _45 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _43 = call const fn baml.Array.push<copy _45>(copy _3, copy _44) -> [bb2];
     }
 
     bb18: {
-        _20 = copy _21 > const 0_i64;
-        branch copy _20 -> [bb19, bb2];
+        _12 = copy _11;
+        _14 = copy _3;
+        _15 = copy _4;
+        _13 = call const fn ai.internal._flush_orphaned_calls(copy _14, copy _15) -> [bb19];
     }
 
     bb19: {
-        _24 = copy _16;
-        _25 = copy _12.1;
-        _23 = ai.events.AssistantMessage { copy _24, copy _25 };
-        _26 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _22 = call const fn baml.Array.push<copy _26>(copy _3, copy _23) -> [bb20];
+        _17 = copy _12.0;
+        _19 = copy _12.1;
+        _18 = copy _19 == copy _2;
+        _16 = call const fn ai.internal._wire_blocks(copy _17, copy _18) -> [bb20];
     }
 
     bb20: {
-        _27 = copy _16;
-        _28 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _27) -> [bb21];
+        _21 = len(_16);
+        goto -> bb21;
     }
 
     bb21: {
-        _29 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _28) -> [bb22];
+        _20 = copy _21 > const 0_i64;
+        branch copy _20 -> [bb22, bb2];
     }
 
     bb22: {
-        _30 = is_type(copy _29, baml.iter.Done);
-        branch copy _30 -> [bb2, bb23];
+        _24 = copy _16;
+        _25 = copy _12.1;
+        _23 = ai.events.AssistantMessage { copy _24, copy _25 };
+        _26 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _22 = call const fn baml.Array.push<copy _26>(copy _3, copy _23) -> [bb23];
     }
 
     bb23: {
+        _27 = copy _16;
+        _28 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _27) -> [bb24];
+    }
+
+    bb24: {
+        _29 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _28) -> [bb25];
+    }
+
+    bb25: {
+        _30 = is_type(copy _29, baml.iter.Done);
+        branch copy _30 -> [bb2, bb26];
+    }
+
+    bb26: {
         _31 = copy _29;
         fresh_cell(_32);
         _32 = copy _31;
         _33 = copy _32;
-        _33 = narrow_bind copy _33 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb24, bb21];
-    }
-
-    bb24: {
-        _34 = copy _33;
-        _36 = copy _34.0;
-        _37 = load_type(string);
-        _35 = call const fn baml.Array.push<copy _37>(copy _4, copy _36) -> [bb21];
-    }
-
-    bb25: {
-        _66 = copy _3;
-        _67 = copy _4;
-        _65 = call const fn ai.internal._flush_orphaned_calls(copy _66, copy _67) -> [bb26];
-    }
-
-    bb26: {
-        _68 = copy _3;
-        _0 = ai.Journal { copy _68 };
-        goto -> bb27;
+        _33 = narrow_bind copy _33 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb27, bb24];
     }
 
     bb27: {
+        _34 = copy _33;
+        _36 = copy _34.0;
+        _37 = load_type(string);
+        _35 = call const fn baml.Array.push<copy _37>(copy _4, copy _36) -> [bb24];
+    }
+
+    bb28: {
+        _74 = copy _3;
+        _75 = copy _4;
+        _73 = call const fn ai.internal._flush_orphaned_calls(copy _74, copy _75) -> [bb29];
+    }
+
+    bb29: {
+        _76 = copy _3;
+        _0 = ai.Journal { copy _76 };
+        goto -> bb30;
+    }
+
+    bb30: {
         return;
     }
 }
@@ -11280,14 +11503,14 @@ fn ai.Runner.run(_1: void, _2: void) -> void {
     }
 }
 
-fn ai.Agent.new(max_steps: int, schema_attempts: int, client: null | ai.Client, tool_errors: ai.tools.ErrorMode, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> ai.Agent {
+fn ai.Agent.new(max_steps: int, schema_attempts: int, client: null | ai.Client, tool_errors: ai.tools.ErrorMode, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> ai.Agent {
     // Locals:
     let _0: ai.Agent // _0 // return
     let _1: int // max_steps // param
     let _2: int // schema_attempts // param
     let _3: null | ai.Client // client // param
     let _4: ai.tools.ErrorMode // tool_errors // param
-    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _6: bool
     let _7: bool
     let _8: bool
@@ -11295,7 +11518,7 @@ fn ai.Agent.new(max_steps: int, schema_attempts: int, client: null | ai.Client, 
     let _10: bool
     let _11: bool
     let _12: baml.errors.InvalidArgument
-    let _13: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
+    let _13: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)
     let _14: reflect.Type
 
     bb0: {
@@ -11417,7 +11640,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     let _10: unknown // e
     let _11: map<string, unknown>
     let _12: void
-    let _13: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _13: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _14: ai.events.ToolFailed
     let _15: string
     let _16: string
@@ -11439,12 +11662,12 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     let _32: string | null
     let _33: string // output
     let _34: void
-    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _36: ai.events.ToolCompleted
     let _37: string
     let _38: string
     let _39: void
-    let _40: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _40: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _41: ai.events.ToolFailed
     let _42: string
     let _43: string
@@ -11472,7 +11695,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     bb3: {
         _43 = const "tool is not in the active toolbox: " + copy _44;
         _41 = ai.events.ToolFailed { copy _42, copy _43 };
-        _40 = [copy _41]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _40 = [copy _41]: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _39 = call const fn ai.Journal.append_all(copy _4, copy _40) -> [bb4];
     }
 
@@ -11499,7 +11722,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
 
     bb8: {
         _14 = ai.events.ToolFailed { copy _15, copy _16 };
-        _13 = [copy _14]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _13 = [copy _14]: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _12 = call const fn ai.Journal.append_all(copy _4, copy _13) -> [bb9];
     }
 
@@ -11539,7 +11762,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
         _37 = copy _3.0;
         _38 = copy _33;
         _36 = ai.events.ToolCompleted { copy _37, copy _38 };
-        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _34 = call const fn ai.Journal.append_all(copy _4, copy _35) -> [bb16];
     }
 
@@ -12293,7 +12516,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     let _32: int | null
     let _33: bool
     let _34: int
-    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // batch
+    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // batch
     let _36: ai.events.AssistantMessage
     let _37: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
     let _38: string
@@ -12341,7 +12564,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     let _80: reflect.Type
     let _81: bool
     let _82: void
-    let _83: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _83: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _84: ai.content.StopReason
     let _85: int
     let _86: ai.errors.FinishReasonError
@@ -12355,11 +12578,11 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     let _94: ai.events.UserMessage
     let _95: reflect.Type
     let _96: void
-    let _97: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _97: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _98: int
     let _99: reflect.Type
     let _100: void
-    let _101: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _101: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _102: ai.errors.ParseFailed
     let _103: string
     let _104: string
@@ -12450,7 +12673,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
 
     bb13: {
         _36 = ai.events.AssistantMessage { copy _37, copy _38 };
-        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _39 = copy _7.3;
         _40 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _39) -> [bb14];
     }
@@ -12469,7 +12692,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
         fresh_cell(_44);
         _44 = copy _43;
         _46 = copy _44;
-        _47 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _47 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _45 = call const fn baml.Array.push<copy _47>(copy _35, copy _46) -> [bb14];
     }
 
@@ -12498,7 +12721,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
         _57 = copy _53.1;
         _58 = copy _53.2;
         _55 = ai.events.ToolRequested { copy _56, copy _57, copy _58 };
-        _59 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _59 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _54 = call const fn baml.Array.push<copy _59>(copy _35, copy _55) -> [bb19];
     }
 
@@ -12511,7 +12734,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     bb23: {
         _62 = copy _61;
         _64 = copy _62;
-        _65 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _65 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _63 = call const fn baml.Array.push<copy _65>(copy _35, copy _64) -> [bb24];
     }
 
@@ -12597,7 +12820,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
 
     bb40: {
         _94 = ai.events.UserMessage { const "The reply did not match the required schema. Answer again with only the corrected value." };
-        _95 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _95 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _93 = call const fn baml.Array.push<copy _95>(copy _35, copy _94) -> [bb41];
     }
 
@@ -12659,22 +12882,22 @@ fn ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
     let _1: ai.Agent // self // param
     let _2: ai.Journal // j // param
     let _3: int // seen // param
-    let _4: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // entries
-    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _6: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _7: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
+    let _4: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // entries
+    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)
+    let _6: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)
+    let _7: (ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
     let _8: int // i
     let _9: bool
     let _10: int
     let _11: int
-    let _12: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _12: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _13: int
     let _14: reflect.Type
-    let _15: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _16: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced // e
+    let _15: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
+    let _16: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced // e
     let _17: void
-    let _18: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
-    let _19: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _18: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never
+    let _19: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _20: int
 
     bb0: {
@@ -12684,7 +12907,7 @@ fn ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
     bb1: {
         _5 = copy _1.4;
         _6 = copy _5;
-        _6 = narrow_bind copy _6 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb2, bb5];
+        _6 = narrow_bind copy _6 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserContent" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb2, bb5];
     }
 
     bb2: {
@@ -12715,55 +12938,59 @@ fn ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
 
     bb7: {
         _13 = copy _8;
-        _14 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _14 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _12 = call const fn baml.Array.at<copy _14>(copy _4, copy _13) -> [bb8];
     }
 
     bb8: {
         _15 = copy _12;
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb9];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb9];
     }
 
     bb9: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb10];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb10];
     }
 
     bb10: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb11];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserContent" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb11];
     }
 
     bb11: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb12];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb12];
     }
 
     bb12: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb13];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb13];
     }
 
     bb13: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb14];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb14];
     }
 
     bb14: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb15];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb15];
     }
 
     bb15: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb16];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb16];
     }
 
     bb16: {
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb18];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb17];
     }
 
     bb17: {
-        _16 = copy _15;
-        _18 = copy _7;
-        _19 = copy _16;
-        _17 = call copy _18(copy _19) -> [bb18];
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb19];
     }
 
     bb18: {
+        _16 = copy _15;
+        _18 = copy _7;
+        _19 = copy _16;
+        _17 = call copy _18(copy _19) -> [bb19];
+    }
+
+    bb19: {
         _20 = copy _8;
         _8 = copy _20 + const 1_i64;
         goto -> bb3;
@@ -12803,7 +13030,7 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     let _28: bool
     let _29: int
     let _30: int // before
-    let _31: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _31: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _32: baml.future.Future<void, ai.errors.ToolFailedError>[] // futures
     let _33: (ai.content.ToolUse) -> baml.future.Future<void, ai.errors.ToolFailedError> throws never
     let _34: reflect.Type
@@ -12819,15 +13046,15 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     let _44: int
     let _45: ai.Journal
     let _46: int
-    let _47: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // entries
+    let _47: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[] // entries
     let _48: int // i
     let _49: bool
     let _50: int
     let _51: int
-    let _52: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _52: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _53: int
     let _54: reflect.Type
-    let _55: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _55: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage
     let _56: ai.events.ToolFailed // f [captured]
     let _57: null | ai.content.ToolUse // failed_call
     let _58: (ai.content.ToolUse) -> bool throws never
@@ -12895,7 +13122,7 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     let _120: baml.json.JsonSerializationError
     let _121: reflect.Type
     let _122: void
-    let _123: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _123: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage)[]
     let _124: ai.events.FinalProduced
     let _125: string
     let _126: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
@@ -13039,7 +13266,7 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
 
     bb23: {
         _124 = ai.events.FinalProduced { copy _125 };
-        _123 = [copy _124]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _123 = [copy _124]: ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _122 = call const fn ai.Journal.append_all(copy _8, copy _123) -> [bb24];
     }
 
@@ -13117,7 +13344,7 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
 
     bb37: {
         _53 = copy _48;
-        _54 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _54 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
         _52 = call const fn baml.Array.at<copy _54>(copy _47, copy _53) -> [bb38];
     }
 
@@ -13401,12 +13628,12 @@ fn .<lambda(prompt, 0)>(ctx: ai.Context) -> ai.Prompt {
     }
 }
 
-fn ai.FunctionSpec.call(self: ai.FunctionSpec, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)) -> Out {
+fn ai.FunctionSpec.call(self: ai.FunctionSpec, client: null | ai.Client, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never)) -> Out {
     // Locals:
     let _0: Out // _0 // return
     let _1: ai.FunctionSpec // self // param
     let _2: null | ai.Client // client // param
-    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // on_event // param
+    let _3: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserContent | ai.events.UserMessage) -> void throws never) // on_event // param
     let _4: bool
     let _5: bool
     let _6: ai.RunResult<Out>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
@@ -250,7 +250,7 @@ function ai.content.kind(self: ?) -> string  [expr] {
   {  } match (self.media) { image: baml.media.Image => "image", audio: baml.media.Audio => "audio", video: baml.media.Video => "video", pdf: baml.media.Pdf => "pdf" }
 }
 function ai.content.new(value: image | audio | video | pdf, provider_id: string? = null, revised_prompt: string? = null) -> ai.content.Media  [expr] {
-  { let envelope = baml.json.to_json(value) catch_all (e) { _ => { throw baml.errors.InvalidArgument { message: `...` } } }; let part: root.MediaPart = baml.json.from_json(envelope) catch_all (e) { _ => { throw baml.errors.InvalidArgument { message: `...` } } } } ai.content.Media { media: part, provider_id: provider_id, revised_prompt: revised_prompt }
+  {  } ai.content.Media { media: root.internal.media_part(value), provider_id: provider_id, revised_prompt: revised_prompt }
 }
 
 --- <builtin>/ai/ns_errors/errors.baml ---
@@ -518,16 +518,25 @@ class ai.events.Usage$stream {
   cached_input_tokens: int | null
   reasoning_tokens: int | null
 }
+class ai.events.UserContent {
+  parts: root.PromptPart[]
+}
+class ai.events.UserContent$stream {
+  parts: root.PromptPart$stream[]
+}
 class ai.events.UserMessage {
   content: string
 }
 class ai.events.UserMessage$stream {
   content: string | null
 }
-type ai.events.Event = ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
-type ai.events.Event$stream = ai.events.RunStarted$stream | ai.events.UserMessage$stream | ai.events.AssistantMessage$stream | ai.events.ToolRequested$stream | ai.events.ToolCompleted$stream | ai.events.ToolFailed$stream | ai.events.Usage$stream | ai.events.LLMCall$stream | ai.events.FinalProduced$stream
+type ai.events.Event = ai.events.RunStarted | ai.events.UserMessage | ai.events.UserContent | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+type ai.events.Event$stream = ai.events.RunStarted$stream | ai.events.UserMessage$stream | ai.events.UserContent$stream | ai.events.AssistantMessage$stream | ai.events.ToolRequested$stream | ai.events.ToolCompleted$stream | ai.events.ToolFailed$stream | ai.events.Usage$stream | ai.events.LLMCall$stream | ai.events.FinalProduced$stream
 function ai.events.guard(listener: (ai.events.Event) -> void throws E?) -> (ai.events.Event) -> void throws never?  [expr] {
   {  } if let cb: (ai.events.Event) -> void throws E = listener {  } (e: ai.events.Event) -> void { {  } cb(e) catch_all (err) { _ => {  } } } else {  } null
+}
+function ai.events.new(parts: string | image | audio | video | pdf[]) -> ai.events.UserContent  [expr] {
+  { let out: root.PromptPart[] = []; for part in parts {  } if let text: string = part { out.push(text) } else { out.push(root.internal.media_part(part)) } } ai.events.UserContent { parts: out }
 }
 
 --- captures ---
@@ -617,6 +626,9 @@ function ai.internal._resolve_media_content(url: string?, file: string?, inline:
 }
 function ai.internal._resolve_media_preview_content(url: string?, file: string?, inline: string, mime: string) -> root.wire.ResolvedMedia  [expr] {
   { if let path: string = file { throw ai.errors.PreviewUnsupported { provider: "media-preview", detail: `...` } }; if (inline Ne "") { return root.wire.ResolvedMedia { url: null, base64: inline, mime_type: mime } }; if let media_url: string = url { if (media_url.starts_with("data:")) { if let separator: int = media_url.index_of(";base64,") { return root.wire.ResolvedMedia { url: null, base64: media_url.slice(separator Add 8, media_url.length()), mime_type: media_url.slice(5, separator) } }; throw ai.errors.PreviewUnsupported { provider: "media-preview", detail: "request preview c..." } }; return root.wire.ResolvedMedia { url: media_url, base64: null, mime_type: mime } }; throw ai.errors.PreviewUnsupported { provider: "media-preview", detail: "request preview r..." } }
+}
+function ai.internal.media_part(value: image | audio | video | pdf) -> root.MediaPart  [expr] {
+  { let envelope = baml.json.to_json(value) catch_all (e) { _ => { throw baml.errors.InvalidArgument { message: `...` } } } } baml.json.from_json(envelope) catch_all (e) { _ => { throw baml.errors.InvalidArgument { message: `...` } } }
 }
 
 --- <builtin>/ai/ns_internal/prompt.baml ---
@@ -926,13 +938,16 @@ function ai.wire.resolve_media_preview(media: ai.MediaPart) -> ai.wire.ResolvedM
   {  } match (media) { image: baml.media.Image => { let source = image.file() NullCoalesce image.url() NullCoalesce "" } root.internal._resolve_media_preview_content(image.url(), image.file(), image.base64(), root.internal._media_mime_type(image.mime_type(), source, "image")), audio: baml.media.Audio => { let source = audio.file() NullCoalesce audio.url() NullCoalesce "" } root.internal._resolve_media_preview_content(audio.url(), audio.file(), audio.base64(), root.internal._media_mime_type(audio.mime_type(), source, "audio")), video: baml.media.Video => { let source = video.file() NullCoalesce video.url() NullCoalesce "" } root.internal._resolve_media_preview_content(video.url(), video.file(), video.base64(), root.internal._media_mime_type(video.mime_type(), source, "video")), pdf: baml.media.Pdf => { let source = pdf.file() NullCoalesce pdf.url() NullCoalesce "" } root.internal._resolve_media_preview_content(pdf.url(), pdf.file(), pdf.base64(), root.internal._media_mime_type(pdf.mime_type(), source, "pdf")) }
 }
 function ai.wire.sanitize_for_client(j: root.Journal, client_id: string) -> root.Journal  [expr] {
-  { let out: root.events.Event[] = []; let pending: string[] = []; for event in j.entries() { match (event) { assistant: root.events.AssistantMessage => { root.internal._flush_orphaned_calls(out, pending); let blocks = root.internal._wire_blocks(assistant.content, assistant.client_id Eq client_id); if (blocks.length() Gt 0) { out.push(root.events.AssistantMessage { content: blocks, client_id: assistant.client_id }); for block in blocks {  } if let use: root.content.ToolUse = block { pending.push(use.id) } } null else {  } null } null, user: root.events.UserMessage => { root.internal._flush_orphaned_calls(out, pending); out.push(user) } null, completed: root.events.ToolCompleted => { root.internal._resolve_pending_call(pending, completed.id); out.push(completed) } null, failed: root.events.ToolFailed => { root.internal._resolve_pending_call(pending, failed.id); out.push(failed) } null, _ => { out.push(event) } null } }; root.internal._flush_orphaned_calls(out, pending) } root.Journal { log: out }
+  { let out: root.events.Event[] = []; let pending: string[] = []; for event in j.entries() { match (event) { assistant: root.events.AssistantMessage => { root.internal._flush_orphaned_calls(out, pending); let blocks = root.internal._wire_blocks(assistant.content, assistant.client_id Eq client_id); if (blocks.length() Gt 0) { out.push(root.events.AssistantMessage { content: blocks, client_id: assistant.client_id }); for block in blocks {  } if let use: root.content.ToolUse = block { pending.push(use.id) } } null else {  } null } null, user: root.events.UserMessage => { root.internal._flush_orphaned_calls(out, pending); out.push(user) } null, content: root.events.UserContent => { root.internal._flush_orphaned_calls(out, pending); out.push(content) } null, completed: root.events.ToolCompleted => { root.internal._resolve_pending_call(pending, completed.id); out.push(completed) } null, failed: root.events.ToolFailed => { root.internal._resolve_pending_call(pending, failed.id); out.push(failed) } null, _ => { out.push(event) } null } }; root.internal._flush_orphaned_calls(out, pending) } root.Journal { log: out }
 }
 function ai.wire.send_as(req: baml.http.Request, provider: string, request_timeout_ms: int? = null) -> T  [expr] {
   { let timeout = match (request_timeout_ms) { milliseconds: int => baml.time.Duration.from_milliseconds(milliseconds), null => null }; let resp = baml.http.send(req, timeout = timeout) catch_all (e) { timeout: baml.errors.Timeout => throw timeout, _ => { throw root.errors.NetworkFailure { status_code: null, provider: provider, detail: `...`, raw_body: null } } }; let text = resp.text() catch_all (e) { timeout: baml.errors.Timeout => throw timeout, _ => { throw root.errors.NetworkFailure { status_code: null, provider: provider, detail: "the response body...", raw_body: null } } }; if (Not resp.ok()) { throw root.errors.classify_http(provider, resp.status_code, text, headers = resp.headers) } } baml.json.from_string(text) catch_all (e) { _ => throw root.errors.ParseFailed { provider: provider, raw_output: text } }
 }
 function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_name: string, capture_wire: bool = true, request_timeout_ms: int? = null) -> ai.wire.SentAs<T>  [expr] {
   { let started = baml.time.Instant.now(); let timeout = match (request_timeout_ms) { milliseconds: int => baml.time.Duration.from_milliseconds(milliseconds), null => null }; let resp = baml.http.send(req, timeout = timeout) catch_all (e) { timeout: baml.errors.Timeout => throw timeout, _ => { throw root.errors.NetworkFailure { status_code: null, provider: provider, detail: `...`, raw_body: null } } }; let text = resp.text() catch_all (e) { timeout: baml.errors.Timeout => throw timeout, _ => { throw root.errors.NetworkFailure { status_code: null, provider: provider, detail: "the response body...", raw_body: null } } }; if (Not resp.ok()) { throw root.errors.classify_http(provider, resp.status_code, text, headers = resp.headers) }; let value = baml.json.from_string(text) catch_all (e) { _ => throw root.errors.ParseFailed { provider: provider, raw_output: text } }; let call = root.events.LLMCall { client_name: client_name, provider: provider, timing: root.events.Timing { start_time_utc_ms: started.to_timestamp_milliseconds(), duration_ms: started.elapsed().to_milliseconds(), ttft_ms: null }, http_request: if (capture_wire) {  } baml.http.Request { method: req.method, url: redact_url_secrets(req.url), headers: redact_request_headers(req.headers), body: req.body } else {  } null, http_response: root.events.HttpResponse { status: resp.status_code, headers: resp.headers, body: if (capture_wire) {  } redact_url_secrets(text) else {  } null }, usage: null, selected: true, sse_responses: null } } ai.wire.SentAs { value: value, call: call }
+}
+function ai.wire.user_content_message(event: root.events.UserContent) -> root.PromptMessage  [expr] {
+  { let text: string[] = []; for part in event.parts { match (part) { s: string => { text.push(s) } null, image: baml.media.Image => { text.push("[image]") } null, audio: baml.media.Audio => { text.push("[audio]") } null, video: baml.media.Video => { text.push("[video]") } null, pdf: baml.media.Pdf => { text.push("[pdf]") } null } } } root.PromptMessage { role: "user", content: text.join(""), parts: event.parts, metadata: map {  } }
 }
 
 --- <builtin>/ai/runner.baml ---


### PR DESCRIPTION
## Problem

How does an agent add an image (or any media) to the conversation after the first turn?

Today the only way media reaches a provider request is the prompt template (`ai.FunctionSpec.prompt_template`), which every client re-renders at the top of the request on each turn. The journal — the event log a runner appends to imperatively while it loops — can only carry text: `ai.events.UserMessage { content: string }` and `ai.events.ToolCompleted { id, output: string }`. A computer-use agent that screenshots after every tool call therefore has nowhere to put the screenshot *after* the tool result. The workaround (a mutable object rendered in the template's first user message, overwritten after every action) defeats prompt caching — every turn's request differs from the first content part onward, so the growing journal never hits a prefix cache — and confuses the model: a tool result says a new screenshot exists but nothing new appears after it; the fresh image sits where the *starting* screenshot was.

## Design

A new journal event that carries prompt parts, media included, which every provider client lowers to a user turn **at its position in the journal**:

```baml
/// A user turn carrying prompt parts: text and media, in order. A runner
/// appends it imperatively mid-run — a screenshot after a tool ran, a
/// document the host attaches — and every client lowers it to a user
/// message at its position in the journal. `UserMessage` stays text-only.
class UserContent {
    parts: root.PromptPart[],

    function new(parts: (string | image | audio | video | pdf)[]) -> UserContent { ... }
}

type Event = RunStarted | UserMessage | UserContent | AssistantMessage | ...;
```

- `UserMessage` is unchanged, so every existing construction site compiles; BAML classes have no field defaults, so a new variant is the only non-breaking shape.
- `parts` is `ai.PromptPart[]` — the same type a rendered `ai.PromptMessage` carries — so each client hands the event to the **same helper it already uses for prompt media** and a mid-run screenshot takes exactly the wire shape the template's media would. The shared adapter is `ai.wire.user_content_message(event) -> ai.PromptMessage` (role `user`, the event's parts verbatim, `content` = text parts with `[image]`/`[audio]`/`[video]`/`[pdf]` placeholders for text-only consumers).
- **`UserContent.new(...)` exists because `image` and `baml.media.Image` are distinct static types.** `baml.media.Image.from_base64` returns the `image` primitive, and the type checker does not accept it where the `baml.media.Image` wrapper class (a member of `ai.PromptPart`) is expected — so a plain `ai.events.UserContent { parts: ["...", img] }` does not typecheck from user code. `ai.content.Media.new` already bridges the two through the BEP-038 JSON envelope; that bridge is now factored into `ai.internal.media_part(value)` and shared by `Media.new` and `UserContent.new`. The plain constructor remains for parts that are already `PromptPart` (a rendered prompt's, an `ai.content.Media`'s).
- `ai.wire.sanitize_for_client` treats `UserContent` exactly like `UserMessage`: an unanswered tool call is closed with the synthesized `ToolFailed` before the turn.

## Clients touched

Each provider's journal lowering gains a `UserContent` arm that reuses its prompt-parts helper; the helpers need `preview` (and, for Gemini, `fetch_url`), so those are now threaded into the lowering functions from the request builders where they were already in scope:

| Client | File | Lowering | Helper reused |
|---|---|---|---|
| Google Gemini + Vertex | `google/ns_internal/gemini.baml` | `google_lower_journal(j, fetch_url, preview)` — flushes pending `functionResponse` parts first, like `UserMessage` | `_gm_prompt_parts` |
| Anthropic | `anthropic/ns_internal/messages.baml` | `_anthropic_lower_journal(j, preview)` | `_anthropic_prompt_blocks` |
| OpenAI Chat (+ every chat-compat provider) | `openai/ns_internal/chat.baml` | `chat_lower_journal(j, compat, preview)` | `_chat_prompt_parts` + `_chat_content` |
| OpenAI Responses | `openai/ns_internal/responses.baml` | `openai_lower_journal(j, preview)` | `_openai_prompt_content` |
| AWS Bedrock Converse | `aws/ns_internal/bedrock.baml` | `_lower_journal(journal, with_status, preview)` | `_prompt_content` |
| Claude Code CLI | `claude_code/ns_internal/cli.baml` | `transcript_text` renders `user: <text> [image]` | `ai.wire.user_content_message(..).content` |
| OpenAI Images / Vercel gateway Images | `openai/ns_internal/images.baml`, `vercel/ns_internal/images.baml` | text parts join the prompt text; media is rejected with the same typed error the template path raises | — |

Vertex goes through `gemini_build_body`, so it picks up the Gemini change (with `fetch_url = false`, i.e. URL passthrough).

Anthropic and Bedrock both require tool results to open the user turn that answers a tool call, and both already merge adjacent same-role messages; a `UserContent` appended right after a tool result therefore lands in that same user message *after* the `tool_result`/`toolResult` blocks, which is the shape those APIs want.

## Tests

New tests, one per client, each seeding a journal with an assistant tool call, its `ToolCompleted`, and then `UserContent.new(["Screenshot after the tool ran:", Image.from_base64(...)])`, and asserting the user turn with the image appears **after** the tool result in the lowered body:

- `ns_llm_google`: `google_user_content_after_tool_result`, `vertex_user_content_after_tool_result` (`contents[3]` = user text + `inlineData`, after the `functionResponse` content)
- `ns_llm_anthropic`: `anthropic_user_content_after_tool_result` (`messages[2]` = `[tool_result, text, image]`), `anthropic_orphaned_tool_call_closed_before_user_content` (sanitizer)
- `ns_llm_openai_chat`: `chat_user_content_after_tool_result` (`messages[5]` = user `[text, image_url]` after the `tool` message)
- `ns_llm_openai_responses`: `oai_user_content_after_tool_result` (user `[input_text, input_image]` item immediately after `function_call_output`)
- `ns_llm_bedrock`: `bedrock_user_content_after_tool_result` (`messages[2]` = `[toolResult, text, image]`)
- `ns_llm_on_event`: `claude_code_transcript_with_user_content` (CLI transcript placeholder rendering); `label_of` gained the `UserContent` arm the exhaustive match requires

## What was run

All from `baml_language/` in the worktree, debug `baml-cli` built with `cargo build -p baml_cli`:

- `baml-cli check --project crates/baml_tests/baml_src` — 0 errors (292 files)
- `baml-cli test --project crates/baml_tests/baml_src` (default `offline` profile, whole corpus) — **3564 passed, 0 failed**
- `cargo insta test --test-runner nextest --dnd -p baml_tests --all-features --unreferenced=reject --accept` — **2046 passed, 1 failed**, 22 skipped. The one failure is `baml_tests::shell claude_code_client_preserves_process_wait_timeout` (`unexpected:NetworkFailure { .. "the Claude Code CLI produced no result within 25ms" }` instead of the typed `Timeout`). It fails identically on the untouched base commit `5f8cc28af` (verified by stashing this change and running the test alone), so it is a pre-existing race between the process-wait timeout and `baml.future.with_timeout` at 25 ms, unrelated to this PR.
- `cargo nextest run --all-features --workspace --exclude baml_tests --exclude baml_cli --exclude baml_lsp2_actions --exclude "sdk_test_*" --exclude baml_bridge` — **4257 passed, 0 failed**, 5 skipped

## Snapshot changes accepted

41 files under `crates/baml_tests/snapshots/baml_src/`, all mechanical consequences of the new `Event` variant (audited: outside `stdlib/ai`, every added line contains `UserContent`):

- 38 per-namespace `bytecode.snap` / `mir.snap` files (e.g. `ns_env_ref_clients`, `ns_streaming_parsing`, `ns_fixtures/*`): the `on_event` parameter type of every `@spec`-derived function spells out the `ai.events.Event` union, which now includes `ai.events.UserContent`.
- `stdlib/ai/{ppir,mir,bytecode}.snap`: the new `ai.events.UserContent` class and its `new`, `ai.wire.user_content_message`, `ai.internal.media_part`, the `sanitize_for_client` arm, and `ai.content.Media.new` now delegating to `media_part`.

No `.snap.new` files are committed.

## Notes for downstream

- Runners append it as `journal.append_all([ai.events.UserContent.new(["...", screenshot])])`.
- `on_event` listeners that match exhaustively on `ai.events.Event` need a `UserContent` arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches journal-to-wire lowering across all major LLM clients; incorrect merging with tool results could break multi-turn agent requests, though behavior is heavily tested.
> 
> **Overview**
> Adds **`ai.events.UserContent`** so runners can append ordered text and media to the journal mid-run (e.g. a screenshot after a tool result), while **`UserMessage`** stays text-only. **`UserContent.new(...)`** accepts strings plus primitive `image`/`audio`/`video`/`pdf` values; media is bridged via new **`root.internal.media_part`**, which **`root.content.Media.new`** now calls instead of inlining JSON encode/decode.
> 
> **`ai.wire.user_content_message`** turns a `UserContent` event into a `user` **`PromptMessage`** (parts verbatim, joined text with `[image]`-style placeholders for text-only paths). **`sanitize_for_client`** treats **`UserContent`** like **`UserMessage`** for flushing orphaned tool calls.
> 
> Provider journal lowering (Anthropic, Bedrock, Gemini/Vertex, OpenAI Chat & Responses, Claude Code transcript) routes **`UserContent`** through the same prompt-part helpers as template media, with **`preview`** (and Gemini **`fetch_url`**) threaded into journal lowering. Images gateway clients accept text from **`UserContent`** and reject media parts.
> 
> Tests assert post–tool-result screenshots land in the correct wire shape per client; bytecode/MIR snapshots pick up **`UserContent`** on the **`on_event`** event union.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c13423479966ba706aaf981bc317a9ef04bf6f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user content turns containing text and image, audio, video, or PDF media.
  * Preserved media and text ordering when replaying conversation history.
  * Added support across Anthropic, Bedrock, Google, OpenAI, Vercel, and Claude Code integrations.
  * User content now appears correctly in transcripts and provider requests, including after tool results.

* **Bug Fixes**
  * Improved handling of unfinished tool calls before a new user content turn.
  * Added consistent media placeholders and preview rendering across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->