### PR TITLE
docs: backtest changelog drafting process on 0.18.0

### DIFF
--- a/typescript2/app-website/blog-releases/backtest-findings.md
+++ b/typescript2/app-website/blog-releases/backtest-findings.md
@@ -1,0 +1,49 @@
+# Backtest findings for the `0.18.0` changelog process
+
+## Result
+
+The process produced 67 PRs with user-visible effects from 89 commits touching `baml_language/`. The historical `0.18.0` changelog references 56 of those PRs. The backtest therefore found 11 additional PRs that satisfy the proposed inclusion rule. The other 22 PRs are excluded explicitly in `step1-prs-only-user-visible.md`.
+
+The historical changelog is a strong semantic oracle for the 56 PRs it includes. Its grouping is generally good, but its cutoff and completeness are not mechanically auditable from the rendered notes.
+
+## Backtest inputs
+
+- Base tag: `baml-language-0.17.0` at `36545fde3913aa3699a27aed11365541c8123821`.
+- Head tag: `baml-language-0.18.0` at `7622555396a99db466afaea09dea2cad259d4033`.
+- Historical changelog comparison head: `f3e1e25210b1ac551a4d1ffd0238db5d85824789`.
+- Scoped history command: `git log --reverse --format='%h %s' baml-language-0.17.0..baml-language-0.18.0 -- baml_language/`.
+
+## Additional user-visible PRs found by the backtest
+
+- [#4460](https://github.com/BoundaryML/baml/pull/4460) rejects unsupported runtime-dependent generic checks at compile time instead of omitting checks or panicking.
+- [#4529](https://github.com/BoundaryML/baml/pull/4529) fixes method calls on global bindings and normalizes session `let` binding types.
+- [#4531](https://github.com/BoundaryML/baml/pull/4531) checks session assignments against the original binding type.
+- [#4560](https://github.com/BoundaryML/baml/pull/4560) changes observable runtime type identity behavior, including runtime-defined types crossing reflection and host boundaries.
+- [#4568](https://github.com/BoundaryML/baml/pull/4568) rejects corrupt or incompatible generated artifacts with actionable regeneration errors.
+- [#4571](https://github.com/BoundaryML/baml/pull/4571) keeps reflection sessions usable after rejected compilation artifacts and prevents invalid artifact reuse.
+- [#4581](https://github.com/BoundaryML/baml/pull/4581) ships a new language server implementation with user-facing editor behavior, including standard-library navigation and testset code lenses.
+- [#4603](https://github.com/BoundaryML/baml/pull/4603) prevents invalid compiler types from silently degrading into `unknown` and rejects invalid numeric compound assignments.
+- [#4619](https://github.com/BoundaryML/baml/pull/4619) rejects class constructors that omit required fields.
+- [#4621](https://github.com/BoundaryML/baml/pull/4621) rejects unspecialized generic functions stored as values and gives concrete migration guidance.
+- [#4593](https://github.com/BoundaryML/baml/pull/4593) rejects `throws unknown` when the implementation does not actually expose an unknown error boundary.
+
+The last three user-visible PRs landed after `f3e1e25210`, the source commit named in the historical `0.18.0` changelog comparison URL, but before the `baml-language-0.18.0` tag. That mismatch explains those three omissions. It does not explain the other eight.
+
+## Process weaknesses exposed by the backtest
+
+1. The release boundary is ambiguous. The instructions discover a canary tag and compare it with `origin/canary`, while the published release may use a source commit that differs from the eventual stable tag. The process should record `BASE_SHA`, `HEAD_SHA`, and the artifact source SHA in every draft.
+2. Commit subjects are not sufficient for sparse titles such as `LSP (#4581)` or internally worded changes such as `Version compiler artifact envelopes (#4568)`. The process should require diff inspection for every commit whose subject does not state a user action or observable behavior.
+3. A net-zero public change can appear as two apparently user-visible commits. The process correctly needs a range-level check so additions reverted before the release, such as #4464/#4469, are excluded.
+4. The requested workflow does not name a file for the aggregated Step 2 output or the Step 3 classifications. This backtest uses `step2b-aggregated-user-effects.md` for both.
+5. The blog template says “Thanks to everyone who contributed!” but does not define whether contributor names are required. The historical package changelog records authors, while this blog draft does not invent an attribution policy.
+6. “User-visible” needs an explicit rule for developer-facing correctness changes. This backtest includes new diagnostics, prevention of compiler crashes, artifact compatibility errors, and IDE behavior because users can directly observe them.
+
+## Recommended amendments to `RELEASING.md`
+
+- Pin and print the exact comparison before analysis: `BASE_TAG`, `BASE_SHA`, `HEAD_REF`, `HEAD_SHA`, and the release artifact source SHA.
+- Run `git log --reverse --format='%H%x09%s' "$BASE_SHA..$HEAD_SHA" -- baml_language/` so later inspection never depends on abbreviated hashes.
+- Add a range-level verification pass: “For every included PR, confirm its user-visible effect remains present at `HEAD_SHA`.”
+- Add an explicit sparse-message rule: “Inspect the PR diff when the subject does not name the affected command, API, diagnostic, performance characteristic, or behavior.”
+- Define Step 2b and Step 3 output filenames.
+- Require every aggregate entry to carry PR links and exactly one classification token.
+- Add a reconciliation table against any package changelog generated elsewhere, so omissions and cutoff mismatches are visible before publishing.

--- a/typescript2/app-website/blog-releases/baml-language-0.18.0.md
+++ b/typescript2/app-website/blog-releases/baml-language-0.18.0.md
@@ -1,0 +1,284 @@
+Thanks to everyone who contributed!
+
+# Query your BAML execution history with SQL
+
+BAML now records detailed execution profiles locally. You can query calls, timing, errors, arguments, outputs, and call paths with portable SQL. The new playground Telemetry tab explores the same profile store. No external telemetry service is required. ([#4548](https://github.com/BoundaryML/baml/pull/4548), [#4563](https://github.com/BoundaryML/baml/pull/4563), [#4578](https://github.com/BoundaryML/baml/pull/4578))
+
+```shell
+baml query "SELECT thread_id, status, total_errors, started_at FROM threads WHERE parent_thread_id IS NULL ORDER BY started_at DESC LIMIT 20"
+baml query "SELECT fqn, sum(calls_started) AS calls, sum(self_ns) AS self_ns FROM call_path_stats GROUP BY fqn ORDER BY self_ns DESC LIMIT 10"
+```
+
+# Features
+
+## Observe every LLM call with `on_event`
+
+Direct calls, streams, and `ai.Agent` now accept the same `on_event` callback. The callback receives granular model, tool, usage, and lifecycle events. ([#4570](https://github.com/BoundaryML/baml/pull/4570))
+
+```baml
+let on_event = (event: ai.events.Event) -> void {
+    baml.log.info(event.to_string())
+};
+
+let result = Extract("input", on_event = on_event);
+let stream = Extract@stream("input", on_event = on_event);
+let agent = ai.Agent.new(client = MyClient, on_event = on_event);
+```
+
+## Iterate over Python streams asynchronously
+
+Python LLM streams now implement the asynchronous iterator protocol. Streaming parsing also processes ready deltas in batches for better throughput. ([#4604](https://github.com/BoundaryML/baml/pull/4604))
+
+```python
+stream = await StreamingExtract_stream_async("extract")
+async for partial in stream:
+    print(partial)
+final = await stream.final_async()
+```
+
+## Use the new project-aware language server
+
+The BAML editor extension now uses a new project-aware language server. It provides diagnostics, completion, hover, go-to-definition, references, symbols, semantic tokens, inlay hints, and code lenses. `baml ide install` materializes standard-library sources for go-to-definition and adds run code lenses for testsets. ([#4581](https://github.com/BoundaryML/baml/pull/4581))
+
+## Migrate Python applications more easily
+
+The Python SDK can preview prompts without provider secrets. It adds `FinishReasonError`, provider-specific response metadata, and other BAML v0 migration helpers. ([#4459](https://github.com/BoundaryML/baml/pull/4459))
+
+## Reflect over runtime classes and generic functions
+
+`reflect.AnyClass` provides checked, read-only access to static and runtime-created class values. Reflection can list generic functions, inspect their parameters, and specialize them before invocation. ([#4491](https://github.com/BoundaryML/baml/pull/4491), [#4493](https://github.com/BoundaryML/baml/pull/4493), [#4519](https://github.com/BoundaryML/baml/pull/4519))
+
+## Use runtime types in more places
+
+`unreflect(value)` can now appear in any type position where the runtime type does not escape its valid scope. `reflect.call_any<R>` also checks that the dynamic return value matches `R`. ([#4574](https://github.com/BoundaryML/baml/pull/4574), [#4600](https://github.com/BoundaryML/baml/pull/4600))
+
+## Program against common I/O interfaces
+
+`baml.io.Read` and `baml.io.Write` provide shared interfaces for files, network streams, subprocesses, byte arrays, and other standard I/O values. ([#4606](https://github.com/BoundaryML/baml/pull/4606))
+
+## Serialize values typed as `unknown`
+
+`baml.json.to_string(value)` and `baml.json.to_json(value)` inspect the runtime value, so they now work when its static type is `unknown`. ([#4601](https://github.com/BoundaryML/baml/pull/4601))
+
+## Use truthy values in conditions
+
+Conditions now accept truthy and falsy values such as numbers, strings, and collections. Branches narrow those values based on the condition. Strings also provide `is_empty()`. ([#4498](https://github.com/BoundaryML/baml/pull/4498))
+
+```baml
+if (items) {
+    // items is non-empty here
+}
+```
+
+## Project interface members
+
+BAML now supports `(Type as Interface).member` and `Interface.method(instance)`. ([#4500](https://github.com/BoundaryML/baml/pull/4500))
+
+## Infer stored lambda parameter types
+
+Stored lambdas can infer omitted parameter types from a concrete later use. ([#4599](https://github.com/BoundaryML/baml/pull/4599))
+
+## Preserve context when wrapping unknown errors
+
+`baml.errors.UnknownError` wraps arbitrary failures while retaining the original cause and stack trace. ([#4441](https://github.com/BoundaryML/baml/pull/4441))
+
+## Bound lazy iterators
+
+Lazy iterators now support `take`, `skip`, `take_while`, and `skip_while`. The adapters can safely bound infinite iterators. ([#4510](https://github.com/BoundaryML/baml/pull/4510))
+
+```baml
+let first_five = baml.iter.Repeat.new(0).take(5).collect();
+let page = baml.iter.Range.new(0, 100).skip(20).take(10).collect();
+```
+
+## Make primitive randomness reproducible
+
+`int.random`, `float.random`, `bool.random`, and `bigint.random` accept an optional `rng` value. ([#4135](https://github.com/BoundaryML/baml/pull/4135))
+
+## Control CLI language logs
+
+`baml run` and `baml test` now respect `BAML_LOG` and `--log <LEVEL>`. The CLI also explains when shutdown is waiting for active futures. ([#4408](https://github.com/BoundaryML/baml/pull/4408), [#4409](https://github.com/BoundaryML/baml/pull/4409))
+
+## Compile runtime packages faster
+
+Runtime package compilation starts faster because the standard-library prefix is precompiled. ([#4453](https://github.com/BoundaryML/baml/pull/4453))
+
+## Run compiler inference faster
+
+Compiler inference reuses canonical facts and alias caches across more queries. ([#4458](https://github.com/BoundaryML/baml/pull/4458), [#4461](https://github.com/BoundaryML/baml/pull/4461), [#4463](https://github.com/BoundaryML/baml/pull/4463))
+
+## Produce cleaner formatted code
+
+`baml fmt` removes redundant parentheses in binary expressions, call arguments, and method receivers. ([#4489](https://github.com/BoundaryML/baml/pull/4489), [#4541](https://github.com/BoundaryML/baml/pull/4541))
+
+## Detect incompatible generated artifacts
+
+Generated programs, packed binaries, and mounted package interfaces now carry version and checksum metadata. Corrupt or mismatched artifacts fail early with guidance to regenerate the SDK and bridge from the same build. ([#4568](https://github.com/BoundaryML/baml/pull/4568))
+
+# Breaking changes
+
+## Move reflection APIs to `reflect.*`
+
+Reflection is now a root package. Type views are also no longer accepted where an API requires a concrete `reflect.Type`. ([#4543](https://github.com/BoundaryML/baml/pull/4543), [#4580](https://github.com/BoundaryML/baml/pull/4580))
+
+Update code like this:
+
+```baml
+let t = type.of<User>();
+let package: baml.reflect.Package = baml.reflect.Package.compile(source);
+```
+
+To use the root package:
+
+```baml
+let t = reflect.Type.of<User>();
+let package: reflect.Package = reflect.Package.compile(source);
+```
+
+Host code that matches reflected error class names must also change `baml.reflect.errors.*` strings to `reflect.errors.*`.
+
+## Rename reflected field reads
+
+Update every `reflect.class.Field.read<T>()` call to `value<T>()`. ([#4493](https://github.com/BoundaryML/baml/pull/4493))
+
+```baml
+// Before
+let name = field.read<string>();
+
+// After
+let name = field.value<string>();
+```
+
+## Simplify JSON serialization
+
+`baml.json.encode` has been removed. `baml.json.to_string` and `baml.json.to_json` no longer take explicit generic arguments. ([#4601](https://github.com/BoundaryML/baml/pull/4601))
+
+```baml
+// Before
+let text = baml.json.encode(value);
+let json_value = baml.json.to_json<MyType>(value);
+
+// After
+let text = baml.json.to_string(value);
+let json_value = baml.json.to_json(value);
+```
+
+## Replace hash-delimited templates
+
+Hash-delimited Jinja string literals are no longer supported. Use BAML template literals. ([#4565](https://github.com/BoundaryML/baml/pull/4565))
+
+```baml
+// Before
+#"Hello {{ name }}"#
+
+// After
+`Hello ${name}`
+```
+
+## Rewrite legacy test declarations
+
+BAML v0 test declarations have been removed. Tests must use BAML v1 expression bodies. ([#4602](https://github.com/BoundaryML/baml/pull/4602))
+
+```baml
+// Before
+test ClassifyMessage {
+    functions [Classify1, Classify2]
+    args { input "hello" }
+}
+
+// After
+test "classifies a message" {
+    let result = Classify1("hello");
+    assert.equal(result, Expected)
+}
+```
+
+## Call `ctx.output_format`
+
+`ctx.output_format` is now a method. The method also restores controls for prefixes, enum formatting, class hoisting, map style, and null rendering. ([#4567](https://github.com/BoundaryML/baml/pull/4567))
+
+```baml
+// Before
+`${ctx.output_format}`
+
+// After
+`${ctx.output_format()}`
+```
+
+## Update generated SDK paths
+
+The default `baml_sdk` output directory is now beside `baml.toml`, not in its parent directory. Update imports or configure an explicit output directory if the old layout is required. ([#4522](https://github.com/BoundaryML/baml/pull/4522))
+
+## Rename the generated C# namespace
+
+Generated C# clients now use `baml_sdk` instead of `baml_client`. Update C# namespace imports and references. ([#4535](https://github.com/BoundaryML/baml/pull/4535))
+
+## Remove output generics from agents and runners
+
+`ai.Agent<Out>` and `ai.Runner<Out>` become `ai.Agent` and `ai.Runner`. The output type is inferred by `run<Out>`. Low-level `TurnStream.next()` consumers must also handle `string[] | Done` instead of `string | Done`. ([#4570](https://github.com/BoundaryML/baml/pull/4570), [#4604](https://github.com/BoundaryML/baml/pull/4604))
+
+```baml
+// Before
+let runner: ai.Runner<Result> = make_runner();
+
+// After
+let runner: ai.Runner = make_runner();
+let result: ai.RunResult<Result> = runner.run(spec);
+```
+
+## Specialize generic functions before storing them
+
+Stored function values are monomorphic. A bare generic function can no longer be assigned to a local and called with different inferred types. Direct calls remain generic. ([#4621](https://github.com/BoundaryML/baml/pull/4621))
+
+```baml
+// Before
+let copy = identity;
+
+// After: explicit specialization
+let copy = identity<string>;
+
+// Or provide a concrete function type
+let copy: (string) -> string throws never = identity;
+```
+
+## Make `throws unknown` precise
+
+`throws unknown` is rejected when a function throws nothing or only known, narrower types. Remove the declaration and use inferred throws, or declare the precise error type. Genuine unknown error boundaries can still use `throws unknown`. ([#4593](https://github.com/BoundaryML/baml/pull/4593))
+
+```baml
+// Before
+function parse() -> int throws unknown {
+    throw "invalid"
+}
+
+// After
+function parse() -> int throws string {
+    throw "invalid"
+}
+```
+
+# Bug fixes
+
+- Fixed: unsupported runtime-dependent checks now receive a compiler diagnostic instead of panicking or being silently omitted in release builds. ([#4460](https://github.com/BoundaryML/baml/pull/4460))
+- Fixed: member access and calls on `unknown` now report a compiler error instead of reaching an internal VM error. ([#4466](https://github.com/BoundaryML/baml/pull/4466))
+- Fixed: literal patterns use type-membership semantics instead of runtime equality. ([#4478](https://github.com/BoundaryML/baml/pull/4478))
+- Fixed: object mutations performed by callees inside loops persist on the original value. ([#4467](https://github.com/BoundaryML/baml/pull/4467))
+- Fixed: non-data LLM output schemas produce catchable diagnostics instead of crashes or silent schema omission. ([#4470](https://github.com/BoundaryML/baml/pull/4470))
+- Fixed: invalid dynamic use of unspecialized reflected generics produces a targeted error. ([#4473](https://github.com/BoundaryML/baml/pull/4473))
+- Fixed: `for` loops over joined collection arms and `Iterable`-bounded generics no longer abort the compiler. ([#4490](https://github.com/BoundaryML/baml/pull/4490))
+- Fixed: optional method calls preserve explicit and inferred type arguments. ([#4495](https://github.com/BoundaryML/baml/pull/4495))
+- Fixed: runtime-created and compiled-package types retain their identity, definitions, and source names through interface dispatch. ([#4501](https://github.com/BoundaryML/baml/pull/4501), [#4516](https://github.com/BoundaryML/baml/pull/4516), [#4536](https://github.com/BoundaryML/baml/pull/4536))
+- Fixed: invalid inline `unreflect` types receive actionable diagnostics when they would escape through return or thrown types. ([#4518](https://github.com/BoundaryML/baml/pull/4518), [#4530](https://github.com/BoundaryML/baml/pull/4530))
+- Fixed: method calls work on global bindings, and session assignments preserve each binding's type. ([#4529](https://github.com/BoundaryML/baml/pull/4529), [#4531](https://github.com/BoundaryML/baml/pull/4531))
+- Fixed: unsupported `naming_convention = "language"` SDK generation returns a normal error instead of panicking. ([#4526](https://github.com/BoundaryML/baml/pull/4526))
+- Fixed: reassigned short-circuit locals and branch-carried locals keep correct values after optimization. ([#4508](https://github.com/BoundaryML/baml/pull/4508), [#4544](https://github.com/BoundaryML/baml/pull/4544))
+- Fixed: match exhaustiveness preserves array type ascriptions. ([#4547](https://github.com/BoundaryML/baml/pull/4547))
+- Fixed: runtime-created types survive reflection and host boundaries without name collisions or lost identity. ([#4560](https://github.com/BoundaryML/baml/pull/4560), [#4577](https://github.com/BoundaryML/baml/pull/4577))
+- Fixed: type diagnostics point to the correct signature or default expression and no longer crash rendering. ([#4566](https://github.com/BoundaryML/baml/pull/4566))
+- Fixed: ambiguous empty arrays and maps receive a compiler diagnostic. ([#4573](https://github.com/BoundaryML/baml/pull/4573))
+- Fixed: rejected reflection compile artifacts no longer poison sessions, and invalid artifact reuse fails clearly. ([#4571](https://github.com/BoundaryML/baml/pull/4571))
+- Fixed: `eval()` preserves original runtime diagnostics and reflected schemas. ([#4583](https://github.com/BoundaryML/baml/pull/4583))
+- Fixed: invalid compiler types no longer degrade into `unknown`, and incompatible numeric compound assignments are rejected. ([#4603](https://github.com/BoundaryML/baml/pull/4603))
+- Fixed: HTTP operations work again in `baml run` and the playground. ([#4609](https://github.com/BoundaryML/baml/pull/4609))
+- Fixed: optional nested class values survive LLM response parsing when omitted fields are valid. ([#4612](https://github.com/BoundaryML/baml/pull/4612))
+- Fixed: class constructors that omit required fields receive a diagnostic listing the missing fields. ([#4619](https://github.com/BoundaryML/baml/pull/4619))

--- a/typescript2/app-website/blog-releases/step1-prs-only-user-visible.md
+++ b/typescript2/app-website/blog-releases/step1-prs-only-user-visible.md
@@ -1,0 +1,96 @@
+# Step 1: PRs with user-visible effects in `baml-language-0.17.0..baml-language-0.18.0`
+
+Scope: commits returned by `git log --reverse --format='%h %s' baml-language-0.17.0..baml-language-0.18.0 -- baml_language/` after fetching `origin` tags.
+
+- [#4453](https://github.com/BoundaryML/baml/pull/4453) — Precompile the standard-library prefix for runtime package compilation.
+- [#4458](https://github.com/BoundaryML/baml/pull/4458) — Memoize canonical compiler inference facts.
+- [#4460](https://github.com/BoundaryML/baml/pull/4460) — Harden runtime compilation boundaries and reject unsupported runtime-checked indirect calls.
+- [#4461](https://github.com/BoundaryML/baml/pull/4461) — Reuse compiler inference caches.
+- [#4463](https://github.com/BoundaryML/baml/pull/4463) — Restore alias memoization during implementation scans.
+- [#4408](https://github.com/BoundaryML/baml/pull/4408) — Log when CLI shutdown waits for active futures.
+- [#4409](https://github.com/BoundaryML/baml/pull/4409) — Surface log events from `baml run` and `baml test`.
+- [#4466](https://github.com/BoundaryML/baml/pull/4466) — Restore diagnostics for member access on `unknown` values.
+- [#4478](https://github.com/BoundaryML/baml/pull/4478) — Make literal patterns use membership semantics.
+- [#4489](https://github.com/BoundaryML/baml/pull/4489) — Remove redundant same-precedence parentheses in formatted code.
+- [#4467](https://github.com/BoundaryML/baml/pull/4467) — Preserve mutable object identity across calls inside loops.
+- [#4470](https://github.com/BoundaryML/baml/pull/4470) — Reject non-data LLM output schemas with diagnostics.
+- [#4473](https://github.com/BoundaryML/baml/pull/4473) — Diagnose unspecialized reflected generic functions.
+- [#4491](https://github.com/BoundaryML/baml/pull/4491) — Add read-only `AnyClass` reflection.
+- [#4493](https://github.com/BoundaryML/baml/pull/4493) — Refine the `AnyClass` API and related reflection behavior.
+- [#4490](https://github.com/BoundaryML/baml/pull/4490) — Prevent compiler aborts for joined collection arms and generic iterables.
+- [#4495](https://github.com/BoundaryML/baml/pull/4495) — Preserve type arguments through optional-chained calls.
+- [#4501](https://github.com/BoundaryML/baml/pull/4501) — Preserve runtime type definitions through dispatch and nested views.
+- [#4498](https://github.com/BoundaryML/baml/pull/4498) — Add truthiness in condition positions.
+- [#4518](https://github.com/BoundaryML/baml/pull/4518) — Diagnose inline `unreflect` type arguments that escape their call.
+- [#4516](https://github.com/BoundaryML/baml/pull/4516) — Preserve minted type identity through interface dispatch.
+- [#4519](https://github.com/BoundaryML/baml/pull/4519) — Add generic function listing and specialization to reflection.
+- [#4529](https://github.com/BoundaryML/baml/pull/4529) — Make global `let` bindings behave like ordinary bindings.
+- [#4531](https://github.com/BoundaryML/baml/pull/4531) — Type-check session assignments against their bindings.
+- [#4530](https://github.com/BoundaryML/baml/pull/4530) — Extend runtime-type escape checks to throws and optional chains.
+- [#4441](https://github.com/BoundaryML/baml/pull/4441) — Add first-class `UnknownError` wrapping.
+- [#4535](https://github.com/BoundaryML/baml/pull/4535) — Generate C# clients under `baml_sdk`.
+- [#4459](https://github.com/BoundaryML/baml/pull/4459) — Add Python SDK migration primitives for BAML v0 compatibility.
+- [#4526](https://github.com/BoundaryML/baml/pull/4526) — Return a normal error for unsupported `naming_convention = "language"` SDK generation.
+- [#4510](https://github.com/BoundaryML/baml/pull/4510) — Add lazy iterator bounding adapters.
+- [#4536](https://github.com/BoundaryML/baml/pull/4536) — Preserve compiled package type identity through interface dispatch.
+- [#4500](https://github.com/BoundaryML/baml/pull/4500) — Add interface member projections.
+- [#4508](https://github.com/BoundaryML/baml/pull/4508) — Materialize reassigned short-circuit locals correctly.
+- [#4544](https://github.com/BoundaryML/baml/pull/4544) — Prove stack-carried locals using predecessor coverage.
+- [#4522](https://github.com/BoundaryML/baml/pull/4522) — Generate `baml_sdk` next to `baml.toml` by default.
+- [#4547](https://github.com/BoundaryML/baml/pull/4547) — Preserve array type ascriptions in match coverage.
+- [#4548](https://github.com/BoundaryML/baml/pull/4548) — Add the segmented local profiling backend.
+- [#4541](https://github.com/BoundaryML/baml/pull/4541) — Remove redundant receiver parentheses and prevent an `unreflect` compiler crash.
+- [#4543](https://github.com/BoundaryML/baml/pull/4543) — Move reflection to the root `reflect` package.
+- [#4560](https://github.com/BoundaryML/baml/pull/4560) — Give runtime types stable heap-backed identity.
+- [#4565](https://github.com/BoundaryML/baml/pull/4565) — Reject legacy hash-delimited string literals.
+- [#4566](https://github.com/BoundaryML/baml/pull/4566) — Preserve diagnostic ownership and source locations for type references.
+- [#4135](https://github.com/BoundaryML/baml/pull/4135) — Add optional RNG parameters to primitive random methods.
+- [#4580](https://github.com/BoundaryML/baml/pull/4580) — Stop treating type views as subtypes of `reflect.Type`.
+- [#4570](https://github.com/BoundaryML/baml/pull/4570) — Add unified `on_event` handling to agents, direct calls, and streams.
+- [#4563](https://github.com/BoundaryML/baml/pull/4563) — Add `baml query` for SQL queries over local profiles.
+- [#4578](https://github.com/BoundaryML/baml/pull/4578) — Add a playground Telemetry tab backed by the local profile store.
+- [#4573](https://github.com/BoundaryML/baml/pull/4573) — Diagnose untyped empty arrays and maps.
+- [#4567](https://github.com/BoundaryML/baml/pull/4567) — Restore `ctx.output_format` options through a callable API.
+- [#4581](https://github.com/BoundaryML/baml/pull/4581) — Ship the new language server and IDE analysis layer.
+- [#4568](https://github.com/BoundaryML/baml/pull/4568) — Version and checksum compiler artifacts.
+- [#4571](https://github.com/BoundaryML/baml/pull/4571) — Make reflection compilation and session states explicit and recoverable.
+- [#4577](https://github.com/BoundaryML/baml/pull/4577) — Preserve runtime type identity across reflection boundaries.
+- [#4574](https://github.com/BoundaryML/baml/pull/4574) — Allow `unreflect` in any type position.
+- [#4583](https://github.com/BoundaryML/baml/pull/4583) — Preserve runtime diagnostics and reflected schemas.
+- [#4601](https://github.com/BoundaryML/baml/pull/4601) — Make JSON serialization work through `unknown` and simplify its API.
+- [#4600](https://github.com/BoundaryML/baml/pull/4600) — Validate `reflect.call_any` return values.
+- [#4603](https://github.com/BoundaryML/baml/pull/4603) — Stop invalid types from degrading into `unknown`.
+- [#4602](https://github.com/BoundaryML/baml/pull/4602) — Remove legacy test declarations.
+- [#4604](https://github.com/BoundaryML/baml/pull/4604) — Stabilize `Runner`, add async-iterable Python streams, and batch stream deltas.
+- [#4606](https://github.com/BoundaryML/baml/pull/4606) — Add `baml.io.Read` and `baml.io.Write` interfaces.
+- [#4599](https://github.com/BoundaryML/baml/pull/4599) — Infer stored lambda parameters from later uses.
+- [#4609](https://github.com/BoundaryML/baml/pull/4609) — Restore HTTP support in `baml run` and the playground.
+- [#4612](https://github.com/BoundaryML/baml/pull/4612) — Preserve optional classes whose fields are omitted in LLM output.
+- [#4619](https://github.com/BoundaryML/baml/pull/4619) — Reject class values that omit required fields.
+- [#4621](https://github.com/BoundaryML/baml/pull/4621) — Reject stored generic function values that have not been specialized.
+- [#4593](https://github.com/BoundaryML/baml/pull/4593) — Reject imprecise `throws unknown` declarations.
+
+## Excluded commits
+
+- [#4455](https://github.com/BoundaryML/baml/pull/4455) — Documentation-only update to the previous release's changelog.
+- [#4462](https://github.com/BoundaryML/baml/pull/4462) — CI-only fixture serialization.
+- [#4464](https://github.com/BoundaryML/baml/pull/4464) — Public reflection surface added and then reverted within this release range.
+- [#4469](https://github.com/BoundaryML/baml/pull/4469) — Revert of #4464, leaving no net public change.
+- [#4456](https://github.com/BoundaryML/baml/pull/4456) — Release automation and changelog cleanup.
+- [#4472](https://github.com/BoundaryML/baml/pull/4472) — Release verification policy only.
+- [#4378](https://github.com/BoundaryML/baml/pull/4378) — Private Ruby bridge prerequisite without a released user-facing Ruby SDK surface.
+- [#4465](https://github.com/BoundaryML/baml/pull/4465) — Binary size baseline refresh only.
+- [#4499](https://github.com/BoundaryML/baml/pull/4499) — Test timing and hermeticity only.
+- [#4517](https://github.com/BoundaryML/baml/pull/4517) — Test cleanup only.
+- [#4481](https://github.com/BoundaryML/baml/pull/4481) — CI performance changes only.
+- [#4533](https://github.com/BoundaryML/baml/pull/4533) — Python bridge test setup performance only.
+- [#4554](https://github.com/BoundaryML/baml/pull/4554) — Binary size baseline refresh only.
+- [#4562](https://github.com/BoundaryML/baml/pull/4562) — Internal bytecode snapshot rendering only.
+- [#4564](https://github.com/BoundaryML/baml/pull/4564) — Release verification fixes only.
+- [#4569](https://github.com/BoundaryML/baml/pull/4569) — Removal of an already-unused playground message protocol.
+- [#4572](https://github.com/BoundaryML/baml/pull/4572) — Test fixture cleanup only.
+- [#4575](https://github.com/BoundaryML/baml/pull/4575) — C# release verification refactor only.
+- [#4582](https://github.com/BoundaryML/baml/pull/4582) — CI cache and parallelism changes only.
+- [#4626](https://github.com/BoundaryML/baml/pull/4626) — Deterministic LSP test assertion only.
+- [#4628](https://github.com/BoundaryML/baml/pull/4628) — Changelog-only release documentation.
+- [#4629](https://github.com/BoundaryML/baml/pull/4629) — Release version stamping only.

--- a/typescript2/app-website/blog-releases/step2a-pr-user-effects.md
+++ b/typescript2/app-website/blog-releases/step2a-pr-user-effects.md
@@ -1,0 +1,349 @@
+# Step 2a: user effects by PR
+
+## [#4453](https://github.com/BoundaryML/baml/pull/4453)
+
+- Runtime calls to `reflect.Package.compile` start faster because the standard-library compiler prefix is precompiled.
+
+## [#4458](https://github.com/BoundaryML/baml/pull/4458)
+
+- Repeated compiler queries avoid recomputing canonical body-inference facts.
+- Compilation is faster without changing valid program behavior.
+
+## [#4460](https://github.com/BoundaryML/baml/pull/4460)
+
+- Unsupported runtime-checked arguments on indirect calls now receive an `E0010` diagnostic.
+- Release builds no longer silently omit those runtime checks.
+- Runtime-created type names no longer leak through mounted-package diagnostics.
+
+## [#4461](https://github.com/BoundaryML/baml/pull/4461)
+
+- Compiler inference caches are reused across more queries.
+- Compilation is faster without changing valid program behavior.
+
+## [#4463](https://github.com/BoundaryML/baml/pull/4463)
+
+- Implementation scans reuse alias inference results.
+- Compilation is faster for code with aliases and implementations.
+
+## [#4408](https://github.com/BoundaryML/baml/pull/4408)
+
+- The CLI logs when shutdown is waiting for spawned work to finish.
+- Users can identify background tasks that delay process exit.
+
+## [#4409](https://github.com/BoundaryML/baml/pull/4409)
+
+- `baml run` and `baml test` surface language log events.
+- `BAML_LOG` and `--log <LEVEL>` control those events.
+
+## [#4466](https://github.com/BoundaryML/baml/pull/4466)
+
+- Member access and method calls on `unknown` produce a compiler diagnostic.
+- Invalid calls no longer reach an internal VM error.
+
+## [#4478](https://github.com/BoundaryML/baml/pull/4478)
+
+- Literal patterns now test whether a value belongs to the literal type.
+- They no longer behave like a runtime `==` comparison.
+
+## [#4489](https://github.com/BoundaryML/baml/pull/4489)
+
+- `baml fmt` removes redundant parentheses in binary chains and call arguments.
+
+## [#4467](https://github.com/BoundaryML/baml/pull/4467)
+
+- Mutations to maps, arrays, and class values persist when a called function mutates them inside a loop.
+- The compiler no longer reallocates the pre-loop value on every iteration.
+
+## [#4470](https://github.com/BoundaryML/baml/pull/4470)
+
+- Non-data types such as function values and raw type values cannot be used as LLM output schemas.
+- Invalid schemas produce catchable diagnostics instead of aborting or silently omitting the schema.
+
+## [#4473](https://github.com/BoundaryML/baml/pull/4473)
+
+- Extracting or dynamically invoking an unspecialized generic function produces a targeted reflection diagnostic.
+- Generated generic companions remain discoverable.
+
+## [#4491](https://github.com/BoundaryML/baml/pull/4491)
+
+- `reflect.AnyClass` can hold either a static class value or a runtime-created class value.
+- Users can inspect fields and read their values through a checked reflection API.
+
+## [#4493](https://github.com/BoundaryML/baml/pull/4493)
+
+- `reflect.class.Field.read<T>()` is renamed to `value<T>()`.
+- Invalid construction of built-in companion classes produces a compiler diagnostic.
+- Infinite `while (true)` loops without reachable breaks count as diverging control flow.
+
+## [#4490](https://github.com/BoundaryML/baml/pull/4490)
+
+- `for` loops work over collection values joined from conditional arms.
+- `for` loops work over values bounded by `baml.iter.Iterable`.
+- These cases no longer abort the compiler.
+
+## [#4495](https://github.com/BoundaryML/baml/pull/4495)
+
+- Optional-chained method calls preserve explicit and inferred type arguments.
+- Calls such as `value?.method<T>()` no longer fail with an internal frame error.
+
+## [#4501](https://github.com/BoundaryML/baml/pull/4501)
+
+- Runtime-defined types retain their definitions through interface dispatch.
+- Nested type views and pending reflection fields keep the correct metadata.
+
+## [#4498](https://github.com/BoundaryML/baml/pull/4498)
+
+- Conditions accept truthy and falsy values such as numbers, strings, and collections.
+- `if` branches narrow types based on truthiness.
+- Strings provide an `is_empty()` helper.
+
+## [#4518](https://github.com/BoundaryML/baml/pull/4518)
+
+- Inline `unreflect(value)` type arguments that escape into a published result receive `E0168`.
+- The diagnostic suggests binding the runtime type to a named type first.
+
+## [#4516](https://github.com/BoundaryML/baml/pull/4516)
+
+- Runtime-created class and enum types preserve identity through interface calls.
+- Identity-keyed type registries no longer miss values inside implementations.
+
+## [#4519](https://github.com/BoundaryML/baml/pull/4519)
+
+- `reflect.Package.functions()` lists generic functions.
+- Reflection exposes generic parameter inspection and explicit specialization.
+- Specialized reflected functions can be invoked with runtime-created type arguments.
+
+## [#4529](https://github.com/BoundaryML/baml/pull/4529)
+
+- Method calls work on top-level bindings such as declared clients.
+- Session `let` bindings widen fresh literal values to their ordinary base types.
+
+## [#4531](https://github.com/BoundaryML/baml/pull/4531)
+
+- Assignments inside a reflection session are checked against the binding's type.
+- Invalid assignments fail during compilation instead of corrupting the session value.
+
+## [#4530](https://github.com/BoundaryML/baml/pull/4530)
+
+- The `unreflect` escape diagnostic also covers thrown types and optional-chained return types.
+- Naming the runtime type before use remains the supported migration.
+
+## [#4441](https://github.com/BoundaryML/baml/pull/4441)
+
+- `baml.errors.UnknownError` wraps arbitrary errors while preserving their cause and stack trace.
+- Users can normalize unknown failures without discarding debugging context.
+
+## [#4535](https://github.com/BoundaryML/baml/pull/4535)
+
+- Generated C# code uses the `baml_sdk` namespace instead of `baml_client`.
+
+## [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+- Python can preview prompts without requiring provider secrets.
+- Python exposes `FinishReasonError` and provider-specific response metadata.
+- Python gains migration helpers for BAML v0 applications.
+
+## [#4526](https://github.com/BoundaryML/baml/pull/4526)
+
+- SDK generation with unsupported `naming_convention = "language"` returns a normal error.
+- The generator no longer panics.
+
+## [#4510](https://github.com/BoundaryML/baml/pull/4510)
+
+- Lazy iterators support `take`, `skip`, `take_while`, and `skip_while`.
+- These adapters can bound infinite iterators without eagerly consuming them.
+
+## [#4536](https://github.com/BoundaryML/baml/pull/4536)
+
+- Types from a compiled package keep their package-specific identity through interface dispatch.
+- Runtime diagnostics and JSON conversion display source names instead of internal names.
+
+## [#4500](https://github.com/BoundaryML/baml/pull/4500)
+
+- Users can access interface members through `(Type as Interface).member`.
+- Users can call instance methods through `Interface.method(instance)`.
+
+## [#4508](https://github.com/BoundaryML/baml/pull/4508)
+
+- Reassigned locals used by short-circuit expressions retain their values.
+- Valid code no longer reads an uninitialized or stale local after optimization.
+
+## [#4544](https://github.com/BoundaryML/baml/pull/4544)
+
+- Locals carried across branches and loops are initialized using all predecessor paths.
+- Valid control-flow code no longer fails because of an incorrect stack-local proof.
+
+## [#4522](https://github.com/BoundaryML/baml/pull/4522)
+
+- Generated SDKs are written beside `baml.toml` by default.
+- Projects that expected `baml_sdk` in the parent directory must update imports or generator output settings.
+
+## [#4547](https://github.com/BoundaryML/baml/pull/4547)
+
+- Match exhaustiveness preserves authored array type ascriptions.
+- Array arms are no longer treated as the wrong shape during coverage analysis.
+
+## [#4548](https://github.com/BoundaryML/baml/pull/4548)
+
+- BAML records local execution profiles in a segmented store.
+- Profiles retain call-tree and exact execution evidence for later queries.
+
+## [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+- `baml fmt` removes redundant parentheses around method-call receivers.
+- Valid `unreflect` expressions no longer trigger a MIR compiler crash.
+
+## [#4543](https://github.com/BoundaryML/baml/pull/4543)
+
+- Reflection moves from `baml.reflect.*` to the root `reflect.*` package.
+- `type.of<T>()` becomes `reflect.Type.of<T>()`.
+- Reflection error class names exposed to host SDKs also move to `reflect.errors.*`.
+
+## [#4560](https://github.com/BoundaryML/baml/pull/4560)
+
+- Runtime-created type declarations have stable identity even when names collide.
+- Runtime-defined class and enum values can safely cross reflection and host boundaries.
+- Recursive type aliases work in more runtime reflection paths.
+
+## [#4565](https://github.com/BoundaryML/baml/pull/4565)
+
+- Hash-delimited Jinja string literals such as `#"..."#` are rejected.
+- LLM prompts must use BAML template literals.
+
+## [#4566](https://github.com/BoundaryML/baml/pull/4566)
+
+- Type errors in function signatures and parameter defaults point to the correct source range.
+- Unresolved types no longer panic diagnostic rendering.
+
+## [#4135](https://github.com/BoundaryML/baml/pull/4135)
+
+- `int.random`, `float.random`, `bool.random`, and `bigint.random` accept an optional `rng` argument.
+- Users can make primitive random generation reproducible.
+
+## [#4580](https://github.com/BoundaryML/baml/pull/4580)
+
+- Reflection type views are no longer accepted where a concrete `reflect.Type` is required.
+- Users must resolve or construct a concrete reflected type before passing it to those APIs.
+
+## [#4570](https://github.com/BoundaryML/baml/pull/4570)
+
+- Direct LLM calls, streams, and `ai.Agent` accept the same `on_event` callback.
+- The callback exposes granular model, tool, usage, and lifecycle events.
+- `ai.Agent` no longer takes an output type parameter.
+
+## [#4563](https://github.com/BoundaryML/baml/pull/4563)
+
+- `baml query` executes SQL against local execution profiles.
+- Users can inspect runs without exporting telemetry to another service.
+
+## [#4578](https://github.com/BoundaryML/baml/pull/4578)
+
+- The playground has a Telemetry tab for exploring locally stored profiles.
+- The tab reads the same canonical profile store as `baml query`.
+
+## [#4573](https://github.com/BoundaryML/baml/pull/4573)
+
+- Empty arrays and maps require enough context to infer their element types.
+- Ambiguous empty containers produce a compiler diagnostic instead of an invalid runtime value.
+
+## [#4567](https://github.com/BoundaryML/baml/pull/4567)
+
+- `ctx.output_format` becomes the callable `ctx.output_format()` API.
+- Output-format controls such as prefixes, enum formatting, class hoisting, map style, and null rendering are restored.
+
+## [#4581](https://github.com/BoundaryML/baml/pull/4581)
+
+- The BAML extension uses a new project-aware language server.
+- Editor features include diagnostics, completion, hover, go-to-definition, references, symbols, semantic tokens, inlay hints, and code lenses.
+- `baml ide install` materializes standard-library sources so go-to-definition can open them.
+- Testset blocks receive run code lenses.
+
+## [#4568](https://github.com/BoundaryML/baml/pull/4568)
+
+- Generated programs, packed binaries, and mounted package interfaces carry version and integrity metadata.
+- Corrupt or incompatible artifacts fail early with instructions to regenerate matching SDK and bridge artifacts.
+
+## [#4571](https://github.com/BoundaryML/baml/pull/4571)
+
+- Reflection compile artifacts cannot be consumed twice or as the wrong artifact kind.
+- Sessions remain usable after a rejected compile artifact.
+- Session-generated names no longer collide with user bindings.
+
+## [#4577](https://github.com/BoundaryML/baml/pull/4577)
+
+- Runtime type identity survives additional reflection and dispatch boundaries.
+- Reflected schemas and values continue to refer to the same runtime declaration.
+
+## [#4574](https://github.com/BoundaryML/baml/pull/4574)
+
+- `unreflect(value)` can appear in any type position when its runtime scope is valid.
+
+## [#4583](https://github.com/BoundaryML/baml/pull/4583)
+
+- Errors thrown by evaluated code retain their original runtime diagnostics.
+- Reflected schemas survive evaluation and package boundaries.
+
+## [#4601](https://github.com/BoundaryML/baml/pull/4601)
+
+- `baml.json.to_string(value)` and `baml.json.to_json(value)` serialize values typed as `unknown`.
+- The functions no longer take explicit generic arguments.
+- `baml.json.encode` is removed.
+
+## [#4600](https://github.com/BoundaryML/baml/pull/4600)
+
+- `reflect.call_any<R>` checks the dynamic function result against `R`.
+- Mismatches raise a reflection error instead of returning an invalid typed value.
+
+## [#4603](https://github.com/BoundaryML/baml/pull/4603)
+
+- Invalid or unresolved compiler types no longer silently become the valid top type `unknown`.
+- Invalid numeric compound assignments are rejected during compilation.
+
+## [#4602](https://github.com/BoundaryML/baml/pull/4602)
+
+- BAML v0 `test Name { functions [...] }` declarations are removed.
+- Tests must use BAML v1 expression bodies.
+
+## [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+- Python LLM streams support `async for`.
+- Streaming parsing consumes ready delta batches for better throughput.
+- `ai.Runner<Out>` becomes `ai.Runner`, with `Out` inferred by `run<Out>`.
+- `TurnStream.next()` returns `string[] | Done` instead of `string | Done`.
+
+## [#4606](https://github.com/BoundaryML/baml/pull/4606)
+
+- `baml.io.Read` and `baml.io.Write` define common I/O interfaces.
+- Files, network streams, subprocesses, byte arrays, and other standard I/O values implement the shared interfaces where appropriate.
+
+## [#4599](https://github.com/BoundaryML/baml/pull/4599)
+
+- A stored lambda can infer omitted parameter types from later uses.
+- Users need fewer redundant lambda annotations when a concrete call or assignment supplies the type.
+
+## [#4609](https://github.com/BoundaryML/baml/pull/4609)
+
+- HTTP operations work again in `baml run` and the playground.
+
+## [#4612](https://github.com/BoundaryML/baml/pull/4612)
+
+- LLM response parsing preserves an optional nested class when omitted fields are valid.
+- The parser no longer collapses that class to `null` solely because optional fields are absent.
+
+## [#4619](https://github.com/BoundaryML/baml/pull/4619)
+
+- Class constructors that omit non-nullable fields receive a diagnostic listing every missing field.
+- Nullable fields remain omittable.
+- `unknown` fields require an explicit value and are not implicitly omitted.
+
+## [#4621](https://github.com/BoundaryML/baml/pull/4621)
+
+- A generic function cannot be stored before its type parameters are specialized.
+- The diagnostic suggests an explicit specialization or a concrete function-type annotation.
+- Direct generic calls continue to infer fresh type arguments.
+
+## [#4593](https://github.com/BoundaryML/baml/pull/4593)
+
+- `throws unknown` is rejected when the function throws nothing or only a narrower known type.
+- A genuine unknown error boundary can still declare `throws unknown`.
+- The diagnostic suggests inference or a precise explicit throws type.

--- a/typescript2/app-website/blog-releases/step2b-aggregated-user-effects.md
+++ b/typescript2/app-website/blog-releases/step2b-aggregated-user-effects.md
@@ -1,0 +1,327 @@
+# Step 2b and Step 3: aggregated user effects with classifications
+
+Each entry has exactly one classification. A PR may appear in more than one entry when it has separate user effects that belong in different changelog sections.
+
+## Local execution telemetry and SQL queries
+
+- Classification: `HEADLINE_CHANGE`
+- PRs: [#4548](https://github.com/BoundaryML/baml/pull/4548), [#4563](https://github.com/BoundaryML/baml/pull/4563), [#4578](https://github.com/BoundaryML/baml/pull/4578)
+- BAML now stores local execution profiles, queries them with SQL through `baml query`, and explores them in the playground Telemetry tab.
+
+## Unified LLM event callbacks
+
+- Classification: `FEATURE`
+- PRs: [#4570](https://github.com/BoundaryML/baml/pull/4570)
+- Direct LLM calls, streams, and agents now accept the same `on_event` callback for granular model, tool, usage, and lifecycle events.
+
+## Async-iterable Python streams
+
+- Classification: `FEATURE`
+- PRs: [#4604](https://github.com/BoundaryML/baml/pull/4604)
+- Python users can consume LLM streams with `async for`, while batched delta processing improves streaming throughput.
+
+## New project-aware language server
+
+- Classification: `FEATURE`
+- PRs: [#4581](https://github.com/BoundaryML/baml/pull/4581)
+- The editor extension gains a new project-aware language server, standard-library go-to-definition, and run code lenses for testsets.
+
+## Python SDK migration support
+
+- Classification: `FEATURE`
+- PRs: [#4459](https://github.com/BoundaryML/baml/pull/4459)
+- Python can preview prompts without provider secrets and exposes finish-reason failures, provider metadata, and BAML v0 migration helpers.
+
+## Runtime class and generic function reflection
+
+- Classification: `FEATURE`
+- PRs: [#4491](https://github.com/BoundaryML/baml/pull/4491), [#4493](https://github.com/BoundaryML/baml/pull/4493), [#4519](https://github.com/BoundaryML/baml/pull/4519)
+- Reflection can inspect `AnyClass` values, list generic functions, and explicitly specialize reflected generics.
+
+## More flexible dynamic types and calls
+
+- Classification: `FEATURE`
+- PRs: [#4574](https://github.com/BoundaryML/baml/pull/4574), [#4600](https://github.com/BoundaryML/baml/pull/4600)
+- `unreflect` works in any valid type position, and `reflect.call_any<R>` verifies that dynamic results match `R`.
+
+## Common read and write interfaces
+
+- Classification: `FEATURE`
+- PRs: [#4606](https://github.com/BoundaryML/baml/pull/4606)
+- `baml.io.Read` and `baml.io.Write` provide shared interfaces across standard I/O values.
+
+## JSON serialization through `unknown`
+
+- Classification: `FEATURE`
+- PRs: [#4601](https://github.com/BoundaryML/baml/pull/4601)
+- `baml.json.to_string` and `baml.json.to_json` can serialize values whose static type is `unknown`.
+
+## Truthy conditions
+
+- Classification: `FEATURE`
+- PRs: [#4498](https://github.com/BoundaryML/baml/pull/4498)
+- Condition positions accept truthy and falsy values and narrow branch types accordingly. Strings also provide `is_empty()`.
+
+## Interface member projections
+
+- Classification: `FEATURE`
+- PRs: [#4500](https://github.com/BoundaryML/baml/pull/4500)
+- Users can access `(Type as Interface).member` and call `Interface.method(instance)`.
+
+## Lambda parameter inference from later use
+
+- Classification: `FEATURE`
+- PRs: [#4599](https://github.com/BoundaryML/baml/pull/4599)
+- Stored lambdas can infer omitted parameter types from concrete later uses.
+
+## Error wrapping that preserves context
+
+- Classification: `FEATURE`
+- PRs: [#4441](https://github.com/BoundaryML/baml/pull/4441)
+- `baml.errors.UnknownError` wraps arbitrary errors without losing the original cause or stack trace.
+
+## Lazy iterator bounds
+
+- Classification: `FEATURE`
+- PRs: [#4510](https://github.com/BoundaryML/baml/pull/4510)
+- Iterators support `take`, `skip`, `take_while`, and `skip_while`.
+
+## Reproducible primitive random values
+
+- Classification: `FEATURE`
+- PRs: [#4135](https://github.com/BoundaryML/baml/pull/4135)
+- Primitive random methods accept an optional RNG instance.
+
+## CLI language logs
+
+- Classification: `FEATURE`
+- PRs: [#4408](https://github.com/BoundaryML/baml/pull/4408), [#4409](https://github.com/BoundaryML/baml/pull/4409)
+- `baml run` and `baml test` respect log-level controls and explain shutdown waits.
+
+## Faster runtime package compilation
+
+- Classification: `FEATURE`
+- PRs: [#4453](https://github.com/BoundaryML/baml/pull/4453)
+- Precompiled standard-library state reduces the startup cost of `reflect.Package.compile`.
+
+## Faster compiler inference
+
+- Classification: `FEATURE`
+- PRs: [#4458](https://github.com/BoundaryML/baml/pull/4458), [#4461](https://github.com/BoundaryML/baml/pull/4461), [#4463](https://github.com/BoundaryML/baml/pull/4463)
+- Reused inference facts and alias caches reduce repeated compiler work.
+
+## Cleaner formatter output
+
+- Classification: `FEATURE`
+- PRs: [#4489](https://github.com/BoundaryML/baml/pull/4489), [#4541](https://github.com/BoundaryML/baml/pull/4541)
+- `baml fmt` removes redundant parentheses in binary expressions, call arguments, and method receivers.
+
+## Self-validating compiler artifacts
+
+- Classification: `FEATURE`
+- PRs: [#4568](https://github.com/BoundaryML/baml/pull/4568)
+- Generated programs, packed binaries, and package interfaces carry version and checksum metadata so incompatible artifacts fail with regeneration guidance.
+
+## Reflection package and type migration
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4543](https://github.com/BoundaryML/baml/pull/4543), [#4580](https://github.com/BoundaryML/baml/pull/4580)
+- Reflection APIs move from `baml.reflect.*` to `reflect.*`, and type views can no longer stand in for concrete `reflect.Type` values.
+
+## Reflection field accessor rename
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4493](https://github.com/BoundaryML/baml/pull/4493)
+- `reflect.class.Field.read<T>()` is renamed to `value<T>()`.
+
+## JSON API simplification
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4601](https://github.com/BoundaryML/baml/pull/4601)
+- Remove `baml.json.encode` and remove explicit generic arguments from `baml.json.to_string` and `baml.json.to_json`.
+
+## Hash-delimited templates removed
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4565](https://github.com/BoundaryML/baml/pull/4565)
+- Hash-delimited Jinja strings are rejected; prompts must use BAML template literals.
+
+## Legacy test declarations removed
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4602](https://github.com/BoundaryML/baml/pull/4602)
+- BAML v0 test declarations must be rewritten as BAML v1 expression-body tests.
+
+## Callable output-format context
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4567](https://github.com/BoundaryML/baml/pull/4567)
+- `ctx.output_format` becomes `ctx.output_format()`, with the v0 formatting options restored as arguments.
+
+## Generated SDK location
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4522](https://github.com/BoundaryML/baml/pull/4522)
+- `baml_sdk` is generated beside `baml.toml` instead of in its parent directory.
+
+## Generated C# namespace
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4535](https://github.com/BoundaryML/baml/pull/4535)
+- Generated C# code uses `baml_sdk` instead of `baml_client`.
+
+## Agent, runner, and low-level stream generics
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4570](https://github.com/BoundaryML/baml/pull/4570), [#4604](https://github.com/BoundaryML/baml/pull/4604)
+- Remove the output generic from `ai.Agent` and `ai.Runner`, infer it on `run`, and return batches from `TurnStream.next()`.
+
+## Stored generic functions require specialization
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4621](https://github.com/BoundaryML/baml/pull/4621)
+- A generic function stored as a value must have explicit type arguments or a concrete function-type context.
+
+## Precise `throws unknown` contracts
+
+- Classification: `BREAKING_CHANGE`
+- PRs: [#4593](https://github.com/BoundaryML/baml/pull/4593)
+- `throws unknown` is rejected unless an unknown-typed failure can actually escape.
+
+## Runtime compilation boundary diagnostics
+
+- Classification: `BUGFIX`
+- PRs: [#4460](https://github.com/BoundaryML/baml/pull/4460)
+- Unsupported runtime-dependent checks fail at compile time instead of panicking or being omitted in release builds.
+
+## Diagnostics for member access on `unknown`
+
+- Classification: `BUGFIX`
+- PRs: [#4466](https://github.com/BoundaryML/baml/pull/4466)
+- Invalid member access on `unknown` reports a compiler error instead of reaching the VM.
+
+## Literal pattern semantics
+
+- Classification: `BUGFIX`
+- PRs: [#4478](https://github.com/BoundaryML/baml/pull/4478)
+- Literal patterns use type-membership semantics rather than runtime equality.
+
+## Mutable identity across loop calls
+
+- Classification: `BUGFIX`
+- PRs: [#4467](https://github.com/BoundaryML/baml/pull/4467)
+- Mutations performed by callees inside loops persist on the original object.
+
+## Invalid LLM output schemas
+
+- Classification: `BUGFIX`
+- PRs: [#4470](https://github.com/BoundaryML/baml/pull/4470)
+- Non-data LLM schemas produce catchable diagnostics instead of crashes or silent schema omission.
+
+## Unspecialized reflected generic diagnostics
+
+- Classification: `BUGFIX`
+- PRs: [#4473](https://github.com/BoundaryML/baml/pull/4473)
+- Invalid dynamic use of unspecialized reflected generics fails with a targeted error.
+
+## Generic and joined-collection loops
+
+- Classification: `BUGFIX`
+- PRs: [#4490](https://github.com/BoundaryML/baml/pull/4490)
+- Loops over joined collection arms and `Iterable`-bounded generics no longer abort compilation.
+
+## Optional-chained generic calls
+
+- Classification: `BUGFIX`
+- PRs: [#4495](https://github.com/BoundaryML/baml/pull/4495)
+- Optional method calls preserve explicit and inferred type arguments.
+
+## Runtime type identity through dispatch
+
+- Classification: `BUGFIX`
+- PRs: [#4501](https://github.com/BoundaryML/baml/pull/4501), [#4516](https://github.com/BoundaryML/baml/pull/4516), [#4536](https://github.com/BoundaryML/baml/pull/4536)
+- Runtime-created and compiled-package types retain identity, definitions, and source names through interface dispatch.
+
+## Safe inline `unreflect`
+
+- Classification: `BUGFIX`
+- PRs: [#4518](https://github.com/BoundaryML/baml/pull/4518), [#4530](https://github.com/BoundaryML/baml/pull/4530)
+- Runtime types that would escape through return or thrown types receive an actionable diagnostic instead of reaching invalid lowering.
+
+## Global and session bindings
+
+- Classification: `BUGFIX`
+- PRs: [#4529](https://github.com/BoundaryML/baml/pull/4529), [#4531](https://github.com/BoundaryML/baml/pull/4531)
+- Method calls work on global bindings, and session assignments preserve the binding's declared type.
+
+## SDK naming errors
+
+- Classification: `BUGFIX`
+- PRs: [#4526](https://github.com/BoundaryML/baml/pull/4526)
+- Unsupported language-native SDK naming returns a normal error instead of panicking.
+
+## Correct stack-carried locals
+
+- Classification: `BUGFIX`
+- PRs: [#4508](https://github.com/BoundaryML/baml/pull/4508), [#4544](https://github.com/BoundaryML/baml/pull/4544)
+- Reassigned short-circuit locals and branch-carried locals retain correct values after optimization.
+
+## Array match coverage
+
+- Classification: `BUGFIX`
+- PRs: [#4547](https://github.com/BoundaryML/baml/pull/4547)
+- Match exhaustiveness preserves array type ascriptions.
+
+## Stable runtime type identity
+
+- Classification: `BUGFIX`
+- PRs: [#4560](https://github.com/BoundaryML/baml/pull/4560), [#4577](https://github.com/BoundaryML/baml/pull/4577)
+- Runtime-created types survive reflection and host boundaries without name collisions or lost identity.
+
+## Correct diagnostic source locations
+
+- Classification: `BUGFIX`
+- PRs: [#4566](https://github.com/BoundaryML/baml/pull/4566)
+- Type errors point to their owning signature or default expression and no longer crash rendering.
+
+## Ambiguous empty containers
+
+- Classification: `BUGFIX`
+- PRs: [#4573](https://github.com/BoundaryML/baml/pull/4573)
+- Empty arrays and maps without enough type context receive a diagnostic.
+
+## Recoverable reflection sessions
+
+- Classification: `BUGFIX`
+- PRs: [#4571](https://github.com/BoundaryML/baml/pull/4571)
+- Rejected compile artifacts no longer poison sessions, and invalid artifact reuse fails clearly.
+
+## Preserved evaluated errors and schemas
+
+- Classification: `BUGFIX`
+- PRs: [#4583](https://github.com/BoundaryML/baml/pull/4583)
+- `eval()` preserves original runtime diagnostics and reflected schema values.
+
+## Invalid compiler types
+
+- Classification: `BUGFIX`
+- PRs: [#4603](https://github.com/BoundaryML/baml/pull/4603)
+- Invalid types no longer degrade into `unknown`, and incompatible numeric compound assignments are rejected.
+
+## HTTP in CLI and playground
+
+- Classification: `BUGFIX`
+- PRs: [#4609](https://github.com/BoundaryML/baml/pull/4609)
+- HTTP operations work again in `baml run` and the playground.
+
+## Optional nested classes in LLM output
+
+- Classification: `BUGFIX`
+- PRs: [#4612](https://github.com/BoundaryML/baml/pull/4612)
+- Optional nested class values survive response parsing when their omitted fields are valid.
+
+## Missing required class fields
+
+- Classification: `BUGFIX`
+- PRs: [#4619](https://github.com/BoundaryML/baml/pull/4619)
+- Class constructors that omit required fields receive one diagnostic listing the missing fields.


### PR DESCRIPTION
## Summary

- backtest the proposed changelog drafting workflow against `baml-language-0.17.0..baml-language-0.18.0`
- add the filtered PR inventory, per-PR user effects, aggregated classifications, and a release-style changelog draft
- document the release-boundary ambiguity and 11 user-visible PRs omitted from the historical 0.18.0 changelog

## Validation

- reconciled all 89 scoped PR IDs: 67 included and 22 explicitly excluded
- verified the same 67 included PRs appear in every drafting artifact
- verified all 54 aggregate entries have exactly one classification
- checked balanced code fences and trailing whitespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive BAML 0.18.0 release notes covering new features, breaking changes, and bug fixes.
  * Documented user-visible changes across the compiler, runtime, SDKs, language server, CLI, and playground.
  * Added categorized summaries of individual pull requests and their user-facing effects.
  * Added a backtest report evaluating the changelog process and identifying recommended improvements.
  * Documented changes included in the BAML 0.17.0–0.18.0 release range, including excluded non-user-facing work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->