### PR TITLE
Connect generated reference discovery

### DIFF
--- a/typescript2/app-developer-docs/app/baml/packages/[version]/[...fqn]/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/[version]/[...fqn]/page.tsx
@@ -3,12 +3,18 @@ import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import {
   GeneratedReferenceContent,
+  type ReferenceChildLink,
   referencePageTableOfContents,
 } from '@/components/generated-reference';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { directRouteChildren } from '@/lib/generated-content/routes';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
@@ -32,7 +38,20 @@ async function loadPage(version: string, fqn: readonly string[]) {
   const page = snapshot?.pages.find(
     (candidate) => candidate.route_path === routePath,
   );
-  return page ?? null;
+  return page && snapshot ? { page, snapshot } : null;
+}
+
+function directNamespacedChildren(
+  routePath: string,
+  pages: NonNullable<
+    Awaited<ReturnType<typeof loadGeneratedReleaseSnapshot>>
+  >['pages'],
+): ReferenceChildLink[] {
+  return directRouteChildren(routePath, pages).map((candidate) => ({
+    page_kind: candidate.page_kind,
+    qualified_name: candidate.qualified_name,
+    route_path: candidate.route_path,
+  }));
 }
 
 export async function generateMetadata({
@@ -41,14 +60,18 @@ export async function generateMetadata({
   params: Promise<{ fqn: string[]; version: string }>;
 }): Promise<Metadata> {
   const { fqn, version } = await params;
-  const page = await loadPage(version, fqn);
-  if (!page) return {};
-  return {
-    description:
-      page.page_data.summary ??
-      `${page.page_kind} reference for ${page.qualified_name}.`,
+  const loaded = await loadPage(version, fqn);
+  if (!loaded) return {};
+  const { page, snapshot } = loaded;
+  const description =
+    page.page_data.summary ??
+    `${page.page_kind} reference for ${page.qualified_name}.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/baml/packages/${version}/${fqn.join('/')}`,
     title: `${page.qualified_name} — ${version}`,
-  };
+  });
 }
 
 export default async function ReferencePage({
@@ -57,8 +80,17 @@ export default async function ReferencePage({
   params: Promise<{ fqn: string[]; version: string }>;
 }) {
   const { fqn, version } = await params;
-  const page = await loadPage(version, fqn);
-  if (!page) notFound();
+  const loaded = await loadPage(version, fqn);
+  if (!loaded) notFound();
+  const { page, snapshot } = loaded;
+  const namespacedChildren =
+    page.page_kind === 'package' || page.page_kind === 'namespace'
+      ? []
+      : directNamespacedChildren(page.route_path, snapshot.pages);
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'package',
+    routePath: page.route_path,
+  });
   const qualifiedParts = page.qualified_name.split('.');
   const breadcrumbs = [
     { href: '/baml', label: 'BAML' },
@@ -83,9 +115,14 @@ export default async function ReferencePage({
         `${page.page_kind} in the ${page.page_data.package_name} package.`
       }
       title={page.qualified_name}
-      toc={referencePageTableOfContents(page.page_data)}
+      toc={referencePageTableOfContents(page.page_data, namespacedChildren)}
     >
-      <GeneratedReferenceContent page={page.page_data} routeVersion={version} />
+      <GeneratedVersionSwitcher options={versionOptions} />
+      <GeneratedReferenceContent
+        namespacedChildren={namespacedChildren}
+        page={page.page_data}
+        routeVersion={version}
+      />
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/app/baml/packages/[version]/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/[version]/page.tsx
@@ -2,16 +2,40 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { DocsShell } from '@/components/docs-shell';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const versions = await listGeneratedReleaseRouteVersions();
   return versions.map((version) => ({ version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ version: string }>;
+}) {
+  const { version } = await params;
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  if (!snapshot) return {};
+  const channelLabel = snapshot.channels.length
+    ? ` (${snapshot.channels.join(', ')})`
+    : '';
+  const description = `Immutable package reference generated from BAML ${snapshot.release.version}${channelLabel}.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/baml/packages/${version}`,
+    title: `Standard packages ${version}`,
+  });
 }
 
 export default async function PackageVersionPage({
@@ -28,6 +52,9 @@ export default async function PackageVersionPage({
   const channelLabel = snapshot.channels.length
     ? ` (${snapshot.channels.join(', ')})`
     : '';
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'package',
+  });
 
   return (
     <DocsShell
@@ -43,6 +70,7 @@ export default async function PackageVersionPage({
         { href: '#release', label: 'Release provenance' },
       ]}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="packages">Packages</h2>
       <ul>
         {packagePages.map((page) => (

--- a/typescript2/app-developer-docs/app/baml/packages/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/page.tsx
@@ -1,27 +1,27 @@
+import Link from 'next/link';
+
 import { DocsShell } from '@/components/docs-shell';
+import { GeneratedReleaseCatalog } from '@/components/generated-release-catalog';
+import {
+  listGeneratedReleaseSummaries,
+  loadGeneratedReleaseSnapshot,
+  selectFeaturedGeneratedRelease,
+} from '@/lib/generated-content/build-content';
+import { documentationMetadata } from '@/lib/metadata';
 
-export const metadata = {
+export const metadata = documentationMetadata({
   description: 'Versioned reference for BAML standard packages.',
+  path: '/baml/packages',
   title: 'Standard packages',
-};
+});
 
-const packages = [
-  'baml',
-  'reflect',
-  'boundary',
-  'testing',
-  'assert',
-  'log',
-  'ai',
-  'openai',
-  'anthropic',
-  'google',
-  'aws',
-  'vercel',
-  'claude_code',
-];
+export default async function PackagesPage() {
+  const releases = await listGeneratedReleaseSummaries();
+  const featuredRelease = selectFeaturedGeneratedRelease(releases);
+  const featured = featuredRelease
+    ? await loadGeneratedReleaseSnapshot(featuredRelease.routeVersion)
+    : null;
 
-export default function PackagesPage() {
   return (
     <DocsShell
       breadcrumbs={[
@@ -30,26 +30,23 @@ export default function PackagesPage() {
       ]}
       description="Versioned package reference generated from the exact compiled BAML toolchain."
       title="Standard packages"
-      toc={[
-        { href: '#published', label: 'Published versions' },
-        { href: '#packages', label: 'Package catalog' },
-      ]}
+      toc={[{ href: '#published', label: 'Published reference' }]}
     >
-      <h2 id="published">Published versions</h2>
+      <h2 id="published">Published reference</h2>
       <p>
-        Exact-version pages will appear after their complete immutable package
-        and CLI records are published. Canary and nightly snapshots will be
-        labeled explicitly and will never be presented as stable.
+        Choose a published release to browse reference generated from that exact
+        BAML toolchain. Exact-version URLs never move or silently fall forward
+        to another release.
       </p>
-      <h2 id="packages">Package catalog</h2>
-      <p>The initial publication allowlist contains:</p>
-      <ul className="columns-2 sm:columns-3">
-        {packages.map((packageName) => (
-          <li key={packageName}>
-            <code>{packageName}</code>
-          </li>
-        ))}
-      </ul>
+      <GeneratedReleaseCatalog
+        featured={featured}
+        product="packages"
+        releases={releases}
+      />
+      <p>
+        Use the <Link href="/changelog">changelog</Link> to review language,
+        toolchain, and package changes between releases.
+      </p>
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/app/changelog/page.tsx
+++ b/typescript2/app-developer-docs/app/changelog/page.tsx
@@ -1,11 +1,13 @@
 import { ChangelogContent } from '@/components/changelog-content';
 import { DocsShell } from '@/components/docs-shell';
 import { loadCanonicalChangelog } from '@/lib/changelog/loader';
+import { documentationMetadata } from '@/lib/metadata';
 
-export const metadata = {
+export const metadata = documentationMetadata({
   description: 'Canonical BAML language and toolchain release history.',
+  path: '/changelog',
   title: 'Changelog',
-};
+});
 
 export default async function ChangelogPage() {
   const changelog = await loadCanonicalChangelog();

--- a/typescript2/app-developer-docs/app/cli/[version]/commands/[...command]/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/commands/[...command]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import { CliCommandContent } from '@/components/generated-cli';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
@@ -10,6 +12,8 @@ import {
   findCliCommand,
   flattenCliCommands,
 } from '@/lib/generated-content/cli-routes';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
@@ -43,11 +47,15 @@ export async function generateMetadata({
   const { command, version } = await params;
   const commandNode = await loadCommand(version, command);
   if (!commandNode) return {};
-  return {
-    description:
-      commandNode.description ?? `Reference for baml ${command.join(' ')}.`,
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  const description =
+    commandNode.description ?? `Reference for baml ${command.join(' ')}.`;
+  return documentationMetadata({
+    description,
+    index: snapshot !== null && !isPrereleaseVersion(snapshot.release.version),
+    path: `/cli/${version}/commands/${command.join('/')}`,
     title: `baml ${command.join(' ')} — ${version}`,
-  };
+  });
 }
 
 export default async function CliCommandPage({
@@ -58,6 +66,10 @@ export default async function CliCommandPage({
   const { command, version } = await params;
   const commandNode = await loadCommand(version, command);
   if (!commandNode) notFound();
+  const versionOptions = await listGeneratedVersionOptions({
+    commandPath: command,
+    kind: 'cli-command',
+  });
   const breadcrumbs = [
     { href: '/cli', label: 'BAML CLI' },
     { href: `/cli/${version}`, label: version },
@@ -92,6 +104,7 @@ export default async function CliCommandPage({
       title={`baml ${command.join(' ')}`}
       toc={toc}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <CliCommandContent command={commandNode} routeVersion={version} />
     </DocsShell>
   );

--- a/typescript2/app-developer-docs/app/cli/[version]/commands/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/commands/page.tsx
@@ -1,16 +1,37 @@
 import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import { CliCommandTree } from '@/components/generated-cli';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const versions = await listGeneratedReleaseRouteVersions();
   return versions.map((version) => ({ version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ version: string }>;
+}) {
+  const { version } = await params;
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  if (!snapshot) return {};
+  const description = `Every public command captured from the exact BAML ${snapshot.release.version} executable.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/cli/${version}/commands`,
+    title: `Command index — ${version}`,
+  });
 }
 
 export default async function CliCommandsPage({
@@ -21,6 +42,9 @@ export default async function CliCommandsPage({
   const { version } = await params;
   const snapshot = await loadGeneratedReleaseSnapshot(version);
   if (!snapshot) notFound();
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'cli-command-index',
+  });
 
   return (
     <DocsShell
@@ -33,6 +57,7 @@ export default async function CliCommandsPage({
       title="Command index"
       toc={[{ href: '#commands', label: 'Commands' }]}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="commands">Commands</h2>
       <CliCommandTree
         commands={snapshot.cli.payload.root.subcommands}

--- a/typescript2/app-developer-docs/app/cli/[version]/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/page.tsx
@@ -2,16 +2,39 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import { CliCommandTree } from '@/components/generated-cli';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const versions = await listGeneratedReleaseRouteVersions();
   return versions.map((version) => ({ version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ version: string }>;
+}) {
+  const { version } = await params;
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  if (!snapshot) return {};
+  const description =
+    snapshot.cli.payload.root.description ??
+    `Exact command reference for BAML ${snapshot.release.version}.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/cli/${version}`,
+    title: `BAML CLI ${version}`,
+  });
 }
 
 export default async function CliVersionPage({
@@ -23,6 +46,9 @@ export default async function CliVersionPage({
   const snapshot = await loadGeneratedReleaseSnapshot(version);
   if (!snapshot) notFound();
   const root = snapshot.cli.payload.root;
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'cli-overview',
+  });
 
   return (
     <DocsShell
@@ -38,6 +64,7 @@ export default async function CliVersionPage({
         { href: '#release', label: 'Release provenance' },
       ]}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="usage">Usage</h2>
       <pre>
         <code>{root.usage}</code>

--- a/typescript2/app-developer-docs/app/cli/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/page.tsx
@@ -1,5 +1,32 @@
 import { AuthoredPage, authoredMetadata } from '@/components/authored-page';
+import { GeneratedReleaseCatalog } from '@/components/generated-release-catalog';
+import {
+  listGeneratedReleaseSummaries,
+  loadGeneratedReleaseSnapshot,
+  selectFeaturedGeneratedRelease,
+} from '@/lib/generated-content/build-content';
+
 export const metadata = authoredMetadata('/cli');
-export default function CliPage() {
-  return <AuthoredPage path="/cli" />;
+
+export default async function CliPage() {
+  const releases = await listGeneratedReleaseSummaries();
+  const featuredRelease = selectFeaturedGeneratedRelease(releases);
+  const featured = featuredRelease
+    ? await loadGeneratedReleaseSnapshot(featuredRelease.routeVersion)
+    : null;
+
+  return (
+    <AuthoredPage
+      components={{
+        GeneratedReleaseCatalog: () => (
+          <GeneratedReleaseCatalog
+            featured={featured}
+            product="cli"
+            releases={releases}
+          />
+        ),
+      }}
+      path="/cli"
+    />
+  );
 }

--- a/typescript2/app-developer-docs/app/page.tsx
+++ b/typescript2/app-developer-docs/app/page.tsx
@@ -10,6 +10,7 @@ import {
 import Link from 'next/link';
 
 import { PageHeader } from '@/components/page-header';
+import { documentationMetadata } from '@/lib/metadata';
 
 const sections = [
   {
@@ -57,9 +58,12 @@ const sections = [
 ];
 
 export const dynamic = 'force-static';
-export const metadata = {
+export const metadata = documentationMetadata({
+  description:
+    'Technical documentation for BAML, the BAML CLI, and Boundary Cloud Services.',
+  path: '/',
   title: 'BAML Developer Documentation',
-};
+});
 
 export default function HomePage() {
   return (

--- a/typescript2/app-developer-docs/app/search-index.json/route.ts
+++ b/typescript2/app-developer-docs/app/search-index.json/route.ts
@@ -1,0 +1,7 @@
+import { buildGeneratedSearchIndex } from '@/lib/generated-content/discovery';
+
+export const dynamic = 'force-static';
+
+export async function GET() {
+  return Response.json(await buildGeneratedSearchIndex());
+}

--- a/typescript2/app-developer-docs/app/sitemap.ts
+++ b/typescript2/app-developer-docs/app/sitemap.ts
@@ -1,18 +1,28 @@
 import type { MetadataRoute } from 'next';
 
+import { listGeneratedSitemapRoutes } from '@/lib/generated-content/discovery';
 import { documentationPages } from '@/lib/navigation';
 import { siteConfig } from '@/lib/site-config';
 
 export const dynamic = 'force-static';
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const paths = documentationPages.map((page) =>
     page.href === '/' ? '' : page.href,
   );
+  const generatedRoutes = await listGeneratedSitemapRoutes();
 
-  return paths.map((path, index) => ({
-    changeFrequency: 'weekly',
-    priority: index === 0 ? 1 : 0.8,
-    url: `${siteConfig.url}${path}`,
-  }));
+  return [
+    ...paths.map((path, index) => ({
+      changeFrequency: 'weekly' as const,
+      priority: index === 0 ? 1 : 0.8,
+      url: `${siteConfig.url}${path}`,
+    })),
+    ...generatedRoutes.map((route) => ({
+      changeFrequency: 'never' as const,
+      lastModified: route.lastModified,
+      priority: 0.6,
+      url: `${siteConfig.url}${route.path}`,
+    })),
+  ];
 }

--- a/typescript2/app-developer-docs/components/authored-page.tsx
+++ b/typescript2/app-developer-docs/components/authored-page.tsx
@@ -1,8 +1,10 @@
+import type { MDXComponents } from 'mdx/types';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { DocsShell } from '@/components/docs-shell';
 import { authoredSource } from '@/lib/content/source';
+import { documentationMetadata } from '@/lib/metadata';
 import { useMDXComponents } from '@/mdx-components';
 
 function pageFromPath(path: string) {
@@ -13,13 +15,20 @@ function pageFromPath(path: string) {
 export function authoredMetadata(path: string): Metadata {
   const page = pageFromPath(path);
   if (!page) return {};
-  return {
+  return documentationMetadata({
     description: page.data.description,
+    path,
     title: page.data.title,
-  };
+  });
 }
 
-export function AuthoredPage({ path }: { path: string }) {
+export function AuthoredPage({
+  components = {},
+  path,
+}: {
+  components?: MDXComponents;
+  path: string;
+}) {
   const page = pageFromPath(path);
   if (!page) notFound();
   const Content = page.data.body;
@@ -33,7 +42,7 @@ export function AuthoredPage({ path }: { path: string }) {
         label: item.title,
       }))}
     >
-      <Content components={useMDXComponents({})} />
+      <Content components={useMDXComponents(components)} />
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/components/generated-reference.tsx
+++ b/typescript2/app-developer-docs/components/generated-reference.tsx
@@ -76,6 +76,12 @@ const implementationSchema = z
 type ExportedMember = z.output<typeof memberSchema>;
 type ExportedSignature = z.output<typeof signatureSchema>;
 
+export interface ReferenceChildLink {
+  page_kind: ReferencePageData['page_kind'];
+  qualified_name: string;
+  route_path: string;
+}
+
 function Docstring({ value }: { value: string }) {
   return <ReactMarkdown>{value}</ReactMarkdown>;
 }
@@ -147,10 +153,7 @@ function ChildLinks({
   items,
   routeVersion,
 }: {
-  items: Extract<
-    ReferencePageData,
-    { page_kind: 'package' | 'namespace' }
-  >['children'];
+  items: ReferenceChildLink[];
   routeVersion: string;
 }) {
   return (
@@ -169,6 +172,7 @@ function ChildLinks({
 
 export function referencePageTableOfContents(
   page: ReferencePageData,
+  namespacedChildren: readonly ReferenceChildLink[] = [],
 ): { href: string; label: string }[] {
   if (page.page_kind === 'package' || page.page_kind === 'namespace') {
     return [{ href: '#contents', label: 'Contents' }];
@@ -184,13 +188,18 @@ export function referencePageTableOfContents(
     ...(page.cross_references.length > 0
       ? [{ href: '#related', label: 'Related definitions' }]
       : []),
+    ...(namespacedChildren.length > 0
+      ? [{ href: '#namespaced-definitions', label: 'Namespaced definitions' }]
+      : []),
   ];
 }
 
 export function GeneratedReferenceContent({
+  namespacedChildren = [],
   page,
   routeVersion,
 }: {
+  namespacedChildren?: ReferenceChildLink[];
   page: ReferencePageData;
   routeVersion: string;
 }) {
@@ -331,6 +340,16 @@ export function GeneratedReferenceContent({
               </li>
             ))}
           </ul>
+        </section>
+      ) : null}
+      {namespacedChildren.length > 0 ? (
+        <section>
+          <h2 id="namespaced-definitions">Namespaced definitions</h2>
+          <p>
+            These definitions use this declaration name as their namespace
+            prefix.
+          </p>
+          <ChildLinks items={namespacedChildren} routeVersion={routeVersion} />
         </section>
       ) : null}
     </>

--- a/typescript2/app-developer-docs/components/generated-release-catalog.tsx
+++ b/typescript2/app-developer-docs/components/generated-release-catalog.tsx
@@ -1,0 +1,151 @@
+import Link from 'next/link';
+
+import type {
+  GeneratedReleaseSnapshot,
+  GeneratedReleaseSummary,
+} from '@/lib/generated-content/build-content';
+
+type GeneratedProduct = 'cli' | 'packages';
+
+function productRoot(product: GeneratedProduct): string {
+  return product === 'packages' ? '/baml/packages' : '/cli';
+}
+
+function productLabel(product: GeneratedProduct): string {
+  return product === 'packages' ? 'standard packages' : 'CLI reference';
+}
+
+function formatReleaseDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function channelText(release: GeneratedReleaseSummary): string {
+  return release.channels.length > 0
+    ? release.channels.join(', ')
+    : 'historical';
+}
+
+function ReleaseLink({
+  product,
+  release,
+}: {
+  product: GeneratedProduct;
+  release: GeneratedReleaseSummary;
+}) {
+  const href = `${productRoot(product)}/${release.routeVersion}`;
+  return (
+    <li>
+      <Link href={href}>
+        <code>{release.routeVersion}</code>
+      </Link>{' '}
+      <span className="text-muted-foreground">
+        {channelText(release)} · published{' '}
+        <time dateTime={release.release.released_at.toISOString()}>
+          {formatReleaseDate(release.release.released_at)}
+        </time>
+      </span>
+    </li>
+  );
+}
+
+export function GeneratedReleaseCatalog({
+  featured,
+  product,
+  releases,
+}: {
+  featured: GeneratedReleaseSnapshot | null;
+  product: GeneratedProduct;
+  releases: GeneratedReleaseSummary[];
+}) {
+  if (releases.length === 0) {
+    return (
+      <p>
+        No complete generated releases are published yet. This page will list a
+        release only after both its package and CLI records are available.
+      </p>
+    );
+  }
+
+  const currentReleases = releases.filter(
+    (release) => release.channels.length > 0,
+  );
+  const displayedCurrentReleases =
+    currentReleases.length > 0 ? currentReleases : releases.slice(0, 1);
+  const hasStable = currentReleases.some((release) =>
+    release.channels.includes('stable'),
+  );
+
+  return (
+    <>
+      <h3>{hasStable ? 'Current stable release' : 'Current snapshots'}</h3>
+      {!hasStable ? (
+        <p>
+          No stable release has been published in this catalog. Canary and
+          nightly entries are labeled explicitly and are not stable releases.
+        </p>
+      ) : null}
+      <ul>
+        {displayedCurrentReleases.map((release) => (
+          <ReleaseLink
+            key={release.routeVersion}
+            product={product}
+            release={release}
+          />
+        ))}
+      </ul>
+
+      {featured && product === 'packages' ? (
+        <>
+          <h3>
+            Package catalog for <code>{featured.routeVersion}</code>
+          </h3>
+          <ul className="columns-2 sm:columns-3">
+            {featured.pages
+              .filter((page) => page.page_kind === 'package')
+              .map((page) => (
+                <li key={page.route_path}>
+                  <Link
+                    href={`/baml/packages/${featured.routeVersion}/${page.route_path}`}
+                  >
+                    <code>{page.qualified_name}</code>
+                  </Link>
+                </li>
+              ))}
+          </ul>
+        </>
+      ) : null}
+
+      {featured && product === 'cli' ? (
+        <p>
+          Browse the{' '}
+          <Link href={`/cli/${featured.routeVersion}`}>
+            {featured.routeVersion} CLI overview
+          </Link>{' '}
+          or open its{' '}
+          <Link href={`/cli/${featured.routeVersion}/commands`}>
+            complete command index
+          </Link>
+          .
+        </p>
+      ) : null}
+
+      <h3>All published versions</h3>
+      <p>
+        Every link below opens immutable {productLabel(product)} generated from
+        that exact BAML toolchain release.
+      </p>
+      <ul>
+        {releases.map((release) => (
+          <ReleaseLink
+            key={release.routeVersion}
+            product={product}
+            release={release}
+          />
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/typescript2/app-developer-docs/components/generated-version-switcher.tsx
+++ b/typescript2/app-developer-docs/components/generated-version-switcher.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import type { GeneratedVersionOption } from '@/lib/generated-content/discovery';
+
+export function GeneratedVersionSwitcher({
+  options,
+}: {
+  options: GeneratedVersionOption[];
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const current = options.find((option) => option.href === pathname);
+
+  if (options.length === 0) return null;
+
+  return (
+    <label className="flex max-w-md items-center gap-3 rounded-lg border bg-muted/40 px-3 py-2 text-sm">
+      <span className="font-medium">Reference version</span>
+      <select
+        aria-label="Reference version"
+        className="ml-auto min-w-0 rounded border border-input bg-background px-2 py-1 font-mono text-xs text-foreground"
+        onChange={(event) => router.push(event.target.value)}
+        value={current?.href ?? options[0]?.href}
+      >
+        {options.map((option) => (
+          <option key={option.href} value={option.href}>
+            {option.routeVersion}
+            {option.channels.length ? ` (${option.channels.join(', ')})` : ''}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/typescript2/app-developer-docs/components/search-menu.tsx
+++ b/typescript2/app-developer-docs/components/search-menu.tsx
@@ -11,6 +11,17 @@ import {
 } from 'react';
 
 import { searchablePages } from '@/lib/navigation';
+import {
+  type GeneratedSearchIndex,
+  generatedSearchIndexSchema,
+  type SearchEntry,
+} from '@/lib/search';
+
+const authoredEntries: SearchEntry[] = searchablePages.map((page) => ({
+  ...page,
+  current: true,
+}));
+const MAX_RESULTS = 100;
 
 function isEditableTarget(target: EventTarget | null) {
   return (
@@ -25,18 +36,32 @@ export function SearchMenu() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [generatedIndex, setGeneratedIndex] =
+    useState<GeneratedSearchIndex | null>(null);
+  const [generatedIndexError, setGeneratedIndexError] = useState(false);
+  const [versionFilter, setVersionFilter] = useState('current');
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
-  const results = useMemo(() => {
+  const matchingResults = useMemo(() => {
+    const entries = [
+      ...authoredEntries,
+      ...(generatedIndex?.entries ?? []),
+    ].filter((page) => {
+      if (!page.version) return true;
+      if (versionFilter === 'all') return true;
+      if (versionFilter === 'current') return page.current;
+      return page.version === versionFilter;
+    });
     const normalized = query.trim().toLowerCase();
-    if (!normalized) return searchablePages;
-    return searchablePages.filter((page) =>
-      `${page.label} ${page.group} ${page.href}`
+    if (!normalized) return entries;
+    return entries.filter((page) =>
+      `${page.label} ${page.group} ${page.href} ${page.keywords ?? ''}`
         .toLowerCase()
         .includes(normalized),
     );
-  }, [query]);
+  }, [generatedIndex, query, versionFilter]);
+  const results = matchingResults.slice(0, MAX_RESULTS);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -60,6 +85,17 @@ export function SearchMenu() {
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(frame);
   }, [open]);
+
+  useEffect(() => {
+    if (!open || generatedIndex || generatedIndexError) return;
+    void fetch('/search-index.json')
+      .then(async (response) => {
+        if (!response.ok) throw new Error('Unable to load search index.');
+        return generatedSearchIndexSchema.parse(await response.json());
+      })
+      .then(setGeneratedIndex)
+      .catch(() => setGeneratedIndexError(true));
+  }, [generatedIndex, generatedIndexError, open]);
 
   const visit = (href: string) => {
     setOpen(false);
@@ -134,30 +170,68 @@ export function SearchMenu() {
               className="scrollbar-none min-h-80 max-h-[22rem] overflow-y-auto scroll-py-1.5 py-1.5"
               id="search-results"
             >
-              {results.length ? (
-                results.map((page, index) => (
-                  <button
-                    className="flex h-9 w-full items-center gap-3 rounded-md border border-transparent px-3 text-left text-sm font-medium outline-none data-[selected=true]:border-input data-[selected=true]:bg-input/50 hover:bg-input/40"
-                    data-selected={index === selectedIndex}
-                    id={`search-result-${index}`}
-                    key={page.href}
-                    onClick={() => visit(page.href)}
-                    onMouseEnter={() => setSelectedIndex(index)}
-                    type="button"
+              {generatedIndex?.versions.length ? (
+                <label className="mb-1 flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground">
+                  Reference version
+                  <select
+                    className="ml-auto rounded border border-input bg-background px-2 py-1 text-foreground"
+                    onChange={(event) => {
+                      setVersionFilter(event.target.value);
+                      setSelectedIndex(0);
+                    }}
+                    value={versionFilter}
                   >
-                    <ArrowRight
-                      aria-hidden="true"
-                      className="size-4 text-muted-foreground"
-                    />
-                    <span>{page.label}</span>
-                    <span className="ml-auto text-xs font-normal text-muted-foreground">
-                      {page.group}
-                    </span>
-                  </button>
-                ))
+                    <option value="current">Current channels</option>
+                    {generatedIndex.versions.map((version) => (
+                      <option
+                        key={version.routeVersion}
+                        value={version.routeVersion}
+                      >
+                        {version.routeVersion}
+                        {version.channels.length
+                          ? ` (${version.channels.join(', ')})`
+                          : ''}
+                      </option>
+                    ))}
+                    <option value="all">All versions</option>
+                  </select>
+                </label>
+              ) : null}
+              {results.length ? (
+                <>
+                  {results.map((page, index) => (
+                    <button
+                      className="flex min-h-9 w-full items-center gap-3 rounded-md border border-transparent px-3 py-2 text-left text-sm font-medium outline-none data-[selected=true]:border-input data-[selected=true]:bg-input/50 hover:bg-input/40"
+                      data-selected={index === selectedIndex}
+                      id={`search-result-${index}`}
+                      key={`${page.href}-${page.label}`}
+                      onClick={() => visit(page.href)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                      type="button"
+                    >
+                      <ArrowRight
+                        aria-hidden="true"
+                        className="size-4 shrink-0 text-muted-foreground"
+                      />
+                      <span className="min-w-0 truncate">{page.label}</span>
+                      <span className="ml-auto max-w-44 shrink-0 truncate text-xs font-normal text-muted-foreground">
+                        {page.group}
+                      </span>
+                    </button>
+                  ))}
+                  {matchingResults.length > MAX_RESULTS ? (
+                    <p className="px-3 py-2 text-xs text-muted-foreground">
+                      Showing the first {MAX_RESULTS} of{' '}
+                      {matchingResults.length} results. Refine your search to
+                      narrow the list.
+                    </p>
+                  ) : null}
+                </>
               ) : (
                 <p className="py-12 text-center text-sm text-muted-foreground">
-                  No results found.
+                  {generatedIndexError
+                    ? 'Generated reference search is unavailable. Authored pages remain searchable.'
+                    : 'No results found.'}
                 </p>
               )}
             </div>

--- a/typescript2/app-developer-docs/content/cli/index.mdx
+++ b/typescript2/app-developer-docs/content/cli/index.mdx
@@ -1,17 +1,19 @@
 ---
 title: BAML CLI
-description: Install, configure, and use the exact BAML toolchain version that matches your project.
+description: Browse exact-version command reference generated from the BAML toolchain that matches your project.
 breadcrumbs:
   - label: BAML CLI
 ---
 
 ## Overview
 
-The CLI documentation covers installation, public commands, configuration, environment variables, and exit behavior. Command nesting mirrors the tokens accepted by the executable.
+The initial CLI reference covers the public command tree, arguments, flags, defaults, and allowed values exposed by the selected executable. Command nesting mirrors the tokens accepted by that exact toolchain version.
 
 ## Versioned reference
 
 Exact command pages are generated from the noncolored help emitted by the corresponding compiled wrapper and toolchain binaries. Unknown versions remain real 404s rather than silently falling forward.
+
+<GeneratedReleaseCatalog />
 
 <div className="docs-card-grid">
   <DocsCard description="Create a normal BAML project and check it with the toolchain." href="/baml/get-started" title="Get started with BAML" />

--- a/typescript2/app-developer-docs/lib/generated-content/build-content.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/build-content.ts
@@ -17,10 +17,17 @@ export interface GeneratedReleaseSnapshot {
   routeVersion: string;
 }
 
+export interface GeneratedReleaseSummary {
+  channels: ChannelPointerRow['channel'][];
+  release: ReleaseRow;
+  routeVersion: string;
+}
+
 const snapshotPromises = new Map<
   string,
   Promise<GeneratedReleaseSnapshot | null>
 >();
+let releaseSummariesPromise: Promise<GeneratedReleaseSummary[]> | undefined;
 
 export function canonicalVersionToRouteVersion(version: string): string {
   return `v${version}`;
@@ -35,16 +42,52 @@ export function routeVersionToCanonicalVersion(
   return routeVersion.slice(1);
 }
 
-export async function listGeneratedReleaseRouteVersions(): Promise<string[]> {
+async function readReleaseSummaries(): Promise<GeneratedReleaseSummary[]> {
   const reader = createGeneratedContentReader();
   try {
-    const releases = await reader.listReleases();
-    return releases.map((release) =>
-      canonicalVersionToRouteVersion(release.version),
-    );
+    const [releases, channels] = await Promise.all([
+      reader.listReleases(),
+      reader.listChannels(),
+    ]);
+    return releases.map((release) => ({
+      channels: channels
+        .filter((pointer) => pointer.release_version === release.version)
+        .map((pointer) => pointer.channel),
+      release,
+      routeVersion: canonicalVersionToRouteVersion(release.version),
+    }));
   } finally {
     await reader.close();
   }
+}
+
+export function listGeneratedReleaseSummaries(): Promise<
+  GeneratedReleaseSummary[]
+> {
+  releaseSummariesPromise ??= readReleaseSummaries();
+  return releaseSummariesPromise;
+}
+
+export async function listGeneratedReleaseRouteVersions(): Promise<string[]> {
+  return (await listGeneratedReleaseSummaries()).map(
+    (release) => release.routeVersion,
+  );
+}
+
+export function selectFeaturedGeneratedRelease(
+  releases: readonly GeneratedReleaseSummary[],
+): GeneratedReleaseSummary | null {
+  for (const channel of ['stable', 'canary', 'nightly'] as const) {
+    const release = releases.find((candidate) =>
+      candidate.channels.includes(channel),
+    );
+    if (release) return release;
+  }
+  return releases[0] ?? null;
+}
+
+export function isPrereleaseVersion(version: string): boolean {
+  return version.includes('-');
 }
 
 async function readSnapshot(
@@ -53,26 +96,26 @@ async function readSnapshot(
   const version = routeVersionToCanonicalVersion(routeVersion);
   if (!version) return null;
 
+  const releaseSummary = (await listGeneratedReleaseSummaries()).find(
+    (candidate) => candidate.release.version === version,
+  );
+  if (!releaseSummary) return null;
+
   const reader = createGeneratedContentReader();
   try {
-    const [releases, channels, packages, pages, cli] = await Promise.all([
-      reader.listReleases(),
-      reader.listChannels(),
+    const [packages, pages, cli] = await Promise.all([
       reader.listPackageExports(version),
       reader.listReferencePages(version),
       reader.getCliArtifact(version),
     ]);
-    const release = releases.find((candidate) => candidate.version === version);
-    if (!release || !cli) return null;
+    if (!cli) return null;
 
     return {
-      channels: channels
-        .filter((pointer) => pointer.release_version === version)
-        .map((pointer) => pointer.channel),
+      channels: releaseSummary.channels,
       cli,
       packages,
       pages,
-      release,
+      release: releaseSummary.release,
       routeVersion,
     };
   } finally {

--- a/typescript2/app-developer-docs/lib/generated-content/discovery.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/discovery.ts
@@ -1,0 +1,198 @@
+import {
+  type GeneratedReleaseSnapshot,
+  type GeneratedReleaseSummary,
+  isPrereleaseVersion,
+  listGeneratedReleaseSummaries,
+  loadGeneratedReleaseSnapshot,
+} from '@/lib/generated-content/build-content';
+import {
+  findCliCommand,
+  flattenCliCommands,
+} from '@/lib/generated-content/cli-routes';
+import type { GeneratedSearchIndex, SearchEntry } from '@/lib/search';
+
+function channelSuffix(channels: readonly string[]): string {
+  return channels.length > 0 ? ` · ${channels.join(', ')}` : '';
+}
+
+export interface GeneratedVersionOption {
+  channels: string[];
+  href: string;
+  routeVersion: string;
+}
+
+type VersionDestination =
+  | { kind: 'cli-command'; commandPath: readonly string[] }
+  | { kind: 'cli-command-index' }
+  | { kind: 'cli-overview' }
+  | { kind: 'package'; routePath?: string };
+
+export async function listGeneratedVersionOptions(
+  destination: VersionDestination,
+): Promise<GeneratedVersionOption[]> {
+  const releases = await listGeneratedReleaseSummaries();
+  const options: GeneratedVersionOption[] = [];
+
+  for (const release of releases) {
+    const snapshot = await loadGeneratedReleaseSnapshot(release.routeVersion);
+    if (!snapshot) continue;
+    let suffix = '';
+    if (destination.kind === 'package') {
+      if (
+        destination.routePath &&
+        !snapshot.pages.some(
+          (page) => page.route_path === destination.routePath,
+        )
+      ) {
+        continue;
+      }
+      suffix = destination.routePath ? `/${destination.routePath}` : '';
+    } else if (destination.kind === 'cli-command') {
+      if (!findCliCommand(snapshot.cli.payload.root, destination.commandPath)) {
+        continue;
+      }
+      suffix = `/commands/${destination.commandPath.join('/')}`;
+    } else if (destination.kind === 'cli-command-index') {
+      suffix = '/commands';
+    }
+    const root = destination.kind === 'package' ? '/baml/packages' : '/cli';
+    options.push({
+      channels: release.channels,
+      href: `${root}/${release.routeVersion}${suffix}`,
+      routeVersion: release.routeVersion,
+    });
+  }
+
+  return options;
+}
+
+export function generatedRoutePaths(
+  snapshot: GeneratedReleaseSnapshot,
+): string[] {
+  const packageRoot = `/baml/packages/${snapshot.routeVersion}`;
+  const cliRoot = `/cli/${snapshot.routeVersion}`;
+  return [
+    packageRoot,
+    ...snapshot.pages.map((page) => `${packageRoot}/${page.route_path}`),
+    cliRoot,
+    `${cliRoot}/commands`,
+    ...flattenCliCommands(snapshot.cli.payload.root).map(
+      (command) => `${cliRoot}/commands/${command.command_path.join('/')}`,
+    ),
+  ];
+}
+
+export function generatedSearchEntries(
+  release: GeneratedReleaseSummary,
+  snapshot: GeneratedReleaseSnapshot,
+): SearchEntry[] {
+  const entries: SearchEntry[] = [];
+  const current = release.channels.length > 0;
+  const version = release.routeVersion;
+  const packageGroup = `Standard packages · ${version}${channelSuffix(release.channels)}`;
+  const cliGroup = `CLI · ${version}${channelSuffix(release.channels)}`;
+  const packageRoot = `/baml/packages/${version}`;
+  const cliRoot = `/cli/${version}`;
+
+  entries.push(
+    {
+      current,
+      group: packageGroup,
+      href: packageRoot,
+      label: `Standard packages ${version}`,
+      version,
+    },
+    {
+      current,
+      group: cliGroup,
+      href: cliRoot,
+      label: `BAML CLI ${version}`,
+      version,
+    },
+    {
+      current,
+      group: cliGroup,
+      href: `${cliRoot}/commands`,
+      label: `Command index ${version}`,
+      version,
+    },
+  );
+
+  for (const page of snapshot.pages) {
+    const href = `${packageRoot}/${page.route_path}`;
+    entries.push({
+      current,
+      group: packageGroup,
+      href,
+      keywords: `${page.page_kind} ${page.page_data.summary ?? ''}`,
+      label: page.qualified_name,
+      version,
+    });
+    if ('member_anchors' in page.page_data) {
+      for (const member of page.page_data.member_anchors) {
+        entries.push({
+          current,
+          group: packageGroup,
+          href: `${href}#${member.anchor}`,
+          keywords: member.member_kind,
+          label: `${page.qualified_name}.${member.label}`,
+          version,
+        });
+      }
+    }
+  }
+
+  for (const command of flattenCliCommands(snapshot.cli.payload.root)) {
+    entries.push({
+      current,
+      group: cliGroup,
+      href: `${cliRoot}/commands/${command.command_path.join('/')}`,
+      keywords: command.description ?? '',
+      label: `baml ${command.command_path.join(' ')}`,
+      version,
+    });
+  }
+
+  return entries;
+}
+
+export async function listGeneratedSitemapRoutes(): Promise<
+  { lastModified: Date; path: string }[]
+> {
+  const releases = await listGeneratedReleaseSummaries();
+  const routes: { lastModified: Date; path: string }[] = [];
+
+  for (const release of releases) {
+    if (isPrereleaseVersion(release.release.version)) continue;
+    const snapshot = await loadGeneratedReleaseSnapshot(release.routeVersion);
+    if (!snapshot) continue;
+    routes.push(
+      ...generatedRoutePaths(snapshot).map((path) => ({
+        lastModified: release.release.released_at,
+        path,
+      })),
+    );
+  }
+
+  return routes;
+}
+
+export async function buildGeneratedSearchIndex(): Promise<GeneratedSearchIndex> {
+  const releases = await listGeneratedReleaseSummaries();
+  const entries: SearchEntry[] = [];
+
+  for (const release of releases) {
+    const snapshot = await loadGeneratedReleaseSnapshot(release.routeVersion);
+    if (!snapshot) continue;
+    entries.push(...generatedSearchEntries(release, snapshot));
+  }
+
+  return {
+    entries,
+    versions: releases.map((release) => ({
+      channels: release.channels,
+      current: release.channels.length > 0,
+      routeVersion: release.routeVersion,
+    })),
+  };
+}

--- a/typescript2/app-developer-docs/lib/generated-content/routes.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/routes.ts
@@ -47,6 +47,17 @@ export function deriveParentQualifiedName(
   return segments.length === 1 ? null : segments.slice(0, -1).join('.');
 }
 
+export function directRouteChildren<T extends { route_path: string }>(
+  routePath: string,
+  pages: readonly T[],
+): T[] {
+  const prefix = `${routePath}/`;
+  return pages.filter((candidate) => {
+    if (!candidate.route_path.startsWith(prefix)) return false;
+    return !candidate.route_path.slice(prefix.length).includes('/');
+  });
+}
+
 export function qualifyExportedName(
   packageName: string,
   namespace: readonly string[],

--- a/typescript2/app-developer-docs/lib/metadata.ts
+++ b/typescript2/app-developer-docs/lib/metadata.ts
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+
+import { shouldIndexDeployment } from '@/lib/deployment';
+
+export function documentationMetadata({
+  description,
+  index = true,
+  path,
+  title,
+}: {
+  description: string;
+  index?: boolean;
+  path: string;
+  title: string;
+}): Metadata {
+  const deploymentIsPublic = shouldIndexDeployment();
+  return {
+    alternates: { canonical: path },
+    description,
+    openGraph: {
+      description,
+      title,
+      url: path,
+    },
+    robots: {
+      follow: deploymentIsPublic,
+      index: deploymentIsPublic && index,
+    },
+    title,
+  };
+}

--- a/typescript2/app-developer-docs/lib/search.ts
+++ b/typescript2/app-developer-docs/lib/search.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const searchEntrySchema = z
+  .object({
+    current: z.boolean(),
+    group: z.string(),
+    href: z.string().startsWith('/'),
+    keywords: z.string().optional(),
+    label: z.string(),
+    version: z.string().optional(),
+  })
+  .strict();
+
+const searchVersionSchema = z
+  .object({
+    channels: z.array(z.string()),
+    current: z.boolean(),
+    routeVersion: z.string(),
+  })
+  .strict();
+
+export const generatedSearchIndexSchema = z
+  .object({
+    entries: z.array(searchEntrySchema),
+    versions: z.array(searchVersionSchema),
+  })
+  .strict();
+
+export type SearchEntry = z.output<typeof searchEntrySchema>;
+export type SearchVersion = z.output<typeof searchVersionSchema>;
+export type GeneratedSearchIndex = z.output<typeof generatedSearchIndexSchema>;

--- a/typescript2/app-developer-docs/scripts/check-static-links.ts
+++ b/typescript2/app-developer-docs/scripts/check-static-links.ts
@@ -4,6 +4,7 @@ import { extname, relative, resolve, sep } from 'node:path';
 const outputRoot = resolve(import.meta.dirname, '..', 'out');
 const hrefPattern = /\shref=(?:"([^"]+)"|'([^']+)')/g;
 const idPattern = /\sid=(?:"([^"]+)"|'([^']+)')/g;
+const sitemapLocationPattern = /<loc>([^<]+)<\/loc>/g;
 
 async function collectHtmlFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -79,7 +80,10 @@ async function resolveTarget(route: string) {
 }
 
 const failures = new Set<string>();
+const routeLinks = new Map<string, Set<string>>();
 for (const [currentRoute, page] of pages) {
+  const links = new Set<string>();
+  routeLinks.set(currentRoute, links);
   for (const match of page.html.matchAll(hrefPattern)) {
     const href = match[1] ?? match[2];
     const target = internalTarget(href, currentRoute);
@@ -89,6 +93,7 @@ for (const [currentRoute, page] of pages) {
       failures.add(`${relative(outputRoot, page.file)}: missing route ${href}`);
       continue;
     }
+    if (pages.has(target.route)) links.add(target.route);
     if (
       target.fragment &&
       !targetPage.anchors.has(decodeURIComponent(target.fragment))
@@ -100,10 +105,61 @@ for (const [currentRoute, page] of pages) {
   }
 }
 
+const reachableRoutes = new Set(['/']);
+const pendingRoutes = ['/'];
+while (pendingRoutes.length > 0) {
+  const route = pendingRoutes.shift();
+  if (!route) continue;
+  for (const target of routeLinks.get(route) ?? []) {
+    if (reachableRoutes.has(target)) continue;
+    reachableRoutes.add(target);
+    pendingRoutes.push(target);
+  }
+}
+for (const route of pages.keys()) {
+  if (route === '/404' || route === '/_not-found') continue;
+  if (!reachableRoutes.has(route)) {
+    failures.add(`${route}: static page is unreachable from /`);
+  }
+}
+
+const sitemapSource = await readFile(
+  resolve(outputRoot, 'sitemap.xml'),
+  'utf8',
+);
+const sitemapRoutes = new Set(
+  [...sitemapSource.matchAll(sitemapLocationPattern)].flatMap((match) => {
+    const location = match[1];
+    if (!location) return [];
+    const route = new URL(location).pathname;
+    return [route === '/' ? '/' : route.replace(/\/$/, '')];
+  }),
+);
+const excludedFromSitemap = new Set(['/404', '/_not-found']);
+for (const [route, page] of pages) {
+  if (excludedFromSitemap.has(route)) continue;
+  const noindex = /<meta[^>]+name="robots"[^>]+content="[^"]*noindex/i.test(
+    page.html,
+  );
+  if (!noindex && !sitemapRoutes.has(route)) {
+    failures.add(`${route}: indexable page is missing from sitemap.xml`);
+  }
+  if (noindex && sitemapRoutes.has(route)) {
+    failures.add(`${route}: noindex page is present in sitemap.xml`);
+  }
+}
+for (const route of sitemapRoutes) {
+  if (!pages.has(route)) {
+    failures.add(`sitemap.xml: missing static page ${route}`);
+  }
+}
+
 if (failures.size > 0) {
   throw new Error(
     `Static internal-link validation failed:\n${[...failures].join('\n')}`,
   );
 }
 
-console.log(`Validated internal links across ${pages.size} static HTML pages.`);
+console.log(
+  `Validated links, reachability, and sitemap coverage across ${pages.size} static HTML pages.`,
+);

--- a/typescript2/app-developer-docs/tests/generated-routes.test.ts
+++ b/typescript2/app-developer-docs/tests/generated-routes.test.ts
@@ -3,12 +3,21 @@ import test from 'node:test';
 
 import {
   canonicalVersionToRouteVersion,
+  type GeneratedReleaseSnapshot,
+  type GeneratedReleaseSummary,
+  isPrereleaseVersion,
   routeVersionToCanonicalVersion,
+  selectFeaturedGeneratedRelease,
 } from '../lib/generated-content/build-content.ts';
 import {
   findCliCommand,
   flattenCliCommands,
 } from '../lib/generated-content/cli-routes.ts';
+import {
+  generatedRoutePaths,
+  generatedSearchEntries,
+} from '../lib/generated-content/discovery.ts';
+import { directRouteChildren } from '../lib/generated-content/routes.ts';
 import type { CliCommandNodeInput } from '../lib/generated-content/schemas.ts';
 
 const leaf: CliCommandNodeInput = {
@@ -55,4 +64,139 @@ test('CLI routes mirror command tokens and reject unknown paths', () => {
   );
   assert.equal(findCliCommand(root, ['generate', 'add']), leaf);
   assert.equal(findCliCommand(root, ['generate', 'remove']), null);
+});
+
+function releaseSummary(
+  version: string,
+  channels: GeneratedReleaseSummary['channels'],
+): GeneratedReleaseSummary {
+  return {
+    channels,
+    release: {
+      created_at: new Date('2026-09-01T00:00:00Z'),
+      generated_at: new Date('2026-09-01T00:00:00Z'),
+      generator_version: '2b85a0ae8a258b7dbe21c346ffe05b051d62a08d',
+      released_at: new Date('2026-09-01T00:00:00Z'),
+      source_commit: '5a29ca428e3a964d262506ed90d889b3ab4d01a7',
+      version,
+    },
+    routeVersion: `v${version}`,
+  };
+}
+
+test('release discovery prefers stable and keeps prereleases explicit', () => {
+  const nightly = releaseSummary('0.18.1-nightly.20260901.a', ['nightly']);
+  const canary = releaseSummary('0.18.1-canary.1', ['canary']);
+  const stable = releaseSummary('0.18.0', ['stable']);
+
+  assert.equal(
+    selectFeaturedGeneratedRelease([nightly, canary, stable]),
+    stable,
+  );
+  assert.equal(selectFeaturedGeneratedRelease([nightly, canary]), canary);
+  assert.equal(isPrereleaseVersion(nightly.release.version), true);
+  assert.equal(isPrereleaseVersion(stable.release.version), false);
+});
+
+test('direct route children make hidden namespace descendants discoverable', () => {
+  const pages = [
+    { route_path: 'boundary/id' },
+    { route_path: 'boundary/id/current' },
+    { route_path: 'boundary/id/nested/value' },
+    { route_path: 'boundary/other' },
+  ];
+  assert.deepEqual(directRouteChildren('boundary/id', pages), [pages[1]]);
+});
+
+test('generated discovery covers exact routes and member search anchors', () => {
+  const summary = releaseSummary('0.18.1-nightly.20260901.a', ['nightly']);
+  const hash = '0'.repeat(64);
+  const snapshot: GeneratedReleaseSnapshot = {
+    channels: summary.channels,
+    cli: {
+      payload: {
+        artifact_schema_version: 1,
+        product_version: summary.release.version,
+        raw_help: [
+          {
+            command_path: [],
+            invocation: ['help'],
+            sha256: hash,
+            text: 'BAML help',
+          },
+        ],
+        root,
+        wrapper_version: '0.2.4',
+      },
+      row: {
+        artifact_schema_version: 1,
+        generated_at: new Date('2026-09-01T00:00:00Z'),
+        payload_json: '{}',
+        payload_sha256: hash,
+        release_version: summary.release.version,
+        source_sha256: hash,
+        wrapper_version: '0.2.4',
+      },
+    },
+    packages: [],
+    pages: [
+      {
+        generated_at: new Date('2026-09-01T00:00:00Z'),
+        package_export_id: 1,
+        page_data: {
+          cross_references: [],
+          declaration: {
+            id: 'V:boundary.id.current',
+            kind: 'function',
+            name: 'current',
+          },
+          display_name: 'current',
+          exported_id: 'V:boundary.id.current',
+          implementations: [],
+          member_anchors: [
+            {
+              anchor: 'value',
+              exported_id: 'F:boundary.id.current.value',
+              label: 'value',
+              member_kind: 'field',
+            },
+          ],
+          namespace_path: ['id'],
+          package_name: 'boundary',
+          page_kind: 'function',
+          qualified_name: 'boundary.id.current',
+          schema_version: 1,
+          summary: 'Returns the current identifier.',
+        },
+        page_kind: 'function',
+        page_schema_version: 1,
+        qualified_name: 'boundary.id.current',
+        route_path: 'boundary/id/current',
+      },
+    ],
+    release: summary.release,
+    routeVersion: summary.routeVersion,
+  };
+
+  const paths = generatedRoutePaths(snapshot);
+  assert.ok(paths.includes(`/baml/packages/${summary.routeVersion}`));
+  assert.ok(
+    paths.includes(
+      `/baml/packages/${summary.routeVersion}/boundary/id/current`,
+    ),
+  );
+  assert.ok(
+    paths.includes(`/cli/${summary.routeVersion}/commands/generate/add`),
+  );
+
+  const search = generatedSearchEntries(summary, snapshot);
+  assert.ok(
+    search.some(
+      (entry) =>
+        entry.label === 'boundary.id.current.value' &&
+        entry.href.endsWith('/boundary/id/current#value') &&
+        entry.current,
+    ),
+  );
+  assert.ok(search.some((entry) => entry.label === 'baml generate add'));
 });

--- a/typescript2/app-developer-docs/tests/navigation.test.ts
+++ b/typescript2/app-developer-docs/tests/navigation.test.ts
@@ -106,3 +106,26 @@ test('the docs shell preserves the measured shadcn geometry', async () => {
   assert.doesNotMatch(headerSource, /border-b/);
   assert.doesNotMatch(globalStyles, /fumadocs-ui\/css/);
 });
+
+test('generated reference hubs, search, and sitemap share published release data', async () => {
+  const [packageHub, cliHub, cliContent, searchMenu, searchRoute, sitemap] =
+    await Promise.all([
+      readFile(resolve(process.cwd(), 'app/baml/packages/page.tsx'), 'utf8'),
+      readFile(resolve(process.cwd(), 'app/cli/page.tsx'), 'utf8'),
+      readFile(resolve(process.cwd(), 'content/cli/index.mdx'), 'utf8'),
+      readFile(resolve(process.cwd(), 'components/search-menu.tsx'), 'utf8'),
+      readFile(
+        resolve(process.cwd(), 'app/search-index.json/route.ts'),
+        'utf8',
+      ),
+      readFile(resolve(process.cwd(), 'app/sitemap.ts'), 'utf8'),
+    ]);
+
+  assert.match(packageHub, /listGeneratedReleaseSummaries/);
+  assert.doesNotMatch(packageHub, /const packages =/);
+  assert.match(cliHub, /listGeneratedReleaseSummaries/);
+  assert.match(cliContent, /<GeneratedReleaseCatalog \/>/);
+  assert.match(searchMenu, /fetch\('\/search-index\.json'/);
+  assert.match(searchRoute, /buildGeneratedSearchIndex/);
+  assert.match(sitemap, /listGeneratedSitemapRoutes/);
+});


### PR DESCRIPTION
## What developers see

Before this change, `/baml/packages` and `/cli` described generated references but did not link to the already-published release. All 1,527 generated pages were unreachable from Home, absent from search, and unknown to the sitemap.

After this change:

- `/baml/packages` lists current channel snapshots, every immutable release, and direct stdlib package links.
- `/cli` links the matching exact-version overview and command index.
- Generated package definitions, nested members, and CLI commands are searchable with a release filter.
- Exact-version pages expose a version switcher that preserves the current definition or command when available.
- Stable generated releases are added to the sitemap; prerelease snapshots remain explicitly labeled and `noindex`.
- The temporary `boundary.id` namespace exception remains narrow while `boundary.id.current` is reachable through the declaration page.

## Guardrails

The post-build link check now fails on orphaned static pages and mismatches between indexable HTML and `sitemap.xml`, covering the failure mode that allowed this issue through. No private planning/status Markdown files are included.

## Validation

- `pnpm --filter app-developer-docs lint`
- `pnpm --filter app-developer-docs typecheck`
- `pnpm --filter app-developer-docs test` (33 passing)
- Full generated export and route-graph validation run in the protected PR build because the database URL is a non-downloadable Vercel/GitHub secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added generated release catalogs for CLI and package documentation, including featured releases, channels, and published versions.
  - Added version selectors across versioned CLI and package reference pages.
  - Added namespaced definitions sections and links to generated reference pages.
  - Added generated search results with version filtering and up to 100 results.
  - Added a downloadable generated search index and expanded sitemap coverage.

- **Bug Fixes**
  - Improved metadata, canonical links, and prerelease indexing behavior across documentation pages.
  - Added checks for unreachable pages and sitemap coverage issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->