### PR TITLE
ci: pull language release build images through GCP cache

### DIFF
--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -53,7 +53,7 @@ jobs:
             # This is newer than the ideal glibc floor; our users still need the oldest
             # practical compatible baseline we can support for this target.
             # See https://github.com/BoundaryML/baml/issues/2736
-            container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+            container: us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275
             before: |
               echo "CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8" >> "$GITHUB_ENV"
           - target: aarch64-apple-darwin

--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -29,6 +29,9 @@ on:
       # Node build matrix can be exercised on a branch before release.
       - sam/publish-nodejs
 
+permissions:
+  contents: read
+
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow
   group: ${{ github.workflow }}-${{ github.ref }}-build-nodejs-sdk

--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -53,7 +53,7 @@ jobs:
             # This is newer than the ideal glibc floor; our users still need the oldest
             # practical compatible baseline we can support for this target.
             # See https://github.com/BoundaryML/baml/issues/2736
-            container: us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275
+            container: us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64
             before: |
               echo "CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8" >> "$GITHUB_ENV"
           - target: aarch64-apple-darwin

--- a/.github/workflows/build2-python-sdk.reusable.yaml
+++ b/.github/workflows/build2-python-sdk.reusable.yaml
@@ -28,8 +28,8 @@ defaults:
     shell: bash
 
 jobs:
-  # Target set + per-target runner/manylinux/architecture come from the platform
-  # contract (`release/platforms.json`), not a hand-copied matrix list.
+  # Targets and their runner/manylinux/architecture/container come from
+  # `release/platforms.json`, not a hand-copied matrix list.
   matrix:
     name: Compute target matrix
     runs-on: ubuntu-latest
@@ -45,13 +45,15 @@ jobs:
         run: |
           set -euo pipefail
           # target + python runner (as `runs_on`) + optional manylinux tag +
-          # optional python-setup architecture. maturin/setup-python treat an
-          # absent field as empty, so only-when-set matches the old matrix.
+          # optional python-setup architecture and build container.
+          # maturin/setup-python treat an absent field as empty, so
+          # only-when-set matches the old matrix.
           include="$(jq -c '[.targets[]
             | select(.artifacts.python != null)
             | .artifacts.python as $p
             | {target: .triple, runs_on: $p.runner}
               + (if $p.manylinux then {manylinux: $p.manylinux} else {} end)
+              + (if $p.container then {container: $p.container} else {} end)
               + (if $p.architecture then {architecture: $p.architecture} else {} end)]' release/platforms.json)"
           echo "include=$include" >> "$GITHUB_OUTPUT"
           jq . <<<"$include"
@@ -134,6 +136,8 @@ jobs:
           # baml_language/Cargo.toml.
           args: --release --strip --out dist
           manylinux: ${{ matrix._.manylinux }}
+          # Explicit musl images bypass maturin-action's implicit GHCR defaults.
+          container: ${{ matrix._.container }}
           before-script-linux: |
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -11,29 +11,29 @@
 # flags must be listed here explicitly or they never reach the compilers.
 #
 # Preserve cross 0.2.5's default images, but pull through our public GCP cache.
-# Pin index digests to keep upstream tag updates out of release builds.
+# Follow the upstream tags without pinning image digests.
 # Toolchain/wrapper jobs select their own images through CROSS_CONFIG.
-# See docs/ci-infra-gcp.md for setup, updates, and rollback.
+# See docs/ci-infra-gcp.md for the registry setup.
 [target.x86_64-unknown-linux-gnu]
-image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/x86_64-unknown-linux-gnu:0.2.5@sha256:9e5b39c09874bc1816c675ed11afca2c2ed6cee0c4ed2b3c1d5763c346c9ae3f"
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/x86_64-unknown-linux-gnu:0.2.5"
 
 [target.x86_64-unknown-linux-gnu.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-gnu]
-image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/aarch64-unknown-linux-gnu:0.2.5@sha256:7f8308a8734d9fcd2ebbe9a3e4bdea74af293f0799d80c3cc341e340cda49a4c"
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/aarch64-unknown-linux-gnu:0.2.5"
 
 [target.aarch64-unknown-linux-gnu.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.x86_64-unknown-linux-musl]
-image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/x86_64-unknown-linux-musl:0.2.5@sha256:77db671d8356a64ae72a3e1415e63f547f26d374fbe3c4762c1cd36c7eac7b99"
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/x86_64-unknown-linux-musl:0.2.5"
 
 [target.x86_64-unknown-linux-musl.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
 [target.aarch64-unknown-linux-musl]
-image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/aarch64-unknown-linux-musl:0.2.5@sha256:702154f52b2d8091671aa2c84d5582d849f949977228c735ff8462f93cc0e1e4"
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/aarch64-unknown-linux-musl:0.2.5"
 
 [target.aarch64-unknown-linux-musl.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]

--- a/baml_language/Cross.toml
+++ b/baml_language/Cross.toml
@@ -1,4 +1,4 @@
-# `cross` configuration for the `bridge_cffi` cdylib build.
+# `cross` configuration for the CFFI and Java cdylib builds.
 #
 # `.github/workflows/build2-bridge-cffi.reusable.yaml` runs `cross` for the
 # linux targets. Every leg receives deterministic `--remap-path-prefix` flags.
@@ -9,14 +9,31 @@
 # `cross` runs the build inside a container and forwards only a curated set of
 # environment variables, so the source fingerprint and Rust/native remapping
 # flags must be listed here explicitly or they never reach the compilers.
+#
+# Preserve cross 0.2.5's default images, but pull through our public GCP cache.
+# Pin index digests to keep upstream tag updates out of release builds.
+# Toolchain/wrapper jobs select their own images through CROSS_CONFIG.
+# See docs/ci-infra-gcp.md for setup, updates, and rollback.
+[target.x86_64-unknown-linux-gnu]
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/x86_64-unknown-linux-gnu:0.2.5@sha256:9e5b39c09874bc1816c675ed11afca2c2ed6cee0c4ed2b3c1d5763c346c9ae3f"
+
 [target.x86_64-unknown-linux-gnu.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+
+[target.aarch64-unknown-linux-gnu]
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/aarch64-unknown-linux-gnu:0.2.5@sha256:7f8308a8734d9fcd2ebbe9a3e4bdea74af293f0799d80c3cc341e340cda49a4c"
 
 [target.aarch64-unknown-linux-gnu.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
 
+[target.x86_64-unknown-linux-musl]
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/x86_64-unknown-linux-musl:0.2.5@sha256:77db671d8356a64ae72a3e1415e63f547f26d374fbe3c4762c1cd36c7eac7b99"
+
 [target.x86_64-unknown-linux-musl.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]
+
+[target.aarch64-unknown-linux-musl]
+image = "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/cross-rs/aarch64-unknown-linux-musl:0.2.5@sha256:702154f52b2d8091671aa2c84d5582d849f949977228c735ff8462f93cc0e1e4"
 
 [target.aarch64-unknown-linux-musl.env]
 passthrough = ["BAML_GIT_SHA", "RUSTFLAGS", "CFLAGS", "CXXFLAGS"]

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -248,10 +248,13 @@ mod tests {
                 let image = python
                     .container
                     .expect("musl must override maturin's GHCR default");
-                assert!(image.starts_with(&format!(
-                    "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:{}-musl@sha256:",
-                    target.arch
-                )));
+                assert_eq!(
+                    image,
+                    format!(
+                        "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:{}-musl",
+                        target.arch
+                    )
+                );
             } else {
                 assert!(
                     python.container.is_none(),
@@ -276,7 +279,7 @@ mod tests {
         assert_eq!(
             arm.container.as_deref(),
             Some(
-                "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275"
+                "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64"
             )
         );
         assert!(arm.cross_image.is_none());

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -238,69 +238,6 @@ mod tests {
     }
 
     #[test]
-    fn python_musl_images_are_explicit_without_changing_wheel_policy() {
-        for target in platforms().targets {
-            let Some(python) = target.artifacts.python else {
-                continue;
-            };
-            if target.libc.as_deref() == Some("musl") {
-                assert_eq!(python.manylinux.as_deref(), Some("musllinux_1_1"));
-                let image = python
-                    .container
-                    .expect("musl must override maturin's GHCR default");
-                assert_eq!(
-                    image,
-                    format!(
-                        "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:{}-musl",
-                        target.arch
-                    )
-                );
-            } else {
-                assert!(
-                    python.container.is_none(),
-                    "preserve non-musl image defaults"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn toolchain_build_modes_are_preserved_and_mutually_exclusive() {
-        let p = platforms();
-        let arm = p
-            .targets
-            .iter()
-            .find(|target| target.triple == "aarch64-unknown-linux-gnu")
-            .unwrap()
-            .artifacts
-            .toolchain
-            .as_ref()
-            .unwrap();
-        assert_eq!(
-            arm.container.as_deref(),
-            Some(
-                "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64"
-            )
-        );
-        assert!(arm.cross_image.is_none());
-
-        let json = r#"{
-            "schema": 1,
-            "targets": [{
-                "triple": "aarch64-unknown-linux-gnu", "os": "linux", "arch": "aarch64",
-                "libc": "gnu", "archive_suffix": ".tar.gz",
-                "artifacts": { "toolchain": {
-                    "runner": "ubuntu-24.04-arm",
-                    "container": "native-image",
-                    "cross_image": "cross-image"
-                } }
-            }]
-        }"#;
-        let p: Platforms = serde_json::from_str(json).unwrap();
-        assert!(validate_platforms(&p).is_err());
-    }
-
-    #[test]
     fn toolchain_artifact_rejects_unknown_fields() {
         let json = r#"{
             "runner": "ubuntu-latest",

--- a/baml_language/crates/baml_release/src/platforms.rs
+++ b/baml_language/crates/baml_release/src/platforms.rs
@@ -80,6 +80,9 @@ pub struct PythonArtifact {
     /// `manylinux`/`musllinux` platform tag for maturin (Linux targets only).
     #[serde(default)]
     pub manylinux: Option<String>,
+    /// Explicit maturin build container (otherwise the action selects its default).
+    #[serde(default)]
+    pub container: Option<String>,
     /// Python-setup architecture override (arm64-Windows only).
     #[serde(default)]
     pub architecture: Option<String>,
@@ -235,6 +238,30 @@ mod tests {
     }
 
     #[test]
+    fn python_musl_images_are_explicit_without_changing_wheel_policy() {
+        for target in platforms().targets {
+            let Some(python) = target.artifacts.python else {
+                continue;
+            };
+            if target.libc.as_deref() == Some("musl") {
+                assert_eq!(python.manylinux.as_deref(), Some("musllinux_1_1"));
+                let image = python
+                    .container
+                    .expect("musl must override maturin's GHCR default");
+                assert!(image.starts_with(&format!(
+                    "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:{}-musl@sha256:",
+                    target.arch
+                )));
+            } else {
+                assert!(
+                    python.container.is_none(),
+                    "preserve non-musl image defaults"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn toolchain_build_modes_are_preserved_and_mutually_exclusive() {
         let p = platforms();
         let arm = p
@@ -248,7 +275,9 @@ mod tests {
             .unwrap();
         assert_eq!(
             arm.container.as_deref(),
-            Some("ghcr.io/rust-cross/manylinux_2_28-cross:aarch64")
+            Some(
+                "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275"
+            )
         );
         assert!(arm.cross_image.is_none());
 

--- a/docs/ci-infra-gcp.md
+++ b/docs/ci-infra-gcp.md
@@ -25,14 +25,14 @@ The repository was created manually on September 4, 2026. There is no Terraform,
 
 ## Image routing and scope
 
-Replace only the registry prefix, keeping the upstream owner, repository, tag, and digest:
+Replace only the registry prefix, keeping the upstream owner, repository, and tag:
 
 ```text
-ghcr.io/<owner>/<image>:<tag>@sha256:<digest>
-  -> us-central1-docker.pkg.dev/baml-infra/ghcr-cache/<owner>/<image>:<tag>@sha256:<digest>
+ghcr.io/<owner>/<image>:<tag>
+  -> us-central1-docker.pkg.dev/baml-infra/ghcr-cache/<owner>/<image>:<tag>
 ```
 
-The references in the repository pin the verified upstream index digest as well as retaining the descriptive tag. The digest is authoritative; moving the upstream tag does not update our builds. Index pins preserve platform selection instead of forcing the ARM jobs onto an amd64 child manifest.
+Image references use upstream tags without digest pins so builds can receive updates to those tags through the cache. Tag refreshes follow Artifact Registry's caching behavior; they are not guaranteed to reflect an upstream change immediately.
 
 | Upstream repository:tag | Consumers | Image selection |
 | --- | --- | --- |
@@ -49,7 +49,7 @@ The authoritative entry point is [release-baml-language.yml](../.github/workflow
 
 The explicit Python override is necessary because [maturin-action](https://github.com/PyO3/maturin-action#inputs) otherwise constructs its own GHCR musl reference. [Cross target image overrides](https://github.com/cross-rs/cross/wiki/Configuration#targettargetimage) similarly bypass cross 0.2.5's implicit GHCR defaults. Merely replacing literal `ghcr.io` strings in workflow YAML misses these paths.
 
-This changes image delivery and freezes image versions, not container contents, entrypoints, mounts, runners, compilers, or artifact policies. Python keeps `musllinux_1_1`, its existing GNU manylinux policies, and the Python 3.10 abi3 floor. The rust-cross index exposes both Linux amd64 and arm64 host variants; cross-rs 0.2.5 uses amd64 hosts even when cross-compiling to aarch64. Existing native ARM versus cross-compilation choices are unchanged.
+This changes image delivery while preserving the existing image tags, entrypoints, mounts, runners, compilers, and artifact policies. Python keeps `musllinux_1_1`, its existing GNU manylinux policies, and the Python 3.10 abi3 floor. The rust-cross index exposes both Linux amd64 and arm64 host variants; cross-rs 0.2.5 uses amd64 hosts even when cross-compiling to aarch64. Existing native ARM versus cross-compilation choices are unchanged.
 
 Alpine, Microsoft, Quay, and Docker Hub images are unchanged. The PyPI publishing action's own `ghcr.io/pypa/gh-action-pypi-publish` image is outside this rust-cross/cross-rs migration. Legacy `engine` release workflows and integration-test Dockerfiles are also outside the BAML Language release graph and are not migrated here. This does not eliminate every repository dependency on GHCR or GitHub.
 
@@ -87,39 +87,3 @@ gcloud artifacts repositories get-iam-policy ghcr-cache \
 gcloud artifacts docker images list \
   us-central1-docker.pkg.dev/baml-infra/ghcr-cache --include-tags
 ```
-
-## Verification and upgrades
-
-An anonymous manifest request tests public access without consulting Docker's credential helpers or downloading image layers:
-
-```sh
-curl --fail --silent --show-error --dump-header - --output /dev/null \
-  --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
-  'https://us-central1-docker.pkg.dev/v2/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross/manifests/sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275'
-```
-
-Expect HTTP 200 and the matching `Docker-Content-Digest`. Provisioning verified all eight index digests anonymously, relevant amd64/arm64 child manifests and config blobs, plus two tiny layer downloads. That is not a full image pull or a release build: uncached layers are fetched lazily. Full outage protection requires every needed platform's layers to have been pulled successfully before the outage.
-
-For an intentional image upgrade, inspect the upstream tag's manifest index, compare the cache response and digest, check required host platforms, and update every occurrence of the affected pin in one reviewed PR. Do not silently substitute a single-platform digest or advance the cross version. Update matching platform tests. No automatic tag-based image updates are configured; the release maintainers must schedule upstream security review and digest refreshes.
-
-Representative pre-release checks, on a suitable Linux Docker host:
-
-1. Pull each pinned image for every host platform used by CI, without credentials. ARM64 toolchain and Node jobs need the arm64 rust-cross variant; the wrapper and Python cross-builds need amd64. Cross-rs targets need amd64.
-2. Run the GNU ARM64 container with Bash and a bind mount to verify executable permissions, workspace writes, networking, and required tools, for example `docker run --rm --platform linux/arm64 --entrypoint bash -v "$PWD:/workspace" -w /workspace "$IMAGE" -lc 'id; test -w /workspace; command -v bash curl tar; ldd --version'`, with `IMAGE` set to the committed reference.
-3. Exercise both Python musl matrix legs using the existing maturin workflow commands; inspect output wheel names for `cp310-abi3` and the expected `musllinux_1_1_<arch>` tag, then install/import on representative musl systems.
-4. Exercise all four Linux CFFI builds and both Java musl builds; verify expected ELF architecture, dynamic-library output, and consumer loading. Preserve `RUSTFLAGS`, source-remapping variables, and musl `-crt-static`.
-5. Exercise GNU toolchain/wrapper builds and ARM64 Node packaging; run existing artifact/consumer smoke tests. Confirm logs name `us-central1-docker.pkg.dev` for the eight scoped images.
-
-Use normal reviewed CI/release procedures for build validation. Provisioning and the migration PR do not dispatch releases or publish test artifacts to production registries.
-
-## Operations, security, and rollback
-
-Anonymous read access is intentionally public to the internet, not restricted to BoundaryML workflows. It does not grant public writes or administration, but this remote repository can cache other public GHCR paths: the configuration is not an owner/image allowlist. Third parties can consume storage, egress, and request quota by pulling through it. Do not add private upstream credentials to this public repository.
-
-Monitor [Artifact Registry quotas](https://docs.cloud.google.com/artifact-registry/quotas), repository size, and [storage/network charges](https://cloud.google.com/artifact-registry/pricing), especially internet egress to GitHub runners. Budget alerts and abuse-related quota review are operational follow-ups, not configured by this setup; a budget alert is not a spending cap. If public-cache abuse becomes material, reassess the public access design rather than putting a secret in every job without accounting for pre-step container pulls.
-
-No cleanup policy is configured, deliberately preserving old release pins for rollback. If adding cleanup later, retain every digest still referenced by supported release commits; deleting cached content reintroduces an upstream dependency. Cached content can survive an upstream outage, but the single GCP region and project remain availability dependencies.
-
-Digest pins protect content identity, not upstream trust or vulnerability status. This setup does not add signature/attestation verification, rebuild the images, or enable vulnerability scanning. Upstream image licensing and security maintenance obligations remain unchanged. Review upstream provenance and vulnerabilities when updating pins, and retain evidence with the PR.
-
-If GCP pulls fail, first check anonymous manifest access, repository IAM, quotas/billing, and upstream availability. Roll back image routing by replacing `us-central1-docker.pkg.dev/baml-infra/ghcr-cache/` with `ghcr.io/` in the platform contract, Node workflow, and Cross.toml, updating matching tests while retaining the digest pins and explicit Python container wiring. This returns to upstream delivery without changing image contents. Do not delete the cache or change public IAM as part of a workflow rollback; either affects other users independently.

--- a/docs/ci-infra-gcp.md
+++ b/docs/ci-infra-gcp.md
@@ -1,0 +1,125 @@
+# GCP container cache for release CI
+
+The BAML Language release pulls its `rust-cross` and `cross-rs` build images through a public Google Artifact Registry remote repository. GitHub-hosted runners need no Google credentials, OIDC step, registry password, or Docker login, including for job-level `container:` images that are pulled before steps run. Administrative changes still require an authorized Google identity.
+
+This is a pull-through cache, not a replacement image build pipeline: Google fetches public images from GHCR on demand and serves cached content. Cache misses still depend on GHCR. See Google's [remote repository behavior](https://docs.cloud.google.com/artifact-registry/docs/repositories/remote-overview) and [public repository access](https://docs.cloud.google.com/artifact-registry/docs/access-control#configuring_public_access_to_a_repository).
+
+## Provisioned resource
+
+| Setting | Value |
+| --- | --- |
+| Project | `baml-infra` |
+| Project number | `964166623930` |
+| Location | `us-central1` |
+| Repository | `ghcr-cache` |
+| Format / mode | `DOCKER` / `REMOTE_REPOSITORY` |
+| Upstream | `https://ghcr.io` |
+| Pull prefix | `us-central1-docker.pkg.dev/baml-infra/ghcr-cache` |
+| Repository IAM | `allUsers` has `roles/artifactregistry.reader` |
+| Upstream credentials | None; only public GHCR images are intended |
+| Encryption | Google-managed key |
+| Cleanup policies | None configured |
+| Vulnerability scanning | Disabled; `containerscanning.googleapis.com` is not enabled |
+
+The repository was created manually on September 4, 2026. There is no Terraform, CDK, or other IaC state. BoundaryML's `baml-infra` project administrators own IAM, billing, quotas, and cache availability; image contents remain maintained by the upstream projects. [Open the repository in Cloud Console](https://console.cloud.google.com/artifacts/docker/baml-infra/us-central1/ghcr-cache?project=baml-infra).
+
+## Image routing and scope
+
+Replace only the registry prefix, keeping the upstream owner, repository, tag, and digest:
+
+```text
+ghcr.io/<owner>/<image>:<tag>@sha256:<digest>
+  -> us-central1-docker.pkg.dev/baml-infra/ghcr-cache/<owner>/<image>:<tag>@sha256:<digest>
+```
+
+The references in the repository pin the verified upstream index digest as well as retaining the descriptive tag. The digest is authoritative; moving the upstream tag does not update our builds. Index pins preserve platform selection instead of forcing the ARM jobs onto an amd64 child manifest.
+
+| Upstream repository:tag | Consumers | Image selection |
+| --- | --- | --- |
+| `rust-cross/manylinux_2_28-cross:aarch64` | GNU ARM64 toolchain, wrapper, Node SDK | [Platform contract](../release/platforms.json), [Node workflow](../.github/workflows/build2-nodejs-sdk.reusable.yaml) |
+| `rust-cross/manylinux2014-cross:x86_64` | GNU x86_64 toolchain and wrapper | [Platform contract](../release/platforms.json) |
+| `rust-cross/rust-musl-cross:aarch64-musl` | ARM64 Python musl wheel | Python `container` in the platform contract, forwarded by the [Python workflow](../.github/workflows/build2-python-sdk.reusable.yaml) |
+| `rust-cross/rust-musl-cross:x86_64-musl` | x86_64 Python musl wheel | Python `container` in the platform contract, forwarded by the Python workflow |
+| `cross-rs/aarch64-unknown-linux-gnu:0.2.5` | ARM64 CFFI | [Cross.toml](../baml_language/Cross.toml) |
+| `cross-rs/x86_64-unknown-linux-gnu:0.2.5` | x86_64 CFFI | Cross.toml |
+| `cross-rs/aarch64-unknown-linux-musl:0.2.5` | ARM64 CFFI and Java musl | Cross.toml |
+| `cross-rs/x86_64-unknown-linux-musl:0.2.5` | x86_64 CFFI and Java musl | Cross.toml |
+
+The authoritative entry point is [release-baml-language.yml](../.github/workflows/release-baml-language.yml). Its [toolchain](../.github/workflows/build2-toolchain.reusable.yaml) and [wrapper](../.github/workflows/build2-wrapper.reusable.yaml) workflows consume platform-contract images; their temporary `CROSS_CONFIG` takes precedence over workspace defaults. The [CFFI](../.github/workflows/build2-bridge-cffi.reusable.yaml) and [Java](../.github/workflows/build2-java-sdk.reusable.yaml) workflows run from `baml_language` and use its `Cross.toml`, preserving environment passthrough. Local `cross` builds from that workspace use the same cache.
+
+The explicit Python override is necessary because [maturin-action](https://github.com/PyO3/maturin-action#inputs) otherwise constructs its own GHCR musl reference. [Cross target image overrides](https://github.com/cross-rs/cross/wiki/Configuration#targettargetimage) similarly bypass cross 0.2.5's implicit GHCR defaults. Merely replacing literal `ghcr.io` strings in workflow YAML misses these paths.
+
+This changes image delivery and freezes image versions, not container contents, entrypoints, mounts, runners, compilers, or artifact policies. Python keeps `musllinux_1_1`, its existing GNU manylinux policies, and the Python 3.10 abi3 floor. The rust-cross index exposes both Linux amd64 and arm64 host variants; cross-rs 0.2.5 uses amd64 hosts even when cross-compiling to aarch64. Existing native ARM versus cross-compilation choices are unchanged.
+
+Alpine, Microsoft, Quay, and Docker Hub images are unchanged. The PyPI publishing action's own `ghcr.io/pypa/gh-action-pypi-publish` image is outside this rust-cross/cross-rs migration. Legacy `engine` release workflows and integration-test Dockerfiles are also outside the BAML Language release graph and are not migrated here. This does not eliminate every repository dependency on GHCR or GitHub.
+
+## Administrative setup and inspection
+
+These are the commands used to provision the existing resource, not commands CI should run. Do not recreate or delete a working repository just to refresh this setup. See Google's [creation reference](https://docs.cloud.google.com/sdk/gcloud/reference/artifacts/repositories/create).
+
+```sh
+gcloud auth login
+gcloud config set project baml-infra
+gcloud auth list --filter=status:ACTIVE --format='value(account)'
+gcloud config get-value project
+gcloud billing projects describe baml-infra
+
+gcloud services enable artifactregistry.googleapis.com --project=baml-infra
+gcloud artifacts repositories create ghcr-cache \
+  --project=baml-infra --location=us-central1 \
+  --repository-format=docker --mode=remote-repository \
+  --remote-docker-repo=https://ghcr.io \
+  --description='Public GHCR pull-through cache for BAML release build images'
+gcloud artifacts repositories add-iam-policy-binding ghcr-cache \
+  --project=baml-infra --location=us-central1 \
+  --member=allUsers --role=roles/artifactregistry.reader
+```
+
+The project needs active billing, permission to enable the API and create repositories, and permission to set repository IAM. Organization policies must permit this location and the public IAM member. No GitHub or upstream secret is configured.
+
+Inspect without changing anything:
+
+```sh
+gcloud artifacts repositories describe ghcr-cache \
+  --project=baml-infra --location=us-central1 --format=json
+gcloud artifacts repositories get-iam-policy ghcr-cache \
+  --project=baml-infra --location=us-central1 --format=json
+gcloud artifacts docker images list \
+  us-central1-docker.pkg.dev/baml-infra/ghcr-cache --include-tags
+```
+
+## Verification and upgrades
+
+An anonymous manifest request tests public access without consulting Docker's credential helpers or downloading image layers:
+
+```sh
+curl --fail --silent --show-error --dump-header - --output /dev/null \
+  --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json' \
+  'https://us-central1-docker.pkg.dev/v2/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross/manifests/sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275'
+```
+
+Expect HTTP 200 and the matching `Docker-Content-Digest`. Provisioning verified all eight index digests anonymously, relevant amd64/arm64 child manifests and config blobs, plus two tiny layer downloads. That is not a full image pull or a release build: uncached layers are fetched lazily. Full outage protection requires every needed platform's layers to have been pulled successfully before the outage.
+
+For an intentional image upgrade, inspect the upstream tag's manifest index, compare the cache response and digest, check required host platforms, and update every occurrence of the affected pin in one reviewed PR. Do not silently substitute a single-platform digest or advance the cross version. Update matching platform tests. No automatic tag-based image updates are configured; the release maintainers must schedule upstream security review and digest refreshes.
+
+Representative pre-release checks, on a suitable Linux Docker host:
+
+1. Pull each pinned image for every host platform used by CI, without credentials. ARM64 toolchain and Node jobs need the arm64 rust-cross variant; the wrapper and Python cross-builds need amd64. Cross-rs targets need amd64.
+2. Run the GNU ARM64 container with Bash and a bind mount to verify executable permissions, workspace writes, networking, and required tools, for example `docker run --rm --platform linux/arm64 --entrypoint bash -v "$PWD:/workspace" -w /workspace "$IMAGE" -lc 'id; test -w /workspace; command -v bash curl tar; ldd --version'`, with `IMAGE` set to the committed reference.
+3. Exercise both Python musl matrix legs using the existing maturin workflow commands; inspect output wheel names for `cp310-abi3` and the expected `musllinux_1_1_<arch>` tag, then install/import on representative musl systems.
+4. Exercise all four Linux CFFI builds and both Java musl builds; verify expected ELF architecture, dynamic-library output, and consumer loading. Preserve `RUSTFLAGS`, source-remapping variables, and musl `-crt-static`.
+5. Exercise GNU toolchain/wrapper builds and ARM64 Node packaging; run existing artifact/consumer smoke tests. Confirm logs name `us-central1-docker.pkg.dev` for the eight scoped images.
+
+Use normal reviewed CI/release procedures for build validation. Provisioning and the migration PR do not dispatch releases or publish test artifacts to production registries.
+
+## Operations, security, and rollback
+
+Anonymous read access is intentionally public to the internet, not restricted to BoundaryML workflows. It does not grant public writes or administration, but this remote repository can cache other public GHCR paths: the configuration is not an owner/image allowlist. Third parties can consume storage, egress, and request quota by pulling through it. Do not add private upstream credentials to this public repository.
+
+Monitor [Artifact Registry quotas](https://docs.cloud.google.com/artifact-registry/quotas), repository size, and [storage/network charges](https://cloud.google.com/artifact-registry/pricing), especially internet egress to GitHub runners. Budget alerts and abuse-related quota review are operational follow-ups, not configured by this setup; a budget alert is not a spending cap. If public-cache abuse becomes material, reassess the public access design rather than putting a secret in every job without accounting for pre-step container pulls.
+
+No cleanup policy is configured, deliberately preserving old release pins for rollback. If adding cleanup later, retain every digest still referenced by supported release commits; deleting cached content reintroduces an upstream dependency. Cached content can survive an upstream outage, but the single GCP region and project remain availability dependencies.
+
+Digest pins protect content identity, not upstream trust or vulnerability status. This setup does not add signature/attestation verification, rebuild the images, or enable vulnerability scanning. Upstream image licensing and security maintenance obligations remain unchanged. Review upstream provenance and vulnerabilities when updating pins, and retain evidence with the PR.
+
+If GCP pulls fail, first check anonymous manifest access, repository IAM, quotas/billing, and upstream availability. Roll back image routing by replacing `us-central1-docker.pkg.dev/baml-infra/ghcr-cache/` with `ghcr.io/` in the platform contract, Node workflow, and Cross.toml, updating matching tests while retaining the digest pins and explicit Python container wiring. This returns to upstream delivery without changing image contents. Do not delete the cache or change public IAM as part of a workflow rollback; either affects other users independently.

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -69,12 +69,12 @@
       "artifacts": {
         "toolchain": {
           "runner": "ubuntu-24.04-arm",
-          "container": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275"
         },
         "wrapper": {
           "runner": "ubuntu-latest",
           "variants": ["self-update", "no-self-update"],
-          "cross_image": "ghcr.io/rust-cross/manylinux_2_28-cross:aarch64"
+          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275"
         },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
@@ -104,7 +104,11 @@
           "runner": "ubuntu-24.04-arm",
           "variants": ["self-update"]
         },
-        "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
+        "python": {
+          "runner": "ubuntu-latest",
+          "manylinux": "musllinux_1_1",
+          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643"
+        },
         "nodejs": {},
         "java": {
           "platform": "linux-aarch64-musl",
@@ -133,12 +137,12 @@
       "artifacts": {
         "toolchain": {
           "runner": "ubuntu-latest",
-          "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64"
+          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux2014-cross:x86_64@sha256:13670ccc63c35e072661938181c046243c01d7bca7976b3914177fb9b162998d"
         },
         "wrapper": {
           "runner": "ubuntu-latest",
           "variants": ["self-update", "no-self-update"],
-          "cross_image": "ghcr.io/rust-cross/manylinux2014-cross:x86_64"
+          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux2014-cross:x86_64@sha256:13670ccc63c35e072661938181c046243c01d7bca7976b3914177fb9b162998d"
         },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},
@@ -166,7 +170,11 @@
       "artifacts": {
         "toolchain": { "runner": "ubuntu-latest" },
         "wrapper": { "runner": "ubuntu-latest", "variants": ["self-update"] },
-        "python": { "runner": "ubuntu-latest", "manylinux": "musllinux_1_1" },
+        "python": {
+          "runner": "ubuntu-latest",
+          "manylinux": "musllinux_1_1",
+          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a"
+        },
         "nodejs": {},
         "java": {
           "platform": "linux-x86_64-musl",

--- a/release/platforms.json
+++ b/release/platforms.json
@@ -69,12 +69,12 @@
       "artifacts": {
         "toolchain": {
           "runner": "ubuntu-24.04-arm",
-          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275"
+          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64"
         },
         "wrapper": {
           "runner": "ubuntu-latest",
           "variants": ["self-update", "no-self-update"],
-          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64@sha256:ca53fa07ecf1c3e6408c51fbca64c036d9d29af832d3f8bb954910e89097f275"
+          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux_2_28-cross:aarch64"
         },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_24" },
         "nodejs": {},
@@ -107,7 +107,7 @@
         "python": {
           "runner": "ubuntu-latest",
           "manylinux": "musllinux_1_1",
-          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643"
+          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:aarch64-musl"
         },
         "nodejs": {},
         "java": {
@@ -137,12 +137,12 @@
       "artifacts": {
         "toolchain": {
           "runner": "ubuntu-latest",
-          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux2014-cross:x86_64@sha256:13670ccc63c35e072661938181c046243c01d7bca7976b3914177fb9b162998d"
+          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux2014-cross:x86_64"
         },
         "wrapper": {
           "runner": "ubuntu-latest",
           "variants": ["self-update", "no-self-update"],
-          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux2014-cross:x86_64@sha256:13670ccc63c35e072661938181c046243c01d7bca7976b3914177fb9b162998d"
+          "cross_image": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/manylinux2014-cross:x86_64"
         },
         "python": { "runner": "ubuntu-latest", "manylinux": "2_17" },
         "nodejs": {},
@@ -173,7 +173,7 @@
         "python": {
           "runner": "ubuntu-latest",
           "manylinux": "musllinux_1_1",
-          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a"
+          "container": "us-central1-docker.pkg.dev/baml-infra/ghcr-cache/rust-cross/rust-musl-cross:x86_64-musl"
         },
         "nodejs": {},
         "java": {


### PR DESCRIPTION
Get rid of our direct GHCR dependency, set up a GCP artifact registry as a pull-through cache for GHCR.

I thought we were seeing a bunch of failures around container fetch, but this is also I think a defensible move because of how bad GH availability is these days.