### PR TITLE
Preserve discarded effects and optimize stackified bytecode

### DIFF
--- a/baml_language/crates/baml_artifact/src/lib.rs
+++ b/baml_language/crates/baml_artifact/src/lib.rs
@@ -17,7 +17,7 @@ pub const MAGIC: &[u8; 8] = b"BAMLART\0";
 /// Any change to a Borsh-derived type reachable from `Program` or
 /// `PackageInterface` bumps this. The same rule applies to other payload types
 /// stored in this envelope, such as the `baml pack` dispatch envelope.
-pub const FORMAT_VERSION: u32 = 2;
+pub const FORMAT_VERSION: u32 = 3;
 
 /// Git commit used to build this crate, or the canonical BAML version when the
 /// source was built outside a Git checkout.

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -81,15 +81,15 @@ pub(crate) enum LocalClassification {
     /// At def sites: emit rvalue but NOT store (leave on stack).
     /// At Return: don't emit `LoadVar` for _0 (value already on stack).
     ReturnPhi,
-    /// Call result immediate: defined by Call/Await/SysOp, used exactly once
+    /// Call result immediate: defined by Call/VirtualCall/Await/SysOp, used exactly once
     /// immediately in the continuation block.
     /// At def site (after Call): don't emit Store (leave on stack).
     /// At use site: don't emit `LoadVar` (value already on stack from Call).
     CallResultImmediate,
-    /// Call/Await/SysOp result carried as part of a map/array aggregate prefix.
+    /// A value carried as part of an aggregate, binary, or call operand prefix.
     ///
     /// At def site: don't store the result; leave it on the stack.
-    /// At aggregate use site: don't emit `LoadVar`; the aggregate consumes the
+    /// At use site: don't emit `LoadVar`; the operation consumes the
     /// already-stacked value in operand order.
     AggregateOperand,
     /// Copy of another local: `_X = copy _Y` where _Y is a parameter or simple local.
@@ -1067,6 +1067,15 @@ fn classify_locals(
                 copy_sources.insert(local, source);
                 LocalClassification::CopyOf
             }
+        } else if !(opt == OptLevel::Zero && is_user_local)
+            && is_call_result_aggregate_operand(local, du, body, def_use)
+        {
+            stack_carry_candidates.insert(local, stack_carry::StackCarryKind::AggregateOperand);
+            if can_be_virtual(du, dominators, body, arity, def_use, predecessors) {
+                LocalClassification::Virtual
+            } else {
+                LocalClassification::Real
+            }
         } else if can_be_virtual(du, dominators, body, arity, def_use, predecessors) {
             if opt == OptLevel::Zero && is_user_local {
                 LocalClassification::Real
@@ -1080,10 +1089,6 @@ fn classify_locals(
         } else if is_return_phi(local, body, def_use, redirect_targets) {
             // Stack-carry candidate validated in a later stack simulation pass.
             stack_carry_candidates.insert(local, stack_carry::StackCarryKind::ReturnPhi);
-            LocalClassification::Real
-        } else if is_call_result_aggregate_operand(local, du, body, def_use) {
-            // Stack-carry candidate validated in a later stack simulation pass.
-            stack_carry_candidates.insert(local, stack_carry::StackCarryKind::AggregateOperand);
             LocalClassification::Real
         } else if is_call_result_immediate(local, du, body) {
             // Stack-carry candidate validated in a later stack simulation pass.
@@ -1101,6 +1106,7 @@ fn classify_locals(
         def_use,
         &stack_carry_candidates,
         &mut classifications,
+        predecessors,
     );
 
     (classifications, copy_sources)
@@ -2022,11 +2028,11 @@ fn ty_could_be_int(ty: &RuntimeTy) -> bool {
     }
 }
 
-/// Check if a local is a "call result immediate": defined by Call/Await/SysOp,
+/// Check if a local is a "call result immediate": defined by a call-like terminator,
 /// used exactly once in the continuation block.
 ///
 /// Call result immediate applies when:
-/// 1. The local is defined by a Call/Await/SysOp terminator
+/// 1. The local has exactly one definition, from Call/VirtualCall/Await/SysOp
 /// 2. It has exactly one use
 /// 3. The use is in the continuation block (target of the Call)
 ///
@@ -2037,7 +2043,7 @@ fn ty_could_be_int(ty: &RuntimeTy) -> bool {
 /// This eliminates the redundant `StoreVar("_X"); LoadVar("_X")` pattern for call results.
 fn is_call_result_immediate(local: Local, du: &LocalDefUse, body: &MirFunctionBody<'_>) -> bool {
     // Must have exactly one use
-    if du.uses.len() != 1 {
+    if du.uses.len() != 1 || du.all_defs.len() != 1 {
         return false;
     }
 
@@ -2066,7 +2072,7 @@ fn is_call_result_immediate(local: Local, du: &LocalDefUse, body: &MirFunctionBo
         return false;
     }
 
-    // Must have a definition from a terminator (Call/Await/SysOp)
+    // Must have a definition from a call-like terminator.
     let Some(def) = &du.def else {
         return false;
     };
@@ -2076,11 +2082,13 @@ fn is_call_result_immediate(local: Local, du: &LocalDefUse, body: &MirFunctionBo
         return false;
     }
 
-    // Get the defining block and check that its terminator is Call/Await/SysOp
+    // Get the defining block and check that its terminator is call-like
     // that defines this local.
     let def_block = body.block(def.block);
     match &def_block.terminator {
-        Some(Terminator::Call { destination, .. }) => {
+        Some(
+            Terminator::Call { destination, .. } | Terminator::VirtualCall { destination, .. },
+        ) => {
             matches!(destination, Place::Local(l) if *l == local)
         }
         Some(Terminator::Await { destination, .. }) => {
@@ -2092,12 +2100,6 @@ fn is_call_result_immediate(local: Local, du: &LocalDefUse, body: &MirFunctionBo
         // into an indexed `await futures[i]`; carrying the result on the stack
         // across that combination misaligns the stack. Always store it to a
         // local instead (correct, marginally less optimal).
-        //
-        // `VirtualCall` is likewise excluded: its result lands on the stack like
-        // `Call`, but the open-world dispatch first pushes the interface type +
-        // method-name operands, and the carry-result/store-elision path is not
-        // wired for that shape. Storing to a local is correct and only
-        // marginally less optimal; carrying can be enabled later.
         Some(Terminator::SysOp { destination, .. }) => {
             matches!(destination, Place::Local(l) if *l == local)
         }
@@ -2123,18 +2125,7 @@ fn is_call_result_aggregate_operand(
     let [use_loc] = du.uses.as_slice() else {
         return false;
     };
-    let StatementRef::Statement(stmt_idx) = use_loc.statement_ref else {
-        return false;
-    };
-    let Some(StatementKind::Assign { value, .. }) = body
-        .block(use_loc.block)
-        .statements
-        .get(stmt_idx)
-        .map(|stmt| &stmt.kind)
-    else {
-        return false;
-    };
-    let Some(operands) = aggregate_stack_prefix_operands(value) else {
+    let Some(operands) = stack_prefix_operands(body, use_loc) else {
         return false;
     };
 
@@ -2146,7 +2137,7 @@ fn is_call_result_aggregate_operand(
 
         if operand_local == local {
             found_local = true;
-            continue;
+            break;
         }
 
         let Some(operand_du) = def_use.get(&operand_local) else {
@@ -2167,10 +2158,30 @@ fn is_call_result_aggregate_operand(
     found_local
 }
 
+pub(crate) fn stack_prefix_operands<'a, 'db>(
+    body: &'a MirFunctionBody<'db>,
+    use_loc: &UseLocation,
+) -> Option<Vec<&'a Operand<'db>>> {
+    let block = body.block(use_loc.block);
+    match use_loc.statement_ref {
+        StatementRef::Statement(index) => match &block.statements.get(index)?.kind {
+            StatementKind::Assign { value, .. } => aggregate_stack_prefix_operands(value),
+            _ => None,
+        },
+        StatementRef::Terminator => match block.terminator.as_ref()? {
+            Terminator::Call { args, .. } | Terminator::VirtualCall { args, .. } => {
+                Some(args.iter().collect())
+            }
+            _ => None,
+        },
+    }
+}
+
 fn aggregate_stack_prefix_operands<'a, 'db>(
     rvalue: &'a Rvalue<'db>,
 ) -> Option<Vec<&'a Operand<'db>>> {
     match rvalue {
+        Rvalue::BinaryOp { left, right, .. } => Some(vec![left, right]),
         Rvalue::Array(_, elements) => Some(elements.iter().collect()),
         // Map lowering emits all values first, then all keys, because the VM
         // consumes maps as `[v1, v2, ..., k1, k2, ...]`. A carried key would sit
@@ -2208,7 +2219,7 @@ fn operand_local(operand: &Operand<'_>) -> Option<Local> {
 }
 
 fn is_call_like_result_local(local: Local, du: &LocalDefUse, body: &MirFunctionBody<'_>) -> bool {
-    if du.uses.len() != 1 {
+    if du.uses.len() != 1 || du.all_defs.len() != 1 {
         return false;
     }
 
@@ -2216,13 +2227,24 @@ fn is_call_like_result_local(local: Local, du: &LocalDefUse, body: &MirFunctionB
         return false;
     };
     if def.statement_ref != StatementRef::Terminator {
-        return false;
+        return def.block != du.uses[0].block
+            && matches!(
+                def.rvalue,
+                Rvalue::Use(Operand::Constant(
+                    Constant::Int(_)
+                        | Constant::Bool(_)
+                        | Constant::Float(_)
+                        | Constant::String(_)
+                        | Constant::Null
+                ))
+            );
     }
 
     let def_block = body.block(def.block);
     match &def_block.terminator {
         Some(
             Terminator::Call { destination, .. }
+            | Terminator::VirtualCall { destination, .. }
             | Terminator::Await { destination, .. }
             // `AwaitAny` deliberately excluded — see the note in the sibling
             // call-result-immediate check above.
@@ -2333,7 +2355,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregate_operand_requires_all_prefix_operands_to_be_stack_carried() {
+    fn aggregate_operand_allows_non_carried_trailing_operands() {
         let target = Local(1);
         let body = MirFunctionBody {
             blocks: vec![
@@ -2391,7 +2413,7 @@ mod tests {
         };
         let def_use = HashMap::from([(target, du.clone())]);
 
-        assert!(!is_call_result_aggregate_operand(
+        assert!(is_call_result_aggregate_operand(
             target, &du, &body, &def_use,
         ));
     }
@@ -2503,7 +2525,7 @@ mod tests {
                     statements: prior_definition.into_iter().collect(),
                     terminator: Some(Terminator::ShortCircuit {
                         operand: Operand::Constant(Constant::Bool(true)),
-                        is_and: true,
+                        kind: baml_compiler2_mir::ShortCircuitKind::And,
                         destination: Place::Local(destination),
                         eval_rhs: BlockId(1),
                         join: BlockId(4),
@@ -2516,7 +2538,7 @@ mod tests {
                     statements: vec![],
                     terminator: Some(Terminator::ShortCircuit {
                         operand: Operand::Constant(Constant::Bool(true)),
-                        is_and: true,
+                        kind: baml_compiler2_mir::ShortCircuitKind::And,
                         destination: Place::Local(destination),
                         eval_rhs: BlockId(2),
                         join: BlockId(3),
@@ -2604,6 +2626,31 @@ mod tests {
     }
 
     #[test]
+    fn named_scalar_prefix_stays_in_a_slot_at_o0() {
+        let mut entry = BasicBlock::new(BlockId(0));
+        entry.statements.push(assign_bool(Local(1), true));
+        entry.terminator = Some(Terminator::Goto { target: BlockId(1) });
+        let mut result = return_local_block(BlockId(1), Local(1));
+        result.statements[0].kind = StatementKind::Assign {
+            destination: Place::Local(Local(0)),
+            value: Rvalue::BinaryOp {
+                op: baml_compiler2_mir::BinOp::Eq,
+                left: Operand::copy_local(Local(1)),
+                right: Operand::Constant(Constant::Bool(true)),
+            },
+        };
+        let body = bool_body(vec![entry, result], Some("first"));
+        assert_eq!(
+            AnalysisResult::analyze(&body, 0, OptLevel::Zero).classifications[&Local(1)],
+            LocalClassification::Real
+        );
+        assert_eq!(
+            analyzed_classification(&body, Local(1)),
+            LocalClassification::AggregateOperand
+        );
+    }
+
+    #[test]
     fn nested_short_circuit_definitions_are_stack_carried() {
         let body = nested_short_circuit_body(None, false);
 
@@ -2676,7 +2723,7 @@ mod tests {
                     statements: vec![],
                     terminator: Some(Terminator::ShortCircuit {
                         operand: Operand::Constant(Constant::Bool(true)),
-                        is_and: true,
+                        kind: baml_compiler2_mir::ShortCircuitKind::And,
                         destination: Place::Local(destination),
                         eval_rhs: BlockId(2),
                         join: BlockId(3),
@@ -2727,7 +2774,7 @@ mod tests {
                     statements: vec![],
                     terminator: Some(Terminator::ShortCircuit {
                         operand: Operand::Constant(Constant::Bool(true)),
-                        is_and: true,
+                        kind: baml_compiler2_mir::ShortCircuitKind::And,
                         destination: Place::Local(destination),
                         eval_rhs: BlockId(2),
                         join: BlockId(4),
@@ -2772,7 +2819,7 @@ mod tests {
                     statements: vec![],
                     terminator: Some(Terminator::ShortCircuit {
                         operand: Operand::Constant(Constant::Bool(true)),
-                        is_and: true,
+                        kind: baml_compiler2_mir::ShortCircuitKind::And,
                         destination: Place::Local(destination),
                         eval_rhs: BlockId(1),
                         join: BlockId(2),
@@ -2821,6 +2868,51 @@ mod tests {
             destination: Place::Local(Local(1)),
             target,
             unwind: None,
+        }
+    }
+
+    #[test]
+    fn virtual_call_result_carries_only_on_single_entry_continuations() {
+        let mut entry = BasicBlock::new(BlockId(0));
+        entry.terminator = Some(virtual_call_into(BlockId(1)));
+        let body = bool_body(
+            vec![entry.clone(), return_local_block(BlockId(1), Local(1))],
+            None,
+        );
+        assert_eq!(
+            analyzed_classification(&body, Local(1)),
+            LocalClassification::CallResultImmediate
+        );
+
+        let mut header = BasicBlock::new(BlockId(1));
+        header.terminator = Some(Terminator::Branch {
+            condition: Operand::copy_local(Local(1)),
+            then_block: BlockId(2),
+            else_block: BlockId(3),
+        });
+        let mut backedge = BasicBlock::new(BlockId(2));
+        backedge.terminator = Some(Terminator::Goto { target: BlockId(1) });
+        let mut exit = BasicBlock::new(BlockId(3));
+        exit.statements.push(assign_bool(Local(0), false));
+        exit.terminator = Some(Terminator::Return);
+        let loop_body = bool_body(vec![entry, header, backedge, exit], None);
+        assert_eq!(
+            analyzed_classification(&loop_body, Local(1)),
+            LocalClassification::Real
+        );
+    }
+
+    #[test]
+    fn call_result_with_a_prior_definition_is_not_carried() {
+        for call in [call_into(BlockId(1), None), virtual_call_into(BlockId(1))] {
+            let mut entry = BasicBlock::new(BlockId(0));
+            entry.statements.push(assign_bool(Local(1), false));
+            entry.terminator = Some(call);
+            let body = bool_body(vec![entry, return_local_block(BlockId(1), Local(1))], None);
+            assert_eq!(
+                analyzed_classification(&body, Local(1)),
+                LocalClassification::Real
+            );
         }
     }
 

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1355,6 +1355,21 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         }
     }
 
+    /// Select polarity from the actual layout, after redirect resolution.
+    fn emit_branch(&mut self, then_block: BlockId, else_block: BlockId) {
+        let resolved_else = self.resolve_pending_target(else_block);
+        if matches!(resolved_else, PendingJumpTarget::Block(block) if Some(block) == self.next_block)
+        {
+            let target = self.resolve_pending_target(then_block);
+            let jump = self.emit(Instruction::PopJumpIfTrue(0));
+            self.pending_jumps.push((jump, target));
+        } else {
+            let jump = self.emit(Instruction::PopJumpIfFalse(0));
+            self.pending_jumps.push((jump, resolved_else));
+            self.emit_jump_unless_fallthrough(then_block);
+        }
+    }
+
     /// Emit an unconditional jump to a target, even when the target is the
     /// next emitted MIR block.
     ///
@@ -2255,13 +2270,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 else_block,
             } => {
                 self.emit_operand_pull(condition);
-                // PopJumpIfFalse to else_block (pops condition from stack).
-                // Apply jump threading to resolve through empty blocks.
-                let resolved_else = self.resolve_pending_target(*else_block);
-                let else_jump = self.emit(Instruction::PopJumpIfFalse(0));
-                self.pending_jumps.push((else_jump, resolved_else));
-                // Jump to then_block (may be elided if it's next).
-                self.emit_jump_unless_fallthrough(*then_block);
+                self.emit_branch(*then_block, *else_block);
             }
 
             Terminator::NarrowBind {
@@ -2273,10 +2282,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             } => {
                 self.emit_operand_pull(source);
                 self.emit_narrow_bind(ty_template, *destination);
-                let resolved_else = self.resolve_pending_target(*else_block);
-                let else_jump = self.emit(Instruction::PopJumpIfFalse(0));
-                self.pending_jumps.push((else_jump, resolved_else));
-                self.emit_jump_unless_fallthrough(*then_block);
+                self.emit_branch(*then_block, *else_block);
             }
 
             Terminator::Switch {
@@ -2576,12 +2582,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
             Terminator::ShortCircuit {
                 operand,
-                is_and,
+                kind,
                 destination,
                 eval_rhs,
                 join,
             } => {
-                // Short-circuit lowering using JumpIfFalse (peek, no pop).
+                // Fused branches retain the value when taken and pop it otherwise.
                 //
                 // The short-circuit (taken) path leaves the operand value on TOS
                 // and jumps to the join. The `eval_rhs` block computes and stores
@@ -2602,38 +2608,24 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 );
                 self.emit_operand_pull(operand);
 
-                if *is_and {
-                    // &&: false → short-circuit edge (materialize dest), jump to join.
-                    //     true → pop, evaluate rhs.
-                    let sc_jump = self.emit(Instruction::JumpIfFalse(0));
-                    let resolved_join = self.resolve_pending_target(*join);
-                    if store_on_taken_path {
-                        self.emit(Instruction::Pop(1));
-                        self.emit_jump_always(*eval_rhs);
-                        let taken_pc = self.bytecode.instructions.len();
-                        self.patch_jump_to(sc_jump, taken_pc);
-                        self.emit_store_place(destination);
-                        let join_jump = self.emit(Instruction::Jump(0));
-                        self.pending_jumps.push((join_jump, resolved_join));
-                    } else {
-                        self.pending_jumps.push((sc_jump, resolved_join));
-                        self.emit(Instruction::Pop(1));
-                        self.emit_jump_unless_fallthrough(*eval_rhs);
+                let instruction = match kind {
+                    baml_compiler2_mir::ShortCircuitKind::And => Instruction::JumpIfFalseOrPop(0),
+                    baml_compiler2_mir::ShortCircuitKind::Or => Instruction::JumpIfTrueOrPop(0),
+                    baml_compiler2_mir::ShortCircuitKind::Coalesce => {
+                        Instruction::JumpIfNotNullOrPop(0)
                     }
+                };
+                let sc_jump = self.emit(instruction);
+                let resolved_join = self.resolve_pending_target(*join);
+                if store_on_taken_path {
+                    self.emit_jump_always(*eval_rhs);
+                    let taken_pc = self.bytecode.instructions.len();
+                    self.patch_jump_to(sc_jump, taken_pc);
+                    self.emit_store_place(destination);
+                    let join_jump = self.emit(Instruction::Jump(0));
+                    self.pending_jumps.push((join_jump, resolved_join));
                 } else {
-                    // ||: false → pop, evaluate rhs.
-                    //     true → short-circuit edge (materialize dest), jump to join.
-                    let false_jump = self.emit(Instruction::JumpIfFalse(0));
-                    let resolved_join = self.resolve_pending_target(*join);
-                    if store_on_taken_path {
-                        self.emit_store_place(destination);
-                    }
-                    let true_jump = self.emit(Instruction::Jump(0));
-                    self.pending_jumps.push((true_jump, resolved_join));
-                    // False landing: patch JumpIfFalse to here, pop, fall to eval_rhs.
-                    let false_pc = self.bytecode.instructions.len();
-                    self.patch_jump_to(false_jump, false_pc);
-                    self.emit(Instruction::Pop(1));
+                    self.pending_jumps.push((sc_jump, resolved_join));
                     self.emit_jump_unless_fallthrough(*eval_rhs);
                 }
             }
@@ -2649,6 +2641,44 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         for (instruction_idx, target) in self.pending_jumps.clone() {
             let target_pc = self.resolve_pending_target_pc(target);
             self.patch_jump_to(instruction_idx, target_pc);
+        }
+        // A taken value-preserving branch already established the predicate.
+        // Thread identical tests without moving PCs or skipping debugger stops.
+        for source in 0..self.bytecode.instructions.len() {
+            let branch = &self.bytecode.instructions[source];
+            let offset = match branch {
+                Instruction::JumpIfFalseOrPop(offset)
+                | Instruction::JumpIfTrueOrPop(offset)
+                | Instruction::JumpIfNotNullOrPop(offset) => *offset,
+                _ => continue,
+            };
+            let mut target = source.wrapping_add_signed(offset);
+            while target > source && target < self.bytecode.instructions.len() {
+                if self
+                    .bytecode
+                    .line_table
+                    .iter()
+                    .any(|entry| entry.pc == target && entry.sequence_point)
+                {
+                    break;
+                }
+                let next = &self.bytecode.instructions[target];
+                if std::mem::discriminant(next) != std::mem::discriminant(branch) {
+                    break;
+                }
+                let next_offset = match next {
+                    Instruction::JumpIfFalseOrPop(offset)
+                    | Instruction::JumpIfTrueOrPop(offset)
+                    | Instruction::JumpIfNotNullOrPop(offset)
+                        if *offset > 0 =>
+                    {
+                        *offset
+                    }
+                    _ => break,
+                };
+                target = target.wrapping_add_signed(next_offset);
+            }
+            self.patch_jump_to(source, target);
         }
     }
 
@@ -2681,6 +2711,19 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             Instruction::JumpIfFalse(_) => {
                 self.bytecode.instructions[instruction_idx] = Instruction::JumpIfFalse(offset);
+            }
+            Instruction::PopJumpIfTrue(_) => {
+                self.bytecode.instructions[instruction_idx] = Instruction::PopJumpIfTrue(offset);
+            }
+            Instruction::JumpIfFalseOrPop(_) => {
+                self.bytecode.instructions[instruction_idx] = Instruction::JumpIfFalseOrPop(offset);
+            }
+            Instruction::JumpIfTrueOrPop(_) => {
+                self.bytecode.instructions[instruction_idx] = Instruction::JumpIfTrueOrPop(offset);
+            }
+            Instruction::JumpIfNotNullOrPop(_) => {
+                self.bytecode.instructions[instruction_idx] =
+                    Instruction::JumpIfNotNullOrPop(offset);
             }
             _ => panic!("expected jump instruction at index {instruction_idx}"),
         }

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -960,32 +960,8 @@ fn simulate_rvalue_pull_stack<'db>(
     classifications: &HashMap<Local, LocalClassification>,
     def_use: &HashMap<Local, LocalDefUse>,
 ) -> bool {
-    if let Rvalue::BinaryOp { left, right, .. } = rvalue
-        && [left, right].iter().all(|operand| {
-            operand_as_local(operand).is_some_and(|local| {
-                local == carried_local
-                    || classifications
-                        .get(&local)
-                        .copied()
-                        .is_some_and(is_stack_carried_local)
-            })
-        })
-    {
-        return simulate_stack_consuming_aggregate(
-            AggregateStackShape {
-                value_operands: &[left, right],
-                trailing_operands: &[],
-                total_pops: 2,
-                extra_pushes_before_alloc: 0,
-            },
-            sim,
-            carried_local,
-            classifications,
-            def_use,
-        );
-    }
     if let Some(result) =
-        simulate_aggregate_operand_pull_stack(rvalue, sim, carried_local, classifications, def_use)
+        simulate_operand_prefix_pull_stack(rvalue, sim, carried_local, classifications, def_use)
     {
         return result;
     }
@@ -1070,7 +1046,9 @@ fn simulate_rvalue_pull_stack<'db>(
     pull_semantics::walk_rvalue_pull(&mut sink, rvalue).is_ok()
 }
 
-fn simulate_aggregate_operand_pull_stack(
+/// Validate operand prefixes both at direct evaluations and through inlined
+/// locals. Binary operands already stacked in source order need no reordering.
+fn simulate_operand_prefix_pull_stack(
     rvalue: &Rvalue<'_>,
     sim: &mut StackCarrySim,
     carried_local: Local,
@@ -1078,6 +1056,30 @@ fn simulate_aggregate_operand_pull_stack(
     def_use: &HashMap<Local, LocalDefUse>,
 ) -> Option<bool> {
     match rvalue {
+        Rvalue::BinaryOp { left, right, .. }
+            if [left, right].iter().all(|operand| {
+                operand_as_local(operand).is_some_and(|local| {
+                    local == carried_local
+                        || classifications
+                            .get(&local)
+                            .copied()
+                            .is_some_and(is_stack_carried_local)
+                })
+            }) =>
+        {
+            Some(simulate_stack_consuming_aggregate(
+                AggregateStackShape {
+                    value_operands: &[left, right],
+                    trailing_operands: &[],
+                    total_pops: 2,
+                    extra_pushes_before_alloc: 0,
+                },
+                sim,
+                carried_local,
+                classifications,
+                def_use,
+            ))
+        }
         Rvalue::Array(_, elements) => {
             let values = elements.iter().collect::<Vec<_>>();
             Some(simulate_stack_consuming_aggregate(
@@ -1231,7 +1233,7 @@ fn simulate_stack_consuming_aggregate(
 fn aggregate_value_operand_index<'db>(rvalue: &Rvalue<'db>, local: Local) -> Option<usize> {
     let operands: Vec<&Operand<'db>> = match rvalue {
         Rvalue::Array(_, elements) => elements.iter().collect(),
-        // See `simulate_aggregate_operand_pull_stack`: only map values are
+        // See `simulate_operand_prefix_pull_stack`: only map values are
         // valid stack-carry prefix operands for the current VM stack layout.
         Rvalue::Map(_, _, entries) => entries.iter().map(|(_key, value)| value).collect(),
         Rvalue::Aggregate {
@@ -1399,7 +1401,7 @@ impl<'a> PullSink<'a> for StackCarryPullSink<'a> {
                 ) {
                     return Err(());
                 }
-                if let Some(ok) = simulate_aggregate_operand_pull_stack(
+                if let Some(ok) = simulate_operand_prefix_pull_stack(
                     &def.rvalue,
                     self.sim,
                     self.carried_local,
@@ -1740,6 +1742,76 @@ mod tests {
     }
 
     #[test]
+    fn inlined_binary_prefix_preserves_both_operand_depths() {
+        use baml_compiler2_mir::BlockId;
+
+        use crate::analysis::{AnalysisResult, OptLevel};
+
+        let left = Local(1);
+        let right = Local(2);
+        let mut body = body_with_locals(vec![int_ty(), int_ty(), int_ty()]);
+        body.blocks[0].statements.push(Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(left),
+                value: Rvalue::Use(Operand::Constant(Constant::Int(20))),
+            },
+            span: None,
+        });
+        body.blocks[0].terminator = Some(Terminator::Call {
+            callee: Operand::Constant(Constant::Null),
+            args: vec![],
+            ntypeargs: 0,
+            runtime_type_check: false,
+            runtime_id: None,
+            destination: Place::Local(right),
+            target: BlockId(1),
+            unwind: None,
+        });
+        let mut continuation = BasicBlock::new(BlockId(1));
+        continuation.statements.push(Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(Local(0)),
+                value: Rvalue::BinaryOp {
+                    op: BinOp::Sub,
+                    left: Operand::copy_local(left),
+                    right: Operand::copy_local(right),
+                },
+            },
+            span: None,
+        });
+        continuation.terminator = Some(Terminator::Return);
+        body.blocks.push(continuation);
+        let analysis = AnalysisResult::analyze(&body, 0, OptLevel::One);
+        assert_eq!(
+            analysis.classifications[&Local(0)],
+            LocalClassification::Virtual
+        );
+        for (local, expected_depth) in [(left, 1), (right, 0)] {
+            assert_eq!(
+                analysis.classifications[&local],
+                LocalClassification::AggregateOperand
+            );
+            for depth in [0, 1] {
+                let mut sim = StackCarrySim {
+                    depth: Some(depth),
+                    used: false,
+                };
+                assert_eq!(
+                    simulate_operand_pull_stack(
+                        &Operand::copy_local(Local(0)),
+                        &mut sim,
+                        local,
+                        &analysis.classifications,
+                        &analysis.def_use,
+                    ),
+                    depth == expected_depth,
+                    "{local:?} at depth {depth}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn aggregate_stack_carry_accepts_array_value_prefix() {
         let carried = Local(1);
         let sibling = Local(2);
@@ -1749,7 +1821,7 @@ mod tests {
             used: false,
         };
 
-        let ok = simulate_aggregate_operand_pull_stack(
+        let ok = simulate_operand_prefix_pull_stack(
             &Rvalue::Array(
                 TyTemplate::from(RealizedTy::unknown()),
                 vec![
@@ -1778,7 +1850,7 @@ mod tests {
             used: false,
         };
 
-        let ok = simulate_aggregate_operand_pull_stack(
+        let ok = simulate_operand_prefix_pull_stack(
             &Rvalue::Aggregate {
                 kind: AggregateKind::Array,
                 fields: vec![Operand::copy_local(sibling), Operand::copy_local(carried)],
@@ -1803,7 +1875,7 @@ mod tests {
             used: false,
         };
 
-        let ok = simulate_aggregate_operand_pull_stack(
+        let ok = simulate_operand_prefix_pull_stack(
             &Rvalue::Map(
                 TyTemplate::from(RealizedTy::string()),
                 TyTemplate::from(RealizedTy::unknown()),
@@ -1851,7 +1923,7 @@ mod tests {
             used: false,
         };
 
-        let ok = simulate_aggregate_operand_pull_stack(
+        let ok = simulate_operand_prefix_pull_stack(
             &Rvalue::Array(
                 TyTemplate::from(RealizedTy::unknown()),
                 vec![
@@ -1879,7 +1951,7 @@ mod tests {
             used: false,
         };
 
-        let ok = simulate_aggregate_operand_pull_stack(
+        let ok = simulate_operand_prefix_pull_stack(
             &Rvalue::Aggregate {
                 kind: AggregateKind::Class {
                     name: "Box".to_string(),
@@ -1913,7 +1985,7 @@ mod tests {
         let mut sim = StackCarrySim::new();
 
         assert_eq!(
-            simulate_aggregate_operand_pull_stack(
+            simulate_operand_prefix_pull_stack(
                 &rvalue,
                 &mut sim,
                 carried,

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -43,17 +43,43 @@ pub(super) fn refine_stack_carry_classifications(
     def_use: &HashMap<Local, LocalDefUse>,
     candidates: &HashMap<Local, StackCarryKind>,
     classifications: &mut HashMap<Local, LocalClassification>,
+    predecessors: &HashMap<baml_compiler2_mir::BlockId, Vec<baml_compiler2_mir::BlockId>>,
 ) {
     let mut locals: Vec<Local> = candidates.keys().copied().collect();
     // Deterministic greedy order. Aggregate operands are ordered by their use
     // position so earlier stacked values are activated before later ones.
     locals.sort_by_key(|l| stack_carry_sort_key(*l, body, def_use, candidates));
 
-    for local in locals {
+    let fallback = classifications.clone();
+    for &local in &locals {
         let kind = candidates[&local];
-        let is_safe = is_stack_carry_use_safe(local, kind, body, classifications, def_use);
+        let is_safe =
+            is_stack_carry_use_safe(local, kind, body, classifications, def_use, predecessors);
         if is_safe {
             classifications.insert(local, kind.to_classification());
+        }
+    }
+    // Activating a later candidate changes earlier candidates' stack prefixes.
+    // Recheck the final plan, and propagate any rejection to its dependents.
+    loop {
+        let mut changed = false;
+        for &local in &locals {
+            if classifications[&local] == candidates[&local].to_classification()
+                && !is_stack_carry_use_safe(
+                    local,
+                    candidates[&local],
+                    body,
+                    classifications,
+                    def_use,
+                    predecessors,
+                )
+            {
+                classifications.insert(local, fallback[&local]);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
         }
     }
 }
@@ -66,14 +92,15 @@ fn stack_carry_sort_key(
 ) -> (usize, usize, usize, usize) {
     if candidates.get(&local) == Some(&StackCarryKind::AggregateOperand)
         && let Some(use_loc) = def_use.get(&local).and_then(|du| du.uses.first())
-        && let StatementRef::Statement(stmt_idx) = use_loc.statement_ref
-        && let Some(StatementKind::Assign { value, .. }) = body
-            .block(use_loc.block)
-            .statements
-            .get(stmt_idx)
-            .map(|stmt| &stmt.kind)
-        && let Some(operand_idx) = aggregate_value_operand_index(value, local)
+        && let Some(operands) = crate::analysis::stack_prefix_operands(body, use_loc)
+        && let Some(operand_idx) = operands
+            .iter()
+            .position(|operand| is_operand_local(operand, local))
     {
+        let stmt_idx = match use_loc.statement_ref {
+            StatementRef::Statement(index) => index,
+            StatementRef::Terminator => body.block(use_loc.block).statements.len(),
+        };
         return (0, use_loc.block.0, stmt_idx, operand_idx);
     }
 
@@ -153,6 +180,7 @@ fn is_stack_carry_use_safe(
     body: &MirFunctionBody<'_>,
     classifications: &HashMap<Local, LocalClassification>,
     def_use: &HashMap<Local, LocalDefUse>,
+    predecessors: &HashMap<baml_compiler2_mir::BlockId, Vec<baml_compiler2_mir::BlockId>>,
 ) -> bool {
     // `analysis::is_return_phi` already proves stack safety for this shape by
     // requiring only stack-neutral statements between def and `Return`.
@@ -170,6 +198,7 @@ fn is_stack_carry_use_safe(
         return false;
     };
     let mut sim = StackCarrySim::new();
+    let mut start_statement = 0;
     let mut current_block = match kind {
         StackCarryKind::PhiLike => use_loc.block,
         StackCarryKind::CallResultImmediate | StackCarryKind::AggregateOperand => {
@@ -177,48 +206,79 @@ fn is_stack_carry_use_safe(
                 return false;
             };
             let def_block = body.block(def.block);
-            match &def_block.terminator {
-                Some(Terminator::Call {
-                    destination,
-                    target,
-                    ..
-                }) => {
-                    if !matches!(destination, Place::Local(l) if *l == local) {
-                        return false;
-                    }
-                    *target
+            if let StatementRef::Statement(index) = def.statement_ref {
+                if kind != StackCarryKind::AggregateOperand {
+                    return false;
                 }
-                Some(Terminator::Await {
-                    destination,
-                    target,
-                    ..
-                }) => {
-                    if !matches!(destination, Place::Local(l) if *l == local) {
-                        return false;
+                start_statement = index + 1;
+                def.block
+            } else {
+                match &def_block.terminator {
+                    Some(
+                        Terminator::Call {
+                            destination,
+                            target,
+                            ..
+                        }
+                        | Terminator::VirtualCall {
+                            destination,
+                            target,
+                            ..
+                        },
+                    ) => {
+                        if !matches!(destination, Place::Local(l) if *l == local) {
+                            return false;
+                        }
+                        *target
                     }
-                    *target
-                }
-                Some(Terminator::SysOp {
-                    destination,
-                    target,
-                    ..
-                }) => {
-                    if !matches!(destination, Place::Local(l) if *l == local) {
-                        return false;
+                    Some(Terminator::Await {
+                        destination,
+                        target,
+                        ..
+                    }) => {
+                        if !matches!(destination, Place::Local(l) if *l == local) {
+                            return false;
+                        }
+                        *target
                     }
-                    *target
+                    Some(Terminator::SysOp {
+                        destination,
+                        target,
+                        ..
+                    }) => {
+                        if !matches!(destination, Place::Local(l) if *l == local) {
+                            return false;
+                        }
+                        *target
+                    }
+                    // `AwaitAny` intentionally omitted: its result is never stack-
+                    // carried (it falls through to `return false` here), because
+                    // the opcode rewinds + re-executes across the engine suspend
+                    // and a carried result does not survive that. See the matching
+                    // note in `analysis.rs` (call-result-immediate checks).
+                    _ => return false,
                 }
-                // `AwaitAny` intentionally omitted: its result is never stack-
-                // carried (it falls through to `return false` here), because
-                // the opcode rewinds + re-executes across the engine suspend
-                // and a carried result does not survive that. See the matching
-                // note in `analysis.rs` (call-result-immediate checks).
-                _ => return false,
             }
         }
         StackCarryKind::ReturnPhi => unreachable!("handled above"),
     };
 
+    let single_entry = |from, to| {
+        to != body.entry
+            && !body.catch_regions.iter().any(|region| region.handler == to)
+            && predecessors
+                .get(&to)
+                .is_some_and(|preds| preds.as_slice() == [from])
+    };
+    if matches!(
+        kind,
+        StackCarryKind::CallResultImmediate | StackCarryKind::AggregateOperand
+    ) && let Some(def) = &du.def
+        && def.statement_ref == StatementRef::Terminator
+        && !single_entry(def.block, current_block)
+    {
+        return false;
+    }
     let mut visited = HashSet::new();
     loop {
         if !visited.insert(current_block) {
@@ -230,7 +290,10 @@ fn is_stack_carry_use_safe(
         if current_block == use_loc.block {
             match use_loc.statement_ref {
                 StatementRef::Statement(stmt_idx) => {
-                    for stmt in &block.statements[..stmt_idx] {
+                    if start_statement > stmt_idx {
+                        return false;
+                    }
+                    for stmt in &block.statements[start_statement..stmt_idx] {
                         if !simulate_statement_stack(
                             &stmt.kind,
                             &mut sim,
@@ -258,7 +321,7 @@ fn is_stack_carry_use_safe(
                     }
                 }
                 StatementRef::Terminator => {
-                    for stmt in &block.statements {
+                    for stmt in &block.statements[start_statement..] {
                         if !simulate_statement_stack(
                             &stmt.kind,
                             &mut sim,
@@ -293,7 +356,7 @@ fn is_stack_carry_use_safe(
         // Intermediate blocks on the carried path must be straight-line. Aggregate
         // operand carry can cross later call-like terminators because their
         // results may become later aggregate operands stacked above this one.
-        for stmt in &block.statements {
+        for stmt in &block.statements[start_statement..] {
             if !simulate_statement_stack(
                 &stmt.kind,
                 &mut sim,
@@ -305,14 +368,16 @@ fn is_stack_carry_use_safe(
                 return false;
             }
         }
+        start_statement = 0;
 
         let Some(term) = block.terminator.as_ref() else {
             return false;
         };
 
-        current_block = match term {
+        let next_block = match term {
             Terminator::Goto { target } => *target,
             Terminator::Call { target, .. }
+            | Terminator::VirtualCall { target, .. }
             | Terminator::SysOp { target, .. }
             | Terminator::Await { target, .. }
             | Terminator::AwaitAny { target, .. }
@@ -326,6 +391,10 @@ fn is_stack_carry_use_safe(
             }
             _ => return false,
         };
+        if !single_entry(current_block, next_block) {
+            return false;
+        }
+        current_block = next_block;
     }
 }
 
@@ -553,6 +622,34 @@ fn simulate_terminator_stack<'db>(
             destination,
             ..
         } => {
+            if args.iter().any(|arg| is_operand_local(arg, carried_local)) {
+                let direct = pull_semantics::resolve_constant_function_item(
+                    callee,
+                    classifications,
+                    def_use,
+                )
+                .is_some();
+                let values = args.iter().collect::<Vec<_>>();
+                let mut trailing = Vec::new();
+                if !direct {
+                    trailing.push(callee);
+                }
+                if let Some(id) = runtime_id {
+                    trailing.push(id);
+                }
+                return simulate_stack_consuming_aggregate(
+                    AggregateStackShape {
+                        value_operands: &values,
+                        trailing_operands: &trailing,
+                        total_pops: values.len() + trailing.len(),
+                        extra_pushes_before_alloc: 0,
+                    },
+                    sim,
+                    carried_local,
+                    classifications,
+                    def_use,
+                ) && simulate_store_place_stack(destination, sim, classifications);
+            }
             let runtime_id_slots = usize::from(runtime_id.is_some());
             let direct_call =
                 pull_semantics::resolve_constant_function_item(callee, classifications, def_use)
@@ -603,6 +700,22 @@ fn simulate_terminator_stack<'db>(
             destination,
             ..
         } => {
+            if args.iter().any(|arg| is_operand_local(arg, carried_local)) {
+                let values = args.iter().collect::<Vec<_>>();
+                let trailing = runtime_id.iter().collect::<Vec<_>>();
+                return simulate_stack_consuming_aggregate(
+                    AggregateStackShape {
+                        value_operands: &values,
+                        trailing_operands: &trailing,
+                        total_pops: values.len() + trailing.len() + 2,
+                        extra_pushes_before_alloc: 2,
+                    },
+                    sim,
+                    carried_local,
+                    classifications,
+                    def_use,
+                ) && simulate_store_place_stack(destination, sim, classifications);
+            }
             {
                 let mut sink = StackCarryPullSink {
                     sim,
@@ -847,6 +960,30 @@ fn simulate_rvalue_pull_stack<'db>(
     classifications: &HashMap<Local, LocalClassification>,
     def_use: &HashMap<Local, LocalDefUse>,
 ) -> bool {
+    if let Rvalue::BinaryOp { left, right, .. } = rvalue
+        && [left, right].iter().all(|operand| {
+            operand_as_local(operand).is_some_and(|local| {
+                local == carried_local
+                    || classifications
+                        .get(&local)
+                        .copied()
+                        .is_some_and(is_stack_carried_local)
+            })
+        })
+    {
+        return simulate_stack_consuming_aggregate(
+            AggregateStackShape {
+                value_operands: &[left, right],
+                trailing_operands: &[],
+                total_pops: 2,
+                extra_pushes_before_alloc: 0,
+            },
+            sim,
+            carried_local,
+            classifications,
+            def_use,
+        );
+    }
     if let Some(result) =
         simulate_aggregate_operand_pull_stack(rvalue, sim, carried_local, classifications, def_use)
     {
@@ -1090,6 +1227,7 @@ fn simulate_stack_consuming_aggregate(
     true
 }
 
+#[cfg(test)]
 fn aggregate_value_operand_index<'db>(rvalue: &Rvalue<'db>, local: Local) -> Option<usize> {
     let operands: Vec<&Operand<'db>> = match rvalue {
         Rvalue::Array(_, elements) => elements.iter().collect(),

--- a/baml_language/crates/baml_compiler2_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/builder.rs
@@ -298,14 +298,14 @@ impl<'db> MirBuilder<'db> {
     pub(crate) fn short_circuit(
         &mut self,
         operand: Operand<'db>,
-        is_and: bool,
+        kind: crate::ShortCircuitKind,
         destination: Place,
         eval_rhs: BlockId,
         join: BlockId,
     ) {
         self.set_terminator(Terminator::ShortCircuit {
             operand,
-            is_and,
+            kind,
             destination,
             eval_rhs,
             join,

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -1007,6 +1007,64 @@ pub enum Rvalue<'db> {
     CurrentPackage(String),
 }
 
+impl Rvalue<'_> {
+    /// Whether an unused evaluation can be erased, including its operand reads.
+    /// Non-mutating operations can still fail (arithmetic, indexing, allocation).
+    pub fn can_discard(&self) -> bool {
+        let operand = |op: &Operand<'_>| {
+            matches!(
+                op,
+                Operand::Constant(_)
+                    | Operand::Copy(Place::Local(_) | Place::Capture(_))
+                    | Operand::Move(Place::Local(_) | Place::Capture(_))
+            )
+        };
+        match self {
+            Self::Use(op) => operand(op),
+            Self::BinaryOp { op, left, right } => {
+                matches!(
+                    op,
+                    BinOp::Eq
+                        | BinOp::Ne
+                        | BinOp::Lt
+                        | BinOp::Le
+                        | BinOp::Gt
+                        | BinOp::Ge
+                        | BinOp::BitAnd
+                        | BinOp::BitOr
+                        | BinOp::BitXor
+                ) && operand(left)
+                    && operand(right)
+            }
+            Self::UnaryOp { op, operand: arg } => {
+                matches!(op, UnaryOp::Not | UnaryOp::Truthy) && operand(arg)
+            }
+            Self::IsType { operand: arg, .. } | Self::IsTypeTag { operand: arg, .. } => {
+                operand(arg)
+            }
+            Self::RuntimeIsType {
+                operand: arg,
+                type_value,
+            } => operand(arg) && operand(type_value),
+            Self::TypeTag(place) => matches!(place, Place::Local(_) | Place::Capture(_)),
+            Self::LoadType(_) | Self::CurrentPackage(_) => true,
+            Self::Array(..)
+            | Self::Uint8Array(_)
+            | Self::Map(..)
+            | Self::Aggregate { .. }
+            | Self::Discriminant(_)
+            | Self::Len(_)
+            | Self::MakeClosure { .. }
+            | Self::MakeBoundMethod { .. }
+            | Self::MakeVirtualBoundMethod { .. }
+            | Self::MakeVirtualFunction { .. }
+            | Self::VirtualFieldAccess { .. }
+            | Self::MakeGenericFunction { .. }
+            | Self::MakeGenericFunctionFromValue { .. } => false,
+        }
+    }
+}
+
 /// The kind of aggregate being constructed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AggregateKind {

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -625,23 +625,29 @@ pub enum Terminator<'db> {
         otherwise: BlockId,
     },
 
-    /// Short-circuit `&&` / `||`.
+    /// Short-circuit `&&` / `||` / `??`.
     ///
-    /// Evaluates `operand` and peeks at the result (without popping):
-    /// - `&&` (`is_and = true`): if false, jump to `join` (value stays on stack);
-    ///   if true, pop and fall through to `eval_rhs`.
-    /// - `||` (`is_and = false`): if true, jump to `join` (value stays on stack);
-    ///   if false, pop and fall through to `eval_rhs`.
+    /// On the short-circuit edge, assign `operand` to `destination` and go
+    /// to `join`: when false for `&&`, true for `||`, or non-null for `??`.
+    /// Otherwise, go to `eval_rhs` without assigning `destination`.
     ///
     /// The `eval_rhs` block must assign to `destination` and then goto `join`.
-    /// At `join`, `destination` is on TOS from whichever path executed.
+    /// At `join`, `destination` holds the expression value. Stackification
+    /// decides whether that value lives on the operand stack or in a slot.
     ShortCircuit {
         operand: Operand<'db>,
-        is_and: bool,
+        kind: ShortCircuitKind,
         destination: Place,
         eval_rhs: BlockId,
         join: BlockId,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShortCircuitKind {
+    And,
+    Or,
+    Coalesce,
 }
 
 /// The type arguments of the `Future<T, E>` a [`Terminator::Spawn`] yields.
@@ -1009,15 +1015,26 @@ pub enum Rvalue<'db> {
 
 impl Rvalue<'_> {
     /// Whether an unused evaluation can be erased, including its operand reads.
-    /// Non-mutating operations can still fail (arithmetic, indexing, allocation).
+    /// Allocation identity is unobservable when the result does not escape, but
+    /// evaluating an initializer can still fail (checked arithmetic or indexing).
     pub fn can_discard(&self) -> bool {
-        let operand = |op: &Operand<'_>| {
-            matches!(
-                op,
-                Operand::Constant(_)
-                    | Operand::Copy(Place::Local(_) | Place::Capture(_))
-                    | Operand::Move(Place::Local(_) | Place::Capture(_))
-            )
+        self.can_discard_with(|_| false)
+    }
+
+    /// A bounds proof applies to this evaluation site, not to the entire local.
+    pub(crate) fn can_discard_with(&self, in_bounds: impl Fn(&Place) -> bool) -> bool {
+        fn read(place: &Place, in_bounds: &impl Fn(&Place) -> bool) -> bool {
+            match place {
+                Place::Local(_) | Place::Capture(_) => true,
+                // A fixed field projection is type-checked, not a user accessor.
+                // An indexing operation in its base still needs its own proof.
+                Place::Field { base, .. } => read(base, in_bounds),
+                Place::Index { base, .. } => read(base, in_bounds) && in_bounds(place),
+            }
+        }
+        let operand = |op: &Operand<'_>| match op {
+            Operand::Constant(_) => true,
+            Operand::Copy(place) | Operand::Move(place) => read(place, &in_bounds),
         };
         match self {
             Self::Use(op) => operand(op),
@@ -1046,20 +1063,30 @@ impl Rvalue<'_> {
                 operand: arg,
                 type_value,
             } => operand(arg) && operand(type_value),
-            Self::TypeTag(place) => matches!(place, Place::Local(_) | Place::Capture(_)),
-            Self::LoadType(_) | Self::CurrentPackage(_) => true,
-            Self::Array(..)
+            Self::TypeTag(place) | Self::Discriminant(place) | Self::Len(place) => {
+                read(place, &in_bounds)
+            }
+            Self::LoadType(_)
+            | Self::CurrentPackage(_)
             | Self::Uint8Array(_)
-            | Self::Map(..)
-            | Self::Aggregate { .. }
-            | Self::Discriminant(_)
-            | Self::Len(_)
-            | Self::MakeClosure { .. }
-            | Self::MakeBoundMethod { .. }
-            | Self::MakeVirtualBoundMethod { .. }
+            | Self::MakeGenericFunction { .. } => true,
+            Self::Array(_, elements)
+            | Self::Aggregate {
+                fields: elements, ..
+            } => elements.iter().all(operand),
+            Self::Map(_, _, entries) => entries
+                .iter()
+                .all(|(key, value)| operand(key) && operand(value)),
+            Self::MakeClosure { captures, .. } => captures.iter().all(operand),
+            Self::MakeBoundMethod { receiver, .. } => operand(receiver),
+            Self::VirtualFieldAccess { receiver, .. } => {
+                // The type checker proves the implements rule and total field
+                // links (E0124). Resolution failure is a VM internal invariant
+                // violation, not a BAML panic; the receiver can still trap.
+                operand(receiver)
+            }
+            Self::MakeVirtualBoundMethod { .. }
             | Self::MakeVirtualFunction { .. }
-            | Self::VirtualFieldAccess { .. }
-            | Self::MakeGenericFunction { .. }
             | Self::MakeGenericFunctionFromValue { .. } => false,
         }
     }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -4498,7 +4498,7 @@ impl<'db> LoweringContext<'db> {
         let dummy = MirBuilder::new(Name::new("_dummy"), 0);
         let builder = std::mem::replace(&mut self.builder, dummy);
         let mut mir = builder.build();
-        optimize::optimize_function(&mut mir);
+        optimize::optimize_function(&mut mir, self.opt);
 
         // Drain any lambda functions lowered during this function's body into the
         // MirFunction's lambdas list.  The lambda_idx values in MakeClosure rvalues
@@ -4615,7 +4615,7 @@ impl<'db> LoweringContext<'db> {
         let dummy = MirBuilder::new(Name::new("_dummy"), 0);
         let builder = std::mem::replace(&mut self.builder, dummy);
         let mut body = builder.build_body();
-        optimize::optimize_function_body(&mut body);
+        optimize::optimize_function_body(&mut body, self.opt);
         body
     }
 
@@ -4696,7 +4696,7 @@ impl<'db> LoweringContext<'db> {
         adapter_builder.return_();
 
         let mut adapter_mir = adapter_builder.build();
-        optimize::optimize_function(&mut adapter_mir);
+        optimize::optimize_function(&mut adapter_mir, self.opt);
         adapter_mir.item_ref = ItemRef::Free {
             package: Name::new(""),
             namespace: vec![],
@@ -5036,7 +5036,7 @@ impl<'db> LoweringContext<'db> {
         let dummy = MirBuilder::new(Name::new("_dummy"), 0);
         let lambda_builder = std::mem::replace(&mut self.builder, dummy);
         let mut lambda_mir = lambda_builder.build();
-        optimize::optimize_function(&mut lambda_mir);
+        optimize::optimize_function(&mut lambda_mir, self.opt);
         // Override item_ref with the synthetic name.
         lambda_mir.item_ref = ItemRef::Free {
             package: Name::new(""),
@@ -5591,7 +5591,7 @@ impl<'db> LoweringContext<'db> {
         let dummy = MirBuilder::new(Name::new("_dummy"), 0);
         let lambda_builder = std::mem::replace(&mut self.builder, dummy);
         let mut lambda_mir = lambda_builder.build();
-        optimize::optimize_function(&mut lambda_mir);
+        optimize::optimize_function(&mut lambda_mir, self.opt);
         lambda_mir.item_ref = ItemRef::Free {
             package: Name::new(""),
             namespace: vec![],
@@ -7581,32 +7581,30 @@ impl<'db> LoweringContext<'db> {
         dest: Place,
         is_and: bool,
     ) {
-        // `ShortCircuit`'s destination must be a `Place::Local`: the emitter
-        // materializes it with `emit_store_place` on the short-circuit edge,
-        // which does not handle Field/Index projections. Normalize through a
-        // temp and assign through at the join — mirrors `lower_await`.
-        let (sc_dest, projection_dest) = match dest {
-            Place::Local(_) => (dest, None),
-            projection => {
-                let tmp = self.builder.temp(RuntimeTy::Null {
-                    attr: TyAttr::default(),
-                });
-                (Place::Local(tmp), Some(projection))
-            }
-        };
+        // The expression has one value at its join, even when its eventual
+        // destination has unrelated definitions (mutable locals/projections).
+        let sc_dest = Place::Local(self.builder.temp(RuntimeTy::Bool {
+            attr: TyAttr::default(),
+        }));
 
         let lhs_op = self.lower_condition_operand(lhs);
 
         let bb_rhs = self.builder.create_block();
         let bb_join = self.builder.create_block();
 
-        // ShortCircuit terminator: JumpIfFalse (peek) keeps lhs on TOS when
-        // short-circuiting. The rhs block evaluates and leaves its result on
-        // TOS. At join, dest is on TOS when the destination local is
-        // stack-carried (PhiLike); otherwise the emitter stores to its slot
-        // on both edges and the join reads the slot.
-        self.builder
-            .short_circuit(lhs_op, is_and, sc_dest.clone(), bb_rhs, bb_join);
+        // Both paths define the expression value. Stackification chooses its
+        // storage independently of the eventual mutable destination.
+        self.builder.short_circuit(
+            lhs_op,
+            if is_and {
+                crate::ShortCircuitKind::And
+            } else {
+                crate::ShortCircuitKind::Or
+            },
+            sc_dest.clone(),
+            bb_rhs,
+            bb_join,
+        );
 
         self.builder.set_current_block(bb_rhs);
         self.lower_expr(rhs, sc_dest.clone());
@@ -7627,10 +7625,8 @@ impl<'db> LoweringContext<'db> {
         }
 
         self.builder.set_current_block(bb_join);
-        if let Some(projection) = projection_dest {
-            self.builder
-                .assign(projection, Rvalue::Use(Operand::Copy(sc_dest)));
-        }
+        self.builder
+            .assign(dest, Rvalue::Use(Operand::Copy(sc_dest)));
     }
 
     /// Lower `a ?? b` — evaluate `a`, if null then evaluate `b`, otherwise use `a`.
@@ -7645,36 +7641,21 @@ impl<'db> LoweringContext<'db> {
         let result_place = Place::local(result);
 
         let lhs_op = self.lower_to_operand(lhs);
-        self.builder
-            .assign(result_place.clone(), Rvalue::Use(lhs_op));
-
-        // Test: lhs == null
-        let is_null = Rvalue::BinaryOp {
-            op: BinOp::Eq,
-            left: Operand::Copy(result_place.clone()),
-            right: Operand::Constant(Constant::Null),
-        };
-        let test_local = self.builder.temp(RuntimeTy::Bool {
-            attr: TyAttr::default(),
-        });
-        self.builder.assign(Place::local(test_local), is_null);
-
         let bb_rhs = self.builder.create_block();
-        let bb_lhs = self.builder.create_block();
         let bb_join = self.builder.create_block();
-
-        // If null → evaluate RHS, otherwise keep LHS
-        self.builder
-            .branch(Operand::Copy(Place::Local(test_local)), bb_rhs, bb_lhs);
+        self.builder.short_circuit(
+            lhs_op,
+            crate::ShortCircuitKind::Coalesce,
+            result_place.clone(),
+            bb_rhs,
+            bb_join,
+        );
 
         self.builder.set_current_block(bb_rhs);
         self.lower_expr(rhs, result_place.clone());
         if !self.builder.is_current_terminated() {
             self.builder.goto(bb_join);
         }
-
-        self.builder.set_current_block(bb_lhs);
-        self.builder.goto(bb_join);
 
         self.builder.set_current_block(bb_join);
         self.builder
@@ -10818,7 +10799,14 @@ impl<'db> LoweringContext<'db> {
     /// lowers exactly as before; the branch terminators stay strict-bool.
     fn lower_condition_operand(&mut self, condition: AstExprId) -> Operand<'db> {
         let op = self.lower_to_operand(condition);
-        if !self.tir_truthy_condition(self.expr_metadata_key(condition)) {
+        // `!value` performs truthiness itself, so its operand need not have a
+        // TIR adjustment. Predicate lowering can remove that Not; the branch
+        // must still receive an exact bool, including on this path.
+        let is_bool = matches!(
+            self.expr_ty(condition),
+            RuntimeTy::Bool { .. } | RuntimeTy::Literal(baml_type::Literal::Bool(_), ..)
+        );
+        if is_bool && !self.tir_truthy_condition(self.expr_metadata_key(condition)) {
             return op;
         }
         let coerced = self.builder.temp(RuntimeTy::Bool {
@@ -10834,6 +10822,42 @@ impl<'db> LoweringContext<'db> {
         Operand::Copy(Place::Local(coerced))
     }
 
+    /// A predicate needs control flow, not a materialized logical value.
+    fn lower_condition(&mut self, condition: AstExprId, on_true: BlockId, on_false: BlockId) {
+        match self.body.exprs[condition].clone() {
+            AstExpr::Binary {
+                op: AstBinaryOp::And,
+                lhs,
+                rhs,
+            } => {
+                let next = self.builder.create_block();
+                self.lower_condition(lhs, next, on_false);
+                self.builder.set_current_block(next);
+                self.lower_condition(rhs, on_true, on_false);
+            }
+            AstExpr::Binary {
+                op: AstBinaryOp::Or,
+                lhs,
+                rhs,
+            } => {
+                let next = self.builder.create_block();
+                self.lower_condition(lhs, on_true, next);
+                self.builder.set_current_block(next);
+                self.lower_condition(rhs, on_true, on_false);
+            }
+            AstExpr::Unary {
+                op: AstUnaryOp::Not,
+                expr,
+            } => {
+                self.lower_condition(expr, on_false, on_true);
+            }
+            _ => {
+                let operand = self.lower_condition_operand(condition);
+                self.builder.branch(operand, on_true, on_false);
+            }
+        }
+    }
+
     fn lower_if(
         &mut self,
         _expr_id: AstExprId,
@@ -10842,12 +10866,11 @@ impl<'db> LoweringContext<'db> {
         else_branch: Option<AstExprId>,
         dest: Place,
     ) {
-        let cond_op = self.lower_condition_operand(condition);
         let bb_then = self.builder.create_block();
         let bb_else = self.builder.create_block();
         let bb_join = self.builder.create_block();
 
-        self.builder.branch(cond_op, bb_then, bb_else);
+        self.lower_condition(condition, bb_then, bb_else);
 
         self.builder.set_current_block(bb_then);
         self.lower_expr(then_branch, dest.clone());
@@ -12697,8 +12720,7 @@ impl LoweringContext<'_> {
                 }
 
                 self.builder.set_current_block(bb_cond);
-                let cond_op = self.lower_condition_operand(condition);
-                self.builder.branch(cond_op, bb_body, bb_exit);
+                self.lower_condition(condition, bb_body, bb_exit);
 
                 self.builder.set_current_block(bb_body);
                 let body_ty = self.expr_ty(body);
@@ -13855,9 +13877,8 @@ impl<'db> LoweringContext<'db> {
                 let saved_locals = self.locals.clone();
                 self.bind_pattern_inner(scrutinee, part, arm.pattern, part, false);
                 if let Some(guard) = arm.guard {
-                    let guard_op = self.lower_condition_operand(guard);
                     let bb_guarded = self.builder.create_block();
-                    self.builder.branch(guard_op, bb_guarded, bb_next);
+                    self.lower_condition(guard, bb_guarded, bb_next);
                     self.builder.set_current_block(bb_guarded);
                 }
                 self.lower_expr(arm.body, dest.clone());
@@ -13885,9 +13906,8 @@ impl<'db> LoweringContext<'db> {
         let saved_locals = self.locals.clone();
         self.bind_pattern(scrutinee, arm.pattern);
         if let Some(guard) = arm.guard {
-            let guard_op = self.lower_condition_operand(guard);
             let bb_guarded = self.builder.create_block();
-            self.builder.branch(guard_op, bb_guarded, bb_next);
+            self.lower_condition(guard, bb_guarded, bb_next);
             self.builder.set_current_block(bb_guarded);
         }
         self.lower_expr(arm.body, dest.clone());

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -1229,6 +1229,49 @@ fn apply_subst_to_terminator<'db>(
 fn eliminate_dead_locals(body: &mut MirFunctionBody, arity: usize) {
     let mut uses = count_local_uses(body);
 
+    for block in &mut body.blocks {
+        if let Some(Terminator::ShortCircuit {
+            operand,
+            is_and,
+            destination: Place::Local(local),
+            eval_rhs,
+            join,
+        }) = &block.terminator
+            && local.0 > arity
+            && uses[local.0] == 0
+        {
+            // Discard the result, not the conditional execution of the RHS.
+            block.terminator = Some(Terminator::Branch {
+                condition: operand.clone(),
+                then_block: if *is_and { *eval_rhs } else { *join },
+                else_block: if *is_and { *join } else { *eval_rhs },
+            });
+        }
+
+        let mut statements = Vec::with_capacity(block.statements.len());
+        for statement in std::mem::take(&mut block.statements) {
+            let discard = match &statement.kind {
+                crate::StatementKind::Assign {
+                    destination: Place::Local(local),
+                    value,
+                } if local.0 > arity && uses[local.0] == 0 && !value.can_discard() => Some(*local),
+                _ => None,
+            };
+            let span = statement.span;
+            statements.push(statement);
+            if let Some(local) = discard {
+                // Reuse the existing eval-and-drop representation. This read
+                // keeps the definition alive and pins evaluation to this point.
+                statements.push(crate::Statement {
+                    kind: crate::StatementKind::Drop(Place::Local(local)),
+                    span,
+                });
+                uses[local.0] += 1;
+            }
+        }
+        block.statements = statements;
+    }
+
     // Force-alive: terminator destination locals can't be removed because
     // the terminator has side effects (Call, Await, SysOp, Spawn).
     // Even if the destination local has 0 read-uses, we must keep it.
@@ -1269,10 +1312,8 @@ fn eliminate_dead_locals(body: &mut MirFunctionBody, arity: usize) {
         return;
     }
 
-    // Scrub dead Assign statements: remove assignments whose destination is
-    // a dead plain-Local. All Rvalue variants are pure (no side effects), so
-    // this is always safe. This prevents rewrite_locals_in_statement from
-    // encountering a dead local (old_to_new = None) and panicking.
+    // Potentially failing evaluations gained a Drop use above. The remaining
+    // dead assignments can be removed without losing effects.
     for block in &mut body.blocks {
         block.statements.retain(|stmt| {
             if let crate::StatementKind::Assign {
@@ -1285,22 +1326,6 @@ fn eliminate_dead_locals(body: &mut MirFunctionBody, arity: usize) {
                 true
             }
         });
-    }
-
-    // Replace ShortCircuit terminators whose destination is dead with Goto
-    // to the join block. The now-unreachable eval_rhs block will be cleaned
-    // up by eliminate_dead_blocks.
-    for block in &mut body.blocks {
-        if let Some(Terminator::ShortCircuit {
-            destination: Place::Local(l),
-            join,
-            ..
-        }) = &block.terminator
-        {
-            if old_to_new[l.0].is_none() {
-                block.terminator = Some(Terminator::Goto { target: *join });
-            }
-        }
     }
 
     // Rewrite all Local references

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -1,9 +1,10 @@
 //! Post-lowering MIR optimization passes.
 //!
 //! Runs after `MirBuilder::build()` and performs:
-//! 1. Dead block elimination (reachability-based)
-//! 2. Copy propagation + dead local elimination
-//! 3. RPO block reordering
+//! 1. CFG cleanup, copy propagation, and dead store/local elimination to convergence
+//! 2. Scalar constant folding and branch simplification at O2, within that loop
+//! 3. Infallible operand-prefix materialization at O1 and above
+//! 4. RPO block reordering
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -15,17 +16,15 @@ use crate::{
     Operand, Place, Terminator,
 };
 
+mod effects;
+mod values;
+
 /// Run all optimization passes on a MIR function.
-pub(crate) fn optimize_function(func: &mut MirFunction) {
+pub(crate) fn optimize_function(func: &mut MirFunction, opt: crate::OptLevel) {
     let MirFunctionKind::Bytecode(body) = &mut func.kind else {
         return; // nothing to clean up on builtins
     };
-    eliminate_dead_blocks(body);
-    merge_passthrough_blocks(body);
-    propagate_copies(body, func.arity);
-    eliminate_dead_locals(body, func.arity);
-    merge_passthrough_blocks(body); // catch blocks emptied by copy-prop / dead-local elim
-    reorder_blocks_rpo(body);
+    optimize_body(body, func.arity, opt);
 
     #[cfg(debug_assertions)]
     verify_mir(body, &func.item_ref);
@@ -35,13 +34,8 @@ pub(crate) fn optimize_function(func: &mut MirFunction) {
 ///
 /// Used for let-binding initializers, which are lowered as bodies without
 /// the enclosing `MirFunction` wrapper (arity = 0).
-pub(crate) fn optimize_function_body(body: &mut MirFunctionBody) {
-    eliminate_dead_blocks(body);
-    merge_passthrough_blocks(body);
-    propagate_copies(body, 0);
-    eliminate_dead_locals(body, 0);
-    merge_passthrough_blocks(body); // catch blocks emptied by copy-prop / dead-local elim
-    reorder_blocks_rpo(body);
+pub(crate) fn optimize_function_body(body: &mut MirFunctionBody, opt: crate::OptLevel) {
+    optimize_body(body, 0, opt);
 
     #[cfg(debug_assertions)]
     verify_mir(
@@ -52,6 +46,40 @@ pub(crate) fn optimize_function_body(body: &mut MirFunctionBody) {
             name: Name::new("_"),
         },
     );
+}
+
+fn optimize_body(body: &mut MirFunctionBody, arity: usize, opt: crate::OptLevel) {
+    loop {
+        let size = |body: &MirFunctionBody| {
+            (
+                body.blocks.len(),
+                body.locals.len(),
+                body.blocks
+                    .iter()
+                    .map(|b| b.statements.len())
+                    .sum::<usize>(),
+            )
+        };
+        let before = size(body);
+        eliminate_dead_blocks(body);
+        merge_passthrough_blocks(body);
+        if opt >= crate::OptLevel::Two {
+            values::fold_constants(body, arity);
+            eliminate_dead_blocks(body);
+        }
+        effects::remove_trivial_drops(body);
+        values::eliminate_dead_stores(body, arity, opt);
+        propagate_copies(body, arity);
+        eliminate_dead_locals(body, arity);
+        merge_passthrough_blocks(body);
+        if before == size(body) {
+            break;
+        }
+    }
+    if opt >= crate::OptLevel::One {
+        values::materialize_operand_prefixes(body);
+    }
+    reorder_blocks_rpo(body);
 }
 
 // ============================================================================
@@ -327,14 +355,12 @@ fn merge_passthrough_blocks(body: &mut MirFunctionBody) {
 // Phase 2a: Copy propagation
 // ============================================================================
 
-/// Count uses of each Local across all blocks and catch region error locals.
-/// Collect all locals that appear inside a `Place` projection.
+/// Collect reads in positions that require a `Place` rather than an `Operand`.
 ///
 /// This includes locals used as `Place::Local` bases of field/index projections
-/// and locals used as the `index` field of `Place::Index`. These positions are
-/// typed as `Local` (not `Operand`), so they cannot be replaced by a `Constant`
-/// during copy propagation.
-fn collect_place_index_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
+/// and locals used as the `index` field of `Place::Index`, as well as direct
+/// place reads such as `Len(local)`. A constant cannot replace these reads.
+fn collect_place_bound_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
     fn scan_place(p: &Place, set: &mut HashSet<Local>) {
         match p {
             Place::Local(_) => {}
@@ -354,6 +380,13 @@ fn collect_place_index_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
                 scan_place(base, set);
             }
         }
+    }
+
+    fn scan_place_read(p: &Place, set: &mut HashSet<Local>) {
+        if let Place::Local(local) = p {
+            set.insert(*local);
+        }
+        scan_place(p, set);
     }
 
     fn scan_operand(op: &Operand<'_>, set: &mut HashSet<Local>) {
@@ -389,7 +422,7 @@ fn collect_place_index_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
                 }
             }
             crate::Rvalue::Discriminant(p) | crate::Rvalue::TypeTag(p) | crate::Rvalue::Len(p) => {
-                scan_place(p, set);
+                scan_place_read(p, set);
             }
             crate::Rvalue::IsType { operand, .. } | crate::Rvalue::IsTypeTag { operand, .. } => {
                 scan_operand(operand, set);
@@ -447,7 +480,7 @@ fn collect_place_index_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
                         scan_operand(arg, &mut set);
                     }
                 }
-                crate::StatementKind::Drop(p) => scan_place(p, &mut set),
+                crate::StatementKind::Drop(p) => scan_place_read(p, &mut set),
                 // Exhaustive for the same reason the substitution walk is: a
                 // projected operand missed here lets copy propagation pick a
                 // constant for a local that `apply_subst_to_place_locals` then
@@ -546,7 +579,7 @@ fn collect_place_index_locals(body: &MirFunctionBody<'_>) -> HashSet<Local> {
                     // The awaited place can be a `Place::Index` (e.g.
                     // `await xs[_i]`): its index local is typed `Local` in the
                     // bytecode and cannot be rewritten to a constant.
-                    scan_place(future, &mut set);
+                    scan_place_read(future, &mut set);
                     scan_place(destination, &mut set);
                 }
                 Terminator::AwaitAny {
@@ -880,13 +913,11 @@ fn count_in_terminator(term: &Terminator<'_>, uses: &mut [usize]) {
 
 /// Phase 2a: Propagate trivial copies and single-use constants.
 fn propagate_copies(body: &mut MirFunctionBody, arity: usize) {
+    propagate_block_param_copies(body, arity);
     // Build substitution map: Local -> replacement Operand
     let uses = count_local_uses(body);
     let defs = count_local_defs(body);
-    // Locals used as the `index` field of a `Place::Index` cannot be replaced
-    // with constants — that field is typed `Local`, not `Operand`. Collect them
-    // so we can exclude them from constant inlining below.
-    let used_as_place_index = collect_place_index_locals(body);
+    let place_bound = collect_place_bound_locals(body);
     let mut subst: HashMap<Local, Operand<'_>> = HashMap::new();
 
     // Scan for copy-of-param: `_X = copy _Y` where Y is a param (1..=arity)
@@ -927,19 +958,20 @@ fn propagate_copies(body: &mut MirFunctionBody, arity: usize) {
 
                 match operand {
                     Operand::Copy(Place::Local(src))
-                        if src.0 >= 1 && src.0 <= arity && !used_as_place_index.contains(dest) =>
+                        if src.0 >= 1
+                            && src.0 <= arity
+                            && defs[src.0] == 0
+                            && !body.locals[src.0].is_captured
+                            && !place_bound.contains(dest) =>
                     {
                         // Copy of param — substitute. Skip locals that appear
                         // as a Place::Index index, since removing the copy would
                         // leave the destination Place referencing a dead local.
                         subst.insert(*dest, Operand::Copy(Place::Local(*src)));
                     }
-                    Operand::Constant(c)
-                        if uses[dest.0] == 1 && !used_as_place_index.contains(dest) =>
-                    {
-                        // Single-use, single-definition constant — inline. Skip
-                        // locals that appear as a Place::Index index, since that
-                        // position can only hold a Local, not a Constant.
+                    Operand::Constant(c) if uses[dest.0] == 1 && !place_bound.contains(dest) => {
+                        // Only erase the definition when every read can accept
+                        // the constant substitution, including direct Place reads.
                         subst.insert(*dest, Operand::Constant(c.clone()));
                     }
                     _ => {}
@@ -992,6 +1024,50 @@ fn propagate_copies(body: &mut MirFunctionBody, arity: usize) {
                 true
             }
         });
+    }
+}
+
+/// Extend parameter-copy propagation to reassigned parameters within a block,
+/// up to the next write to either slot. Other values are left for stackification:
+/// substituting their temporaries can destroy profitable single-use carry chains.
+fn propagate_block_param_copies(body: &mut MirFunctionBody<'_>, arity: usize) {
+    let defs = count_local_defs(body);
+    for block in &mut body.blocks {
+        let mut copies = HashMap::new();
+        for statement in &mut block.statements {
+            apply_subst_to_statement(statement, &copies);
+            let destination = match &statement.kind {
+                crate::StatementKind::Assign {
+                    destination: Place::Local(local),
+                    ..
+                }
+                | crate::StatementKind::FreshCell(local) => *local,
+                _ => continue,
+            };
+            copies.retain(|local, value| {
+                *local != destination
+                    && !matches!(value, Operand::Copy(Place::Local(source)) if *source == destination)
+            });
+            if let crate::StatementKind::Assign {
+                value:
+                    crate::Rvalue::Use(
+                        Operand::Copy(Place::Local(source)) | Operand::Move(Place::Local(source)),
+                    ),
+                ..
+            } = &statement.kind
+                && *source != destination
+                && (1..=arity).contains(&source.0)
+                && defs[source.0] > 0
+                && body.locals[destination.0].name.is_none()
+                && !body.locals[destination.0].is_captured
+                && !body.locals[source.0].is_captured
+            {
+                copies.insert(destination, Operand::copy_local(*source));
+            }
+        }
+        if let Some(terminator) = &mut block.terminator {
+            apply_subst_to_terminator(terminator, &copies);
+        }
     }
 }
 
@@ -1227,34 +1303,52 @@ fn apply_subst_to_terminator<'db>(
 
 /// Phase 2b: Remove dead locals and renumber densely.
 fn eliminate_dead_locals(body: &mut MirFunctionBody, arity: usize) {
+    let effects = effects::Analysis::new(body);
     let mut uses = count_local_uses(body);
 
     for block in &mut body.blocks {
         if let Some(Terminator::ShortCircuit {
             operand,
-            is_and,
+            kind,
             destination: Place::Local(local),
             eval_rhs,
             join,
         }) = &block.terminator
             && local.0 > arity
             && uses[local.0] == 0
+            && *kind != crate::ShortCircuitKind::Coalesce
         {
             // Discard the result, not the conditional execution of the RHS.
             block.terminator = Some(Terminator::Branch {
                 condition: operand.clone(),
-                then_block: if *is_and { *eval_rhs } else { *join },
-                else_block: if *is_and { *join } else { *eval_rhs },
+                then_block: if *kind == crate::ShortCircuitKind::And {
+                    *eval_rhs
+                } else {
+                    *join
+                },
+                else_block: if *kind == crate::ShortCircuitKind::And {
+                    *join
+                } else {
+                    *eval_rhs
+                },
             });
         }
 
         let mut statements = Vec::with_capacity(block.statements.len());
-        for statement in std::mem::take(&mut block.statements) {
+        for (index, statement) in std::mem::take(&mut block.statements)
+            .into_iter()
+            .enumerate()
+        {
             let discard = match &statement.kind {
                 crate::StatementKind::Assign {
                     destination: Place::Local(local),
-                    value,
-                } if local.0 > arity && uses[local.0] == 0 && !value.can_discard() => Some(*local),
+                    ..
+                } if local.0 > arity
+                    && uses[local.0] == 0
+                    && !effects.discardable[block.id.0][index] =>
+                {
+                    Some(*local)
+                }
                 _ => None,
             };
             let span = statement.span;
@@ -1282,10 +1376,12 @@ fn eliminate_dead_locals(body: &mut MirFunctionBody, arity: usize) {
                 Terminator::VirtualCall { destination, .. } => destination.base_local(),
                 Terminator::Await { destination, .. } => destination.base_local(),
                 Terminator::AwaitAny { destination, .. } => destination.base_local(),
+                Terminator::Spawn { future, .. } => future.base_local(),
                 Terminator::SysOp { destination, .. } => destination.base_local(),
                 Terminator::NarrowBind { destination, .. } => Some(*destination),
-                // ShortCircuit is side-effect-free (pure control flow), so its
-                // destination can be dead-eliminated like any other local.
+                // Discarded boolean short circuits became Branch above. Keep
+                // coalescing's destination until its null test has executed.
+                Terminator::ShortCircuit { destination, .. } => destination.base_local(),
                 _ => None,
             };
             if let Some(l) = dest_local {
@@ -1995,4 +2091,64 @@ fn reorder_blocks_rpo(body: &mut MirFunctionBody) {
     rewrite_catch_region_blocks(&mut body.catch_regions, &old_to_new);
 
     body.blocks = new_blocks;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Constant, LocalDecl, Rvalue, Statement, StatementKind};
+
+    #[test]
+    fn reassigned_parameter_copies_stop_at_source_or_destination_writes() {
+        for write in [None, Some(Local(1)), Some(Local(2))] {
+            let assign = |local, operand| Statement {
+                kind: StatementKind::Assign {
+                    destination: Place::Local(local),
+                    value: Rvalue::Use(operand),
+                },
+                span: None,
+            };
+            let mut block = BasicBlock::new(BlockId(0));
+            block.statements = vec![
+                assign(Local(1), Operand::Constant(Constant::Int(7))),
+                assign(Local(2), Operand::copy_local(Local(1))),
+            ];
+            if let Some(local) = write {
+                block
+                    .statements
+                    .push(assign(local, Operand::Constant(Constant::Int(9))));
+            }
+            block
+                .statements
+                .push(assign(Local(0), Operand::copy_local(Local(2))));
+            block.terminator = Some(Terminator::Return);
+            let mut body = MirFunctionBody {
+                blocks: vec![block],
+                entry: BlockId(0),
+                locals: [None, Some("parameter"), None]
+                    .into_iter()
+                    .map(|name| LocalDecl {
+                        name: name.map(baml_base::Name::new),
+                        ty: baml_type::RuntimeTy::int(),
+                        span: None,
+                        scope_span: None,
+                        is_captured: false,
+                    })
+                    .collect(),
+                catch_regions: vec![],
+            };
+            propagate_block_param_copies(&mut body, 1);
+            let expected = if write.is_none() { Local(1) } else { Local(2) };
+            assert!(
+                matches!(
+                    &body.blocks[0].statements.last().unwrap().kind,
+                    StatementKind::Assign {
+                        value: Rvalue::Use(Operand::Copy(Place::Local(local))),
+                        ..
+                    } if *local == expected
+                ),
+                "write to {write:?}"
+            );
+        }
+    }
 }

--- a/baml_language/crates/baml_compiler2_mir/src/optimize/effects.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize/effects.rs
@@ -1,0 +1,714 @@
+//! Evaluation-site proofs for dead-code elimination. Facts are intersected at
+//! joins and invalidated by writes/calls; a proof never classifies a whole local
+//! as nontrapping across its other definitions or uses.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use baml_type::{Int63, Literal, RuntimeTy};
+
+use crate::{
+    BinOp, Constant, IndexKind, Local, MirFunctionBody, Operand, Place, Rvalue, StatementKind,
+    Terminator, UnaryOp,
+};
+
+const MIN: i64 = Int63::MIN.get();
+const MAX: i64 = Int63::MAX.get();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Range {
+    lo: i64,
+    hi: i64,
+}
+
+impl Range {
+    const INT: Self = Self { lo: MIN, hi: MAX };
+    const LENGTH: Self = Self { lo: 0, hi: MAX };
+
+    fn exact(n: i64) -> Self {
+        Self { lo: n, hi: n }
+    }
+
+    fn intersect(self, other: Self) -> Option<Self> {
+        let result = Self {
+            lo: self.lo.max(other.lo),
+            hi: self.hi.min(other.hi),
+        };
+        (result.lo <= result.hi).then_some(result)
+    }
+
+    fn join(self, other: Self, widen: bool, domain: Self) -> Self {
+        Self {
+            lo: if widen && other.lo < self.lo {
+                domain.lo
+            } else {
+                self.lo.min(other.lo)
+            },
+            hi: if widen && other.hi > self.hi {
+                domain.hi
+            } else {
+                self.hi.max(other.hi)
+            },
+        }
+    }
+
+    fn arithmetic(self, op: BinOp, rhs: Self) -> Option<Self> {
+        if matches!(op, BinOp::Div | BinOp::Mod)
+            && ((rhs.lo <= 0 && rhs.hi >= 0) || (self.lo == MIN && rhs.lo <= -1 && rhs.hi >= -1))
+        {
+            return None;
+        }
+        if op == BinOp::Mod {
+            return Some(Self::INT);
+        }
+        let mut lo = i128::MAX;
+        let mut hi = i128::MIN;
+        for a in [i128::from(self.lo), i128::from(self.hi)] {
+            for b in [i128::from(rhs.lo), i128::from(rhs.hi)] {
+                let n = match op {
+                    BinOp::Add => a + b,
+                    BinOp::Sub => a - b,
+                    BinOp::Mul => a * b,
+                    BinOp::Div => a / b,
+                    _ => return None,
+                };
+                lo = lo.min(n);
+                hi = hi.max(n);
+            }
+        }
+        (lo >= i128::from(MIN) && hi <= i128::from(MAX)).then_some(Self {
+            lo: i64::try_from(lo).ok()?,
+            hi: i64::try_from(hi).ok()?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Number {
+    Constant(i64),
+    Local(Local),
+    /// Current container length minus a nonnegative constant.
+    Length(Local, i64),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum ReadKey {
+    Local(Local),
+    Field(Box<Self>, usize),
+    Index(Box<Self>, Number, IndexKind),
+}
+
+impl ReadKey {
+    fn depends_on(&self, local: Local) -> bool {
+        match self {
+            Self::Local(root) => *root == local,
+            Self::Field(base, _) => base.depends_on(local),
+            Self::Index(base, index, _) => base.depends_on(local) || index.depends_on(local),
+        }
+    }
+}
+
+impl Number {
+    fn depends_on(self, local: Local) -> bool {
+        matches!(self, Self::Local(l) | Self::Length(l, _) if l == local)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Condition {
+    op: BinOp,
+    left: Number,
+    right: Number,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct Facts {
+    // Copies refer to the same current value only until either slot is written.
+    aliases: HashMap<Local, Local>,
+    reads: HashMap<ReadKey, Local>,
+    integers: HashMap<Local, Range>,
+    lengths: HashMap<Local, Range>,
+    length_values: HashMap<Local, (Local, i64)>,
+    conditions: HashMap<Local, Condition>,
+}
+
+impl Facts {
+    fn root(&self, local: Local) -> Local {
+        self.aliases.get(&local).copied().unwrap_or(local)
+    }
+
+    fn read_key(&self, place: &Place, body: &MirFunctionBody<'_>) -> Option<ReadKey> {
+        let key = match place {
+            Place::Local(local) if !body.locals[local.0].is_captured => {
+                return Some(ReadKey::Local(self.root(*local)));
+            }
+            Place::Field { base, field } => {
+                ReadKey::Field(Box::new(self.read_key(base, body)?), *field)
+            }
+            Place::Index { base, index, kind } => {
+                let mut index = self.number(&Operand::copy_local(*index), body)?;
+                let range = self.range(index);
+                if range.lo == range.hi {
+                    index = Number::Constant(range.lo);
+                }
+                ReadKey::Index(Box::new(self.read_key(base, body)?), index, *kind)
+            }
+            _ => return None,
+        };
+        Some(
+            self.reads
+                .get(&key)
+                .map_or(key.clone(), |local| ReadKey::Local(*local)),
+        )
+    }
+
+    fn number(&self, operand: &Operand<'_>, body: &MirFunctionBody<'_>) -> Option<Number> {
+        match operand {
+            Operand::Constant(Constant::Int(n)) => Some(Number::Constant(*n)),
+            Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))
+                if !body.locals[local.0].is_captured =>
+            {
+                let local = self.root(*local);
+                if let Some((array, offset)) = self.length_values.get(&local) {
+                    return Some(Number::Length(*array, *offset));
+                }
+                if self.integers.contains_key(&local)
+                    || matches!(
+                        body.locals[local.0].ty,
+                        RuntimeTy::Int { .. } | RuntimeTy::Literal(Literal::Int(_), ..)
+                    )
+                {
+                    Some(Number::Local(local))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn range(&self, number: Number) -> Range {
+        match number {
+            Number::Constant(n) => Range::exact(n),
+            Number::Local(local) => self.integers.get(&local).copied().unwrap_or(Range::INT),
+            Number::Length(local, offset) => {
+                let range = self.lengths.get(&local).copied().unwrap_or(Range::LENGTH);
+                Range {
+                    lo: range.lo - offset,
+                    hi: range.hi - offset,
+                }
+            }
+        }
+    }
+
+    fn length_value(&self, value: &Rvalue<'_>, body: &MirFunctionBody<'_>) -> Option<(Local, i64)> {
+        match value {
+            Rvalue::Len(place) => match self.read_key(place, body)? {
+                ReadKey::Local(local) => Some((local, 0)),
+                _ => None,
+            },
+            Rvalue::Use(operand) => match self.number(operand, body)? {
+                Number::Length(local, offset) => Some((local, offset)),
+                _ => None,
+            },
+            Rvalue::BinaryOp {
+                op: BinOp::Sub,
+                left,
+                right,
+            } => {
+                let Number::Length(local, offset) = self.number(left, body)? else {
+                    return None;
+                };
+                let rhs = self.range(self.number(right, body)?);
+                let offset = offset.checked_add(rhs.lo)?;
+                (rhs.lo == rhs.hi && rhs.lo >= 0 && offset <= MAX).then_some((local, offset))
+            }
+            _ => None,
+        }
+    }
+
+    fn integer_value(&self, value: &Rvalue<'_>, body: &MirFunctionBody<'_>) -> Option<Range> {
+        match value {
+            Rvalue::Use(operand) => Some(self.range(self.number(operand, body)?)),
+            Rvalue::Len(_) => Some(Range::LENGTH),
+            Rvalue::BinaryOp { op, left, right } => self
+                .range(self.number(left, body)?)
+                .arithmetic(*op, self.range(self.number(right, body)?)),
+            Rvalue::UnaryOp {
+                op: UnaryOp::Neg,
+                operand,
+            } => Range::exact(0).arithmetic(BinOp::Sub, self.range(self.number(operand, body)?)),
+            _ => None,
+        }
+    }
+
+    fn condition(&self, operand: &Operand<'_>) -> Option<Condition> {
+        match operand {
+            Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local)) => {
+                self.conditions.get(local).copied()
+            }
+            _ => None,
+        }
+    }
+
+    fn forget(&mut self, local: Local) {
+        self.aliases
+            .retain(|dest, source| *dest != local && *source != local);
+        self.reads
+            .retain(|key, dest| *dest != local && !key.depends_on(local));
+        self.integers.remove(&local);
+        self.lengths.remove(&local);
+        self.length_values
+            .retain(|dest, (array, _)| *dest != local && *array != local);
+        self.conditions.retain(|dest, condition| {
+            *dest != local
+                && !condition.left.depends_on(local)
+                && !condition.right.depends_on(local)
+        });
+    }
+
+    fn statement(&mut self, statement: &StatementKind<'_>, body: &MirFunctionBody<'_>) {
+        match statement {
+            StatementKind::Assign {
+                destination: Place::Local(local),
+                value,
+            } => {
+                let read = match value {
+                    Rvalue::Use(Operand::Copy(place) | Operand::Move(place)) => {
+                        self.read_key(place, body)
+                    }
+                    _ => None,
+                };
+                let integer = self.integer_value(value, body);
+                let length_value = self.length_value(value, body);
+                let condition = match value {
+                    Rvalue::Use(operand) => self.condition(operand),
+                    Rvalue::BinaryOp { op, left, right }
+                        if matches!(
+                            op,
+                            BinOp::Eq | BinOp::Ne | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge
+                        ) =>
+                    {
+                        self.number(left, body).zip(self.number(right, body)).map(
+                            |(left, right)| Condition {
+                                op: *op,
+                                left,
+                                right,
+                            },
+                        )
+                    }
+                    Rvalue::UnaryOp {
+                        op: UnaryOp::Not,
+                        operand,
+                    } => self.condition(operand).map(|condition| Condition {
+                        op: invert(condition.op),
+                        ..condition
+                    }),
+                    _ => None,
+                };
+                let length = match value {
+                    Rvalue::Array(_, elements) => {
+                        i64::try_from(elements.len()).ok().map(Range::exact)
+                    }
+                    Rvalue::Uint8Array(bytes) => i64::try_from(bytes.len()).ok().map(Range::exact),
+                    Rvalue::Use(
+                        Operand::Copy(Place::Local(source)) | Operand::Move(Place::Local(source)),
+                    ) => self.lengths.get(source).copied(),
+                    _ => None,
+                };
+                self.forget(*local);
+                if body.locals[local.0].is_captured {
+                    return;
+                }
+                if let Some(read) = read
+                    && !read.depends_on(*local)
+                {
+                    if let ReadKey::Local(source) = read {
+                        self.aliases.insert(*local, source);
+                    } else {
+                        self.reads.insert(read, *local);
+                    }
+                }
+                if let Some(range) = integer {
+                    self.integers.insert(*local, range);
+                }
+                if let Some((array, offset)) = length_value
+                    && array != *local
+                {
+                    self.length_values.insert(*local, (array, offset));
+                }
+                if let Some(condition) = condition
+                    && !condition.left.depends_on(*local)
+                    && !condition.right.depends_on(*local)
+                {
+                    self.conditions.insert(*local, condition);
+                }
+                if let Some(range) = length {
+                    self.lengths.insert(*local, range);
+                }
+            }
+            StatementKind::FreshCell(local) => self.forget(*local),
+            // Aliasing writes may invalidate both a container and references
+            // obtained through it. Do not try to infer disjointness here.
+            StatementKind::Assign { .. }
+            | StatementKind::VirtualFieldStore { .. }
+            | StatementKind::Intrinsic { .. } => *self = Self::default(),
+            StatementKind::Drop(_) | StatementKind::Nop => {}
+        }
+    }
+
+    fn constrain(&mut self, number: Number, range: Range) {
+        match number {
+            Number::Constant(_) => {}
+            Number::Local(local) => {
+                if let Some(range) = self.range(number).intersect(range) {
+                    self.integers.insert(local, range);
+                }
+            }
+            Number::Length(local, offset) => {
+                let bounds = Range {
+                    lo: range.lo.saturating_add(offset),
+                    hi: range.hi.saturating_add(offset),
+                };
+                let old = self.lengths.get(&local).copied().unwrap_or(Range::LENGTH);
+                if let Some(range) = old.intersect(bounds) {
+                    self.lengths.insert(local, range);
+                }
+            }
+        }
+    }
+
+    fn branch(&mut self, condition: Condition, taken: bool) {
+        let op = if taken {
+            condition.op
+        } else {
+            invert(condition.op)
+        };
+        let left = self.range(condition.left);
+        let right = self.range(condition.right);
+        match op {
+            BinOp::Eq => {
+                self.constrain(condition.left, right);
+                self.constrain(condition.right, left);
+            }
+            BinOp::Ne => {
+                for (number, range, excluded) in [
+                    (condition.left, left, right),
+                    (condition.right, right, left),
+                ] {
+                    if excluded.lo == excluded.hi {
+                        if range.lo == excluded.lo {
+                            self.constrain(
+                                number,
+                                Range {
+                                    lo: range.lo + 1,
+                                    ..range
+                                },
+                            );
+                        } else if range.hi == excluded.lo {
+                            self.constrain(
+                                number,
+                                Range {
+                                    hi: range.hi - 1,
+                                    ..range
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            BinOp::Lt | BinOp::Le => {
+                let strict = i64::from(op == BinOp::Lt);
+                self.constrain(
+                    condition.left,
+                    Range {
+                        lo: MIN,
+                        hi: right.hi - strict,
+                    },
+                );
+                self.constrain(
+                    condition.right,
+                    Range {
+                        lo: left.lo + strict,
+                        hi: MAX,
+                    },
+                );
+            }
+            BinOp::Gt | BinOp::Ge => self.branch(
+                Condition {
+                    op: if op == BinOp::Gt {
+                        BinOp::Lt
+                    } else {
+                        BinOp::Le
+                    },
+                    left: condition.right,
+                    right: condition.left,
+                },
+                true,
+            ),
+            _ => {}
+        }
+    }
+
+    fn in_bounds(&self, place: &Place, body: &MirFunctionBody<'_>) -> bool {
+        let Place::Index {
+            base,
+            index,
+            kind: IndexKind::Array,
+        } = place
+        else {
+            return false;
+        };
+        // A completed read can be repeated without trapping until a dependency
+        // changes, even when we cannot express its successful bounds test.
+        if matches!(self.read_key(place, body), Some(ReadKey::Local(_))) {
+            return true;
+        }
+        let Some(ReadKey::Local(array)) = self.read_key(base, body) else {
+            return false;
+        };
+        if body.locals[array.0].is_captured {
+            return false;
+        }
+        let length = self.lengths.get(&array).copied().unwrap_or(Range::LENGTH);
+        let Some(index) = self.number(&Operand::copy_local(*index), body) else {
+            return false;
+        };
+        if let Number::Length(root, offset) = index
+            && root == array
+        {
+            return offset > 0 && offset <= length.lo;
+        }
+        let index = self.range(index);
+        // BAML accepts negative array indices relative to the end.
+        index.lo >= -length.lo && index.hi < length.lo
+    }
+
+    fn can_discard(&self, value: &Rvalue<'_>, body: &MirFunctionBody<'_>) -> bool {
+        value.can_discard_with(|place| self.in_bounds(place, body))
+            || matches!(
+                value,
+                Rvalue::BinaryOp { .. }
+                    | Rvalue::UnaryOp {
+                        op: UnaryOp::Neg,
+                        ..
+                    }
+            ) && self.integer_value(value, body).is_some()
+    }
+
+    fn merge(&mut self, other: &Self, widen: bool) -> bool {
+        let before = self.clone();
+        self.aliases
+            .retain(|local, value| other.aliases.get(local) == Some(value));
+        self.reads
+            .retain(|key, value| other.reads.get(key) == Some(value));
+        self.integers.retain(|local, range| {
+            if let Some(other) = other.integers.get(local) {
+                *range = range.join(*other, widen, Range::INT);
+                true
+            } else {
+                false
+            }
+        });
+        self.lengths.retain(|local, range| {
+            if let Some(other) = other.lengths.get(local) {
+                *range = range.join(*other, widen, Range::LENGTH);
+                true
+            } else {
+                false
+            }
+        });
+        self.length_values
+            .retain(|local, value| other.length_values.get(local) == Some(value));
+        self.conditions
+            .retain(|local, value| other.conditions.get(local) == Some(value));
+        *self != before
+    }
+}
+
+fn invert(op: BinOp) -> BinOp {
+    match op {
+        BinOp::Eq => BinOp::Ne,
+        BinOp::Ne => BinOp::Eq,
+        BinOp::Lt => BinOp::Ge,
+        BinOp::Le => BinOp::Gt,
+        BinOp::Gt => BinOp::Le,
+        BinOp::Ge => BinOp::Lt,
+        _ => unreachable!("only comparisons have branch facts"),
+    }
+}
+
+pub(super) struct Analysis {
+    pub discardable: Vec<Vec<bool>>,
+}
+
+impl Analysis {
+    pub(super) fn new(body: &MirFunctionBody<'_>) -> Self {
+        let handlers: HashSet<_> = body
+            .catch_regions
+            .iter()
+            .map(|region| region.handler)
+            .collect();
+        let mut entries = vec![None; body.blocks.len()];
+        let mut work = VecDeque::new();
+        for entry in std::iter::once(body.entry).chain(handlers.iter().copied()) {
+            entries[entry.0] = Some(Facts::default());
+            work.push_back(entry);
+        }
+        while let Some(id) = work.pop_front() {
+            let mut facts = entries[id.0].clone().unwrap();
+            let block = &body.blocks[id.0];
+            for statement in &block.statements {
+                facts.statement(&statement.kind, body);
+            }
+            let Some(term) = &block.terminator else {
+                continue;
+            };
+            match term {
+                Terminator::Call { .. }
+                | Terminator::VirtualCall { .. }
+                | Terminator::SysOp { .. }
+                | Terminator::Await { .. }
+                | Terminator::AwaitAny { .. }
+                | Terminator::Spawn { .. } => facts = Facts::default(),
+                Terminator::ShortCircuit { destination, .. } => {
+                    if let Place::Local(local) = destination {
+                        facts.forget(*local);
+                    } else {
+                        facts = Facts::default();
+                    }
+                }
+                Terminator::NarrowBind { destination, .. } => facts.forget(*destination),
+                _ => {}
+            }
+            for target in term.successors() {
+                if target == body.entry || handlers.contains(&target) {
+                    continue;
+                }
+                let mut outgoing = facts.clone();
+                if let Terminator::Branch {
+                    condition,
+                    then_block,
+                    else_block,
+                } = term
+                    && then_block != else_block
+                    && let Some(condition) = facts.condition(condition)
+                {
+                    outgoing.branch(condition, target == *then_block);
+                }
+                let changed = if let Some(previous) = &mut entries[target.0] {
+                    // Every cycle includes a backwards-numbered edge. Widen
+                    // growing ranges there, so loop trip counts do not bound
+                    // analysis time. Acyclic backward edges only lose precision.
+                    previous.merge(&outgoing, target.0 <= id.0)
+                } else {
+                    entries[target.0] = Some(outgoing);
+                    true
+                };
+                if changed {
+                    work.push_back(target);
+                }
+            }
+        }
+        let discardable = body
+            .blocks
+            .iter()
+            .map(|block| {
+                let mut facts = entries[block.id.0].clone().unwrap_or_default();
+                block
+                    .statements
+                    .iter()
+                    .map(|statement| {
+                        let safe = match &statement.kind {
+                            StatementKind::Assign { value, .. } => facts.can_discard(value, body),
+                            StatementKind::Drop(place) => {
+                                facts.can_discard(&Rvalue::Use(Operand::Copy(place.clone())), body)
+                            }
+                            _ => false,
+                        };
+                        facts.statement(&statement.kind, body);
+                        safe
+                    })
+                    .collect()
+            })
+            .collect();
+        Self { discardable }
+    }
+}
+
+/// A local read used only to discard its result has no effect itself. Removing
+/// these sinks lets DCE reconsider their producers; potentially trapping
+/// producers will get an explicit discard again in `eliminate_dead_locals`.
+pub(super) fn remove_trivial_drops(body: &mut MirFunctionBody<'_>) {
+    let analysis = Analysis::new(body);
+    for block in &mut body.blocks {
+        let mut index = 0;
+        block.statements.retain(|statement| {
+            let remove = matches!(statement.kind, StatementKind::Drop(_))
+                && analysis.discardable[block.id.0][index];
+            index += 1;
+            !remove
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arithmetic_proofs_cover_extremes_and_interior_values() {
+        let values = [MIN, MIN + 1, -3, -1, 0, 1, 3, MAX - 1, MAX];
+        for &lo in &values {
+            for &hi in values.iter().filter(|&&hi| hi >= lo) {
+                for &rhs_lo in &values {
+                    for &rhs_hi in values.iter().filter(|&&hi| hi >= rhs_lo) {
+                        for op in [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div, BinOp::Mod] {
+                            let Some(proof) = (Range { lo, hi }).arithmetic(
+                                op,
+                                Range {
+                                    lo: rhs_lo,
+                                    hi: rhs_hi,
+                                },
+                            ) else {
+                                continue;
+                            };
+                            for &a in values.iter().filter(|&&n| lo <= n && n <= hi) {
+                                for &b in values.iter().filter(|&&n| rhs_lo <= n && n <= rhs_hi) {
+                                    let (a, b) = (i128::from(a), i128::from(b));
+                                    let result = match op {
+                                        BinOp::Add => Some(a + b),
+                                        BinOp::Sub => Some(a - b),
+                                        BinOp::Mul => Some(a * b),
+                                        BinOp::Div => a.checked_div(b),
+                                        BinOp::Mod => a.checked_rem(b),
+                                        _ => unreachable!(),
+                                    }
+                                    .expect("proven arithmetic must not divide by zero");
+                                    assert!(
+                                        (i128::from(proof.lo)..=i128::from(proof.hi))
+                                            .contains(&result)
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn joins_widen_only_growing_bounds_and_forget_disagreeing_aliases() {
+        let local = Local(1);
+        let mut facts = Facts::default();
+        facts.integers.insert(local, Range::exact(0));
+        facts.aliases.insert(Local(2), local);
+        let mut incoming = Facts::default();
+        incoming.integers.insert(local, Range { lo: 0, hi: 1 });
+        incoming.aliases.insert(Local(2), Local(3));
+        assert!(facts.merge(&incoming, true));
+        assert_eq!(facts.integers[&local], Range { lo: 0, hi: MAX });
+        assert!(facts.aliases.is_empty());
+        assert!(!facts.merge(&incoming, true));
+    }
+}

--- a/baml_language/crates/baml_compiler2_mir/src/optimize/values.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize/values.rs
@@ -1,0 +1,640 @@
+use std::collections::HashMap;
+
+use crate::{
+    BinOp, Constant, MirFunctionBody, Operand, OptLevel, Place, Rvalue, ShortCircuitKind,
+    Statement, StatementKind, Terminator, UnaryOp,
+};
+
+fn scalar(constant: &Constant<'_>) -> bool {
+    matches!(
+        constant,
+        Constant::Int(_)
+            | Constant::Float(_)
+            | Constant::Bool(_)
+            | Constant::String(_)
+            | Constant::Null
+    )
+}
+
+/// Propagate immutable scalar definitions, including named bindings. Keeping the
+/// definitions until ordinary DCE preserves locals used in projection positions.
+pub(super) fn fold_constants(body: &mut MirFunctionBody<'_>, arity: usize) {
+    let mut defs = super::count_local_defs(body);
+    for (_, local) in body.unwind_error_locals() {
+        defs[local.0] += 1;
+    }
+    for region in &body.catch_regions {
+        if let Some(local) = region.stack_trace_local {
+            defs[local.0] += 1;
+        }
+    }
+    let mut constants = HashMap::new();
+    loop {
+        let previous = constants.len();
+        for block in &mut body.blocks {
+            for statement in &mut block.statements {
+                super::apply_subst_to_statement(statement, &constants);
+                if let StatementKind::Assign { destination, value } = &mut statement.kind {
+                    if let Some(constant) = fold(value) {
+                        *value = Rvalue::Use(Operand::Constant(constant));
+                    }
+                    if let Place::Local(local) = destination
+                        && local.0 > arity
+                        && defs[local.0] == 1
+                        && !body.locals[local.0].is_captured
+                        && let Rvalue::Use(Operand::Constant(constant)) = value
+                        && scalar(constant)
+                    {
+                        constants.insert(*local, Operand::Constant(constant.clone()));
+                    }
+                }
+            }
+            if let Some(term) = &mut block.terminator {
+                super::apply_subst_to_terminator(term, &constants);
+            }
+        }
+        if constants.len() == previous {
+            break;
+        }
+    }
+
+    for block in &mut body.blocks {
+        let target = match &block.terminator {
+            Some(Terminator::Branch {
+                condition: Operand::Constant(Constant::Bool(value)),
+                then_block,
+                else_block,
+            }) => Some(if *value { *then_block } else { *else_block }),
+            Some(Terminator::ShortCircuit {
+                operand: Operand::Constant(value),
+                kind,
+                destination,
+                eval_rhs,
+                join,
+            }) if scalar(value) => {
+                let taken = match (kind, value) {
+                    (ShortCircuitKind::And, Constant::Bool(value)) => !value,
+                    (ShortCircuitKind::Or, Constant::Bool(value)) => *value,
+                    (ShortCircuitKind::Coalesce, value) => !matches!(value, Constant::Null),
+                    _ => continue,
+                };
+                if taken {
+                    block.statements.push(Statement {
+                        kind: StatementKind::Assign {
+                            destination: destination.clone(),
+                            value: Rvalue::Use(Operand::Constant(value.clone())),
+                        },
+                        span: block.terminator_span,
+                    });
+                }
+                Some(if taken { *join } else { *eval_rhs })
+            }
+            _ => None,
+        };
+        if let Some(target) = target {
+            block.terminator = Some(Terminator::Goto { target });
+        }
+    }
+    simplify_boolean_diamonds(body);
+}
+
+fn fold<'db>(value: &Rvalue<'db>) -> Option<Constant<'db>> {
+    let int = |value| baml_type::Int63::new(value).map(|n| Constant::Int(n.get()));
+    match value {
+        Rvalue::UnaryOp {
+            op,
+            operand: Operand::Constant(arg),
+        } => match (op, arg) {
+            (UnaryOp::Not, Constant::Bool(value)) => Some(Constant::Bool(!value)),
+            (UnaryOp::Neg, Constant::Int(value)) => int(value.checked_neg()?),
+            (UnaryOp::Neg, Constant::Float(value)) if value.is_finite() => {
+                Some(Constant::Float(-value))
+            }
+            (UnaryOp::Truthy, value) => Some(Constant::Bool(match value {
+                Constant::Null => false,
+                Constant::Bool(value) => *value,
+                Constant::Int(value) => *value != 0,
+                Constant::Float(value) => *value != 0.0,
+                Constant::String(value) => !value.is_empty(),
+                _ => return None,
+            })),
+            _ => None,
+        },
+        Rvalue::BinaryOp {
+            op,
+            left: Operand::Constant(left),
+            right: Operand::Constant(right),
+        } => match (left, right) {
+            (Constant::Int(a), Constant::Int(b)) => match op {
+                BinOp::Add => int(a.checked_add(*b)?),
+                BinOp::Sub => int(a.checked_sub(*b)?),
+                BinOp::Mul => int(a.checked_mul(*b)?),
+                BinOp::Div => int(a.checked_div(*b)?),
+                BinOp::Mod => int(a.checked_rem(*b)?),
+                BinOp::BitAnd => int(a & b),
+                BinOp::BitOr => int(a | b),
+                BinOp::BitXor => int(a ^ b),
+                BinOp::Shl => int(baml_type::Int63::new(*a)?.shift_left(*b).ok()?.get()),
+                BinOp::Shr => int(baml_type::Int63::new(*a)?.shift_right(*b).ok()?.get()),
+                _ => compare(*op, a, b).map(Constant::Bool),
+            },
+            (Constant::Float(a), Constant::Float(b)) if a.is_finite() && b.is_finite() => {
+                if let Some(value) = compare(*op, a, b) {
+                    return Some(Constant::Bool(value));
+                }
+                let value = match op {
+                    BinOp::Add => a + b,
+                    BinOp::Sub => a - b,
+                    BinOp::Mul => a * b,
+                    BinOp::Div if *b != 0.0 => a / b,
+                    _ => return None,
+                };
+                value.is_finite().then_some(Constant::Float(value))
+            }
+            (Constant::Bool(a), Constant::Bool(b)) => compare(*op, a, b).map(Constant::Bool),
+            (Constant::String(a), Constant::String(b)) => {
+                if *op == BinOp::Add && a.len().saturating_add(b.len()) <= 4096 {
+                    Some(Constant::String(format!("{a}{b}")))
+                } else {
+                    compare(*op, a, b).map(Constant::Bool)
+                }
+            }
+            (Constant::Null, Constant::Null) => match op {
+                BinOp::Eq => Some(Constant::Bool(true)),
+                BinOp::Ne => Some(Constant::Bool(false)),
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn compare<T: PartialOrd>(op: BinOp, a: &T, b: &T) -> Option<bool> {
+    Some(match op {
+        BinOp::Eq => a == b,
+        BinOp::Ne => a != b,
+        BinOp::Lt => a < b,
+        BinOp::Le => a <= b,
+        BinOp::Gt => a > b,
+        BinOp::Ge => a >= b,
+        _ => return None,
+    })
+}
+
+fn simplify_boolean_diamonds(body: &mut MirFunctionBody<'_>) {
+    for index in 0..body.blocks.len() {
+        let Some(Terminator::Branch {
+            condition,
+            then_block,
+            else_block,
+        }) = body.blocks[index].terminator.clone()
+        else {
+            continue;
+        };
+        let then_block = &body.blocks[then_block.0];
+        let else_block = &body.blocks[else_block.0];
+        let (
+            Some(Terminator::Goto { target: then_join }),
+            Some(Terminator::Goto { target: else_join }),
+        ) = (&then_block.terminator, &else_block.terminator)
+        else {
+            continue;
+        };
+        if then_join != else_join {
+            continue;
+        }
+        let ([then_stmt], [else_stmt]) = (
+            then_block.statements.as_slice(),
+            else_block.statements.as_slice(),
+        ) else {
+            continue;
+        };
+        let (
+            StatementKind::Assign {
+                destination: Place::Local(then_local),
+                value: Rvalue::Use(Operand::Constant(Constant::Bool(then_value))),
+            },
+            StatementKind::Assign {
+                destination: Place::Local(else_local),
+                value: Rvalue::Use(Operand::Constant(Constant::Bool(else_value))),
+            },
+        ) = (&then_stmt.kind, &else_stmt.kind)
+        else {
+            continue;
+        };
+        if then_local != else_local
+            || then_value == else_value
+            || body.locals[then_local.0].is_captured
+        {
+            continue;
+        }
+        let statement = Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(*then_local),
+                value: if *then_value {
+                    Rvalue::Use(condition)
+                } else {
+                    Rvalue::UnaryOp {
+                        op: UnaryOp::Not,
+                        operand: condition,
+                    }
+                },
+            },
+            span: body.blocks[index].terminator_span,
+        };
+        let target = *then_join;
+        body.blocks[index].statements.push(statement);
+        body.blocks[index].terminator = Some(Terminator::Goto { target });
+    }
+}
+
+/// Backwards liveness removes individual overwritten definitions, rather than
+/// requiring the entire local to be unused. Potentially failing RHSs stay put.
+pub(super) fn eliminate_dead_stores(body: &mut MirFunctionBody<'_>, arity: usize, opt: OptLevel) {
+    let effects = super::effects::Analysis::new(body);
+    let n = body.locals.len();
+    let mut live_in = vec![vec![false; n]; body.blocks.len()];
+    loop {
+        let mut changed = false;
+        for block in body.blocks.iter().rev() {
+            let (mut live, exceptional) = live_out(body, block, &live_in);
+            for statement in block.statements.iter().rev() {
+                transfer(statement, &mut live, &exceptional);
+            }
+            if live != live_in[block.id.0] {
+                live_in[block.id.0] = live;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    for index in 0..body.blocks.len() {
+        let (mut live, exceptional) = live_out(body, &body.blocks[index], &live_in);
+        let statements = &mut body.blocks[index].statements;
+        for (statement_index, statement) in statements.iter_mut().enumerate().rev() {
+            if let StatementKind::Assign {
+                destination: Place::Local(local),
+                ..
+            } = &statement.kind
+                && local.0 > arity
+                && !body.locals[local.0].is_captured
+                // Debugger-visible stores must survive at O0, even if overwritten.
+                && (opt != OptLevel::Zero || body.locals[local.0].name.is_none())
+                && !live[local.0]
+                && effects.discardable[index][statement_index]
+            {
+                statement.kind = StatementKind::Nop;
+            }
+            transfer(statement, &mut live, &exceptional);
+        }
+        statements.retain(|statement| !matches!(statement.kind, StatementKind::Nop));
+    }
+}
+
+fn live_out(
+    body: &MirFunctionBody<'_>,
+    block: &crate::BasicBlock<'_>,
+    live_in: &[Vec<bool>],
+) -> (Vec<bool>, Vec<bool>) {
+    let mut live = vec![false; body.locals.len()];
+    let mut exceptional = live.clone();
+    for region in &body.catch_regions {
+        if region.body_blocks.contains(&block.id) {
+            union(&mut exceptional, &live_in[region.handler.0]);
+        }
+    }
+    if let Some(term) = &block.terminator {
+        for successor in term.successors() {
+            union(&mut live, &live_in[successor.0]);
+        }
+        let mut uses = vec![0; live.len()];
+        super::count_in_terminator(term, &mut uses);
+        for (live, uses) in live.iter_mut().zip(uses) {
+            *live |= uses != 0;
+        }
+        if matches!(term, Terminator::Return) {
+            live[0] = true;
+        }
+    }
+    union(&mut live, &exceptional);
+    (live, exceptional)
+}
+
+fn transfer(statement: &Statement<'_>, live: &mut [bool], exceptional: &[bool]) {
+    if let StatementKind::Assign {
+        destination: Place::Local(local),
+        ..
+    } = &statement.kind
+    {
+        live[local.0] = false;
+    }
+    let mut uses = vec![0; live.len()];
+    super::count_in_statement(statement, &mut uses);
+    for (live, uses) in live.iter_mut().zip(uses) {
+        *live |= uses != 0;
+    }
+    // A panic can enter the handler before this statement stores its result.
+    union(live, exceptional);
+}
+
+fn union(into: &mut [bool], from: &[bool]) {
+    for (into, from) in into.iter_mut().zip(from) {
+        *into |= *from;
+    }
+}
+
+/// Put infallible constants before the next call producing a consumer operand.
+/// This exposes mixed prefixes like `[f(), 2, g()]` without moving any effectful
+/// evaluation. Stackification may still reject carrying and inline the constant.
+pub(super) fn materialize_operand_prefixes(body: &mut MirFunctionBody<'_>) {
+    let defs = super::count_local_defs(body);
+    let uses = super::count_local_uses(body);
+    let mut calls = HashMap::new();
+    for block in &body.blocks {
+        if let Some(
+            Terminator::Call {
+                destination: Place::Local(local),
+                ..
+            }
+            | Terminator::VirtualCall {
+                destination: Place::Local(local),
+                ..
+            }
+            | Terminator::SysOp {
+                destination: Place::Local(local),
+                ..
+            }
+            | Terminator::Await {
+                destination: Place::Local(local),
+                ..
+            },
+        ) = &block.terminator
+            && defs[local.0] == 1
+            && uses[local.0] == 1
+        {
+            calls.insert(*local, block.id);
+        }
+    }
+    for block_index in 0..body.blocks.len() {
+        let statements = body.blocks[block_index].statements.len();
+        for consumer_index in 0..=statements {
+            let operands = prefix_operands(&mut body.blocks[block_index], consumer_index)
+                .into_iter()
+                .map(|operand| operand.clone())
+                .collect::<Vec<_>>();
+            for (index, operand) in operands.iter().enumerate() {
+                let Operand::Constant(constant) = operand else {
+                    continue;
+                };
+                let Some(ty) = constant_type(constant) else {
+                    continue;
+                };
+                let next = operands[index + 1..]
+                    .iter()
+                    .find(|operand| !matches!(operand, Operand::Constant(_)));
+                let Some(Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))) =
+                    next
+                else {
+                    continue;
+                };
+                let Some(def_block) = calls.get(local) else {
+                    continue;
+                };
+                if def_block.0 == block_index {
+                    continue;
+                }
+                let temporary = crate::Local(body.locals.len());
+                body.locals.push(crate::LocalDecl {
+                    name: None,
+                    ty,
+                    span: None,
+                    scope_span: None,
+                    is_captured: false,
+                });
+                body.blocks[def_block.0].statements.push(Statement {
+                    kind: StatementKind::Assign {
+                        destination: Place::Local(temporary),
+                        value: Rvalue::Use(Operand::Constant(constant.clone())),
+                    },
+                    span: None,
+                });
+                *prefix_operands(&mut body.blocks[block_index], consumer_index)[index] =
+                    Operand::Copy(Place::Local(temporary));
+            }
+        }
+    }
+}
+
+fn prefix_operands<'a, 'db>(
+    block: &'a mut crate::BasicBlock<'db>,
+    index: usize,
+) -> Vec<&'a mut Operand<'db>> {
+    if index == block.statements.len() {
+        return match &mut block.terminator {
+            Some(Terminator::Call { args, .. } | Terminator::VirtualCall { args, .. }) => {
+                args.iter_mut().collect()
+            }
+            _ => Vec::new(),
+        };
+    }
+    match &mut block.statements[index].kind {
+        StatementKind::Assign { value, .. } => match value {
+            Rvalue::BinaryOp { left, right, .. } => vec![left, right],
+            Rvalue::Array(_, elements) => elements.iter_mut().collect(),
+            Rvalue::Map(_, _, elements) => elements.iter_mut().map(|(_, value)| value).collect(),
+            Rvalue::Aggregate { fields, .. }
+                if !fields.iter().any(|field| {
+                    matches!(
+                        field,
+                        Operand::Copy(Place::Field { .. }) | Operand::Move(Place::Field { .. })
+                    )
+                }) =>
+            {
+                fields.iter_mut().collect()
+            }
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+fn constant_type(constant: &Constant<'_>) -> Option<baml_type::RuntimeTy> {
+    use baml_type::RuntimeTy;
+    let attr = baml_type::TyAttr::default();
+    Some(match constant {
+        Constant::Int(_) => RuntimeTy::Int { attr },
+        Constant::Float(_) => RuntimeTy::Float { attr },
+        Constant::Bool(_) => RuntimeTy::Bool { attr },
+        Constant::String(_) => RuntimeTy::String { attr },
+        Constant::Null => RuntimeTy::Null { attr },
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_type::RuntimeTy;
+
+    use super::*;
+    use crate::{BasicBlock, BlockId, Local, LocalDecl};
+
+    fn binary(op: BinOp, left: Constant<'static>, right: Constant<'static>) -> Rvalue<'static> {
+        Rvalue::BinaryOp {
+            op,
+            left: Operand::Constant(left),
+            right: Operand::Constant(right),
+        }
+    }
+
+    #[test]
+    fn integer_folding_preserves_overflow_and_zero_divisor_panics() {
+        let min = baml_type::Int63::MIN.get();
+        let max = baml_type::Int63::MAX.get();
+        for (op, left, right) in [
+            (BinOp::Div, 1, 0),
+            (BinOp::Mod, 1, 0),
+            (BinOp::Add, max, 1),
+            (BinOp::Add, i64::MAX, 1),
+            (BinOp::Sub, min, 1),
+            (BinOp::Mul, max, 2),
+            (BinOp::Div, min, -1),
+        ] {
+            assert!(
+                fold(&binary(op, Constant::Int(left), Constant::Int(right))).is_none(),
+                "{left} {op:?} {right}"
+            );
+        }
+        assert!(
+            fold(&Rvalue::UnaryOp {
+                op: UnaryOp::Neg,
+                operand: Operand::Constant(Constant::Int(min)),
+            })
+            .is_none()
+        );
+        for (op, expected) in [
+            (BinOp::Add, 8),
+            (BinOp::Sub, 4),
+            (BinOp::Mul, 12),
+            (BinOp::Div, 3),
+            (BinOp::Mod, 0),
+            (BinOp::BitAnd, 2),
+            (BinOp::BitOr, 6),
+            (BinOp::BitXor, 4),
+            (BinOp::Shl, 24),
+            (BinOp::Shr, 1),
+        ] {
+            assert!(matches!(
+                fold(&binary(op, Constant::Int(6), Constant::Int(2))),
+                Some(Constant::Int(value)) if value == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn float_folding_rejects_zero_division_and_nonfinite_values() {
+        for (op, left, right) in [
+            (BinOp::Div, 1.0, 0.0),
+            (BinOp::Div, 1.0, -0.0),
+            (BinOp::Mul, f64::MAX, 2.0),
+            (BinOp::Add, f64::INFINITY, 1.0),
+            (BinOp::Add, f64::NAN, 1.0),
+        ] {
+            assert!(fold(&binary(op, Constant::Float(left), Constant::Float(right))).is_none());
+        }
+        for (op, expected) in [
+            (BinOp::Add, 8.0_f64),
+            (BinOp::Sub, 4.0),
+            (BinOp::Mul, 12.0),
+            (BinOp::Div, 3.0),
+        ] {
+            assert!(matches!(
+                fold(&binary(op, Constant::Float(6.0), Constant::Float(2.0))),
+                Some(Constant::Float(value)) if value.to_bits() == expected.to_bits()
+            ));
+        }
+    }
+
+    #[test]
+    fn string_folding_obeys_the_allocation_limit() {
+        assert!(matches!(
+            fold(&binary(
+                BinOp::Add,
+                Constant::String("a".repeat(4095)),
+                Constant::String("b".into()),
+            )),
+            Some(Constant::String(value)) if value.len() == 4096 && value.ends_with('b')
+        ));
+        assert!(
+            fold(&binary(
+                BinOp::Add,
+                Constant::String("a".repeat(4096)),
+                Constant::String("b".into()),
+            ))
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn dead_stores_preserve_named_definitions_at_o0_but_optimize_temporaries() {
+        let mut block = BasicBlock::new(BlockId(0));
+        for (local, value) in [(1, 1), (2, 1), (1, 2), (2, 2)] {
+            block.statements.push(Statement {
+                kind: StatementKind::Assign {
+                    destination: Place::Local(Local(local)),
+                    value: Rvalue::Use(Operand::Constant(Constant::Int(value))),
+                },
+                span: None,
+            });
+        }
+        block.statements.push(Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(Local(0)),
+                value: Rvalue::BinaryOp {
+                    op: BinOp::Add,
+                    left: Operand::copy_local(Local(1)),
+                    right: Operand::copy_local(Local(2)),
+                },
+            },
+            span: None,
+        });
+        block.terminator = Some(Terminator::Return);
+        let original = MirFunctionBody {
+            blocks: vec![block],
+            entry: BlockId(0),
+            locals: [None, Some("named"), None]
+                .into_iter()
+                .map(|name| LocalDecl {
+                    name: name.map(baml_base::Name::new),
+                    ty: RuntimeTy::int(),
+                    span: None,
+                    scope_span: None,
+                    is_captured: false,
+                })
+                .collect(),
+            catch_regions: vec![],
+        };
+        for opt in [OptLevel::Zero, OptLevel::One, OptLevel::Two] {
+            let mut body = original.clone();
+            eliminate_dead_stores(&mut body, 0, opt);
+            let defs = super::super::count_local_defs(&body);
+            assert_eq!(
+                defs[1],
+                if opt == OptLevel::Zero { 2 } else { 1 },
+                "{opt:?}"
+            );
+            assert_eq!(defs[2], 1, "unnamed temporary at {opt:?}");
+            if opt == OptLevel::Zero {
+                super::super::optimize_body(&mut body, 0, opt);
+                let named = body
+                    .locals
+                    .iter()
+                    .position(|local| local.name.is_some())
+                    .unwrap();
+                assert_eq!(super::super::count_local_defs(&body)[named], 2);
+            }
+        }
+    }
+}

--- a/baml_language/crates/baml_compiler2_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/pretty.rs
@@ -434,12 +434,16 @@ fn write_terminator(f: &mut impl Write, term: &Terminator<'_>) -> fmt::Result {
         }
         Terminator::ShortCircuit {
             operand,
-            is_and,
+            kind,
             destination,
             eval_rhs,
             join,
         } => {
-            let op = if *is_and { "&&" } else { "||" };
+            let op = match kind {
+                crate::ShortCircuitKind::And => "&&",
+                crate::ShortCircuitKind::Or => "||",
+                crate::ShortCircuitKind::Coalesce => "??",
+            };
             write!(f, "{destination} = short_circuit({op}) ")?;
             write_operand(f, operand)?;
             write!(f, " -> [eval: {eval_rhs}, join: {join}];")

--- a/baml_language/crates/baml_tests/baml_src/ns_optimizer_effects/optimizer_effects.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_optimizer_effects/optimizer_effects.baml
@@ -1,0 +1,53 @@
+class Box { value: int }
+
+function and_inline(a: bool, box: Box) -> int {
+    a && { box.value = box.value + 1; true }
+    box.value
+}
+
+function or_inline(a: bool, box: Box) -> int {
+    a || { box.value = box.value + 1; true }
+    box.value
+}
+
+function and_index(a: bool, values: int[]) -> int {
+    a && { values[0] = values[0] + 1; true }
+    values[0]
+}
+
+function and_capture(a: bool) -> int {
+    let value = 0
+    let read = () => { value }
+    a && { value = 1; true }
+    read()
+}
+
+function unused_division(x: int) -> int {
+    { let unused = 1 / x; 42 } catch (e) {
+        baml.panics.DivisionByZero => 7
+    }
+}
+
+function unused_index(values: int[], index: int) -> int {
+    { let unused = values[index]; 42 } catch (e) {
+        baml.panics.IndexOutOfBounds => 7
+    }
+}
+
+test "discarded logical expressions preserve conditional effects" {
+    assert.equal(and_inline(true, Box { value: 0 }), 1)
+    assert.equal(and_inline(false, Box { value: 0 }), 0)
+    assert.equal(or_inline(false, Box { value: 0 }), 1)
+    assert.equal(or_inline(true, Box { value: 0 }), 0)
+    assert.equal(and_index(true, [0]), 1)
+    assert.equal(and_index(false, [0]), 0)
+    assert.equal(and_capture(true), 1)
+    assert.equal(and_capture(false), 0)
+}
+
+test "unused evaluations preserve catchable panics" {
+    assert.equal(unused_division(0), 7)
+    assert.equal(unused_division(1), 42)
+    assert.equal(unused_index([1], 4), 7)
+    assert.equal(unused_index([1], 0), 42)
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_optimizer_stack/optimizer_stack.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_optimizer_stack/optimizer_stack.baml
@@ -1,0 +1,188 @@
+class Counter { value: int }
+
+interface Source {
+    function next(self) -> int throws never
+}
+
+class Sequence {
+    counter: Counter
+    implements Source {
+        function next(self) -> int { tick(self.counter) }
+    }
+}
+
+function tick(counter: Counter) -> int {
+    counter.value = counter.value + 1
+    counter.value
+}
+
+function number(value: int) -> int { value }
+function combine(a: int, b: int) -> int { a * 10 + b }
+function identity<T>(value: T) -> T { value }
+
+function and_value(a: bool, b: bool, c: bool) -> bool { a && b && c }
+function or_value(a: bool, b: bool, c: bool) -> bool { a || b || c }
+function mixed_value(a: bool, b: bool, c: bool) -> bool { (a && b) || c }
+function predicate(a: bool, b: bool, c: bool) -> bool {
+    if (!(a && b) || c) { true } else { false }
+}
+function negated_truthiness(value: string?) -> int {
+    if (!value) { 1 } else { 2 }
+}
+function mutable_value(a: bool, b: bool, c: bool) -> bool {
+    let value = false
+    if (c) { value = a && b }
+    value
+}
+
+function truth_tables() -> bool {
+    let bits = 0
+    while (bits < 8) {
+        let a = (bits & 1) != 0
+        let b = (bits & 2) != 0
+        let c = (bits & 4) != 0
+        if (and_value(a, b, c) != (bits == 7)) { return false }
+        if (or_value(a, b, c) != (bits != 0)) { return false }
+        if (mixed_value(a, b, c) != ((bits & 3) == 3 || c)) { return false }
+        if (predicate(a, b, c) != ((bits & 3) != 3 || c)) { return false }
+        if (mutable_value(a, b, c) != (bits == 7)) { return false }
+        bits = bits + 1
+    }
+    true
+}
+
+function condition_effects(a: bool, b: bool) -> int {
+    let counter = Counter { value: 0 }
+    if (a && { tick(counter); b } && { tick(counter); true }) { tick(counter) }
+    counter.value
+}
+
+function coalesce(value: int?) -> int { value ?? 42 }
+function coalesce_effect(value: int?) -> int {
+    let counter = Counter { value: 0 }
+    let result = value ?? tick(counter)
+    result * 10 + counter.value
+}
+function coalesce_mutable(value: int?) -> int {
+    let result = 8
+    result = value ?? 42
+    result
+}
+
+function array_mixed() -> int[] { [number(1), 2, number(3)] }
+function array_effects() -> int[] {
+    let counter = Counter { value: 0 };
+    [tick(counter), 42, tick(counter), counter.value]
+}
+function failing_operand(counter: Counter, divisor: int) -> int {
+    tick(counter)
+    1 / divisor
+}
+function prefix_unwind(divisor: int) -> int {
+    let counter = Counter { value: 0 }
+    {
+        let values = [tick(counter), 42, failing_operand(counter, divisor)]
+        values[0] + values[1] + values[2]
+    } catch (e) { baml.panics.DivisionByZero => counter.value }
+}
+function call_effects() -> int {
+    let counter = Counter { value: 0 }
+    combine(tick(counter), tick(counter))
+}
+function indirect_effects() -> int {
+    let counter = Counter { value: 0 }
+    let call = (a: int, b: int) => { a * 10 + b }
+    call(tick(counter), tick(counter))
+}
+function binary_effects() -> int {
+    let counter = Counter { value: 0 }
+    tick(counter) - tick(counter)
+}
+function virtual_result(source: Source) -> int { source.next() }
+function virtual_effects() -> int[] {
+    let source: Source = Sequence { counter: Counter { value: 0 } };
+    [virtual_result(source), 42, source.next()]
+}
+function generic_effects() -> int {
+    let counter = Counter { value: 0 }
+    combine(identity<int>(tick(counter)), identity<int>(tick(counter)))
+}
+
+function constants() -> int { let a = 1 + 2; let b = a * 3; b + 4 }
+function overwritten(a: bool) -> int {
+    let result = 0
+    if (a) { result = 1 } else { result = 2 }
+    result
+}
+function overwritten_panic(divisor: int) -> int {
+    {
+        let result = 1 / divisor
+        result = 42
+        result
+    } catch (e) { baml.panics.DivisionByZero => 7 }
+}
+function handler_observes_store(divisor: int) -> int {
+    let result = 1
+    {
+        result = 2
+        let unused = 1 / divisor
+        result = 3
+        result
+    } catch (e) { baml.panics.DivisionByZero => result }
+}
+function constant_overflow() -> int {
+    {
+        let largest = 4611686018427387903
+        let one = 1
+        largest + one
+    } catch (e) { baml.panics.IntegerOverflow => 7 }
+}
+function parameter_copy(value: int) -> int {
+    let before = value
+    value = 8
+    before
+}
+function loop_values(count: int) -> int {
+    let index = 0
+    let total = 0
+    while (index < count && total < 20000) {
+        let result = (index < 500 && index < 250) || index >= 750
+        if (result) { total = total + 1 }
+        index = index + 1
+    }
+    total
+}
+
+function iterator_sum(values: int[]) -> int {
+    let sum = 0
+    for (let value in values) { sum = sum + value }
+    sum
+}
+
+function verify_all() -> bool {
+    truth_tables()
+        && negated_truthiness("hi") == 2
+        && negated_truthiness("") == 1 && negated_truthiness(null) == 1
+        && condition_effects(false, true) == 0
+        && condition_effects(true, false) == 1
+        && condition_effects(true, true) == 3
+        && coalesce(null) == 42 && coalesce(0) == 0
+        && coalesce_effect(null) == 11 && coalesce_effect(0) == 0
+        && coalesce_mutable(null) == 42 && coalesce_mutable(9) == 9
+        && array_mixed() == [1, 2, 3]
+        && array_effects() == [1, 42, 2, 2]
+        && prefix_unwind(0) == 2 && prefix_unwind(1) == 44
+        && call_effects() == 12 && indirect_effects() == 12
+        && binary_effects() == -1 && virtual_effects() == [1, 42, 2]
+        && generic_effects() == 12 && constants() == 13
+        && overwritten(true) == 1 && overwritten(false) == 2
+        && overwritten_panic(0) == 7 && overwritten_panic(1) == 42
+        && handler_observes_store(0) == 2 && handler_observes_store(1) == 3
+        && constant_overflow() == 7 && parameter_copy(3) == 3
+        && loop_values(1000) == 500
+        && iterator_sum([1, 2, 3, 4]) == 10 && iterator_sum([]) == 0
+}
+
+test "optimized value and predicate paths preserve behavior" {
+    assert.is_true(verify_all())
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
@@ -652,6 +652,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
@@ -655,6 +655,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_array_filled/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_array_filled/bytecode.snap
@@ -70,10 +70,7 @@ function array_filled.array_filled_length_and_value() -> int {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _6
     load_const 0
     cmp_int_op !=
@@ -84,7 +81,7 @@ function array_filled.array_filled_length_and_value() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -105,10 +102,7 @@ function array_filled.array_filled_mutable_value_aliases_all_slots() -> int {
     load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_type int
     load_var _4
     load_const 1
@@ -122,7 +116,7 @@ function array_filled.array_filled_mutable_value_aliases_all_slots() -> int {
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
-  L1:
+  L0:
     load_var _12
     load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
@@ -130,26 +124,23 @@ function array_filled.array_filled_mutable_value_aliases_all_slots() -> int {
     store_var _13
     load_var _13
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _13
     container_len
     store_var _17
     load_var2 3 6
     add_int
     store_var total
-    jump L1
+    jump L0
 
-  L3:
+  L1:
     load_var total
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const 0
 
-  L5:
+  L3:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_array_rest_binding/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_array_rest_binding/bytecode.snap
@@ -165,8 +165,7 @@ function array_rest_binding.arb_grab(xs: int[]) -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -174,24 +173,20 @@ function array_rest_binding.arb_grab(xs: int[]) -> int {
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
     container_len
-    store_var _11
+    store_var _9
     load_var xs
     load_const 1
-    load_var _11
+    load_var _9
     call baml.Array.slice
     load_var xs
     load_const 0
     load_array_element
     load_const 10
     mul_int
-    store_var _13
+    store_var _11
     container_len
-    store_var _15
+    store_var _13
     load_var2 4 5
     add_int
 
@@ -202,66 +197,59 @@ function array_rest_binding.arb_grab(xs: int[]) -> int {
 function array_rest_binding.arb_pick(v: array_rest_binding.ArbNumberBag | int[][]) -> int {
     load_var v
     is_type array_rest_binding.ArbNumberBag
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L2
     load_var v
     is_type _[]
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var v
     container_len
-    store_var_load_var _9
+    store_var_load_var _8
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var v
     load_const 0
     load_array_element
-    store_var_load_var _12
+    store_var_load_var _11
     is_type int[]
-    pop_jump_if_false L1
-    load_var _12
+    pop_jump_if_false L0
+    load_var _11
     is_type int[]
-    pop_jump_if_false L1
-    load_var _12
+    pop_jump_if_false L0
+    load_var _11
     container_len
-    store_var_load_var _15
+    store_var_load_var _14
     load_const 0
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+
+  L0:
+    load_const 0
+    jump L3
 
   L1:
-    load_const 0
-    jump L4
-
-  L2:
     load_var v
     load_const 0
     load_array_element
-    store_var _18
-    load_var _18
+    store_var _17
+    load_var _17
     container_len
-    store_var _20
-    load_var _18
+    store_var _19
+    load_var _17
     load_const 0
-    load_var _20
+    load_var _19
     call baml.Array.slice
     load_const 0
     load_array_element
-    jump L4
+    jump L3
 
-  L3:
-    load_var v
-    load_field .0
-    pop 1
+  L2:
     load_var v
     load_field .0
     load_const 0
     load_array_element
 
-  L4:
+  L3:
     return
 }
 
@@ -279,8 +267,7 @@ function array_rest_binding.arb_pushing_to_rest_does_not_mutate_source() -> int 
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -288,15 +275,11 @@ function array_rest_binding.arb_pushing_to_rest_does_not_mutate_source() -> int 
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
     container_len
-    store_var _10
+    store_var _6
     load_var xs
     load_const 1
-    load_var _10
+    load_var _6
     call baml.Array.slice
     store_var r
     load_type int
@@ -306,14 +289,14 @@ function array_rest_binding.arb_pushing_to_rest_does_not_mutate_source() -> int 
     pop 1
     load_var xs
     container_len
-    store_var _15
-    load_var _15
+    store_var _11
+    load_var _11
     load_const 10
     mul_int
-    store_var _14
+    store_var _10
     load_var r
     container_len
-    store_var _16
+    store_var _12
     load_var2 5 7
     add_int
 
@@ -335,8 +318,7 @@ function array_rest_binding.arb_pushing_to_source_does_not_mutate_rest() -> int 
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -344,23 +326,19 @@ function array_rest_binding.arb_pushing_to_source_does_not_mutate_rest() -> int 
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
     container_len
-    store_var _10
+    store_var _6
     load_var xs
     load_const 1
-    load_var _10
+    load_var _6
     call baml.Array.slice
-    store_var _9
+    store_var _5
     load_type int
     load_var xs
     load_const 7
     call baml.Array.push
     pop 1
-    load_var _9
+    load_var _5
     container_len
 
   L2:
@@ -473,8 +451,7 @@ function array_rest_binding.arb_rest_binding_in_nested_element_pattern() -> int 
     store_var_load_var _10
     load_const 0
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -524,8 +501,7 @@ function array_rest_binding.arb_rest_binds_middle_values() -> int {
     store_var_load_var _3
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -533,30 +509,18 @@ function array_rest_binding.arb_rest_binds_middle_values() -> int {
 
   L1:
     load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
     container_len
-    store_var _7
-    load_var2 1 3
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var _1
-    container_len
-    store_var _14
+    store_var _9
     load_var _1
     load_const 1
-    load_var _14
+    load_var _9
     load_const 1
     sub_int
     call baml.Array.slice
     store_var r
     load_var _1
     container_len
-    store_var _17
+    store_var _12
     load_var r
     load_const 0
     load_array_element
@@ -578,7 +542,7 @@ function array_rest_binding.arb_rest_binds_middle_values() -> int {
     load_const 1000
     mul_int
     add_int
-    load_var2 1 6
+    load_var2 1 5
     load_const 1
     sub_int
     load_array_element
@@ -607,8 +571,7 @@ function array_rest_binding.arb_rest_copy_is_shallow_elements_are_shared() -> in
     store_var_load_var _6
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -616,15 +579,11 @@ function array_rest_binding.arb_rest_copy_is_shallow_elements_are_shared() -> in
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
     container_len
-    store_var _13
+    store_var _9
     load_var xs
     load_const 1
-    load_var _13
+    load_var _9
     call baml.Array.slice
     load_var c
     load_const 5
@@ -650,8 +609,7 @@ function array_rest_binding.arb_rest_is_empty_between_exact_prefix_and_suffix() 
     store_var_load_var _3
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -659,32 +617,20 @@ function array_rest_binding.arb_rest_is_empty_between_exact_prefix_and_suffix() 
 
   L1:
     load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
     container_len
-    store_var _7
-    load_var2 1 3
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var _1
-    container_len
-    store_var _14
+    store_var _9
     load_var _1
     load_const 1
-    load_var _14
+    load_var _9
     load_const 1
     sub_int
     call baml.Array.slice
     load_var _1
     container_len
-    store_var _17
+    store_var _12
     container_len
-    store_var _23
-    load_var _23
+    store_var _18
+    load_var _18
     load_const 100
     mul_int
     load_var _1
@@ -693,7 +639,7 @@ function array_rest_binding.arb_rest_is_empty_between_exact_prefix_and_suffix() 
     load_const 10
     mul_int
     add_int
-    load_var2 1 5
+    load_var2 1 4
     load_const 1
     sub_int
     load_array_element
@@ -715,8 +661,7 @@ function array_rest_binding.arb_rest_is_empty_when_nothing_remains() -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -724,15 +669,11 @@ function array_rest_binding.arb_rest_is_empty_when_nothing_remains() -> int {
 
   L1:
     load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
     container_len
-    store_var _10
+    store_var _6
     load_var _1
     load_const 1
-    load_var _10
+    load_var _6
     call baml.Array.slice
     container_len
 
@@ -768,10 +709,7 @@ function array_rest_binding.arb_rest_only_binding_in_for_loop() -> int {
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _9
     store_var _11
     load_var _11
@@ -788,7 +726,7 @@ function array_rest_binding.arb_rest_only_binding_in_for_loop() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -841,8 +779,7 @@ function array_rest_binding.arb_rest_with_no_suffix_takes_tail() -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -850,21 +787,17 @@ function array_rest_binding.arb_rest_with_no_suffix_takes_tail() -> int {
 
   L1:
     load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
     container_len
-    store_var _11
+    store_var _9
     load_var _1
     load_const 1
-    load_var _11
+    load_var _9
     call baml.Array.slice
     store_var r
     load_var r
     container_len
-    store_var _15
-    load_var _15
+    store_var _13
+    load_var _13
     load_const 10
     mul_int
     load_var r
@@ -889,8 +822,7 @@ function array_rest_binding.arb_tail_len(xs: #0[]) -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const -1
@@ -898,15 +830,11 @@ function array_rest_binding.arb_tail_len(xs: #0[]) -> int {
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
     container_len
-    store_var _10
+    store_var _6
     load_var xs
     load_const 1
-    load_var _10
+    load_var _6
     call baml.Array.slice
     container_len
 
@@ -926,8 +854,7 @@ function array_rest_binding.arb_too_short_array_falls_through_rest_arm() -> int 
     store_var_load_var _3
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 2
@@ -935,30 +862,23 @@ function array_rest_binding.arb_too_short_array_falls_through_rest_arm() -> int 
 
   L1:
     load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
     container_len
-    store_var _7
-    load_var2 1 3
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var _1
-    container_len
-    store_var _13
+    store_var _6
     load_var _1
     load_const 1
-    load_var _13
+    load_var _6
     load_const 1
     sub_int
     call baml.Array.slice
     pop 1
     load_var _1
     container_len
-    store_var _15
+    store_var _8
+    load_var2 1 4
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
     load_const 1
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_array_rest_binding/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_array_rest_binding/bytecode.snap
@@ -174,20 +174,24 @@ function array_rest_binding.arb_grab(xs: int[]) -> int {
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     container_len
-    store_var _10
+    store_var _11
     load_var xs
     load_const 1
-    load_var _10
+    load_var _11
     call baml.Array.slice
     load_var xs
     load_const 0
     load_array_element
     load_const 10
     mul_int
-    store_var _12
+    store_var _13
     container_len
-    store_var _14
+    store_var _15
     load_var2 4 5
     add_int
 
@@ -207,22 +211,22 @@ function array_rest_binding.arb_pick(v: array_rest_binding.ArbNumberBag | int[][
     pop_jump_if_false L1
     load_var v
     container_len
-    store_var_load_var _8
+    store_var_load_var _9
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var v
     load_const 0
     load_array_element
-    store_var_load_var _11
+    store_var_load_var _12
     is_type int[]
     pop_jump_if_false L1
-    load_var _11
+    load_var _12
     is_type int[]
     pop_jump_if_false L1
-    load_var _11
+    load_var _12
     container_len
-    store_var_load_var _14
+    store_var_load_var _15
     load_const 0
     cmp_int_op >=
     pop_jump_if_false L1
@@ -236,19 +240,22 @@ function array_rest_binding.arb_pick(v: array_rest_binding.ArbNumberBag | int[][
     load_var v
     load_const 0
     load_array_element
-    store_var _17
-    load_var _17
+    store_var _18
+    load_var _18
     container_len
-    store_var _19
-    load_var _17
+    store_var _20
+    load_var _18
     load_const 0
-    load_var _19
+    load_var _20
     call baml.Array.slice
     load_const 0
     load_array_element
     jump L4
 
   L3:
+    load_var v
+    load_field .0
+    pop 1
     load_var v
     load_field .0
     load_const 0
@@ -281,11 +288,15 @@ function array_rest_binding.arb_pushing_to_rest_does_not_mutate_source() -> int 
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     container_len
-    store_var _9
+    store_var _10
     load_var xs
     load_const 1
-    load_var _9
+    load_var _10
     call baml.Array.slice
     store_var r
     load_type int
@@ -295,14 +306,14 @@ function array_rest_binding.arb_pushing_to_rest_does_not_mutate_source() -> int 
     pop 1
     load_var xs
     container_len
-    store_var _14
-    load_var _14
+    store_var _15
+    load_var _15
     load_const 10
     mul_int
-    store_var _13
+    store_var _14
     load_var r
     container_len
-    store_var _15
+    store_var _16
     load_var2 5 7
     add_int
 
@@ -333,19 +344,23 @@ function array_rest_binding.arb_pushing_to_source_does_not_mutate_rest() -> int 
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     container_len
-    store_var _9
+    store_var _10
     load_var xs
     load_const 1
-    load_var _9
+    load_var _10
     call baml.Array.slice
-    store_var _8
+    store_var _9
     load_type int
     load_var xs
     load_const 7
     call baml.Array.push
     pop 1
-    load_var _8
+    load_var _9
     container_len
 
   L2:
@@ -518,21 +533,30 @@ function array_rest_binding.arb_rest_binds_middle_values() -> int {
 
   L1:
     load_var _1
-    container_len
-    store_var _6
+    load_const 0
+    load_array_element
+    pop 1
     load_var _1
     container_len
-    store_var _12
+    store_var _7
+    load_var2 1 3
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var _1
+    container_len
+    store_var _14
     load_var _1
     load_const 1
-    load_var _12
+    load_var _14
     load_const 1
     sub_int
     call baml.Array.slice
     store_var r
     load_var _1
     container_len
-    store_var _15
+    store_var _17
     load_var r
     load_const 0
     load_array_element
@@ -592,11 +616,15 @@ function array_rest_binding.arb_rest_copy_is_shallow_elements_are_shared() -> in
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     container_len
-    store_var _12
+    store_var _13
     load_var xs
     load_const 1
-    load_var _12
+    load_var _13
     call baml.Array.slice
     load_var c
     load_const 5
@@ -631,23 +659,32 @@ function array_rest_binding.arb_rest_is_empty_between_exact_prefix_and_suffix() 
 
   L1:
     load_var _1
-    container_len
-    store_var _6
+    load_const 0
+    load_array_element
+    pop 1
     load_var _1
     container_len
-    store_var _12
+    store_var _7
+    load_var2 1 3
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var _1
+    container_len
+    store_var _14
     load_var _1
     load_const 1
-    load_var _12
+    load_var _14
     load_const 1
     sub_int
     call baml.Array.slice
     load_var _1
     container_len
-    store_var _15
+    store_var _17
     container_len
-    store_var _21
-    load_var _21
+    store_var _23
+    load_var _23
     load_const 100
     mul_int
     load_var _1
@@ -687,11 +724,15 @@ function array_rest_binding.arb_rest_is_empty_when_nothing_remains() -> int {
 
   L1:
     load_var _1
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _1
     container_len
-    store_var _9
+    store_var _10
     load_var _1
     load_const 1
-    load_var _9
+    load_var _10
     call baml.Array.slice
     container_len
 
@@ -809,17 +850,21 @@ function array_rest_binding.arb_rest_with_no_suffix_takes_tail() -> int {
 
   L1:
     load_var _1
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _1
     container_len
-    store_var _10
+    store_var _11
     load_var _1
     load_const 1
-    load_var _10
+    load_var _11
     call baml.Array.slice
     store_var r
     load_var r
     container_len
-    store_var _14
-    load_var _14
+    store_var _15
+    load_var _15
     load_const 10
     mul_int
     load_var r
@@ -853,11 +898,15 @@ function array_rest_binding.arb_tail_len(xs: #0[]) -> int {
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     container_len
-    store_var _9
+    store_var _10
     load_var xs
     load_const 1
-    load_var _9
+    load_var _10
     call baml.Array.slice
     container_len
 
@@ -886,21 +935,30 @@ function array_rest_binding.arb_too_short_array_falls_through_rest_arm() -> int 
 
   L1:
     load_var _1
-    container_len
-    store_var _6
+    load_const 0
+    load_array_element
+    pop 1
     load_var _1
     container_len
-    store_var _11
+    store_var _7
+    load_var2 1 3
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var _1
+    container_len
+    store_var _13
     load_var _1
     load_const 1
-    load_var _11
+    load_var _13
     load_const 1
     sub_int
     call baml.Array.slice
     pop 1
     load_var _1
     container_len
-    store_var _13
+    store_var _15
     load_const 1
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_arrays/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_arrays/bytecode.snap
@@ -1282,8 +1282,6 @@ function arrays.<(user.arrays.CompareScore as baml.ops.Compare)>.cmp(self: array
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1304,8 +1302,6 @@ function arrays.<(user.arrays.OutOfBodyScore as baml.ops.Compare)>.cmp(self: arr
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1326,8 +1322,6 @@ function arrays.<(user.arrays.SortableItem as baml.ops.Compare)>.cmp(self: array
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1392,7 +1386,7 @@ function arrays.flaky_cmp(a: arrays.Flaky, b: arrays.Flaky) -> baml.ops.Ordering
     load_field .value
     store_var _4
     load_var _4
-    narrow_bind int, slot=4
+    narrow_bind int, slot=3
     pop_jump_if_false L0
     load_var _4
     store_var x
@@ -1400,9 +1394,8 @@ function arrays.flaky_cmp(a: arrays.Flaky, b: arrays.Flaky) -> baml.ops.Ordering
     load_field .value
     store_var _7
     load_var _7
-    narrow_bind int, slot=6
-    pop_jump_if_false L0
-    jump L1
+    narrow_bind int, slot=5
+    pop_jump_if_true L1
 
   L0:
     load_const "cannot compare null"
@@ -1410,12 +1403,10 @@ function arrays.flaky_cmp(a: arrays.Flaky, b: arrays.Flaky) -> baml.ops.Ordering
     throw
 
   L1:
-    load_var2 5 6
+    load_var2 4 5
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1453,8 +1444,6 @@ function arrays.sort_bigints(xs: bigint[]) -> bigint[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1472,8 +1461,6 @@ function arrays.sort_floats(xs: float[]) -> float[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1482,8 +1469,6 @@ function arrays.sort_generic(xs: #0[]) -> #0[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1492,8 +1477,6 @@ function arrays.sort_ints(xs: int[]) -> int[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1502,8 +1485,6 @@ function arrays.sort_items(xs: arrays.SortableItem[]) -> arrays.SortableItem[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1512,8 +1493,6 @@ function arrays.sort_strings(xs: string[]) -> string[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1524,20 +1503,17 @@ function arrays.sum_int_overflow_(a: int, b: int) -> int {
     load_type baml.Summable<Sum = int>
     load_const "sum"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -1548,7 +1524,5 @@ function arrays.sum_int_two_(a: int, b: int) -> int {
     load_type baml.Summable<Sum = int>
     load_const "sum"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_assignments/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_assignments/bytecode.snap
@@ -200,17 +200,11 @@ function assignments.cross_block_param_mutation(c: bool, p: int) -> int {
 }
 
 function assignments.cross_block_soundness(c: bool) -> int {
-    load_const 1
-    store_var a
-    load_var a
-    store_var b
     load_var c
-    pop_jump_if_false L0
-    load_const 2
-    store_var a
+    pop_jump_if_true L0
 
   L0:
-    load_var b
+    load_const 1
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_await_union/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_await_union/bytecode.snap
@@ -42,19 +42,16 @@ function await_union.await_union_of_futures_value_side() -> int {
     store_var _2
     load_var _2
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _2
     load_const 1
     add_int
 
-  L2:
+  L1:
     return
 }
 
@@ -70,10 +67,7 @@ function await_union.bad_b() -> int {
 
 function await_union.pick_error(use_a: bool) -> int {
     load_var use_a
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     make_closure .<lambda(pick_error, 1)>, 0
     load_const null
     load_const null
@@ -82,9 +76,9 @@ function await_union.pick_error(use_a: bool) -> int {
     spawn
     store_var _6
     load_var _6
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     make_closure .<lambda(pick_error, 0)>, 0
     load_const null
     load_const null
@@ -94,45 +88,36 @@ function await_union.pick_error(use_a: bool) -> int {
     store_var _4
     load_var _4
 
-  L2:
+  L1:
     await
-    jump L7
+    jump L4
     load_var e
     store_var _9
     load_var _9
     narrow_bind string, slot=5
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L3
     load_var e
     store_var _10
     load_var _10
     narrow_bind int, slot=6
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var e
     rethrow
 
-  L5:
+  L2:
     load_var _10
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_const 1
 
-  L7:
+  L4:
     return
 }
 
 function await_union.pick_value(use_int: bool) -> int | string {
     load_var use_int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     make_closure .<lambda(pick_value, 1)>, 0
     load_const null
     load_const null
@@ -141,9 +126,9 @@ function await_union.pick_value(use_int: bool) -> int | string {
     spawn
     store_var _6
     load_var _6
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     make_closure .<lambda(pick_value, 0)>, 0
     load_const null
     load_const null
@@ -153,7 +138,7 @@ function await_union.pick_value(use_int: bool) -> int | string {
     store_var _4
     load_var _4
 
-  L2:
+  L1:
     await
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_backtick_strings/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_backtick_strings/bytecode.snap
@@ -583,24 +583,19 @@ function backtick_strings.bt_bangs(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
+    load_const "!"
     load_var n
     load_const 1
     sub_int
     call user.backtick_strings.bt_bangs
-    store_var _3
-    load_const "!"
-    load_var _3
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const ""
 
-  L2:
+  L1:
     return
 }
 
@@ -610,13 +605,11 @@ function backtick_strings.bt_blank_line_before_closer() -> string {
 }
 
 function backtick_strings.bt_block_body_tail() -> string {
+    load_const "result: "
     load_type string
-    load_const "hi "
-    load_const "there"
-    bin_op +
+    load_const "hi there"
     call baml.String.from
     store_var _2
-    load_const "result: "
     load_var _2
     bin_op +
     load_const "!"
@@ -625,12 +618,12 @@ function backtick_strings.bt_block_body_tail() -> string {
 }
 
 function backtick_strings.bt_block_comment_interp() -> string {
+    load_const "hi "
     load_type string
     load_const "Ada"
     call baml.String.from
-    store_var _2
-    load_const "hi "
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
@@ -665,12 +658,11 @@ function backtick_strings.bt_case_f() -> string {
     load_type string
     load_const "ab"
     call baml.String.from
-    store_var _3
     load_type string
     load_const "cd"
     call baml.String.from
-    store_var _6
-    load_var2 1 2
+    store_var _3
+    load_var _3
     bin_op +
     return
 }
@@ -685,23 +677,23 @@ function backtick_strings.bt_case_g() -> string {
 }
 
 function backtick_strings.bt_case_h() -> string {
+    load_const "!"
     load_type string
     load_const "hi"
     call baml.String.from
-    store_var _2
-    load_const "!"
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
 
 function backtick_strings.bt_case_i() -> string {
+    load_const "X "
     load_type string
     load_const "Y"
     call baml.String.from
-    store_var _3
-    load_const "X "
-    load_var _3
+    store_var _2
+    load_var _2
     bin_op +
     load_const " Z"
     bin_op +
@@ -752,12 +744,12 @@ function backtick_strings.bt_case_m() -> string {
 }
 
 function backtick_strings.bt_case_n() -> string {
+    load_const "Hello "
     load_type string
     load_const "Ada"
     call baml.String.from
-    store_var _3
-    load_const "Hello "
-    load_var _3
+    store_var _2
+    load_var _2
     bin_op +
     call user.backtick_strings.bt_case_n_shout
     return
@@ -791,12 +783,12 @@ function backtick_strings.bt_case_p() -> string {
     load_const "hello"
     call baml.String.to_upper_case
     store_var r
+    load_const "upper: "
     load_type string
     load_var r
     call baml.String.from
-    store_var _2
-    load_const "upper: "
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
@@ -821,14 +813,11 @@ function backtick_strings.bt_cstyle_for_basic() -> string {
     load_var i
     load_const 3
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     return
 
-  L2:
+  L1:
     load_var  __m3_for
     store_var _5
     load_type int
@@ -860,20 +849,17 @@ function backtick_strings.bt_cstyle_for_outer_local() -> string {
     load_var i
     load_const 4
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     return
 
-  L2:
+  L1:
     load_var  __m3_for
-    store_var _7
+    store_var _5
     load_type int
     load_var i
     call baml.String.from
-    store_var _9
+    store_var _7
     load_var2 3 4
     load_const ","
     bin_op +
@@ -896,14 +882,11 @@ function backtick_strings.bt_cstyle_for_step_two() -> string {
     load_var i
     load_const 6
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     return
 
-  L2:
+  L1:
     load_var  __m3_for
     store_var _5
     load_type int
@@ -951,6 +934,7 @@ function backtick_strings.bt_icf_main() -> string {
     load_const "hi"
     call user.backtick_strings.bt_icf_shout
     store_var _4
+    load_const "Loud: "
     load_type string
     load_var _4
     call baml.String.from
@@ -962,7 +946,6 @@ function backtick_strings.bt_icf_main() -> string {
     load_var _7
     call baml.String.from
     store_var _6
-    load_const "Loud: "
     load_var _3
     bin_op +
     load_const " and "
@@ -983,19 +966,16 @@ function backtick_strings.bt_inline_if_classify(x: int) -> string {
     load_var x
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "neg"
+    store_var _2
     jump L1
 
   L0:
-    load_const "neg"
-    store_var _2
-    jump L2
-
-  L1:
     load_const "pos"
     store_var _2
 
-  L2:
+  L1:
     load_type string
     load_var _2
     call baml.String.from
@@ -1005,11 +985,9 @@ function backtick_strings.bt_inline_if_classify(x: int) -> string {
 function backtick_strings.bt_inline_if_int_main() -> string {
     load_const 5
     call user.backtick_strings.bt_inline_if_int_pick
-    store_var _2
     load_const -1
     call user.backtick_strings.bt_inline_if_int_pick
     store_var _3
-    load_var _2
     load_const "/"
     bin_op +
     load_var _3
@@ -1021,19 +999,16 @@ function backtick_strings.bt_inline_if_int_pick(x: int) -> string {
     load_var x
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
+    store_var _2
     jump L1
 
   L0:
-    load_const 2
-    store_var _2
-    jump L2
-
-  L1:
     load_const 1
     store_var _2
 
-  L2:
+  L1:
     load_type int
     load_var _2
     call baml.String.from
@@ -1043,11 +1018,9 @@ function backtick_strings.bt_inline_if_int_pick(x: int) -> string {
 function backtick_strings.bt_inline_if_main() -> string {
     load_const 5
     call user.backtick_strings.bt_inline_if_classify
-    store_var _2
     load_const -1
     call user.backtick_strings.bt_inline_if_classify
     store_var _3
-    load_var _2
     load_const "/"
     bin_op +
     load_var _3
@@ -1056,69 +1029,69 @@ function backtick_strings.bt_inline_if_main() -> string {
 }
 
 function backtick_strings.bt_interp_bool() -> string {
+    load_const "status: "
     load_type bool
     load_const true
     call baml.String.from
-    store_var _2
-    load_const "status: "
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
 
 function backtick_strings.bt_interp_float() -> string {
+    load_const "pi ~ "
     load_type float
     load_const 3.14
     call baml.String.from
-    store_var _2
-    load_const "pi ~ "
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
 
 function backtick_strings.bt_interp_int() -> string {
+    load_const "count: "
     load_type int
     load_const 42
     call baml.String.from
-    store_var _2
-    load_const "count: "
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
 
 function backtick_strings.bt_interp_mixed() -> string {
+    load_const "n="
     load_type int
     load_const 7
     call baml.String.from
-    store_var _11
+    store_var _7
     load_type bool
     load_const false
     call baml.String.from
-    store_var _14
+    store_var _9
     load_type float
     load_const 1.5
     call baml.String.from
-    store_var _17
+    store_var _11
     load_type string
     load_const "test"
     call baml.String.from
-    store_var _20
-    load_const "n="
-    load_var _11
+    store_var _13
+    load_var _7
     bin_op +
     load_const ", ok="
     bin_op +
-    load_var _14
+    load_var _9
     bin_op +
     load_const ", r="
     bin_op +
-    load_var _17
+    load_var _11
     bin_op +
     load_const ", name="
     bin_op +
-    load_var _20
+    load_var _13
     bin_op +
     return
 }
@@ -1138,37 +1111,23 @@ function backtick_strings.bt_keeps_trailing_escaped_newline() -> string {
 }
 
 function backtick_strings.bt_let_bound_if_else() -> string {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const "guest"
-    store_var r
-    jump L2
-
-  L1:
-    load_const "user"
-    store_var r
-
-  L2:
-    load_type string
-    load_var r
-    call baml.String.from
-    store_var _2
     load_const "welcome "
-    load_var _2
+    load_type string
+    load_const "user"
+    call baml.String.from
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
 
 function backtick_strings.bt_line_comment_interp() -> string {
+    load_const "hi "
     load_type string
     load_const "Ada"
     call baml.String.from
-    store_var _2
-    load_const "hi "
-    load_var _2
+    store_var _1
+    load_var _1
     bin_op +
     return
 }
@@ -1183,22 +1142,19 @@ function backtick_strings.bt_loop_in_block() -> string {
     load_var i
     load_const 3
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
+    load_const "loop result: "
     load_type string
     load_var acc
     call baml.String.from
     store_var _2
-    load_const "loop result: "
     load_var _2
     bin_op +
     load_const "!"
     bin_op +
     return
 
-  L2:
+  L1:
     load_var acc
     load_const "x"
     bin_op +
@@ -1214,12 +1170,10 @@ function backtick_strings.bt_m3_block_tag_after_interp() -> string {
     load_const "Alice"
     load_const true
     call user.backtick_strings.bt_m3_block_tag_after_interp_greet
-    store_var _2
     load_const "Bob"
     load_const false
     call user.backtick_strings.bt_m3_block_tag_after_interp_greet
     store_var _3
-    load_var _2
     load_const "|"
     bin_op +
     load_var _3
@@ -1233,19 +1187,16 @@ function backtick_strings.bt_m3_block_tag_after_interp_greet(name: string, extra
     call baml.String.from
     store_var _4
     load_var extra
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
+    store_var _6
     jump L1
 
   L0:
-    load_const ""
-    store_var _6
-    jump L2
-
-  L1:
     load_const "!"
     store_var _6
 
-  L2:
+  L1:
     load_const "Hi "
     load_var _4
     bin_op +
@@ -1264,37 +1215,34 @@ function backtick_strings.bt_m3_for_accumulator_no_capture() -> string {
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
+    store_var _4
 
   L0:
-    load_var _5
+    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _6
-    load_var _6
+    store_var _5
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
-    store_var _10
+    store_var _9
     load_type string
-    load_var _6
+    load_var _5
     call baml.String.from
-    store_var _15
+    store_var _14
     load_type string
     load_const "OUTER"
     call baml.String.from
-    store_var _18
-    load_var _10
+    store_var _17
+    load_var _9
     load_const "<"
-    load_var _15
+    load_var _14
     bin_op +
     load_const ":"
     bin_op +
-    load_var _18
+    load_var _17
     bin_op +
     load_const ">"
     bin_op +
@@ -1302,7 +1250,7 @@ function backtick_strings.bt_m3_for_accumulator_no_capture() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -1328,10 +1276,7 @@ function backtick_strings.bt_m3_for_array_literal() -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _8
     load_type int
@@ -1345,7 +1290,7 @@ function backtick_strings.bt_m3_for_array_literal() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -1371,10 +1316,7 @@ function backtick_strings.bt_m3_for_basic() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _9
     load_type string
@@ -1391,7 +1333,7 @@ function backtick_strings.bt_m3_for_basic() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -1417,10 +1359,7 @@ function backtick_strings.bt_m3_for_empty_body() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _7
     store_var _x
     load_var  __m3_for
@@ -1429,7 +1368,7 @@ function backtick_strings.bt_m3_for_empty_body() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_const "["
     load_var  __m3_for
     bin_op +
@@ -1456,10 +1395,7 @@ function backtick_strings.bt_m3_for_empty_collection() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _11
     load_type string
@@ -1476,7 +1412,7 @@ function backtick_strings.bt_m3_for_empty_collection() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_const "before|"
     load_var  __m3_for
     bin_op +
@@ -1510,14 +1446,11 @@ function backtick_strings.bt_m3_for_inside_if() -> string {
 
 function backtick_strings.bt_m3_for_inside_if_render(show: bool, xs: string[]) -> string {
     load_var show
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const "hidden"
+    jump L3
 
   L0:
-    load_const "hidden"
-    jump L5
-
-  L1:
     load_const ""
     store_var  __m3_for
     load_var xs
@@ -1526,7 +1459,7 @@ function backtick_strings.bt_m3_for_inside_if_render(show: bool, xs: string[]) -
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
-  L2:
+  L1:
     load_var _4
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -1534,10 +1467,7 @@ function backtick_strings.bt_m3_for_inside_if_render(show: bool, xs: string[]) -
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var  __m3_for
     store_var _9
     load_type string
@@ -1552,12 +1482,12 @@ function backtick_strings.bt_m3_for_inside_if_render(show: bool, xs: string[]) -
     bin_op +
     bin_op +
     store_var  __m3_for
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_var  __m3_for
 
-  L5:
+  L3:
     return
 }
 
@@ -1582,10 +1512,7 @@ function backtick_strings.bt_m3_for_interp_body() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _9
     load_type int
@@ -1599,7 +1526,7 @@ function backtick_strings.bt_m3_for_interp_body() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -1614,26 +1541,23 @@ function backtick_strings.bt_m3_for_shadows_outer_let() -> string {
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _6
+    store_var _5
 
   L0:
-    load_var _6
+    load_var _5
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _7
-    load_var _7
+    store_var _6
+    load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
-    store_var _11
+    store_var _10
     load_type string
-    load_var _7
+    load_var _6
     call baml.String.from
-    store_var _13
+    store_var _12
     load_var2 4 5
     load_const ","
     bin_op +
@@ -1641,7 +1565,7 @@ function backtick_strings.bt_m3_for_shadows_outer_let() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     load_const "|"
     bin_op +
@@ -1670,10 +1594,7 @@ function backtick_strings.bt_m3_for_text_around() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _11
     load_type string
@@ -1687,7 +1608,7 @@ function backtick_strings.bt_m3_for_text_around() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_const "header\n"
     load_var  __m3_for
     bin_op +
@@ -1699,11 +1620,9 @@ function backtick_strings.bt_m3_for_text_around() -> string {
 function backtick_strings.bt_m3_if_bare_cond() -> string {
     load_const true
     call user.backtick_strings.bt_m3_if_bare_cond_gate
-    store_var _2
     load_const false
     call user.backtick_strings.bt_m3_if_bare_cond_gate
     store_var _3
-    load_var _2
     load_const "|"
     bin_op +
     load_var _3
@@ -1713,17 +1632,14 @@ function backtick_strings.bt_m3_if_bare_cond() -> string {
 
 function backtick_strings.bt_m3_if_bare_cond_gate(enabled: bool) -> string {
     load_var enabled
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "off"
     jump L1
 
   L0:
-    load_const "off"
-    jump L2
-
-  L1:
     load_const "on"
 
-  L2:
+  L1:
     return
 }
 
@@ -1731,7 +1647,6 @@ function backtick_strings.bt_m3_if_complex_cond() -> string {
     load_const 1
     load_const 1
     call user.backtick_strings.bt_m3_if_complex_cond_f
-    store_var _4
     load_const -1
     load_const 0
     call user.backtick_strings.bt_m3_if_complex_cond_f
@@ -1740,7 +1655,6 @@ function backtick_strings.bt_m3_if_complex_cond() -> string {
     load_const 0
     call user.backtick_strings.bt_m3_if_complex_cond_f
     store_var _6
-    load_var _4
     load_const "|"
     bin_op +
     load_var _5
@@ -1756,45 +1670,32 @@ function backtick_strings.bt_m3_if_complex_cond_f(a: int, b: int) -> string {
     load_var a
     load_const 0
     cmp_int_op >
-    jump_if_false L0
-    pop 1
+    pop_jump_if_false L0
     load_var b
     load_const 0
     cmp_int_op >
+    pop_jump_if_true L2
 
   L0:
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
     load_var a
     load_const 0
     cmp_int_op <
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    pop_jump_if_true L1
     load_var b
     load_const 0
     cmp_int_op <
-
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_const "zero"
-    jump L7
+    jump L3
 
-  L5:
+  L1:
     load_const "neg"
-    jump L7
+    jump L3
 
-  L6:
+  L2:
     load_const "pos"
 
-  L7:
+  L3:
     return
 }
 
@@ -1823,10 +1724,7 @@ function backtick_strings.bt_m3_if_else_branch_for() -> string {
 
 function backtick_strings.bt_m3_if_else_branch_for_render(empty: bool, xs: string[]) -> string {
     load_var empty
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_const ""
     store_var  __m3_for
     load_var xs
@@ -1835,7 +1733,7 @@ function backtick_strings.bt_m3_if_else_branch_for_render(empty: bool, xs: strin
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
-  L1:
+  L0:
     load_var _4
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -1843,10 +1741,7 @@ function backtick_strings.bt_m3_if_else_branch_for_render(empty: bool, xs: strin
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _9
     load_type string
@@ -1858,30 +1753,28 @@ function backtick_strings.bt_m3_if_else_branch_for_render(empty: bool, xs: strin
     bin_op +
     bin_op +
     store_var  __m3_for
-    jump L1
+    jump L0
 
-  L3:
+  L1:
     load_var  __m3_for
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "<none>"
 
-  L5:
+  L3:
     return
 }
 
 function backtick_strings.bt_m3_if_else_chain() -> string {
     load_const 5
     call user.backtick_strings.bt_m3_if_else_chain_classify
-    store_var _4
     load_const -3
     call user.backtick_strings.bt_m3_if_else_chain_classify
     store_var _5
     load_const 0
     call user.backtick_strings.bt_m3_if_else_chain_classify
     store_var _6
-    load_var _4
     load_const " "
     bin_op +
     load_var _5
@@ -1897,98 +1790,41 @@ function backtick_strings.bt_m3_if_else_chain_classify(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var n
     load_const 0
     cmp_int_op <
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "zero"
+    jump L2
+
+  L0:
+    load_const "neg"
     jump L2
 
   L1:
-    load_const "zero"
-    jump L4
-
-  L2:
-    load_const "neg"
-    jump L4
-
-  L3:
     load_const "pos"
 
-  L4:
+  L2:
     return
 }
 
 function backtick_strings.bt_m3_if_empty_true_body() -> string {
-    load_const false
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const ""
-    store_var _3
-    jump L2
-
-  L1:
-    load_const "should_not_appear"
-    store_var _3
-
-  L2:
-    load_const "[|"
-    load_var _3
-    bin_op +
-    load_const "]"
-    bin_op +
+    load_const "[|]"
     return
 }
 
 function backtick_strings.bt_m3_if_false() -> string {
-    load_const false
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const ""
-    jump L2
-
-  L1:
-    load_const "welcome"
-
-  L2:
     load_const "!"
-    bin_op +
     return
 }
 
 function backtick_strings.bt_m3_if_true() -> string {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const ""
-    jump L2
-
-  L1:
     load_const "welcome"
-
-  L2:
     return
 }
 
 function backtick_strings.bt_m3_nested_for_in_if() -> string {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const ""
-    jump L5
-
-  L1:
     load_const ""
     store_var  __m3_for
     load_const "a"
@@ -1998,40 +1834,35 @@ function backtick_strings.bt_m3_nested_for_in_if() -> string {
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _6
+    store_var _4
 
-  L2:
-    load_var _6
+  L0:
+    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _7
-    load_var _7
+    store_var _5
+    load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var  __m3_for
-    store_var _11
+    store_var _9
     load_type string
-    load_var _7
+    load_var _5
     call baml.String.from
-    store_var _14
-    load_var _11
+    store_var _12
+    load_var _9
     load_const "- "
-    load_var _14
+    load_var _12
     bin_op +
     load_const "\n"
     bin_op +
     bin_op +
     store_var  __m3_for
-    jump L2
+    jump L0
 
-  L4:
+  L1:
     load_var  __m3_for
-
-  L5:
     return
 }
 
@@ -2075,40 +1906,30 @@ function backtick_strings.bt_m3_nested_if_in_for_go(flag: bool, xs: string[]) ->
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var _5
     store_var x
     load_var  __m3_for
     store_var _9
     load_var flag
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L1
+    load_const "-"
+    load_type string
+    load_var x
+    call baml.String.from
+    bin_op +
+    store_var _11
+    jump L2
+
+  L1:
+    load_const "+"
+    load_type string
+    load_var x
+    call baml.String.from
+    bin_op +
+    store_var _11
 
   L2:
-    load_type string
-    load_var x
-    call baml.String.from
-    store_var _15
-    load_const "-"
-    load_var _15
-    bin_op +
-    store_var _11
-    jump L4
-
-  L3:
-    load_type string
-    load_var x
-    call baml.String.from
-    store_var _12
-    load_const "+"
-    load_var _12
-    bin_op +
-    store_var _11
-
-  L4:
     load_var2 7 8
     load_const " "
     bin_op +
@@ -2116,7 +1937,7 @@ function backtick_strings.bt_m3_nested_if_in_for_go(flag: bool, xs: string[]) ->
     store_var  __m3_for
     jump L0
 
-  L5:
+  L3:
     load_var  __m3_for
     return
 }
@@ -2142,10 +1963,7 @@ function backtick_strings.bt_m3_ws_case1() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _9
     load_type string
@@ -2162,7 +1980,7 @@ function backtick_strings.bt_m3_ws_case1() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -2188,10 +2006,7 @@ function backtick_strings.bt_m3_ws_case2() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _9
     load_type string
@@ -2203,7 +2018,7 @@ function backtick_strings.bt_m3_ws_case2() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -2229,10 +2044,7 @@ function backtick_strings.bt_m3_ws_case3() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _9
     load_type string
@@ -2249,7 +2061,7 @@ function backtick_strings.bt_m3_ws_case3() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
@@ -2275,10 +2087,7 @@ function backtick_strings.bt_m3_ws_case4() -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _10
     load_type string
@@ -2295,7 +2104,7 @@ function backtick_strings.bt_m3_ws_case4() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     load_const "\nFooter"
     bin_op +
@@ -2305,11 +2114,9 @@ function backtick_strings.bt_m3_ws_case4() -> string {
 function backtick_strings.bt_m3_ws_case5() -> string {
     load_const true
     call user.backtick_strings.bt_m3_ws_case5_greet
-    store_var _2
     load_const false
     call user.backtick_strings.bt_m3_ws_case5_greet
     store_var _3
-    load_var _2
     load_const "|"
     bin_op +
     load_var _3
@@ -2319,19 +2126,16 @@ function backtick_strings.bt_m3_ws_case5() -> string {
 
 function backtick_strings.bt_m3_ws_case5_greet(formal: bool) -> string {
     load_var formal
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
+    store_var _3
     jump L1
 
   L0:
-    load_const ""
-    store_var _3
-    jump L2
-
-  L1:
     load_const ", sir"
     store_var _3
 
-  L2:
+  L1:
     load_const "Hello"
     load_var _3
     bin_op +
@@ -2343,11 +2147,9 @@ function backtick_strings.bt_m3_ws_case5_greet(formal: bool) -> string {
 function backtick_strings.bt_m3_ws_case6() -> string {
     load_const true
     call user.backtick_strings.bt_m3_ws_case6_classify
-    store_var _2
     load_const false
     call user.backtick_strings.bt_m3_ws_case6_classify
     store_var _3
-    load_var _2
     load_const "|"
     bin_op +
     load_var _3
@@ -2357,19 +2159,16 @@ function backtick_strings.bt_m3_ws_case6() -> string {
 
 function backtick_strings.bt_m3_ws_case6_classify(extra: bool) -> string {
     load_var extra
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
+    store_var _3
     jump L1
 
   L0:
-    load_const ""
-    store_var _3
-    jump L2
-
-  L1:
     load_const "Extra\n"
     store_var _3
 
-  L2:
+  L1:
     load_const "Header\n"
     load_var _3
     bin_op +
@@ -2381,11 +2180,9 @@ function backtick_strings.bt_m3_ws_case6_classify(extra: bool) -> string {
 function backtick_strings.bt_m3_ws_case7() -> string {
     load_const true
     call user.backtick_strings.bt_m3_ws_case7_show
-    store_var _2
     load_const false
     call user.backtick_strings.bt_m3_ws_case7_show
     store_var _3
-    load_var _2
     load_const "|"
     bin_op +
     load_var _3
@@ -2395,19 +2192,16 @@ function backtick_strings.bt_m3_ws_case7() -> string {
 
 function backtick_strings.bt_m3_ws_case7_show(extra: bool) -> string {
     load_var extra
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
+    store_var _3
     jump L1
 
   L0:
-    load_const ""
-    store_var _3
-    jump L2
-
-  L1:
     load_const "\nExtra line"
     store_var _3
 
-  L2:
+  L1:
     load_const "Header"
     load_var _3
     bin_op +
@@ -2445,10 +2239,7 @@ function backtick_strings.bt_m3_ws_case8() -> string {
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var _9
     store_var g
     load_var  __m3_for
@@ -2467,7 +2258,7 @@ function backtick_strings.bt_m3_ws_case8() -> string {
     virtual_call nargs=1 ntypeargs=0
     store_var _23
 
-  L2:
+  L1:
     load_var _23
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -2475,10 +2266,7 @@ function backtick_strings.bt_m3_ws_case8() -> string {
     store_var _24
     load_var _24
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var  __m3_for
     store_var _28
     load_type string
@@ -2493,9 +2281,9 @@ function backtick_strings.bt_m3_ws_case8() -> string {
     bin_op +
     bin_op +
     store_var  __m3_for
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_var _13
     load_const "Group: "
     load_var _17
@@ -2508,7 +2296,7 @@ function backtick_strings.bt_m3_ws_case8() -> string {
     store_var  __m3_for
     jump L0
 
-  L5:
+  L3:
     load_var  __m3_for
     return
 }
@@ -2534,10 +2322,7 @@ function backtick_strings.bt_m3_ws_mid_line_indented_for() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _11
     load_type string
@@ -2551,7 +2336,7 @@ function backtick_strings.bt_m3_ws_mid_line_indented_for() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_const "Prefix:\n    "
     load_var  __m3_for
     bin_op +
@@ -2580,10 +2365,7 @@ function backtick_strings.bt_m3_ws_tag_at_literal_start() -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _10
     load_type string
@@ -2597,7 +2379,7 @@ function backtick_strings.bt_m3_ws_tag_at_literal_start() -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     load_const "done"
     bin_op +
@@ -2608,15 +2390,13 @@ function backtick_strings.bt_multi_interp() -> string {
     load_type string
     load_const "ada"
     call baml.String.from
-    store_var _5
     load_type string
     load_const "lovelace"
     call baml.String.from
-    store_var _8
-    load_var _5
+    store_var _5
     load_const " "
     bin_op +
-    load_var _8
+    load_var _5
     bin_op +
     load_const " writes code"
     bin_op +
@@ -2643,13 +2423,13 @@ function backtick_strings.bt_nested_interp() -> string {
     load_const "x"
     call baml.String.from
     store_var _2
+    load_const "outer["
     load_type string
     load_const "inner-"
     load_var _2
     bin_op +
     call baml.String.from
     store_var _5
-    load_const "outer["
     load_var _5
     bin_op +
     load_const "]"
@@ -2679,23 +2459,23 @@ function backtick_strings.bt_recursive_main() -> string {
     load_const 5
     call user.backtick_strings.bt_bangs
     store_var _2
+    load_const "done"
     load_type string
     load_var _2
     call baml.String.from
     store_var _1
-    load_const "done"
     load_var _1
     bin_op +
     return
 }
 
 function backtick_strings.bt_simple_interp() -> string {
+    load_const "Hello, "
     load_type string
     load_const "world"
     call baml.String.from
-    store_var _3
-    load_const "Hello, "
-    load_var _3
+    store_var _2
+    load_var _2
     bin_op +
     load_const "!"
     bin_op +
@@ -2713,10 +2493,6 @@ function backtick_strings.bt_void_tail() -> string {
     load_const "a"
     bin_op +
     store_var  __m3_concat
-    load_const false
-    pop_jump_if_false L0
-
-  L0:
     load_var  __m3_concat
     load_const "b"
     bin_op +
@@ -2735,11 +2511,11 @@ function backtick_strings.bt_xslet_chain() -> string {
     bin_op +
     store_var  __m3_concat
     load_var  __m3_concat
-    store_var _5
+    store_var _4
     load_type string
     load_const "X"
     call baml.String.from
-    store_var _6
+    store_var _5
     load_var2 2 3
     bin_op +
     store_var_load_var  __m3_concat
@@ -2750,13 +2526,11 @@ function backtick_strings.bt_xslet_chain() -> string {
     bin_op +
     store_var  __m3_concat
     load_var  __m3_concat
-    store_var _13
+    store_var _9
     load_type string
-    load_const "X"
-    load_const "Y"
-    bin_op +
+    load_const "XY"
     call baml.String.from
-    store_var _14
+    store_var _10
     load_var2 4 5
     bin_op +
     store_var_load_var  __m3_concat
@@ -2771,11 +2545,11 @@ function backtick_strings.bt_xslet_concat_scope() -> string {
     load_const ""
     store_var  __m3_concat
     load_var  __m3_concat
-    store_var _3
+    store_var _2
     load_type string
     load_const "hi"
     call baml.String.from
-    store_var _4
+    store_var _3
     load_var2 2 3
     bin_op +
     store_var  __m3_concat

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_backtick_strings/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_backtick_strings/bytecode.snap
@@ -609,8 +609,6 @@ function backtick_strings.bt_block_body_tail() -> string {
     load_type string
     load_const "hi there"
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     load_const "!"
     bin_op +
@@ -622,8 +620,6 @@ function backtick_strings.bt_block_comment_interp() -> string {
     load_type string
     load_const "Ada"
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -661,8 +657,6 @@ function backtick_strings.bt_case_f() -> string {
     load_type string
     load_const "cd"
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     return
 }
@@ -681,8 +675,6 @@ function backtick_strings.bt_case_h() -> string {
     load_type string
     load_const "hi"
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -692,8 +684,6 @@ function backtick_strings.bt_case_i() -> string {
     load_type string
     load_const "Y"
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     load_const " Z"
     bin_op +
@@ -748,8 +738,6 @@ function backtick_strings.bt_case_n() -> string {
     load_type string
     load_const "Ada"
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     call user.backtick_strings.bt_case_n_shout
     return
@@ -787,8 +775,6 @@ function backtick_strings.bt_case_p() -> string {
     load_type string
     load_var r
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -938,7 +924,6 @@ function backtick_strings.bt_icf_main() -> string {
     load_type string
     load_var _4
     call baml.String.from
-    store_var _3
     load_const "bye"
     call user.backtick_strings.bt_icf_shout
     store_var _7
@@ -946,7 +931,6 @@ function backtick_strings.bt_icf_main() -> string {
     load_var _7
     call baml.String.from
     store_var _6
-    load_var _3
     bin_op +
     load_const " and "
     bin_op +
@@ -1033,8 +1017,6 @@ function backtick_strings.bt_interp_bool() -> string {
     load_type bool
     load_const true
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -1044,8 +1026,6 @@ function backtick_strings.bt_interp_float() -> string {
     load_type float
     load_const 3.14
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -1055,8 +1035,6 @@ function backtick_strings.bt_interp_int() -> string {
     load_type int
     load_const 42
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -1066,7 +1044,6 @@ function backtick_strings.bt_interp_mixed() -> string {
     load_type int
     load_const 7
     call baml.String.from
-    store_var _7
     load_type bool
     load_const false
     call baml.String.from
@@ -1079,7 +1056,6 @@ function backtick_strings.bt_interp_mixed() -> string {
     load_const "test"
     call baml.String.from
     store_var _13
-    load_var _7
     bin_op +
     load_const ", ok="
     bin_op +
@@ -1115,8 +1091,6 @@ function backtick_strings.bt_let_bound_if_else() -> string {
     load_type string
     load_const "user"
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -1126,8 +1100,6 @@ function backtick_strings.bt_line_comment_interp() -> string {
     load_type string
     load_const "Ada"
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -1147,8 +1119,6 @@ function backtick_strings.bt_loop_in_block() -> string {
     load_type string
     load_var acc
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     load_const "!"
     bin_op +
@@ -2429,8 +2399,6 @@ function backtick_strings.bt_nested_interp() -> string {
     load_var _2
     bin_op +
     call baml.String.from
-    store_var _5
-    load_var _5
     bin_op +
     load_const "]"
     bin_op +
@@ -2463,8 +2431,6 @@ function backtick_strings.bt_recursive_main() -> string {
     load_type string
     load_var _2
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -2474,8 +2440,6 @@ function backtick_strings.bt_simple_interp() -> string {
     load_type string
     load_const "world"
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     load_const "!"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_bigints/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_bigints/bytecode.snap
@@ -911,29 +911,20 @@ function bigints.<(user.bigints.BigintRejectionThenAcceptedRng as baml.random.Rn
     load_const 1
     bin_op +
     store_field .calls
-    load_const b""
-    call baml.deep_copy
-    store_var draw
     load_var self
     load_field .calls
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_const b"\x00\x04"
+    call baml.deep_copy
     jump L2
 
   L1:
-    load_const b"\x00\x04"
-    call baml.deep_copy
-    store_var draw
-    jump L3
-
-  L2:
     load_const b"\x01\x01"
     call baml.deep_copy
-    store_var draw
 
-  L3:
-    load_var draw
+  L2:
     return
 }
 
@@ -1118,8 +1109,7 @@ function bigints.bigint_random_in_range_fn() -> bool {
     load_var r
     load_const 10n
     cmp_bigint_op >=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var r
     load_const 20n
     cmp_bigint_op <

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_cancel_cascade/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_cancel_cascade/bytecode.snap
@@ -53,10 +53,7 @@ function cancel_cascade.cancel_after_gc_relocation_still_settles() -> int {
     load_var i
     load_const 20000
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_const 1n
     call baml.time.Duration.from_milliseconds
     sys_op baml.sys.sleep
@@ -66,23 +63,20 @@ function cancel_cascade.cancel_after_gc_relocation_still_settles() -> int {
     pop 1
     load_var f
     await
-    jump L4
+    jump L2
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L3:
+  L1:
     load_const 0
 
-  L4:
+  L2:
     return
 
-  L5:
+  L3:
     load_var2 3 4
     load_var i
     load_const 1
@@ -118,20 +112,17 @@ function cancel_cascade.cancel_from_handle_then_await_catches_cancelled() -> int
     pop 1
     load_var f
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 
@@ -166,21 +157,18 @@ function cancel_cascade.cancel_unblocks_await_on_non_descendant_fn() -> bool {
     load_var waiter
     await
     store_var got
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 0
     store_var got
 
-  L2:
+  L1:
     load_var started
     call baml.time.Instant.elapsed
     store_var elapsed
@@ -190,14 +178,13 @@ function cancel_cascade.cancel_unblocks_await_on_non_descendant_fn() -> bool {
     load_var got
     load_const 0
     cmp_int_op ==
-    jump_if_false L3
-    pop 1
+    jump_if_false_or_pop L2
     load_var elapsed
     call baml.time.Duration.to_milliseconds
     load_const 5000n
     cmp_bigint_op <
 
-  L3:
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_cancel_token/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_cancel_token/bytecode.snap
@@ -67,20 +67,17 @@ function cancel_token.await_token_cancelled_catches() -> int {
     pop 1
     load_var _10
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_catch_arm_return/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_catch_arm_return/bytecode.snap
@@ -45,14 +45,11 @@ function catch_arm_return.car_throws(x: int) -> int {
     load_var x
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     return
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -60,28 +57,25 @@ function catch_arm_return.car_throws(x: int) -> int {
 function catch_arm_return.catch_arm_return_mixed(x: int) -> int {
     load_var x
     call user.catch_arm_return.car_throws
-    jump L2
+    jump L1
     load_var e
     store_var _4
     load_var _4
     narrow_bind string, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _4
     call baml.String.length
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const 100
     add_int
 
-  L3:
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_spread_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_spread_runtime/bytecode.snap
@@ -54,8 +54,7 @@ function class_spread_runtime.csr_generic_spread() -> bool {
     call_indirect
     load_const 42
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var task
     load_field .events
     load_const "created"
@@ -120,8 +119,7 @@ function class_spread_runtime.csr_spread_with_omitted_defaults() -> bool {
     load_field .budget
     load_const 1
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const 1
     load_type int
     alloc_array 1
@@ -129,28 +127,22 @@ function class_spread_runtime.csr_spread_with_omitted_defaults() -> bool {
     load_field .dispatch
     call_indirect
     container_len
-    store_var _9
-    load_var _9
+    store_var _12
+    load_var _12
     load_const 1
     cmp_int_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var options
     load_field .registry
     load_const null
     call baml.ops.equals_equals
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_var options
     load_field .hook
     load_const null
     call baml.ops.equals_equals
 
-  L2:
+  L0:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_type_args_at_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_type_args_at_runtime/bytecode.snap
@@ -157,6 +157,15 @@ function class_type_args_at_runtime.closure_inside_method_survives_gc_fn() -> st
     return
 
   L2:
+    load_var2 2 2
+    load_const 1
+    add_int
+    load_var i
+    load_const 2
+    add_int
+    load_type int
+    alloc_array 3
+    pop 1
     load_var i
     load_const 1
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_type_args_at_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_class_type_args_at_runtime/bytecode.snap
@@ -81,8 +81,6 @@ function class_type_args_at_runtime.Box.describe(self: class_type_args_at_runtim
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -95,34 +93,12 @@ function class_type_args_at_runtime.Box2.make_describer(self: class_type_args_at
 function class_type_args_at_runtime.check_foo(f: class_type_args_at_runtime.Foo<int> | class_type_args_at_runtime.Foo<string>) -> bool {
     load_var f
     is_type class_type_args_at_runtime.Foo<...>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function class_type_args_at_runtime.check_foo_bare(f: class_type_args_at_runtime.Foo<int> | string) -> bool {
     load_var f
     is_type class_type_args_at_runtime.Foo<...>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -148,24 +124,12 @@ function class_type_args_at_runtime.closure_inside_method_survives_gc_fn() -> st
     load_var i
     load_const 500
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var describe
     call_indirect
     return
 
-  L2:
-    load_var2 2 2
-    load_const 1
-    add_int
-    load_var i
-    load_const 2
-    add_int
-    load_type int
-    alloc_array 3
-    pop 1
+  L1:
     load_var i
     load_const 1
     add_int
@@ -229,17 +193,14 @@ function class_type_args_at_runtime.method_sees_composite_class_type_arg_fn() ->
 function class_type_args_at_runtime.pick(x: class_type_args_at_runtime.Foo<int> | class_type_args_at_runtime.Foo<string>) -> string {
     load_var x
     is_type class_type_args_at_runtime.Foo<...>
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "string"
     jump L1
 
   L0:
-    load_const "string"
-    jump L2
-
-  L1:
     load_const "int"
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_classes/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_classes/bytecode.snap
@@ -266,6 +266,10 @@ function classes.mutable_self_method_fn() -> int {
 
 function classes.nested_construction_dead_store_fn() -> int {
     load_const 42
+    init_instance user.classes.CInner .value
+    init_instance user.classes.COuter .inner
+    pop 1
+    load_const 42
     return
 }
 
@@ -383,6 +387,10 @@ function classes.spread_before_named_fields_fn() -> classes.PointXYZW {
 
 function classes.spread_does_not_break_locals_fn() -> int {
     call user.classes.default_point
+    store_var _2
+    alloc_instance user.classes.PointXYZW
+    load_var _2
+    init_spread .x, .y, .z, .w
     pop 1
     load_const 0
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_classes/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_classes/bytecode.snap
@@ -266,10 +266,6 @@ function classes.mutable_self_method_fn() -> int {
 
 function classes.nested_construction_dead_store_fn() -> int {
     load_const 42
-    init_instance user.classes.CInner .value
-    init_instance user.classes.COuter .inner
-    pop 1
-    load_const 42
     return
 }
 
@@ -387,10 +383,6 @@ function classes.spread_before_named_fields_fn() -> classes.PointXYZW {
 
 function classes.spread_does_not_break_locals_fn() -> int {
     call user.classes.default_point
-    store_var _2
-    alloc_instance user.classes.PointXYZW
-    load_var _2
-    init_spread .x, .y, .z, .w
     pop 1
     load_const 0
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_cleanup/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_cleanup/bytecode.snap
@@ -45,21 +45,18 @@ function cleanup.CleanupResource.cleanup(self: cleanup.CleanupResource) -> void 
     load_type cleanup.CleanupResource
     load_var self
     call baml._cleanup_begin
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_type string
     load_var self
     load_field .log
     load_const "cleaned"
     call baml.Array.push
 
-  L2:
+  L1:
     return
 }
 
@@ -67,21 +64,18 @@ function cleanup.CleanupThrowsNeverR.cleanup(self: cleanup.CleanupThrowsNeverR) 
     load_type cleanup.CleanupThrowsNeverR
     load_var self
     call baml._cleanup_begin
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_type string
     load_var self
     load_field .log
     load_const "cleaned"
     call baml.Array.push
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_closures/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_closures/bytecode.snap
@@ -87,19 +87,16 @@ function closures.ClsCalculator.compute(self: closures.ClsCalculator, a: int, b:
     load_field .op
     load_const "add"
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var2 2 3
+    mul_int
     jump L1
 
   L0:
     load_var2 2 3
-    mul_int
-    jump L2
-
-  L1:
-    load_var2 2 3
     add_int
 
-  L2:
+  L1:
     return
 }
 
@@ -160,8 +157,7 @@ function closures.ClsRangeCheck.is_valid(self: closures.ClsRangeCheck, n: int) -
     load_var2 2 1
     load_field .min
     cmp_int_op >=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var2 2 1
     load_field .max
     cmp_int_op <=
@@ -174,17 +170,14 @@ function closures.ClsWorker.risky(self: closures.ClsWorker, value: int) -> int {
     load_var value
     load_const 0
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .factor
     load_var value
     mul_int
     return
 
-  L1:
+  L0:
     load_const "negative"
     throw
 }
@@ -235,22 +228,19 @@ function closures.closures_bound_throwing_method_reference_catches_error() -> in
     init_instance user.closures.ClsWorker .factor
     make_bound_method user.closures.ClsWorker.risky
     call_indirect
-    jump L2
+    jump L1
     load_var e
     is_type "negative"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const -2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_comparable_sort/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_comparable_sort/bytecode.snap
@@ -172,21 +172,18 @@ function comparable_sort.<(#0[] as user.comparable_sort.FirstNamed)>.first_name(
     load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_const 0
     load_array_element
     load_type comparable_sort.Named
     virtual_load_field .name
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const ""
 
-  L2:
+  L1:
     return
 }
 
@@ -197,22 +194,19 @@ function comparable_sort.<(#0[] as user.comparable_sort.Wrap)>.g(self: #0[]) -> 
     load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_const 0
     load_array_element
     load_type comparable_sort.HasErr
     load_const "f"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 
@@ -233,8 +227,6 @@ function comparable_sort.<(user.comparable_sort.OobScore as baml.ops.Compare)>.c
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -255,8 +247,6 @@ function comparable_sort.<(user.comparable_sort.ParityItem as baml.ops.Compare)>
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -277,8 +267,6 @@ function comparable_sort.<(user.comparable_sort.Ranked as baml.ops.Compare)>.cmp
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -299,8 +287,6 @@ function comparable_sort.<(user.comparable_sort.Resume as baml.ops.Compare)>.cmp
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -327,8 +313,6 @@ function comparable_sort.<(user.comparable_sort.RouteItem as baml.ops.Compare)>.
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -353,33 +337,27 @@ function comparable_sort.<(user.comparable_sort.Score as baml.ops.Compare)>.cmp(
     load_var other
     load_field .points
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .points
     load_var other
     load_field .points
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -400,8 +378,6 @@ function comparable_sort.<(user.comparable_sort.ScorePts as baml.ops.Compare)>.c
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -419,8 +395,6 @@ function comparable_sort.call_g(us: #0[]) -> int {
     load_type comparable_sort.Wrap<WE = (#0 as comparable_sort.HasErr).E>
     load_const "g"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -445,14 +419,11 @@ function comparable_sort.check(xs: #0[], ys: #0[]) -> bool {
     store_var _10
     load_var2 3 4
     cmp_int_op !=
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_const 0
     store_var i
 
-  L1:
+  L0:
     load_var i
     store_var _13
     load_var xs
@@ -460,14 +431,11 @@ function comparable_sort.check(xs: #0[], ys: #0[]) -> bool {
     store_var _14
     load_var2 6 7
     cmp_int_op <
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_const true
-    jump L7
+    jump L4
 
-  L3:
+  L1:
     load_var2 1 5
     load_array_element
     load_var2 2 5
@@ -475,30 +443,25 @@ function comparable_sort.check(xs: #0[], ys: #0[]) -> bool {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _16
-    load_var _16
     load_const baml.ops.Ordering.Equal
     alloc_variant baml.ops.Ordering
     call baml.ops.equals_equals
     unary_op !
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L1
+    jump L0
 
-  L5:
+  L2:
     load_const false
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_const false
 
-  L7:
+  L4:
     return
 }
 
@@ -506,21 +469,18 @@ function comparable_sort.dispatch_f(xs: #0[]) -> #0[] {
     load_type #0
     load_var xs
     call user.comparable_sort.is_fast
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_type #0
+    load_var xs
+    call user.comparable_sort.slow_g
     jump L1
 
   L0:
     load_type #0
     load_var xs
-    call user.comparable_sort.slow_g
-    jump L2
-
-  L1:
-    load_type #0
-    load_var xs
     call user.comparable_sort.fast_g
 
-  L2:
+  L1:
     return
 }
 
@@ -529,8 +489,6 @@ function comparable_sort.do_sort(xs: int[]) -> int[] {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -544,10 +502,7 @@ function comparable_sort.element_dispatch_main() -> int {
     load_var _6
     load_const 0
     cmp_int_op !=
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_type int
     load_const 3
     load_const 1
@@ -559,10 +514,7 @@ function comparable_sort.element_dispatch_main() -> int {
     load_var _11
     load_const 2
     cmp_int_op !=
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_type comparable_sort.RouteItem
     load_const 7
     init_instance user.comparable_sort.RouteItem .rank
@@ -572,16 +524,16 @@ function comparable_sort.element_dispatch_main() -> int {
     load_const 0
     load_array_element
     load_field .rank
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const -2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const -1
 
-  L4:
+  L2:
     return
 }
 
@@ -591,14 +543,10 @@ function comparable_sort.fast_g(xs: #0[]) -> #0[] {
 }
 
 function comparable_sort.float_nan_sort_main() -> bool {
-    call baml.Float.nan
-    store_var _2
-    call baml.Float.inf
-    store_var _3
     load_const 1.0
-    load_var _2
+    call baml.Float.nan
     load_const 0.5
-    load_var _3
+    call baml.Float.inf
     load_type float
     alloc_array 4
     store_var xs
@@ -614,11 +562,7 @@ function comparable_sort.float_nan_sort_main() -> bool {
     load_const 0.5
     call baml.ops.equals_equals
     unary_op !
-    jump_if_false L0
-    jump L1
-
-  L0:
-    pop 1
+    pop_jump_if_true L1
     load_type float
     load_var xs
     load_const 1
@@ -626,29 +570,15 @@ function comparable_sort.float_nan_sort_main() -> bool {
     load_const 1.0
     call baml.ops.equals_equals
     unary_op !
-
-  L1:
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    pop_jump_if_true L1
     load_type float
     load_var xs
     load_const 2
     call baml.Array.at
-    store_var _14
     call baml.Float.inf
-    store_var _16
-    load_var2 4 5
     call baml.ops.equals_equals
     unary_op !
-
-  L3:
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L1
     load_type float
     load_var xs
     load_const 3
@@ -657,22 +587,19 @@ function comparable_sort.float_nan_sort_main() -> bool {
     load_var _18
     load_const null
     cmp_op ==
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L0
     load_var _18
     call baml.Float.is_nan
-    jump L8
+    jump L2
 
-  L6:
+  L0:
     load_const false
-    jump L8
+    jump L2
 
-  L7:
+  L1:
     load_const false
 
-  L8:
+  L2:
     return
 }
 
@@ -702,11 +629,11 @@ function comparable_sort.is_primitive_probe_main() -> int {
     call user.comparable_sort.probe
     load_const 10
     mul_int
-    store_var _2
+    store_var _1
     load_type string
     load_const "s"
     call user.comparable_sort.probe
-    load_var _2
+    load_var _1
     add_int
     return
 }
@@ -716,8 +643,6 @@ function comparable_sort.lt(a: #0, b: #0) -> bool {
     load_type comparable_sort.Cmp
     load_const "compare"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     load_const 0
     cmp_int_op <
     return
@@ -774,58 +699,58 @@ function comparable_sort.parity_main() -> int {
     load_type int
     alloc_array 5
     call user.comparable_sort.check
-    unary_op !
-    pop_jump_if_false L0
-    jump L9
+    pop_jump_if_true L0
+    load_const 1
+    jump L5
 
   L0:
     call baml.Float.nan
-    store_var _7
+    store_var _6
+    call baml.Float.inf
+    store_var _8
     call baml.Float.inf
     store_var _9
-    call baml.Float.inf
+    call baml.Float.nan
     store_var _10
     call baml.Float.nan
-    store_var _11
-    call baml.Float.nan
-    store_var _13
+    store_var _12
+    call baml.Float.inf
+    store_var _14
     call baml.Float.inf
     store_var _15
-    call baml.Float.inf
-    store_var _16
     call baml.Float.nan
-    store_var _17
+    store_var _16
     load_type float
     load_const 2.5
-    load_var _7
+    load_var _6
     load_const 0.0
-    load_var _9
+    load_var _8
     sub_float
     load_const 0.5
-    load_var _10
+    load_var _9
     load_const 0.0
     load_const -0.0
-    load_var _11
+    load_var _10
     load_const 1.5
     load_type float
     alloc_array 9
     load_const 2.5
-    load_var _13
+    load_var _12
     load_const 0.0
-    load_var _15
+    load_var _14
     sub_float
     load_const 0.5
-    load_var _16
+    load_var _15
     load_const 0.0
     load_const -0.0
-    load_var _17
+    load_var _16
     load_const 1.5
     load_type float
     alloc_array 9
     call user.comparable_sort.check
-    unary_op !
-    pop_jump_if_false L1
-    jump L8
+    pop_jump_if_true L1
+    load_const 2
+    jump L5
 
   L1:
     load_type string
@@ -842,9 +767,9 @@ function comparable_sort.parity_main() -> int {
     load_type string
     alloc_array 4
     call user.comparable_sort.check
-    unary_op !
-    pop_jump_if_false L2
-    jump L7
+    pop_jump_if_true L2
+    load_const 3
+    jump L5
 
   L2:
     load_type bigint
@@ -861,9 +786,9 @@ function comparable_sort.parity_main() -> int {
     load_type bigint
     alloc_array 4
     call user.comparable_sort.check
-    unary_op !
-    pop_jump_if_false L3
-    jump L6
+    pop_jump_if_true L3
+    load_const 4
+    jump L5
 
   L3:
     load_type comparable_sort.ParityItem
@@ -884,34 +809,14 @@ function comparable_sort.parity_main() -> int {
     load_type comparable_sort.ParityItem
     alloc_array 3
     call user.comparable_sort.check
-    unary_op !
-    pop_jump_if_false L4
+    pop_jump_if_true L4
+    load_const 5
     jump L5
 
   L4:
     load_const 0
-    jump L10
 
   L5:
-    load_const 5
-    jump L10
-
-  L6:
-    load_const 4
-    jump L10
-
-  L7:
-    load_const 3
-    jump L10
-
-  L8:
-    load_const 2
-    jump L10
-
-  L9:
-    load_const 1
-
-  L10:
     return
 }
 
@@ -923,8 +828,6 @@ function comparable_sort.phase2_compare_explicit_binding_main() -> baml.ops.Orde
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var result
-    load_var result
     return
 }
 
@@ -936,8 +839,6 @@ function comparable_sort.phase2_compare_main() -> baml.ops.Ordering {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1085,8 +986,6 @@ function comparable_sort.phase3_sort_user_class_main() -> int {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var sorted
-    load_var sorted
     load_const 0
     load_array_element
     load_field .points
@@ -1105,8 +1004,6 @@ function comparable_sort.phase5_resume_sort_main() -> int {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var sorted
-    load_var sorted
     load_const 0
     load_array_element
     load_field .rank
@@ -1116,28 +1013,14 @@ function comparable_sort.phase5_resume_sort_main() -> int {
 function comparable_sort.probe(x: #0) -> int {
     load_var x
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 0
-    jump L5
-
-  L4:
     load_const 1
 
-  L5:
+  L1:
     return
 }
 
@@ -1161,14 +1044,10 @@ function comparable_sort.ranked_sort_main() -> string {
     load_type baml.Sortable
     load_const "sort"
     virtual_call nargs=1 ntypeargs=0
-    store_var result
-    load_var2 2 1
+    load_var xs
     call baml.ops.equals_equals
     unary_op !
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type comparable_sort.Ranked
     load_type string
     load_type never
@@ -1180,12 +1059,12 @@ function comparable_sort.ranked_sort_main() -> string {
     load_var _11
     load_const ""
     call baml.Array.join
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "not self"
 
-  L2:
+  L1:
     return
 }
 
@@ -1202,27 +1081,24 @@ function comparable_sort.spike_1a_catch_main() -> string {
     load_const "g"
     virtual_call nargs=1 ntypeargs=0
     store_var v
-    jump L2
+    jump L1
     load_var e
     is_type comparable_sort.Kaboom
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "caught:"
     load_var e
     load_field .message
     bin_op +
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -1234,8 +1110,6 @@ function comparable_sort.spike_1a_never_main() -> int {
     load_type comparable_sort.Wrap<WE = never>
     load_const "g"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1246,27 +1120,24 @@ function comparable_sort.spike_1a_symbolic_main() -> string {
     alloc_array 1
     call user.comparable_sort.call_g
     store_var v
-    jump L2
+    jump L1
     load_var e
     is_type comparable_sort.Kaboom
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "caught:"
     load_var e
     load_field .message
     bin_op +
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -1279,8 +1150,6 @@ function comparable_sort.spike_1b_count_main() -> int {
     load_type comparable_sort.Countable
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1294,8 +1163,6 @@ function comparable_sort.spike_1b_first_name_main() -> string {
     load_type comparable_sort.FirstNamed
     load_const "first_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1314,7 +1181,5 @@ function comparable_sort.three_way(a: #0, b: #0) -> baml.ops.Ordering {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_comparison_driver/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_comparison_driver/bytecode.snap
@@ -140,33 +140,27 @@ function comparison_driver.<(user.comparison_driver.CdMoney as baml.ops.Compare)
     load_var other
     load_field .cents
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .cents
     load_var other
     load_field .cents
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -194,33 +188,27 @@ function comparison_driver.<(user.comparison_driver.CdOdd as baml.ops.Compare)>.
     load_var other
     load_field .n
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .n
     load_var other
     load_field .n
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -280,16 +268,11 @@ function comparison_driver.cd_box_str_one() -> comparison_driver.CdBox<string> {
 function comparison_driver.cd_cheaper() -> bool {
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 2
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -396,11 +379,8 @@ function comparison_driver.cd_eq_bool() -> bool {
 function comparison_driver.cd_eq_box_int_diff() -> bool {
     load_const 5
     call user.comparison_driver.cd_mk_box_int
-    store_var _1
     load_const 6
     call user.comparison_driver.cd_mk_box_int
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -408,11 +388,8 @@ function comparison_driver.cd_eq_box_int_diff() -> bool {
 function comparison_driver.cd_eq_box_int_same() -> bool {
     load_const 5
     call user.comparison_driver.cd_mk_box_int
-    store_var _1
     load_const 5
     call user.comparison_driver.cd_mk_box_int
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -421,12 +398,9 @@ function comparison_driver.cd_eq_class_diff() -> bool {
     load_const 1
     load_const 2
     call user.comparison_driver.cd_mk_point
-    store_var _1
     load_const 1
     load_const 3
     call user.comparison_driver.cd_mk_point
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -437,14 +411,11 @@ function comparison_driver.cd_eq_class_nested() -> bool {
     load_const 1
     load_const 1
     call user.comparison_driver.cd_mk_line
-    store_var _1
     load_const 0
     load_const 0
     load_const 1
     load_const 1
     call user.comparison_driver.cd_mk_line
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -455,14 +426,11 @@ function comparison_driver.cd_eq_class_nested_diff() -> bool {
     load_const 1
     load_const 1
     call user.comparison_driver.cd_mk_line
-    store_var _1
     load_const 0
     load_const 0
     load_const 9
     load_const 1
     call user.comparison_driver.cd_mk_line
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -471,12 +439,9 @@ function comparison_driver.cd_eq_class_same() -> bool {
     load_const 1
     load_const 2
     call user.comparison_driver.cd_mk_point
-    store_var _1
     load_const 1
     load_const 2
     call user.comparison_driver.cd_mk_point
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -492,12 +457,9 @@ function comparison_driver.cd_eq_diff_id() -> bool {
     load_const 1
     load_const "a"
     call user.comparison_driver.cd_mk_tag
-    store_var _1
     load_const 2
     load_const "a"
     call user.comparison_driver.cd_mk_tag
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -567,10 +529,7 @@ function comparison_driver.cd_eq_int_same() -> bool {
 
 function comparison_driver.cd_eq_int_vs_str() -> bool {
     call user.comparison_driver.cd_box_int_one
-    store_var _1
     call user.comparison_driver.cd_box_str_one
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -652,13 +611,10 @@ function comparison_driver.cd_eq_nested_label_differs() -> bool {
     load_const "a"
     load_const "L"
     call user.comparison_driver.cd_mk_wrapper
-    store_var _1
     load_const 1
     load_const "a"
     load_const "M"
     call user.comparison_driver.cd_mk_wrapper
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -668,23 +624,17 @@ function comparison_driver.cd_eq_nested_tag_custom() -> bool {
     load_const "a"
     load_const "L"
     call user.comparison_driver.cd_mk_wrapper
-    store_var _1
     load_const 1
     load_const "b"
     load_const "L"
     call user.comparison_driver.cd_mk_wrapper
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
 
 function comparison_driver.cd_eq_reordered_union() -> bool {
     call user.comparison_driver.cd_mk_ubox_a
-    store_var _1
     call user.comparison_driver.cd_mk_ubox_b
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -693,12 +643,9 @@ function comparison_driver.cd_eq_same() -> bool {
     load_const 7
     load_const "x"
     call user.comparison_driver.cd_mk_tag
-    store_var _1
     load_const 7
     load_const "x"
     call user.comparison_driver.cd_mk_tag
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -707,12 +654,9 @@ function comparison_driver.cd_eq_same_id_diff_note() -> bool {
     load_const 1
     load_const "a"
     call user.comparison_driver.cd_mk_tag
-    store_var _1
     load_const 1
     load_const "b"
     call user.comparison_driver.cd_mk_tag
-    store_var _2
-    load_var2 1 2
     call baml.ops.equals_equals
     return
 }
@@ -745,32 +689,22 @@ function comparison_driver.cd_eq_string_same() -> bool {
 function comparison_driver.cd_ge_equal() -> bool {
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function comparison_driver.cd_ge_smaller() -> bool {
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 2
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -791,11 +725,8 @@ function comparison_driver.cd_generic_int() -> bool {
 function comparison_driver.cd_generic_money() -> bool {
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 2
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 1 2
     call user.comparison_driver.cd_lt_money
     return
 }
@@ -803,11 +734,8 @@ function comparison_driver.cd_generic_money() -> bool {
 function comparison_driver.cd_generic_money_rev() -> bool {
     load_const 2
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 1 2
     call user.comparison_driver.cd_lt_money
     return
 }
@@ -815,32 +743,22 @@ function comparison_driver.cd_generic_money_rev() -> bool {
 function comparison_driver.cd_gt_bigger() -> bool {
     load_const 2
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function comparison_driver.cd_gt_self() -> bool {
     load_const 1
     call user.comparison_driver.cd_odd
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_odd
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -852,40 +770,28 @@ function comparison_driver.cd_gt_variants() -> bool {
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function comparison_driver.cd_le_equal() -> bool {
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function comparison_driver.cd_le_self() -> bool {
     load_const 1
     call user.comparison_driver.cd_odd
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_odd
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -901,8 +807,6 @@ function comparison_driver.cd_lt_g(a: #0, b: #0) -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -928,8 +832,6 @@ function comparison_driver.cd_lt_variants() -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -938,8 +840,6 @@ function comparison_driver.cd_m_ge_b(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -969,8 +869,6 @@ function comparison_driver.cd_m_le_b(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1054,16 +952,11 @@ function comparison_driver.cd_money(c: int) -> comparison_driver.CdMoney {
 function comparison_driver.cd_not_cheaper() -> bool {
     load_const 2
     call user.comparison_driver.cd_money
-    store_var _1
     load_const 1
     call user.comparison_driver.cd_money
-    store_var _2
-    load_var2 2 3
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1078,8 +971,6 @@ function comparison_driver.cd_op_ge_b(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1102,8 +993,6 @@ function comparison_driver.cd_op_gt_b(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1126,8 +1015,6 @@ function comparison_driver.cd_op_le_b(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1157,8 +1044,6 @@ function comparison_driver.cd_op_lt_b(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_compiler/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_compiler/bytecode.snap
@@ -72,6 +72,7 @@ function compiler.AssertMultiRejected(files: map<string, string>, expected: comp
     load_var expected
     container_len
     store_var _21
+    load_const "expected "
     load_type int
     load_var _21
     call baml.String.from
@@ -92,7 +93,6 @@ function compiler.AssertMultiRejected(files: map<string, string>, expected: comp
     load_var _27
     call baml.String.from
     store_var _26
-    load_const "expected "
     load_var _20
     bin_op +
     load_const " compiler diagnostic(s), got "
@@ -118,14 +118,11 @@ function compiler.AssertMultiRejected(files: map<string, string>, expected: comp
     store_var _33
     load_var2 15 16
     cmp_int_op <
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L3
     load_const null
     return
 
-  L4:
+  L3:
     load_var2 2 14
     load_array_element
     load_var2 4 14
@@ -178,17 +175,14 @@ function compiler.CompileDiagnostics(files: map<string, string>, packages: map<s
     load_var packages
     sys_op reflect.Package._compile
     store_var artifact
-    jump L3
+    jump L2
     load_var error
     is_type reflect.errors.CompilationError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var error
     rethrow
 
-  L2:
+  L1:
     load_type reflect.Diagnostic
     load_type never
     load_var error
@@ -196,13 +190,13 @@ function compiler.CompileDiagnostics(files: map<string, string>, packages: map<s
     load_var files
     make_closure .<lambda(CompileDiagnostics, 0)>, 1
     call baml.Array.filter
-    jump L4
+    jump L3
 
-  L3:
+  L2:
     load_type reflect.Diagnostic
     alloc_array 0
 
-  L4:
+  L3:
     return
 }
 
@@ -219,45 +213,44 @@ function compiler.CompileFixturePackage(files: map<string, string>, packages: ma
   L0:
     load_var2 1 2
     sys_op reflect.Package._compile
-    jump L3
+    store_var artifact
+    jump L2
     load_var error
     is_type reflect.errors.CompilationError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var error
     rethrow
 
-  L2:
+  L1:
+    load_const "compiler fixture failed to compile: "
     load_type string
     load_var error
     load_field .message
     call baml.String.from
     store_var _8
-    load_const "compiler fixture failed to compile: "
     load_var _8
     bin_op +
     call baml.sys.panic
+    store_var artifact
 
-  L3:
-    load_var packages
+  L2:
+    load_var2 3 2
     call reflect.Package._finish
-    jump L4
+    jump L3
     load_var error
     throw_if_panic
     load_var error
     call reflect._render_cause
     store_var _15
+    load_const "compiler fixture failed to initialize: "
     load_type string
     load_var _15
     call baml.String.from
     store_var _14
-    load_const "compiler fixture failed to initialize: "
     load_var _14
     bin_op +
     call baml.sys.panic
 
-  L4:
+  L3:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_compiler/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_compiler/bytecode.snap
@@ -76,7 +76,6 @@ function compiler.AssertMultiRejected(files: map<string, string>, expected: comp
     load_type int
     load_var _21
     call baml.String.from
-    store_var _20
     load_var actual
     container_len
     store_var _24
@@ -93,7 +92,6 @@ function compiler.AssertMultiRejected(files: map<string, string>, expected: comp
     load_var _27
     call baml.String.from
     store_var _26
-    load_var _20
     bin_op +
     load_const " compiler diagnostic(s), got "
     bin_op +
@@ -116,16 +114,16 @@ function compiler.AssertMultiRejected(files: map<string, string>, expected: comp
     load_var expected
     container_len
     store_var _33
-    load_var2 15 16
+    load_var2 14 15
     cmp_int_op <
     pop_jump_if_true L3
     load_const null
     return
 
   L3:
-    load_var2 2 14
+    load_var2 2 13
     load_array_element
-    load_var2 4 14
+    load_var2 4 13
     load_array_element
     load_type compiler.DiagnosticExpectation
     load_const "assert_matches"
@@ -227,8 +225,6 @@ function compiler.CompileFixturePackage(files: map<string, string>, packages: ma
     load_var error
     load_field .message
     call baml.String.from
-    store_var _8
-    load_var _8
     bin_op +
     call baml.sys.panic
     store_var artifact
@@ -246,8 +242,6 @@ function compiler.CompileFixturePackage(files: map<string, string>, packages: ma
     load_type string
     load_var _15
     call baml.String.from
-    store_var _14
-    load_var _14
     bin_op +
     call baml.sys.panic
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_const_bindings/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_const_bindings/bytecode.snap
@@ -23,14 +23,11 @@ function const_bindings.const_bindings_with_const() -> int {
     load_var i
     load_const 4
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var sum
     return
 
-  L2:
+  L1:
     load_var2 1 2
     add_int
     store_var sum
@@ -51,14 +48,11 @@ function const_bindings.const_bindings_with_let() -> int {
     load_var i
     load_const 4
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var sum
     return
 
-  L2:
+  L1:
     load_var2 1 2
     add_int
     store_var sum

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_control_flow/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_control_flow/bytecode.snap
@@ -436,6 +436,12 @@ function control_flow.greet_if_let(u: control_flow.User | control_flow.Admin) ->
   L1:
     load_var u
     load_field .0
+    pop 1
+    load_var u
+    load_field .1
+    pop 1
+    load_var u
+    load_field .0
 
   L2:
     return
@@ -452,6 +458,12 @@ function control_flow.greet_let_else(u: control_flow.User | control_flow.Admin) 
     jump L2
 
   L1:
+    load_var u
+    load_field .0
+    pop 1
+    load_var u
+    load_field .1
+    pop 1
     load_var u
     load_field .0
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_control_flow/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_control_flow/bytecode.snap
@@ -175,10 +175,6 @@ function control_flow.$init_test_ns_control_flow_control_flow(registry: testing.
 }
 
 function control_flow.break_loop(x: int) -> int {
-    load_const 0
-    store_var result
-    load_const true
-    pop_jump_if_false L2
     load_var x
     load_const 1
     cmp_int_op ==
@@ -187,15 +183,12 @@ function control_flow.break_loop(x: int) -> int {
 
   L0:
     load_const 2
-    store_var result
     jump L2
 
   L1:
     load_const 40
-    store_var result
 
   L2:
-    load_var result
     return
 }
 
@@ -204,28 +197,22 @@ function control_flow.chain_two(a: control_flow.Ok | control_flow.Err, b: contro
     store_var _3
     load_var _3
     narrow_bind control_flow.Ok, slot=3
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const "a-failed"
+    jump L2
 
   L0:
-    load_const "a-failed"
-    jump L4
-
-  L1:
     load_var _3
     store_var oa
     load_var b
     store_var _5
     load_var _5
     narrow_bind control_flow.Ok, slot=5
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_const "b-failed"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var oa
     load_field .value
     load_const "-"
@@ -234,7 +221,7 @@ function control_flow.chain_two(a: control_flow.Ok | control_flow.Err, b: contro
     load_field .value
     bin_op +
 
-  L4:
+  L2:
     return
 }
 
@@ -248,14 +235,11 @@ function control_flow.concat_oks(items: (control_flow.Ok | control_flow.Err)[]) 
     load_var i
     load_const 3
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var acc
     return
 
-  L2:
+  L1:
     load_var2 1 3
     load_array_element
     store_var item
@@ -283,28 +267,25 @@ function control_flow.continue_loop(x: int) -> int {
     load_var i
     load_const 3
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var i
     return
 
-  L2:
+  L1:
     load_var x
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
+    pop_jump_if_false L2
+    jump L3
 
-  L3:
+  L2:
     load_var i
     load_const 10
     add_int
     store_var i
     jump L0
 
-  L4:
+  L3:
     load_var i
     load_const 1
     add_int
@@ -317,19 +298,16 @@ function control_flow.describe_else_message(r: control_flow.Ok | control_flow.Er
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var r
+    load_field .0
     jump L1
 
   L0:
-    load_var r
-    load_field .0
-    jump L2
-
-  L1:
     load_var _2
     load_field .value
 
-  L2:
+  L1:
     return
 }
 
@@ -338,28 +316,22 @@ function control_flow.describe_or_pattern(r: control_flow.Ok | control_flow.Warn
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var r
     store_var _3
     load_var _3
     narrow_bind control_flow.Warn, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var r
     load_field .0
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var r
     load_type control_flow.HasValue
     virtual_load_field .value
 
-  L3:
+  L1:
     return
 }
 
@@ -368,18 +340,15 @@ function control_flow.describe_then_default(r: control_flow.Ok | control_flow.Er
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no match"
     jump L1
 
   L0:
-    load_const "no match"
-    jump L2
-
-  L1:
     load_var _2
     load_field .value
 
-  L2:
+  L1:
     return
 }
 
@@ -388,18 +357,15 @@ function control_flow.first_value_statement(r: control_flow.Ok | control_flow.Er
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "fell through"
     jump L1
 
   L0:
-    load_const "fell through"
-    jump L2
-
-  L1:
     load_var _2
     load_field .value
 
-  L2:
+  L1:
     return
 }
 
@@ -408,66 +374,45 @@ function control_flow.get_value_or_fallback(r: control_flow.Ok | control_flow.Er
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "fallback"
     jump L1
 
   L0:
-    load_const "fallback"
-    jump L2
-
-  L1:
     load_var _2
     load_field .value
 
-  L2:
+  L1:
     return
 }
 
 function control_flow.greet_if_let(u: control_flow.User | control_flow.Admin) -> string {
     load_var u
     is_type control_flow.User
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "admin"
     jump L1
 
   L0:
-    load_const "admin"
-    jump L2
+    load_var u
+    load_field .0
 
   L1:
-    load_var u
-    load_field .0
-    pop 1
-    load_var u
-    load_field .1
-    pop 1
-    load_var u
-    load_field .0
-
-  L2:
     return
 }
 
 function control_flow.greet_let_else(u: control_flow.User | control_flow.Admin) -> string {
     load_var u
     is_type control_flow.User
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "admin"
     jump L1
 
   L0:
-    load_const "admin"
-    jump L2
+    load_var u
+    load_field .0
 
   L1:
-    load_var u
-    load_field .0
-    pop 1
-    load_var u
-    load_field .1
-    pop 1
-    load_var u
-    load_field .0
-
-  L2:
     return
 }
 
@@ -476,18 +421,15 @@ function control_flow.if_let_call() -> string {
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no match"
     jump L1
 
   L0:
-    load_const "no match"
-    jump L2
-
-  L1:
     load_var _2
     load_field .value
 
-  L2:
+  L1:
     return
 }
 
@@ -496,14 +438,11 @@ function control_flow.inner_throws(r: control_flow.Ok | control_flow.Err) -> str
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     alloc_instance user.control_flow.NoMatch
     throw
 
-  L1:
+  L0:
     load_var _2
     load_field .value
     return
@@ -513,20 +452,17 @@ function control_flow.main_caught() -> string {
     load_const "ignored"
     init_instance user.control_flow.Err .message
     call user.control_flow.inner_throws
-    jump L2
+    jump L1
     load_var e
     is_type control_flow.NoMatch
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "caught"
 
-  L2:
+  L1:
     return
 }
 
@@ -552,8 +488,7 @@ function control_flow.pick_first_ok(items: (control_flow.Ok | control_flow.Err)[
     store_var _10
     load_var _10
     narrow_bind control_flow.Ok, slot=4
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_var result
@@ -572,30 +507,24 @@ function control_flow.pick_first_ok(items: (control_flow.Ok | control_flow.Err)[
 
 function control_flow.pick_let_else(r: control_flow.Ok | control_flow.Warn | control_flow.Err) -> string {
     load_var r
+    store_var _2
+    load_var _2
+    narrow_bind control_flow.Ok, slot=2
+    pop_jump_if_true L0
+    load_var r
     store_var _3
     load_var _3
-    narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
-    jump L2
+    narrow_bind control_flow.Warn, slot=3
+    pop_jump_if_true L0
+    load_const "err"
+    jump L1
 
   L0:
-    load_var r
-    store_var _4
-    load_var _4
-    narrow_bind control_flow.Warn, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const "err"
-    jump L3
-
-  L2:
     load_var r
     load_type control_flow.HasValue
     virtual_load_field .value
 
-  L3:
+  L1:
     return
 }
 
@@ -604,33 +533,27 @@ function control_flow.pick_nested(outer: control_flow.Wrapper, inner: control_fl
     store_var _3
     load_var _3
     narrow_bind control_flow.Wrapper, slot=3
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const "none"
+    jump L2
 
   L0:
-    load_const "none"
-    jump L4
-
-  L1:
     load_var _3
     store_var w
     load_var inner
     store_var _5
     load_var _5
     narrow_bind control_flow.Wrapper, slot=5
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var w
     load_field .payload
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _5
     load_field .payload
 
-  L4:
+  L2:
     return
 }
 
@@ -639,31 +562,25 @@ function control_flow.pick_ok_err_empty(r: control_flow.Ok | control_flow.Err | 
     store_var _2
     load_var _2
     narrow_bind control_flow.Ok, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var r
     store_var _4
     load_var _4
     narrow_bind control_flow.Err, slot=3
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "empty"
+    jump L2
+
+  L0:
+    load_var _4
+    load_field .message
     jump L2
 
   L1:
-    load_const "empty"
-    jump L4
-
-  L2:
-    load_var _4
-    load_field .message
-    jump L4
-
-  L3:
     load_var _2
     load_field .value
 
-  L4:
+  L2:
     return
 }
 
@@ -672,18 +589,15 @@ function control_flow.pick_optional(item: control_flow.Item | null) -> string {
     store_var _2
     load_var _2
     narrow_bind control_flow.Item, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "none"
     jump L1
 
   L0:
-    load_const "none"
-    jump L2
-
-  L1:
     load_var _2
     load_field .name
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_crypto/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_crypto/bytecode.snap
@@ -294,8 +294,6 @@ function crypto.feed_hasher(h: baml.crypto.Hasher, data: uint8array) -> void {
     load_type baml.crypto.Hasher
     load_const "update"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -307,12 +305,11 @@ function crypto.seal_and_open(cipher: baml.crypto.Aead, nonce: uint8array, messa
     virtual_call nargs=4 ntypeargs=0
     store_var _6
     load_var2 1 2
-    load_var2 6 4
+    load_var2 5 4
     load_type baml.crypto.Aead
     load_const "decrypt"
     virtual_call nargs=4 ntypeargs=0
-    store_var _5
-    load_var2 5 3
+    load_var message
     call baml.ops.equals_equals
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_csv/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_csv/bytecode.snap
@@ -4715,6 +4715,9 @@ function csv.csv_smoke_record_error_resumes() -> string {
   L3:
     load_var _
     load_field .2
+    pop 1
+    load_var _
+    load_field .2
     store_var line
     load_var bad
     load_const 1
@@ -4729,16 +4732,16 @@ function csv.csv_smoke_record_error_resumes() -> string {
   L4:
     load_var line
     call baml.json.stringify
-    store_var _15
+    store_var _16
     jump L6
 
   L5:
     load_const "?"
-    store_var _15
+    store_var _16
 
   L6:
     load_const "err@"
-    load_var _15
+    load_var _16
     bin_op +
     store_var step
     jump L9
@@ -4772,10 +4775,10 @@ function csv.csv_smoke_record_error_resumes() -> string {
     load_var seen
     load_const "bad="
     bin_op +
-    store_var _24
+    store_var _25
     load_var bad
     call baml.json.stringify
-    store_var _26
+    store_var _27
     load_var2 9 10
     bin_op +
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_csv/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_csv/bytecode.snap
@@ -704,11 +704,9 @@ function csv.csv_blank_records() -> string {
     store_var kept
     load_var skipped
     call baml.json.stringify
-    store_var _8
     load_var kept
     call baml.json.stringify
     store_var _10
-    load_var _8
     load_const ":"
     bin_op +
     load_var _10
@@ -727,28 +725,21 @@ function csv.csv_bom_stripped_by_default() -> string {
     load_const <omitted>
     call baml.csv.reader
     call baml.csv.Reader.headers
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_type string
     alloc_array 0
-    store_var _6
 
   L0:
-    load_var _6
     store_var h
     load_var rows
     call user.csv.grid
-    store_var _10
     load_var h
     load_const "|"
     call user.csv.join
-    store_var _12
-    load_var _10
+    store_var _11
     load_const "/"
     bin_op +
-    load_var _12
+    load_var _11
     bin_op +
     return
 }
@@ -757,11 +748,11 @@ function csv.csv_caller_owned_handles_stay_open() -> string {
     sys_op baml.time.Instant.now
     call baml.time.Instant.to_timestamp_milliseconds
     store_var _4
+    load_const "/tmp/baml_csv_caller_owned_"
     load_type bigint
     load_var _4
     call baml.String.from
     store_var _3
-    load_const "/tmp/baml_csv_caller_owned_"
     load_var _3
     bin_op +
     load_const ".csv"
@@ -869,11 +860,11 @@ function csv.csv_create_then_fs_read() -> string {
     sys_op baml.time.Instant.now
     call baml.time.Instant.to_timestamp_milliseconds
     store_var _4
+    load_const "/tmp/baml_csv_create_read_"
     load_type bigint
     load_var _4
     call baml.String.from
     store_var _3
-    load_const "/tmp/baml_csv_create_read_"
     load_var _3
     bin_op +
     load_const ".csv"
@@ -914,20 +905,17 @@ function csv.csv_decode_all_cell_types() -> string {
     load_const "name,count,big,ratio,flag,verdict,at\nx,+42,123456789012345678901234567890,2.5e-1,TRUE,Approve,2026-01-02T03:04:05Z\n"
     load_const <omitted>
     call baml.csv.decode
-    store_var _3
+    store_var _2
     load_type csv.FullRow
-    load_var _3
+    load_var _2
     load_const 0
     call baml.Array.at
-    store_var _2
-    load_var _2
+    store_var _1
+    load_var _1
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
-    load_var _2
+    pop_jump_if_true L3
+    load_var _1
     store_var r
     load_type string
     alloc_array 0
@@ -940,7 +928,7 @@ function csv.csv_decode_all_cell_types() -> string {
     load_var r
     load_field .count
     call baml.json.stringify
-    store_var _14
+    store_var _12
     load_type string
     load_var2 4 5
     call baml.Array.push
@@ -950,7 +938,7 @@ function csv.csv_decode_all_cell_types() -> string {
     load_const 123456789012345678901234567890n
     cmp_bigint_op ==
     call baml.json.stringify
-    store_var _18
+    store_var _16
     load_type string
     load_var2 4 6
     call baml.Array.push
@@ -958,7 +946,7 @@ function csv.csv_decode_all_cell_types() -> string {
     load_var r
     load_field .ratio
     call baml.json.stringify
-    store_var _23
+    store_var _21
     load_type string
     load_var2 4 7
     call baml.Array.push
@@ -966,7 +954,7 @@ function csv.csv_decode_all_cell_types() -> string {
     load_var r
     load_field .flag
     call baml.json.stringify
-    store_var _27
+    store_var _25
     load_type string
     load_var2 4 8
     call baml.Array.push
@@ -976,19 +964,19 @@ function csv.csv_decode_all_cell_types() -> string {
     discriminant
     load_const Verdict.Approve
     cmp_int_op ==
-    pop_jump_if_false L1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "Reject"
+    store_var _29
     jump L2
 
   L1:
-    load_const "Reject"
-    store_var _31
-    jump L3
+    load_const "Approve"
+    store_var _29
 
   L2:
-    load_const "Approve"
-    store_var _31
-
-  L3:
     load_type string
     load_var2 4 9
     call baml.Array.push
@@ -998,7 +986,7 @@ function csv.csv_decode_all_cell_types() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _36
+    store_var _34
     load_type string
     load_var2 4 10
     call baml.Array.push
@@ -1006,12 +994,12 @@ function csv.csv_decode_all_cell_types() -> string {
     load_var parts
     load_const " "
     call user.csv.join
-    jump L5
+    jump L4
 
-  L4:
+  L3:
     load_const "missing"
 
-  L5:
+  L4:
     return
 }
 
@@ -1021,17 +1009,14 @@ function csv.csv_decode_error_details() -> string {
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L3
+    jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
@@ -1048,14 +1033,18 @@ function csv.csv_decode_error_details() -> string {
     store_var _14
     load_var e
     load_field .column
-    store_var_load_var _17
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _17
+    jump L3
+
+  L2:
     load_const "?"
     store_var _17
 
-  L2:
+  L3:
     load_var _10
     load_const " line="
     bin_op +
@@ -1069,12 +1058,12 @@ function csv.csv_decode_error_details() -> string {
     bin_op +
     load_var _17
     bin_op +
-    jump L4
-
-  L3:
-    load_const "no-throw"
+    jump L5
 
   L4:
+    load_const "no-throw"
+
+  L5:
     return
 }
 
@@ -1092,18 +1081,15 @@ function csv.csv_decode_extra_columns_ignored() -> string {
     load_var _1
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var _1
+    load_field .first
     jump L1
 
   L0:
-    load_var _1
-    load_field .first
-    jump L2
-
-  L1:
     load_const "missing"
 
-  L2:
+  L1:
     return
 }
 
@@ -1142,10 +1128,7 @@ function csv.csv_decode_headers_override() -> string {
     load_var _6
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _6
     store_var p
     load_var p
@@ -1158,13 +1141,13 @@ function csv.csv_decode_headers_override() -> string {
     load_var2 5 6
     bin_op +
     store_var a
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "missing"
     store_var a
 
-  L2:
+  L1:
     load_type csv.Pos
     load_const "9,y\n"
     load_const null
@@ -1199,10 +1182,7 @@ function csv.csv_decode_headers_override() -> string {
     load_var _18
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _18
     store_var p
     load_var p
@@ -1215,13 +1195,13 @@ function csv.csv_decode_headers_override() -> string {
     load_var2 11 12
     bin_op +
     store_var b
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "missing"
     store_var b
 
-  L5:
+  L3:
     load_var a
     load_const "/"
     bin_op +
@@ -1236,42 +1216,43 @@ function csv.csv_decode_missing_column_is_header_error() -> string {
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L3
+    jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _6
     load_var e
     load_field .column
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _9
+    jump L3
+
+  L2:
     load_const "?"
     store_var _9
 
-  L2:
+  L3:
     load_var _6
     load_const ":"
     bin_op +
     load_var _9
     bin_op +
-    jump L4
-
-  L3:
-    load_const "no-throw"
+    jump L5
 
   L4:
+    load_const "no-throw"
+
+  L5:
     return
 }
 
@@ -1281,28 +1262,25 @@ function csv.csv_decode_one_cases() -> string {
     load_const <omitted>
     call baml.csv.decode_one
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var zero
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var zero
 
-  L3:
+  L2:
     load_type csv.IntRow
     load_const "n\n7\n"
     load_const <omitted>
@@ -1340,28 +1318,25 @@ function csv.csv_decode_one_cases() -> string {
     load_const <omitted>
     call baml.csv.decode_one
     pop 1
-    jump L6
+    jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var e
     rethrow
 
-  L5:
+  L3:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var two
-    jump L7
+    jump L5
 
-  L6:
+  L4:
     load_const "no-throw"
     store_var two
 
-  L7:
+  L5:
     load_var zero
     load_const "/"
     bin_op +
@@ -1387,21 +1362,18 @@ function csv.csv_decode_optional_cases() -> string {
     load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _2
     load_field .n
     call baml.json.stringify
     store_var zero
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "null"
     store_var zero
 
-  L2:
+  L1:
     load_type csv.IntRow
     load_const "n\n7\n"
     load_const <omitted>
@@ -1410,48 +1382,42 @@ function csv.csv_decode_optional_cases() -> string {
     load_var _8
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _8
     load_field .n
     call baml.json.stringify
     store_var one
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "null"
     store_var one
 
-  L5:
+  L3:
     load_type csv.IntRow
     load_const "n\n1\n2\n"
     load_const <omitted>
     call baml.csv.decode_optional
     pop 1
-    jump L8
+    jump L5
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L4
     load_var e
     rethrow
 
-  L7:
+  L4:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var two
-    jump L9
+    jump L6
 
-  L8:
+  L5:
     load_const "no-throw"
     store_var two
 
-  L9:
+  L6:
     load_var zero
     load_const "/"
     bin_op +
@@ -1496,10 +1462,7 @@ function csv.csv_decode_positional() -> string {
     load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _4
     store_var p
     load_var p
@@ -1511,12 +1474,12 @@ function csv.csv_decode_positional() -> string {
     store_var _9
     load_var2 4 5
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "missing"
 
-  L2:
+  L1:
     return
 }
 
@@ -1526,55 +1489,49 @@ function csv.csv_decode_rejects_locale_numbers() -> string {
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var one
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var one
 
-  L3:
+  L2:
     load_type csv.IntRow
     load_const "n\n 5\n"
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L6
+    jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var e
     rethrow
 
-  L5:
+  L3:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var two
-    jump L7
+    jump L5
 
-  L6:
+  L4:
     load_const "no-throw"
     store_var two
 
-  L7:
+  L5:
     load_var one
     load_const "/"
     bin_op +
@@ -1589,26 +1546,23 @@ function csv.csv_decode_rejects_nonfinite_floats() -> string {
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -1618,28 +1572,25 @@ function csv.csv_duplicate_column_matched_is_header_error() -> string {
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var err
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var err
 
-  L3:
+  L2:
     load_const "first,first\nx,y\n"
     load_const <omitted>
     call baml.csv.reader
@@ -1649,31 +1600,23 @@ function csv.csv_duplicate_column_matched_is_header_error() -> string {
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L4
     load_type string
     load_var _9
     load_const 1
     call baml.csv.Record.get_at
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L5
+    jump_if_not_null_or_pop L3
     load_const "<null>"
-    store_var _12
 
-  L5:
-    load_var _12
+  L3:
     store_var positional
-    jump L7
+    jump L5
 
-  L6:
+  L4:
     load_const "none"
     store_var positional
 
-  L7:
+  L5:
     load_var err
     load_const "/"
     bin_op +
@@ -1739,22 +1682,19 @@ function csv.csv_encoding_strict_throws() -> string {
     pop 1
     load_const "expected Encoding error"
     call baml.sys.panic
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
 
-  L2:
+  L1:
     return
 }
 
@@ -1862,11 +1802,11 @@ function csv.csv_file_roundtrip() -> string {
     sys_op baml.time.Instant.now
     call baml.time.Instant.to_timestamp_milliseconds
     store_var _4
+    load_const "/tmp/baml_csv_file_roundtrip_"
     load_type bigint
     load_var _4
     call baml.String.from
     store_var _3
-    load_const "/tmp/baml_csv_file_roundtrip_"
     load_var _3
     bin_op +
     load_const ".csv"
@@ -1898,29 +1838,21 @@ function csv.csv_file_roundtrip() -> string {
     load_var _17
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var _17
     load_field .note
-    store_var_load_var _21
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
     load_const "<null>"
-    store_var _21
+
+  L0:
+    store_var first_note
+    jump L2
 
   L1:
-    load_var _21
-    store_var first_note
-    jump L3
-
-  L2:
     load_const "missing"
     store_var first_note
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -1928,17 +1860,15 @@ function csv.csv_file_roundtrip() -> string {
     load_const 0
     cmp_int_op >
     call baml.json.stringify
-    store_var _29
     load_var back
     container_len
-    store_var _33
-    load_var _33
-    call baml.json.stringify
     store_var _32
-    load_var _29
+    load_var _32
+    call baml.json.stringify
+    store_var _31
     load_const ":"
     bin_op +
-    load_var _32
+    load_var _31
     bin_op +
     load_const ":"
     bin_op +
@@ -1960,85 +1890,73 @@ function csv.csv_header_encoding_failure_is_terminal_for_headers() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _5
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var first
-    jump L4
+    jump L2
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
+    load_const "<"
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _11
-    load_const "<"
     load_var _11
     bin_op +
     load_const ">"
     bin_op +
     store_var first
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "done"
     store_var first
 
-  L4:
+  L2:
     load_var r
     call baml.csv.Reader.headers
     store_var _15
     load_var _15
     load_const null
     cmp_op ==
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L4
     load_var _15
     load_const "|"
     call user.csv.join
     store_var headers_after
-    jump L9
+    jump L5
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L3
     load_var e
     rethrow
 
-  L7:
+  L3:
+    load_const "<"
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _21
-    load_const "<"
     load_var _21
     bin_op +
     load_const ">"
     bin_op +
     store_var headers_after
-    jump L9
+    jump L5
 
-  L8:
+  L4:
     load_const "<null>"
     store_var headers_after
 
-  L9:
+  L5:
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -2046,22 +1964,19 @@ function csv.csv_header_encoding_failure_is_terminal_for_headers() -> string {
     store_var _24
     load_var _24
     is_type baml.iter.Done
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L6
     load_var _24
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var next_after
-    jump L12
+    jump L7
 
-  L11:
+  L6:
     load_const "done"
     store_var next_after
 
-  L12:
+  L7:
     load_var first
     load_const "/"
     bin_op +
@@ -2079,17 +1994,12 @@ function csv.csv_headers_variants() -> string {
     load_const <omitted>
     call baml.csv.reader
     call baml.csv.Reader.headers
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "<null>"
     load_type string
     alloc_array 1
-    store_var _3
 
   L0:
-    load_var _3
     load_const "|"
     call user.csv.join
     store_var with_header
@@ -2115,48 +2025,42 @@ function csv.csv_headers_variants() -> string {
     init_instance baml.csv.ReaderOptions .delimiter, .quote, .quoting, .escape, .has_header, .headers, .comment, .trim, .skip_lines, .skip_blank_records, .ragged, .null_values, .encoding, .bom, .on_error, .on_skip, .max_skipped, .limit
     call baml.csv.reader
     call baml.csv.Reader.headers
-    store_var _8
-    load_var _8
+    store_var _7
+    load_var _7
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var _8
+    pop_jump_if_true L1
+    load_var _7
     load_const "|"
     call user.csv.join
     store_var no_header
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "<null>"
     store_var no_header
 
-  L3:
+  L2:
     load_const ""
     load_const <omitted>
     call baml.csv.reader
     call baml.csv.Reader.headers
-    store_var _15
-    load_var _15
+    store_var _14
+    load_var _14
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
-    load_var _15
+    pop_jump_if_true L3
+    load_var _14
     load_const "|"
     call user.csv.join
     store_var empty_input
-    jump L6
+    jump L4
 
-  L5:
+  L3:
     load_const "<null>"
     store_var empty_input
 
-  L6:
+  L4:
     load_var with_header
     load_const " / "
     bin_op +
@@ -2185,15 +2089,11 @@ function csv.csv_iterator_adapters() -> int {
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = csv.IntRow>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _3
-    load_var _3
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var doubled
     load_const 0
     store_var total
-    load_var doubled
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
@@ -2207,16 +2107,13 @@ function csv.csv_iterator_adapters() -> int {
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var2 5 7
+    pop_jump_if_true L1
+    load_var2 3 5
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -2233,43 +2130,37 @@ function csv.csv_malformed_header_exhausts_reader() -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _4
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var first
-    jump L4
+    jump L2
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
+    load_const "<"
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _10
-    load_const "<"
     load_var _10
     bin_op +
     load_const ">"
     bin_op +
     store_var first
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "done"
     store_var first
 
-  L4:
+  L2:
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -2277,22 +2168,19 @@ function csv.csv_malformed_header_exhausts_reader() -> string {
     store_var _13
     load_var _13
     is_type baml.iter.Done
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_var _13
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var second
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_const "done"
     store_var second
 
-  L7:
+  L4:
     load_var first
     load_const "/"
     bin_op +
@@ -2313,85 +2201,73 @@ function csv.csv_malformed_header_failure_is_terminal_for_headers() -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _4
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var first
-    jump L4
+    jump L2
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
+    load_const "<"
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _10
-    load_const "<"
     load_var _10
     bin_op +
     load_const ">"
     bin_op +
     store_var first
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "done"
     store_var first
 
-  L4:
+  L2:
     load_var r
     call baml.csv.Reader.headers
     store_var _14
     load_var _14
     load_const null
     cmp_op ==
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L4
     load_var _14
     load_const "|"
     call user.csv.join
     store_var headers_after
-    jump L9
+    jump L5
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L3
     load_var e
     rethrow
 
-  L7:
+  L3:
+    load_const "<"
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _20
-    load_const "<"
     load_var _20
     bin_op +
     load_const ">"
     bin_op +
     store_var headers_after
-    jump L9
+    jump L5
 
-  L8:
+  L4:
     load_const "<null>"
     store_var headers_after
 
-  L9:
+  L5:
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -2399,22 +2275,19 @@ function csv.csv_malformed_header_failure_is_terminal_for_headers() -> string {
     store_var _23
     load_var _23
     is_type baml.iter.Done
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L6
     load_var _23
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var next_after
-    jump L12
+    jump L7
 
-  L11:
+  L6:
     load_const "done"
     store_var next_after
 
-  L12:
+  L7:
     load_var first
     load_const "/"
     bin_op +
@@ -2441,21 +2314,22 @@ function csv.csv_null_semantics_empty_unquoted() -> string {
     load_var _3
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L3
     load_var _3
     store_var_load_var p
     load_field .so
-    store_var_load_var _13
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _13
+    jump L2
+
+  L1:
     load_const "<null>"
     store_var _13
 
-  L1:
+  L2:
     load_const "s="
     load_var p
     load_field .s
@@ -2471,15 +2345,15 @@ function csv.csv_null_semantics_empty_unquoted() -> string {
     load_field .io
     load_const "<null>"
     call user.csv.int_or
-    store_var _16
+    store_var _15
     load_var2 4 6
     bin_op +
-    jump L3
-
-  L2:
-    load_const "missing"
+    jump L4
 
   L3:
+    load_const "missing"
+
+  L4:
     return
 }
 
@@ -2497,31 +2371,32 @@ function csv.csv_null_semantics_quoted_empty() -> string {
     load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L3
     load_var _2
     load_field .so
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _9
+    jump L2
+
+  L1:
     load_const "<null>"
     store_var _9
 
-  L1:
+  L2:
     load_const "so="
     load_var _9
     bin_op +
     store_var ok
-    jump L3
+    jump L4
 
-  L2:
+  L3:
     load_const "missing"
     store_var ok
 
-  L3:
+  L4:
     load_type csv.NullProbe
     load_const "a,s,so,io\nx,,,\"\"\n"
     load_const <omitted>
@@ -2530,10 +2405,7 @@ function csv.csv_null_semantics_quoted_empty() -> string {
     jump L6
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L5
     load_var e
     rethrow
 
@@ -2593,21 +2465,22 @@ function csv.csv_null_values_option() -> string {
     load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L3
     load_var _4
     store_var_load_var p
     load_field .so
-    store_var_load_var _14
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _14
+    jump L2
+
+  L1:
     load_const "<null>"
     store_var _14
 
-  L1:
+  L2:
     load_const "so="
     load_var _14
     bin_op +
@@ -2618,17 +2491,17 @@ function csv.csv_null_values_option() -> string {
     load_field .io
     load_const "<null>"
     call user.csv.int_or
-    store_var _17
+    store_var _16
     load_var2 6 8
     bin_op +
     store_var ok
-    jump L3
+    jump L4
 
-  L2:
+  L3:
     load_const "missing"
     store_var ok
 
-  L3:
+  L4:
     load_type csv.NullProbe
     load_const "a,s,so,io\nx,N/A,,\n"
     load_var opts
@@ -2637,10 +2510,7 @@ function csv.csv_null_values_option() -> string {
     jump L6
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L5
     load_var e
     rethrow
 
@@ -2660,38 +2530,30 @@ function csv.csv_null_values_option() -> string {
     load_const "a,s,so,io\nx,y,\"N/A\",\n"
     load_var opts
     call baml.csv.decode
-    store_var _28
+    store_var _27
     load_type csv.NullProbe
-    load_var _28
+    load_var _27
     load_const 0
     call baml.Array.at
-    store_var _27
-    load_var _27
+    store_var _26
+    load_var _26
     load_const null
     cmp_op ==
-    pop_jump_if_false L8
-    jump L10
+    pop_jump_if_true L9
+    load_var _26
+    load_field .so
+    jump_if_not_null_or_pop L8
+    load_const "<null>"
 
   L8:
-    load_var _27
-    load_field .so
-    store_var_load_var _34
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L9
-    load_const "<null>"
-    store_var _34
+    store_var quoted
+    jump L10
 
   L9:
-    load_var _34
-    store_var quoted
-    jump L11
-
-  L10:
     load_const "missing"
     store_var quoted
 
-  L11:
+  L10:
     load_var ok
     load_const "/"
     bin_op +
@@ -2748,10 +2610,7 @@ function csv.csv_on_skip_observer() -> string {
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _8
     store_var rec
     load_var count
@@ -2760,15 +2619,13 @@ function csv.csv_on_skip_observer() -> string {
     store_var count
     jump L0
 
-  L2:
+  L1:
     load_var count
     call baml.json.stringify
-    store_var _13
     load_deref ?1
     load_const ","
     call user.csv.join
     store_var _15
-    load_var _13
     load_const ":"
     bin_op +
     load_var _15
@@ -2780,11 +2637,11 @@ function csv.csv_open_streams_file() -> string {
     sys_op baml.time.Instant.now
     call baml.time.Instant.to_timestamp_milliseconds
     store_var _4
+    load_const "/tmp/baml_csv_open_streams_"
     load_type bigint
     load_var _4
     call baml.String.from
     store_var _3
-    load_const "/tmp/baml_csv_open_streams_"
     load_var _3
     bin_op +
     load_const ".csv"
@@ -2815,17 +2672,14 @@ function csv.csv_open_streams_file() -> string {
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 5 7
     load_field .n
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var r
     call baml.csv.Reader.close
     pop 1
@@ -2860,28 +2714,25 @@ function csv.csv_options_validation() -> string {
     init_instance baml.csv.ReaderOptions .delimiter, .quote, .quoting, .escape, .has_header, .headers, .comment, .trim, .skip_lines, .skip_blank_records, .ragged, .null_values, .encoding, .bom, .on_error, .on_skip, .max_skipped, .limit
     call baml.csv.reader
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var multi
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var multi
 
-  L3:
+  L2:
     load_const "a\n"
     load_const "\""
     load_const null
@@ -2904,28 +2755,25 @@ function csv.csv_options_validation() -> string {
     init_instance baml.csv.ReaderOptions .delimiter, .quote, .quoting, .escape, .has_header, .headers, .comment, .trim, .skip_lines, .skip_blank_records, .ragged, .null_values, .encoding, .bom, .on_error, .on_skip, .max_skipped, .limit
     call baml.csv.reader
     pop 1
-    jump L6
+    jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var e
     rethrow
 
-  L5:
+  L3:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var clash
-    jump L7
+    jump L5
 
-  L6:
+  L4:
     load_const "no-throw"
     store_var clash
 
-  L7:
+  L5:
     load_var multi
     load_const "/"
     bin_op +
@@ -3254,36 +3102,31 @@ function csv.csv_plaindate_cells_roundtrip() -> string {
     load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _4
     store_var_load_var r
     load_field .day
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _9
     load_var r
     load_field .at
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
-    load_var _9
     load_const " "
     bin_op +
     load_var _11
     bin_op +
     store_var rendered
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "missing"
     store_var rendered
 
-  L2:
+  L1:
     load_type csv.DatedRow
     load_var rows
     load_const <omitted>
@@ -3294,28 +3137,25 @@ function csv.csv_plaindate_cells_roundtrip() -> string {
     load_const <omitted>
     call baml.csv.decode
     pop 1
-    jump L5
+    jump L3
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var e
     rethrow
 
-  L4:
+  L2:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var bad
-    jump L6
+    jump L4
 
-  L5:
+  L3:
     load_const "no-throw"
     store_var bad
 
-  L6:
+  L4:
     load_var rendered
     load_const "#"
     bin_op +
@@ -3384,28 +3224,25 @@ function csv.csv_ragged_pad() -> string {
     load_var opts
     call baml.csv.parse
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var long
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var long
 
-  L3:
+  L2:
     load_var short
     load_const "/"
     bin_op +
@@ -3419,21 +3256,17 @@ function csv.csv_ragged_strict() -> string {
     load_const <omitted>
     call baml.csv.parse
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _7
     load_var e
     load_field .expected
     load_const "?"
@@ -3444,7 +3277,6 @@ function csv.csv_ragged_strict() -> string {
     load_const "?"
     call user.csv.int_or
     store_var _11
-    load_var _7
     load_const " expected="
     bin_op +
     load_var _9
@@ -3453,12 +3285,12 @@ function csv.csv_ragged_strict() -> string {
     bin_op +
     load_var _11
     bin_op +
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -3492,28 +3324,25 @@ function csv.csv_ragged_truncate() -> string {
     load_var opts
     call baml.csv.parse
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var short
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var short
 
-  L3:
+  L2:
     load_var long
     load_const "/"
     bin_op +
@@ -3543,26 +3372,23 @@ function csv.csv_reader_close() -> string {
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     load_const ":"
     bin_op +
     store_var _12
@@ -3629,6 +3455,7 @@ function csv.csv_reader_position() -> string {
     load_var r
     call baml.csv.Reader.position
     store_var p2
+    load_const "byte="
     load_var p1
     load_field .byte
     call baml.json.stringify
@@ -3653,7 +3480,6 @@ function csv.csv_reader_position() -> string {
     load_field .record
     call baml.json.stringify
     store_var _26
-    load_const "byte="
     load_var _16
     bin_op +
     load_const " line="
@@ -3691,8 +3517,6 @@ function csv.csv_reader_resumes_after_throw() -> string {
     store_var bad
 
   L0:
-    load_const true
-    pop_jump_if_false L7
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -3700,69 +3524,58 @@ function csv.csv_reader_resumes_after_throw() -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _6
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var step
-    jump L5
+    jump L3
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L3:
+  L1:
     load_var bad
     load_const 1
     add_int
     store_var bad
+    load_const "<"
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _12
-    load_const "<"
     load_var _12
     bin_op +
     load_const ">"
     bin_op +
     store_var step
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "done"
     store_var step
 
-  L5:
+  L3:
     load_var step
     load_const "done"
     cmp_op ==
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L4
     load_type string
     load_var2 2 4
     call baml.Array.push
     pop 1
     jump L0
 
-  L7:
+  L4:
     load_var seen
     load_const ";"
     call user.csv.join
-    store_var _20
     load_var bad
     call baml.json.stringify
     store_var _22
-    load_var _20
     load_const " bad="
     bin_op +
     load_var _22
@@ -3780,10 +3593,7 @@ function csv.csv_record_api() -> string {
     store_var _2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L9
     load_var _2
     store_var rec
     load_type string
@@ -3810,14 +3620,18 @@ function csv.csv_record_api() -> string {
     load_var rec
     load_const "name"
     call baml.csv.Record.get
-    store_var_load_var _16
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _16
+    jump L2
+
+  L1:
     load_const "<null>"
     store_var _16
 
-  L1:
+  L2:
     load_type string
     load_var2 3 6
     call baml.Array.push
@@ -3828,7 +3642,7 @@ function csv.csv_record_api() -> string {
     call baml.csv.Record.get
     load_const "<null>"
     call user.csv.int_or
-    store_var _22
+    store_var _21
     load_type string
     load_var2 3 7
     call baml.Array.push
@@ -3837,14 +3651,18 @@ function csv.csv_record_api() -> string {
     load_var rec
     load_const "absent"
     call baml.csv.Record.get
-    store_var_load_var _28
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
-    load_const "<absent-null>"
-    store_var _28
+    jump_if_not_null_or_pop L3
+    jump L4
 
-  L2:
+  L3:
+    store_var _27
+    jump L5
+
+  L4:
+    load_const "<absent-null>"
+    store_var _27
+
+  L5:
     load_type string
     load_var2 3 8
     call baml.Array.push
@@ -3853,14 +3671,18 @@ function csv.csv_record_api() -> string {
     load_var rec
     load_const 99
     call baml.csv.Record.get_at
-    store_var_load_var _35
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    load_const "<oob-null>"
-    store_var _35
+    jump_if_not_null_or_pop L6
+    jump L7
 
-  L3:
+  L6:
+    store_var _33
+    jump L8
+
+  L7:
+    load_const "<oob-null>"
+    store_var _33
+
+  L8:
     load_type string
     load_var2 3 9
     call baml.Array.push
@@ -3877,12 +3699,12 @@ function csv.csv_record_api() -> string {
     load_var parts
     load_const " "
     call user.csv.join
-    jump L5
+    jump L10
 
-  L4:
+  L9:
     load_const "none"
 
-  L5:
+  L10:
     return
 }
 
@@ -3896,21 +3718,18 @@ function csv.csv_record_decode_single() -> string {
     store_var _2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type csv.IntRow
     load_var _2
     call baml.csv.Record.decode
     load_field .n
     call baml.json.stringify
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "none"
 
-  L2:
+  L1:
     return
 }
 
@@ -3924,10 +3743,7 @@ function csv.csv_record_get_decode_error() -> string {
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L5
     load_type int
     load_var _3
     load_const "n"
@@ -3936,24 +3752,25 @@ function csv.csv_record_get_decode_error() -> string {
     jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var _10
     load_var e
     load_field .column
-    store_var_load_var _13
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _13
+    jump L3
+
+  L2:
     load_const "?"
     store_var _13
 
@@ -4004,39 +3821,33 @@ function csv.csv_record_get_without_headers() -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_type int
     load_var _4
     load_const "n"
     call baml.csv.Record.get
     pop 1
-    jump L3
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L5
+    jump L3
 
-  L3:
+  L1:
     load_const "no-throw"
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "none"
 
-  L5:
+  L3:
     return
 }
 
@@ -4062,17 +3873,14 @@ function csv.csv_record_snapshot_outlives_reader() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type baml.csv.Record
     load_var2 2 4
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_type string
     alloc_array 0
     store_var parts
@@ -4082,7 +3890,7 @@ function csv.csv_record_snapshot_outlives_reader() -> string {
     virtual_call nargs=1 ntypeargs=0
     store_var _14
 
-  L3:
+  L2:
     load_var _14
     load_type baml.iter.Iterator<Error = never, Item = baml.csv.Record>
     load_const "next"
@@ -4090,10 +3898,7 @@ function csv.csv_record_snapshot_outlives_reader() -> string {
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var _15
     call baml.csv.Record.fields
     store_var _21
@@ -4103,9 +3908,9 @@ function csv.csv_record_snapshot_outlives_reader() -> string {
     load_array_element
     call baml.Array.push
     pop 1
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var parts
     load_const ","
     call user.csv.join
@@ -4121,26 +3926,23 @@ function csv.csv_rows_rejects_nested_class() -> string {
     load_var r
     call baml.csv.Reader.rows
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -4153,26 +3955,23 @@ function csv.csv_rows_validates_eagerly() -> string {
     load_var r
     call baml.csv.Reader.rows
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -4241,10 +4040,7 @@ function csv.csv_skip_mode_diagnostics() -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _6
     store_var rec
     load_var count
@@ -4253,7 +4049,7 @@ function csv.csv_skip_mode_diagnostics() -> string {
     store_var count
     jump L0
 
-  L2:
+  L1:
     load_var r
     call baml.csv.Reader.skipped
     store_var _12
@@ -4265,22 +4061,19 @@ function csv.csv_skip_mode_diagnostics() -> string {
     load_var _11
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _11
     load_field .line
     load_const "?"
     call user.csv.int_or
     store_var first_line
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "?"
     store_var first_line
 
-  L5:
+  L3:
     load_var count
     call baml.json.stringify
     store_var _22
@@ -4352,17 +4145,14 @@ function csv.csv_skip_mode_typed_decode() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 4
     load_field .n
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     call baml.json.stringify
     store_var _13
@@ -4392,10 +4182,7 @@ function csv.csv_smoke_decode_typed_rows() -> string {
     load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _4
     store_var l
     load_var l
@@ -4403,10 +4190,7 @@ function csv.csv_smoke_decode_typed_rows() -> string {
     store_var_load_var _8
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _8
     call baml.json.stringify
     store_var _14
@@ -4417,21 +4201,21 @@ function csv.csv_smoke_decode_typed_rows() -> string {
     load_var _14
     bin_op +
     store_var second
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_var l
     load_field .company
     load_const ":null"
     bin_op +
     store_var second
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "missing"
     store_var second
 
-  L4:
+  L2:
     load_var leads
     container_len
     store_var _18
@@ -4464,43 +4248,40 @@ function csv.csv_smoke_decode_user_enum_rows() -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L7
-
-  L1:
+    pop_jump_if_true L6
     load_var _6
     store_var_load_var r
     load_field .color
     discriminant
     load_const CsvSmokeColor.Red
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L5
+    pop_jump_if_false L1
+    jump L4
 
-  L2:
+  L1:
     load_var r
     load_field .color
     discriminant
     load_const CsvSmokeColor.Green
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
+    pop_jump_if_false L2
+    jump L3
 
-  L3:
+  L2:
     load_const "Blue"
     store_var c
-    jump L6
+    jump L5
 
-  L4:
+  L3:
     load_const "Green"
     store_var c
-    jump L6
+    jump L5
 
-  L5:
+  L4:
     load_const "Red"
     store_var c
 
-  L6:
+  L5:
     load_var2 1 4
     load_field .name
     bin_op +
@@ -4513,7 +4294,7 @@ function csv.csv_smoke_decode_user_enum_rows() -> string {
     store_var out
     jump L0
 
-  L7:
+  L6:
     load_var out
     return
 }
@@ -4557,10 +4338,7 @@ function csv.csv_smoke_on_error_skip() -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _6
     store_var rec
     load_var count
@@ -4569,7 +4347,7 @@ function csv.csv_smoke_on_error_skip() -> string {
     store_var count
     jump L0
 
-  L2:
+  L1:
     load_var count
     call baml.json.stringify
     store_var _11
@@ -4625,10 +4403,7 @@ function csv.csv_smoke_reader_streaming_get() -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_type int
     load_var _5
     load_const "n"
@@ -4637,23 +4412,20 @@ function csv.csv_smoke_reader_streaming_get() -> int {
     load_var _10
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _10
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 0
 
-  L4:
+  L2:
     load_var total
     add_int
     store_var total
     jump L0
 
-  L5:
+  L3:
     load_var total
     return
 }
@@ -4687,8 +4459,6 @@ function csv.csv_smoke_record_error_resumes() -> string {
     store_var bad
 
   L0:
-    load_const true
-    pop_jump_if_false L11
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -4696,26 +4466,17 @@ function csv.csv_smoke_record_error_resumes() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L8
-
-  L1:
+    pop_jump_if_true L5
     load_var _7
     call baml.csv.Record.fields
-    jump L7
+    jump L4
     load_var _
     is_type baml.csv.Error
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L3:
-    load_var _
-    load_field .2
-    pop 1
+  L1:
     load_var _
     load_field .2
     store_var line
@@ -4726,44 +4487,38 @@ function csv.csv_smoke_record_error_resumes() -> string {
     load_var line
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var line
     call baml.json.stringify
-    store_var _16
-    jump L6
+    store_var _15
+    jump L3
 
-  L5:
+  L2:
     load_const "?"
-    store_var _16
+    store_var _15
 
-  L6:
+  L3:
     load_const "err@"
-    load_var _16
+    load_var _15
     bin_op +
     store_var step
-    jump L9
+    jump L6
 
-  L7:
+  L4:
     load_const 0
     load_array_element
     store_var step
-    jump L9
+    jump L6
 
-  L8:
+  L5:
     load_const "done"
     store_var step
 
-  L9:
+  L6:
     load_var step
     load_const "done"
     cmp_op ==
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L7
     load_var2 2 4
     bin_op +
     load_const ";"
@@ -4771,14 +4526,14 @@ function csv.csv_smoke_record_error_resumes() -> string {
     store_var seen
     jump L0
 
-  L11:
+  L7:
     load_var seen
     load_const "bad="
     bin_op +
-    store_var _25
+    store_var _24
     load_var bad
     call baml.json.stringify
-    store_var _27
+    store_var _26
     load_var2 9 10
     bin_op +
     return
@@ -4838,31 +4593,23 @@ function csv.csv_smoke_typed_returns_probe() -> string {
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_type string
     load_var _3
     load_const "name"
     call baml.csv.Record.get
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
     load_const "<null>"
-    store_var _6
+
+  L0:
+    store_var rec_name
+    jump L2
 
   L1:
-    load_var _6
-    store_var rec_name
-    jump L3
-
-  L2:
     load_const "none"
     store_var rec_name
 
-  L3:
+  L2:
     load_const 0
     store_var total
     load_type csv.CsvSmokeIntRow
@@ -4871,35 +4618,32 @@ function csv.csv_smoke_typed_returns_probe() -> string {
     load_type baml.iter.Iterable<Error = baml.csv.Error | baml.errors.Io, Item = csv.CsvSmokeIntRow>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _13
+    store_var _12
 
-  L4:
-    load_var _13
+  L3:
+    load_var _12
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = csv.CsvSmokeIntRow>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _14
-    load_var _14
+    store_var _13
+    load_var _13
     is_type baml.iter.Done
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
-    load_var2 5 7
+    pop_jump_if_true L4
+    load_var2 4 6
     load_field .n
     add_int
     store_var total
-    jump L4
+    jump L3
 
-  L6:
+  L4:
     load_var rec_name
     load_const ":"
     bin_op +
-    store_var _19
+    store_var _18
     load_var total
     call baml.json.stringify
-    store_var _21
-    load_var2 8 9
+    store_var _20
+    load_var2 7 8
     bin_op +
     return
 }
@@ -4928,10 +4672,7 @@ function csv.csv_spectrum_core_fixtures() -> string {
     load_var _8
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _8
     store_var_load_var row
     load_field .city
@@ -4941,13 +4682,13 @@ function csv.csv_spectrum_core_fixtures() -> string {
     load_field .zip
     bin_op +
     store_var city
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "missing"
     store_var city
 
-  L2:
+  L1:
     load_type csv.SpectrumAB
     load_var escaped
     load_const 0
@@ -4956,20 +4697,17 @@ function csv.csv_spectrum_core_fixtures() -> string {
     load_var _16
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _16
     load_field .b
     store_var escaped_b
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "missing"
     store_var escaped_b
 
-  L5:
+  L3:
     load_type csv.SpectrumAB
     load_var quotes_newlines
     load_const 0
@@ -4978,20 +4716,17 @@ function csv.csv_spectrum_core_fixtures() -> string {
     load_var _21
     load_const null
     cmp_op ==
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L4
     load_var _21
     load_field .b
     store_var newline_b
-    jump L8
+    jump L5
 
-  L7:
+  L4:
     load_const "missing"
     store_var newline_b
 
-  L8:
+  L5:
     load_var city
     load_const " / "
     bin_op +
@@ -5157,16 +4892,11 @@ function csv.csv_trim_all() -> string {
     store_var r
     load_var r
     call baml.csv.Reader.headers
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_type string
     alloc_array 0
-    store_var _4
 
   L0:
-    load_var _4
     load_const "|"
     call user.csv.join
     store_var h
@@ -5174,25 +4904,22 @@ function csv.csv_trim_all() -> string {
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _10
-    load_var _10
+    store_var _9
+    load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var _10
+    pop_jump_if_true L1
+    load_var _9
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var row
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "none"
     store_var row
 
-  L3:
+  L2:
     load_var h
     load_const "/"
     bin_op +
@@ -5283,22 +5010,19 @@ function csv.csv_unterminated_quote_exhausts() -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _4
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var first
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "done"
     store_var first
 
-  L2:
+  L1:
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -5306,37 +5030,31 @@ function csv.csv_unterminated_quote_exhausts() -> string {
     store_var _10
     load_var _10
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L3
     load_var _10
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var second
-    jump L7
+    jump L4
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var e
     rethrow
 
-  L5:
+  L2:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var second
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_const "done"
     store_var second
 
-  L7:
+  L4:
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -5344,22 +5062,19 @@ function csv.csv_unterminated_quote_exhausts() -> string {
     store_var _17
     load_var _17
     is_type baml.iter.Done
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    pop_jump_if_true L5
     load_var _17
     call baml.csv.Record.fields
     load_const "|"
     call user.csv.join
     store_var third
-    jump L10
+    jump L6
 
-  L9:
+  L5:
     load_const "done"
     store_var third
 
-  L10:
+  L6:
     load_var first
     load_const "/"
     bin_op +
@@ -5390,26 +5105,23 @@ function csv.csv_write_rows_batch_is_atomic() -> string {
     alloc_array 2
     call baml.csv.Writer.write_rows
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     load_const "#"
     bin_op +
     store_var _14
@@ -5516,28 +5228,25 @@ function csv.csv_writer_bom_survives_encode_error() -> string {
     alloc_array 1
     call baml.csv.Writer.write_record
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var caught
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var caught
 
-  L3:
+  L2:
     load_var w
     load_const "x"
     load_type null | bool | int | bigint | float | string
@@ -5624,26 +5333,23 @@ function csv.csv_writer_closed_throws() -> string {
     init_instance user.csv.Pos2 .a, .b
     call baml.csv.Writer.write_row
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     load_const ":"
     bin_op +
     store_var _14
@@ -5702,28 +5408,25 @@ function csv.csv_writer_explicit_header() -> string {
     alloc_array 1
     call baml.csv.Writer.write_header
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var after_data
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var after_data
 
-  L3:
+  L2:
     load_var w
     call baml.csv.Writer.text
     load_const "#"
@@ -5805,26 +5508,23 @@ function csv.csv_writer_nonfinite_float_throws() -> string {
     alloc_array 1
     call baml.csv.Writer.write_record
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
 
-  L3:
+  L2:
     return
 }
 
@@ -5867,28 +5567,25 @@ function csv.csv_writer_quote_styles() -> string {
     init_instance baml.csv.WriterOptions .delimiter, .quote, .quote_style, .escape, .terminator, .write_header, .headers, .null_value, .bom, .sanitize_formulas
     call baml.csv.stringify
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var never_err
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var never_err
 
-  L3:
+  L2:
     load_var all
     load_const "#"
     bin_op +
@@ -5936,28 +5633,25 @@ function csv.csv_writer_state_survives_encode_error() -> string {
     init_instance user.csv.MdRow .metric, .value
     call baml.csv.Writer.write_row
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var caught
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var caught
 
-  L3:
+  L2:
     load_type csv.MdRow
     load_var w
     load_const "ok"
@@ -5989,11 +5683,11 @@ function csv.csv_writer_text_on_file_writer_throws() -> string {
     sys_op baml.time.Instant.now
     call baml.time.Instant.to_timestamp_milliseconds
     store_var _4
+    load_const "/tmp/baml_csv_text_on_file_"
     load_type bigint
     load_var _4
     call baml.String.from
     store_var _3
-    load_const "/tmp/baml_csv_text_on_file_"
     load_var _3
     bin_op +
     load_const ".csv"
@@ -6005,28 +5699,25 @@ function csv.csv_writer_text_on_file_writer_throws() -> string {
     load_var w
     call baml.csv.Writer.text
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.csv.Error
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .kind
     call user.csv.kind_name
     store_var err
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no-throw"
     store_var err
 
-  L3:
+  L2:
     load_var w
     call baml.csv.Writer.close
     pop 1
@@ -6085,10 +5776,7 @@ function csv.grid(rows: string[][]) -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     load_const "|"
     call user.csv.join
@@ -6099,7 +5787,7 @@ function csv.grid(rows: string[][]) -> string {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     load_const ";"
     call user.csv.join
@@ -6110,18 +5798,15 @@ function csv.int_or(v: int | null, fallback: string) -> string {
     load_var v
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var v
+    call baml.json.stringify
     jump L1
 
   L0:
-    load_var v
-    call baml.json.stringify
-    jump L2
-
-  L1:
     load_var fallback
 
-  L2:
+  L1:
     return
 }
 
@@ -6144,17 +5829,11 @@ function csv.join(parts: string[], sep: string) -> string {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _6
     store_var p
     load_var first
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 3 2
     bin_op +
     load_var p
@@ -6162,14 +5841,14 @@ function csv.join(parts: string[], sep: string) -> string {
     store_var out
     jump L0
 
-  L3:
+  L1:
     load_var p
     store_var out
     load_const false
     store_var first
     jump L0
 
-  L4:
+  L2:
     load_var out
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_csv/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_csv/bytecode.snap
@@ -752,8 +752,6 @@ function csv.csv_caller_owned_handles_stay_open() -> string {
     load_type bigint
     load_var _4
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     load_const ".csv"
     bin_op +
@@ -864,8 +862,6 @@ function csv.csv_create_then_fs_read() -> string {
     load_type bigint
     load_var _4
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     load_const ".csv"
     bin_op +
@@ -1806,8 +1802,6 @@ function csv.csv_file_roundtrip() -> string {
     load_type bigint
     load_var _4
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     load_const ".csv"
     bin_op +
@@ -1908,8 +1902,6 @@ function csv.csv_header_encoding_failure_is_terminal_for_headers() -> string {
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _11
-    load_var _11
     bin_op +
     load_const ">"
     bin_op +
@@ -1944,8 +1936,6 @@ function csv.csv_header_encoding_failure_is_terminal_for_headers() -> string {
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _21
-    load_var _21
     bin_op +
     load_const ">"
     bin_op +
@@ -2148,8 +2138,6 @@ function csv.csv_malformed_header_exhausts_reader() -> string {
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _10
-    load_var _10
     bin_op +
     load_const ">"
     bin_op +
@@ -2219,8 +2207,6 @@ function csv.csv_malformed_header_failure_is_terminal_for_headers() -> string {
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _10
-    load_var _10
     bin_op +
     load_const ">"
     bin_op +
@@ -2255,8 +2241,6 @@ function csv.csv_malformed_header_failure_is_terminal_for_headers() -> string {
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _20
-    load_var _20
     bin_op +
     load_const ">"
     bin_op +
@@ -2641,8 +2625,6 @@ function csv.csv_open_streams_file() -> string {
     load_type bigint
     load_var _4
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     load_const ".csv"
     bin_op +
@@ -2673,7 +2655,7 @@ function csv.csv_open_streams_file() -> string {
     load_var _15
     is_type baml.iter.Done
     pop_jump_if_true L1
-    load_var2 5 7
+    load_var2 4 6
     load_field .n
     add_int
     store_var total
@@ -3459,7 +3441,6 @@ function csv.csv_reader_position() -> string {
     load_var p1
     load_field .byte
     call baml.json.stringify
-    store_var _16
     load_var p1
     load_field .line
     call baml.json.stringify
@@ -3480,7 +3461,6 @@ function csv.csv_reader_position() -> string {
     load_field .record
     call baml.json.stringify
     store_var _26
-    load_var _16
     bin_op +
     load_const " line="
     bin_op +
@@ -3546,8 +3526,6 @@ function csv.csv_reader_resumes_after_throw() -> string {
     load_var e
     load_field .kind
     call user.csv.kind_name
-    store_var _12
-    load_var _12
     bin_op +
     load_const ">"
     bin_op +
@@ -5687,8 +5665,6 @@ function csv.csv_writer_text_on_file_writer_throws() -> string {
     load_type bigint
     load_var _4
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     load_const ".csv"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_deep_copy/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_deep_copy/bytecode.snap
@@ -344,16 +344,12 @@ function deep_copy.eq_circular_helper() -> bool {
 }
 
 function deep_copy.eq_different_primitives_helper() -> bool {
-    load_const 42
-    load_const 43
-    cmp_int_op ==
+    load_const false
     return
 }
 
 function deep_copy.eq_primitives_helper() -> bool {
-    load_const 42
-    load_const 42
-    cmp_int_op ==
+    load_const true
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_defer/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_defer/bytecode.snap
@@ -144,14 +144,11 @@ function defer.defer_armed_only_maybe_throw(x: int) -> void {
     load_var x
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const null
     return
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -319,16 +316,13 @@ function defer.defer_call_throws_risky(log: string[]) -> void {
 
 function defer.defer_early_return_helper(log: string[], early: bool) -> int {
     load_var early
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_type string
     load_var log
     load_const "after"
     call baml.Array.push
     pop 1
-    jump L1
+    jump L0
     load_type string
     load_var log
     load_const "cleanup"
@@ -337,7 +331,7 @@ function defer.defer_early_return_helper(log: string[], early: bool) -> int {
     load_var _3
     rethrow
 
-  L1:
+  L0:
     load_const 2
     store_var _0
     load_type string
@@ -345,9 +339,9 @@ function defer.defer_early_return_helper(log: string[], early: bool) -> int {
     load_const "cleanup"
     call baml.Array.push
     pop 1
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const 1
     store_var _0
     load_type string
@@ -356,7 +350,7 @@ function defer.defer_early_return_helper(log: string[], early: bool) -> int {
     call baml.Array.push
     pop 1
 
-  L3:
+  L2:
     load_var _0
     return
 }
@@ -453,23 +447,17 @@ function defer.defer_on_break_main() -> string[] {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var _4
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L4
-
-  L2:
+    pop_jump_if_true L2
     load_type string
     load_var log
     load_const "i"
     call baml.Array.push
     pop 1
-    jump L3
+    jump L1
     load_type string
     load_var log
     load_const "d"
@@ -478,7 +466,7 @@ function defer.defer_on_break_main() -> string[] {
     load_var _9
     rethrow
 
-  L3:
+  L1:
     load_type string
     load_var log
     load_const "d"
@@ -486,14 +474,14 @@ function defer.defer_on_break_main() -> string[] {
     pop 1
     jump L0
 
-  L4:
+  L2:
     load_type string
     load_var log
     load_const "d"
     call baml.Array.push
     pop 1
 
-  L5:
+  L3:
     load_var log
     return
 }
@@ -519,23 +507,17 @@ function defer.defer_on_continue_main() -> string[] {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var _4
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L4
-
-  L2:
+    pop_jump_if_true L2
     load_type string
     load_var log
     load_const "body"
     call baml.Array.push
     pop 1
-    jump L3
+    jump L1
     load_type string
     load_var log
     load_const "d"
@@ -544,23 +526,23 @@ function defer.defer_on_continue_main() -> string[] {
     load_var _9
     rethrow
 
+  L1:
+    load_type string
+    load_var log
+    load_const "d"
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L2:
+    load_type string
+    load_var log
+    load_const "d"
+    call baml.Array.push
+    pop 1
+    jump L0
+
   L3:
-    load_type string
-    load_var log
-    load_const "d"
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L4:
-    load_type string
-    load_var log
-    load_const "d"
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L5:
     load_var log
     return
 }
@@ -586,10 +568,7 @@ function defer.defer_per_loop_iteration_main() -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var i
     load_var log
@@ -601,7 +580,7 @@ function defer.defer_per_loop_iteration_main() -> string {
     store_var log
     jump L0
 
-  L2:
+  L1:
     load_var log
     return
     load_var log
@@ -613,8 +592,6 @@ function defer.defer_per_loop_iteration_main() -> string {
 }
 
 function defer.defer_sees_final_value_main() -> string {
-    load_const ""
-    store_var log
     load_const "pending"
     store_var status
     load_const "complete"
@@ -744,17 +721,14 @@ function defer.unwind_call_free_defer_runs_once() -> int {
     store_var_load_var c
     call user.defer.unwind_risky_counter
     pop 1
-    jump L1
+    jump L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var c
     load_field .n
     return
@@ -766,17 +740,14 @@ function defer.unwind_defer_runs_once() -> string[] {
     store_var_load_var log
     call user.defer.unwind_risky_one
     pop 1
-    jump L1
+    jump L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var log
     return
 }
@@ -787,17 +758,14 @@ function defer.unwind_nested_defers() -> string[] {
     store_var_load_var log
     call user.defer.unwind_risky_nested
     pop 1
-    jump L1
+    jump L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var log
     return
 }
@@ -808,17 +776,14 @@ function defer.unwind_panicking_binding_precedes_side_effects() -> string[] {
     store_var_load_var log
     call user.defer.unwind_risky_binding
     pop 1
-    jump L1
+    jump L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var log
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_frames/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_frames/bytecode.snap
@@ -32,8 +32,6 @@ function dispatch_frames.<(user.dispatch_frames.Box<#0> as user.dispatch_frames.
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -42,8 +40,6 @@ function dispatch_frames.Conv.describe(self: dispatch_frames.Conv<#1>) -> string
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -57,8 +53,6 @@ function dispatch_frames.call_adopted_default() -> string {
     load_type dispatch_frames.Greeter
     load_const "greet"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -67,8 +61,6 @@ function dispatch_frames.call_generic_interface_default() -> string {
     load_type dispatch_frames.Conv<int>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -79,7 +71,5 @@ function dispatch_frames.call_generic_override() -> string {
     load_type dispatch_frames.Tagged
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_matrix/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_matrix/bytecode.snap
@@ -115,8 +115,6 @@ function dispatch_matrix.<(user.dispatch_matrix.Card as user.dispatch_matrix.For
     load_var self
     load_field .formatter
     call_indirect
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -137,8 +135,6 @@ function dispatch_matrix.<(user.dispatch_matrix.Pack<#0> as user.dispatch_matrix
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -153,8 +149,6 @@ function dispatch_matrix.<(user.dispatch_matrix.Wrapping as user.dispatch_matrix
     load_type dispatch_matrix.Wrapping
     load_var self
     call user.dispatch_matrix.Speaker.speak
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -171,8 +165,6 @@ function dispatch_matrix.Formatting.present(self: dispatch_matrix.Formatting) ->
     load_type dispatch_matrix.Formatting
     load_const "formatter"
     virtual_call nargs=2 ntypeargs=0
-    store_var _2
-    load_var _2
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_matrix/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_dispatch_matrix/bytecode.snap
@@ -110,12 +110,12 @@ function dispatch_matrix.<(int as user.dispatch_matrix.Speaker)>.speak(self: int
 }
 
 function dispatch_matrix.<(user.dispatch_matrix.Card as user.dispatch_matrix.Formatting)>.present(self: dispatch_matrix.Card) -> string {
+    load_const "card "
     load_const 7
     load_var self
     load_field .formatter
     call_indirect
     store_var _2
-    load_const "card "
     load_var _2
     bin_op +
     return
@@ -132,12 +132,12 @@ function dispatch_matrix.<(user.dispatch_matrix.Loud as user.dispatch_matrix.Spe
 }
 
 function dispatch_matrix.<(user.dispatch_matrix.Pack<#0> as user.dispatch_matrix.Speaker)>.speak(self: dispatch_matrix.Pack<#0>) -> string {
+    load_const "pack of "
     load_type #0
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
-    load_const "pack of "
     load_var _2
     bin_op +
     return
@@ -149,11 +149,11 @@ function dispatch_matrix.<(user.dispatch_matrix.Tally as user.dispatch_matrix.Co
 }
 
 function dispatch_matrix.<(user.dispatch_matrix.Wrapping as user.dispatch_matrix.Speaker)>.speak(self: dispatch_matrix.Wrapping) -> string {
+    load_const "wrapped "
     load_type dispatch_matrix.Wrapping
     load_var self
     call user.dispatch_matrix.Speaker.speak
     store_var _2
-    load_const "wrapped "
     load_var _2
     bin_op +
     return
@@ -165,13 +165,13 @@ function dispatch_matrix.Counter.start() -> int {
 }
 
 function dispatch_matrix.Formatting.present(self: dispatch_matrix.Formatting) -> string {
+    load_const "presented "
     load_var self
     load_const 1
     load_type dispatch_matrix.Formatting
     load_const "formatter"
     virtual_call nargs=2 ntypeargs=0
     store_var _2
-    load_const "presented "
     load_var _2
     bin_op +
     return
@@ -184,17 +184,14 @@ function dispatch_matrix.Speaker.speak(self: dispatch_matrix.Speaker) -> string 
 
 function dispatch_matrix.pick_speaker(loud: bool) -> dispatch_matrix.Loud | dispatch_matrix.Quiet {
     load_var loud
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    alloc_instance user.dispatch_matrix.Quiet
     jump L1
 
   L0:
-    alloc_instance user.dispatch_matrix.Quiet
-    jump L2
-
-  L1:
     alloc_instance user.dispatch_matrix.Loud
 
-  L2:
+  L1:
     return
 }
 
@@ -230,8 +227,6 @@ function dispatch_matrix.row12_interface_qualified() -> string {
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -240,8 +235,6 @@ function dispatch_matrix.row12_interface_qualified_dynamic(s: dispatch_matrix.Sp
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -258,8 +251,6 @@ function dispatch_matrix.row14_default_field_call() -> string {
     load_type dispatch_matrix.Formatting
     load_const "present"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -268,8 +259,6 @@ function dispatch_matrix.row1_static_provided() -> string {
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -280,8 +269,6 @@ function dispatch_matrix.row2_static_generic_bindings() -> string {
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -290,8 +277,6 @@ function dispatch_matrix.row3_static_adopted_default() -> string {
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -300,8 +285,6 @@ function dispatch_matrix.row4_static_primitive_target() -> string {
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -371,8 +354,6 @@ function dispatch_matrix.row8_default_bypass() -> string {
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -402,7 +383,5 @@ function dispatch_matrix.through_interface(s: dispatch_matrix.Speaker) -> string
     load_type dispatch_matrix.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
@@ -184,12 +184,10 @@ function env_ref_clients.EnvRefDynamicEcho(question: string, client: ai.Client |
     call user.env_ref_clients.EnvRefDynamicEcho@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -236,21 +234,16 @@ function env_ref_clients.EnvRefDynamicEcho@spec(question: string) -> ai.Function
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "BAML_TEST_ENV_REF_UNSET_CLIENT"
     call baml.env.ref
     call baml.env.Ref.get
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "openai/gpt-4o-mini"
-    store_var _8
 
   L0:
-    load_var _8
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "EnvRefDynamicEcho"
     load_deref ?1
     load_const "question"
@@ -322,12 +315,10 @@ function env_ref_clients.EnvRefEcho(question: string, client: ai.Client | null, 
     call user.env_ref_clients.EnvRefEcho@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -374,7 +365,7 @@ function env_ref_clients.EnvRefEcho@spec(question: string) -> ai.FunctionSpec<st
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4o-mini"
     load_const <omitted>
     load_const <omitted>
@@ -393,7 +384,7 @@ function env_ref_clients.EnvRefEcho@spec(question: string) -> ai.FunctionSpec<st
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _6
+    store_var _7
     load_const "EnvRefEcho"
     load_deref ?1
     load_const "question"
@@ -465,12 +456,10 @@ function env_ref_clients.EnvRefResolvedEcho(question: string, client: ai.Client 
     call user.env_ref_clients.EnvRefResolvedEcho@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -517,11 +506,11 @@ function env_ref_clients.EnvRefResolvedEcho@spec(question: string) -> ai.Functio
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "openai/gpt-4o-mini"
     call ai.clients.resolve
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "EnvRefResolvedEcho"
     load_deref ?1
     load_const "question"
@@ -593,12 +582,10 @@ function env_ref_clients.LiveEnvRefEcho(question: string, client: ai.Client | nu
     call user.env_ref_clients.LiveEnvRefEcho@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -645,10 +632,10 @@ function env_ref_clients.LiveEnvRefEcho@spec(question: string) -> ai.FunctionSpe
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.env_ref_clients.LiveEnvRefOpenAi
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "LiveEnvRefEcho"
     load_deref ?1
     load_const "question"
@@ -720,12 +707,10 @@ function env_ref_clients.LiveEnvRefFallbackEcho(question: string, client: ai.Cli
     call user.env_ref_clients.LiveEnvRefFallbackEcho@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -772,21 +757,16 @@ function env_ref_clients.LiveEnvRefFallbackEcho@spec(question: string) -> ai.Fun
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "BAML_TEST_CLIENT_UNSET"
     call baml.env.ref
     call baml.env.Ref.get
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "openai/gpt-4o-mini"
-    store_var _8
 
   L0:
-    load_var _8
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "LiveEnvRefFallbackEcho"
     load_deref ?1
     load_const "question"
@@ -833,14 +813,18 @@ function env_ref_clients.blank_credential_is_unconfigured() -> string {
     load_const ""
     load_const null
     call ai.wire.resolve_credential
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _5
+    jump L2
+
+  L1:
     load_const "<null>"
     store_var _5
 
-  L0:
+  L2:
     load_type string
     load_var _5
     call baml.String.from
@@ -848,43 +832,51 @@ function env_ref_clients.blank_credential_is_unconfigured() -> string {
     load_const "  \t "
     load_const null
     call ai.wire.resolve_credential
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
-    load_const "<null>"
-    store_var _12
+    jump_if_not_null_or_pop L3
+    jump L4
 
-  L1:
+  L3:
+    store_var _11
+    jump L5
+
+  L4:
+    load_const "<null>"
+    store_var _11
+
+  L5:
     load_type string
-    load_var _12
+    load_var _11
     call baml.String.from
-    store_var _10
+    store_var _9
     load_const "BAML_TEST_ENV_REF_UNSET"
     call baml.env.ref
     load_const null
     call ai.wire.resolve_credential
-    store_var_load_var _19
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
-    load_const "<null>"
-    store_var _19
+    jump_if_not_null_or_pop L6
+    jump L7
 
-  L2:
-    load_type string
-    load_var _19
-    call baml.String.from
+  L6:
     store_var _17
+    jump L8
+
+  L7:
+    load_const "<null>"
+    store_var _17
+
+  L8:
+    load_type string
+    load_var _17
+    call baml.String.from
+    store_var _15
     load_type string
     load_const "literal="
     load_var _3
     bin_op +
     load_const "spaces="
-    load_var _10
+    load_var _9
     bin_op +
     load_const "ref="
-    load_var _17
+    load_var _15
     bin_op +
     load_type string
     alloc_array 3
@@ -920,10 +912,10 @@ function env_ref_clients.credential_sources_names_every_variable() -> string {
 function env_ref_clients.dynamic_client_selector_runs_against_the_mock() -> string {
     load_const "{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}"
     call user.llm_mock.MockResponse.ok
-    store_var _3
+    store_var _2
     load_type string
     load_type baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    load_var _3
+    load_var _2
     load_type llm_mock.MockResponse
     alloc_array 1
     make_closure .<lambda(dynamic_client_selector_runs_against_the_mock, 0)>, 0
@@ -935,10 +927,10 @@ function env_ref_clients.dynamic_client_selector_runs_against_the_mock() -> stri
 function env_ref_clients.env_ref_api_key_reaches_the_wire() -> string {
     load_const "{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}"
     call user.llm_mock.MockResponse.ok
-    store_var _3
+    store_var _2
     load_type string
     load_type baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    load_var _3
+    load_var _2
     load_type llm_mock.MockResponse
     alloc_array 1
     make_closure .<lambda(env_ref_api_key_reaches_the_wire, 0)>, 0
@@ -950,10 +942,10 @@ function env_ref_clients.env_ref_api_key_reaches_the_wire() -> string {
 function env_ref_clients.env_ref_base_url_resolves_at_request_time() -> string {
     load_const "{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}"
     call user.llm_mock.MockResponse.ok
-    store_var _3
+    store_var _2
     load_type string
     load_type baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    load_var _3
+    load_var _2
     load_type llm_mock.MockResponse
     alloc_array 1
     make_closure .<lambda(env_ref_base_url_resolves_at_request_time, 0)>, 0
@@ -973,11 +965,8 @@ function env_ref_clients.env_ref_is_pure_data() -> string {
     store_var _5
     load_var r
     call baml.env.Ref.get
-    store_var _10
     load_const "HOME"
     sys_op baml.env.get
-    store_var _11
-    load_var2 5 6
     call baml.ops.equals_equals
     store_var _9
     load_type bool
@@ -1007,11 +996,9 @@ function env_ref_clients.env_ref_is_pure_data() -> string {
 }
 
 function env_ref_clients.env_ref_keeps_the_secret_out_of_the_client() -> string {
+    load_const "gpt-4o-mini"
     load_const "HOME"
     call baml.env.ref
-    store_var _2
-    load_const "gpt-4o-mini"
-    load_var _2
     load_const <omitted>
     load_const <omitted>
     load_const <omitted>
@@ -1069,6 +1056,7 @@ function env_ref_clients.env_ref_secret_visibility() -> string {
     load_const "HOME"
     call baml.String.includes
     store_var _5
+    load_const "name="
     load_type bool
     load_var _5
     call baml.String.from
@@ -1083,7 +1071,6 @@ function env_ref_clients.env_ref_secret_visibility() -> string {
     load_var _8
     call baml.String.from
     store_var _7
-    load_const "name="
     load_var _4
     bin_op +
     load_const "|value="
@@ -1137,11 +1124,9 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     call openai.ResponsesClient.new
     call openai.ResponsesClient.resolved_api_key
     store_var _2
+    load_const "m"
     load_const "HOME"
     call baml.env.ref
-    store_var _8
-    load_const "m"
-    load_var _8
     load_const <omitted>
     load_const <omitted>
     load_const <omitted>
@@ -1157,15 +1142,10 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call openai.ChatClient.new
     call openai.ChatClient.resolved_api_key
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "<null>"
-    store_var _5
 
   L0:
-    load_var _5
     store_var _4
     load_const "m"
     load_const "sk-explicit"
@@ -1186,7 +1166,7 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call openai.ImageClient.new
     call openai.ImageClient.resolved_api_key
-    store_var _10
+    store_var _9
     load_const "m"
     load_const <omitted>
     load_const <omitted>
@@ -1205,16 +1185,11 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call openai.AzureClient.new
     call openai.AzureClient.resolved_api_key
-    store_var_load_var _13
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L1
     load_const "<null>"
-    store_var _13
 
   L1:
-    load_var _13
-    store_var _12
+    store_var _11
     load_const "m"
     load_const "sk-explicit"
     load_const <omitted>
@@ -1229,16 +1204,11 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call openai.OpenRouterClient.new
     call openai.OpenRouterClient.resolved_api_key
-    store_var_load_var _18
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L2
     load_const "<null>"
-    store_var _18
 
   L2:
-    load_var _18
-    store_var _17
+    store_var _15
     load_const "m"
     load_const <omitted>
     load_const "sk-explicit"
@@ -1253,16 +1223,11 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call openai.OllamaClient.new
     call openai.OllamaClient.resolved_api_key
-    store_var_load_var _23
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L3
     load_const "<null>"
-    store_var _23
 
   L3:
-    load_var _23
-    store_var _22
+    store_var _19
     load_const "m"
     load_const <omitted>
     load_const "sk-explicit"
@@ -1279,16 +1244,11 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call openai.GenericClient.new
     call openai.GenericClient.resolved_api_key
-    store_var_load_var _28
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L4
     load_const "<null>"
-    store_var _28
 
   L4:
-    load_var _28
-    store_var _27
+    store_var _23
     load_const "m"
     load_const "sk-explicit"
     load_const <omitted>
@@ -1307,7 +1267,7 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call anthropic.Client.new
     call anthropic.Client.resolved_api_key
-    store_var _32
+    store_var _27
     load_const "m"
     load_const "sk-explicit"
     load_const <omitted>
@@ -1324,7 +1284,7 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call google.GeminiClient.new
     call google.GeminiClient.resolved_api_key
-    store_var _34
+    store_var _29
     load_const "m"
     load_const <omitted>
     load_const <omitted>
@@ -1347,16 +1307,11 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call google.VertexClient.new
     call google.VertexClient.resolved_api_key
-    store_var_load_var _37
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L5
+    jump_if_not_null_or_pop L5
     load_const "<null>"
-    store_var _37
 
   L5:
-    load_var _37
-    store_var _36
+    store_var _31
     load_const "m"
     load_const "sk-explicit"
     load_const <omitted>
@@ -1370,14 +1325,14 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
     load_const <omitted>
     call vercel.AiGatewayImageClient.new
     call vercel.AiGatewayImageClient.resolved_api_key
-    store_var _41
+    store_var _35
     load_type string
     load_var2 1 2
+    load_var2 3 4
     load_var2 5 6
-    load_var2 8 10
-    load_var2 12 14
-    load_var2 15 16
-    load_var _41
+    load_var2 7 8
+    load_var2 9 10
+    load_var _35
     load_type string
     alloc_array 11
     load_const "|"
@@ -1388,10 +1343,10 @@ function env_ref_clients.explicit_credential_wins_per_client_family() -> string 
 function env_ref_clients.explicit_resolve_selector_runs_against_the_mock() -> string {
     load_const "{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}"
     call user.llm_mock.MockResponse.ok
-    store_var _3
+    store_var _2
     load_type string
     load_type baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    load_var _3
+    load_var _2
     load_type llm_mock.MockResponse
     alloc_array 1
     make_closure .<lambda(explicit_resolve_selector_runs_against_the_mock, 0)>, 0
@@ -1429,10 +1384,10 @@ function env_ref_clients.live_env_ref_fallback_selection_answers() -> bool {
 function env_ref_clients.plain_string_api_key_still_works() -> string {
     load_const "{\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"pong\"}]}],\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}"
     call user.llm_mock.MockResponse.ok
-    store_var _3
+    store_var _2
     load_type string
     load_type baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    load_var _3
+    load_var _2
     load_type llm_mock.MockResponse
     alloc_array 1
     make_closure .<lambda(plain_string_api_key_still_works, 0)>, 0
@@ -1465,113 +1420,82 @@ function env_ref_clients.resolve_credential_arms() -> string {
     load_const "sk-literal"
     load_const "HOME"
     call ai.wire.resolve_credential
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "<null>"
-    store_var _3
 
   L0:
-    load_var _3
     store_var _2
     load_const "   "
     load_const "HOME"
     call ai.wire.resolve_credential
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L1
     load_const "<null>"
-    store_var _7
 
   L1:
-    load_var _7
-    store_var _6
+    store_var _5
     load_const "BAML_TEST_ENV_REF_UNSET"
     call baml.env.ref
     load_const "HOME"
     call ai.wire.resolve_credential
-    store_var_load_var _11
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L2
     load_const "<null>"
-    store_var _11
 
   L2:
-    load_var _11
-    store_var _10
+    store_var _8
     load_const "HOME"
     call baml.env.ref
     load_const null
     call ai.wire.resolve_credential
-    store_var_load_var _16
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L3
     load_const "<null>"
-    store_var _16
 
   L3:
-    load_var _16
-    store_var _15
+    store_var _12
     load_const "BAML_TEST_ENV_REF_UNSET"
     call baml.env.ref
     load_const null
     call ai.wire.resolve_credential
-    store_var_load_var _21
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L4
     load_const "<null>"
-    store_var _21
 
   L4:
-    load_var _21
-    store_var _20
+    store_var _16
     load_const null
     load_const "HOME"
     call ai.wire.resolve_credential
-    store_var_load_var _26
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L5
+    jump_if_not_null_or_pop L5
     load_const "<null>"
-    store_var _26
 
   L5:
-    load_var _26
-    store_var _25
+    store_var _20
     load_const null
     load_const null
     call ai.wire.resolve_credential
-    store_var_load_var _30
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
+    jump_if_not_null_or_pop L6
     load_const "<null>"
-    store_var _30
 
   L6:
-    load_var _30
-    store_var _29
+    store_var _23
     load_const null
     load_const "BAML_TEST_ENV_REF_UNSET"
     call ai.wire.resolve_credential
-    store_var_load_var _34
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
-    load_const "<null>"
-    store_var _34
+    jump_if_not_null_or_pop L7
+    jump L8
 
   L7:
+    store_var _27
+    jump L9
+
+  L8:
+    load_const "<null>"
+    store_var _27
+
+  L9:
     load_type string
-    load_var2 1 3
-    load_var2 5 7
-    load_var2 9 11
-    load_var2 13 15
+    load_var2 1 2
+    load_var2 3 4
+    load_var2 5 6
+    load_var2 7 8
     load_type string
     alloc_array 8
     load_const "|"
@@ -1583,6 +1507,7 @@ function env_ref_clients.resolve_credential_arms_expected() -> string {
     load_const "HOME"
     call baml.env.get_or_panic
     store_var home
+    load_const "sk-literal|"
     load_type string
     load_var home
     call baml.String.from
@@ -1599,7 +1524,6 @@ function env_ref_clients.resolve_credential_arms_expected() -> string {
     load_var home
     call baml.String.from
     store_var _18
-    load_const "sk-literal|"
     load_var _9
     bin_op +
     load_const "|"
@@ -1680,21 +1604,18 @@ function env_ref_clients.resolve_of_a_ref_reads_at_call_time() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type ai.errors.InvalidRequest
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .detail
 
-  L2:
+  L1:
     return
 }
 
@@ -1739,34 +1660,29 @@ function env_ref_clients.resolve_unknown_prefix_is_typed() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type ai.errors.InvalidRequest
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_type string
     load_var e
     load_field .provider
     call baml.String.from
-    store_var _5
     load_type string
     load_var e
     load_field .detail
     call baml.String.from
     store_var _8
-    load_var _5
     load_const "|"
     bin_op +
     load_var _8
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -1776,21 +1692,18 @@ function env_ref_clients.resolve_without_a_slash_is_typed() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type ai.errors.InvalidRequest
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .detail
 
-  L2:
+  L1:
     return
 }
 
@@ -1811,30 +1724,25 @@ function env_ref_clients.unset_base_url_is_the_same_configuration_error() -> str
     load_const <omitted>
     call openai.GenericClient.new
     call openai.GenericClient.resolved_base_url
-    jump L2
+    jump L1
     load_var e
     is_type ai.errors.InvalidRequest
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .detail
 
-  L2:
+  L1:
     return
 }
 
 function env_ref_clients.unset_ref_base_url_is_a_configuration_error() -> string {
+    load_const "m"
     load_const "BAML_TEST_ENV_REF_UNSET_BASE_URL"
     call baml.env.ref
-    store_var _2
-    load_const "m"
-    load_var _2
     load_const <omitted>
     load_const <omitted>
     load_const <omitted>
@@ -1849,20 +1757,17 @@ function env_ref_clients.unset_ref_base_url_is_a_configuration_error() -> string
     load_const <omitted>
     call openai.GenericClient.new
     call openai.GenericClient.resolved_base_url
-    jump L2
+    jump L1
     load_var e
     is_type ai.errors.InvalidRequest
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .detail
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
@@ -1060,18 +1060,16 @@ function env_ref_clients.env_ref_secret_visibility() -> string {
     load_type bool
     load_var _5
     call baml.String.from
-    store_var _4
     load_const "HOME"
     call baml.env.get_or_panic
     store_var _9
-    load_var2 1 6
+    load_var2 1 5
     call baml.String.includes
     store_var _8
     load_type bool
     load_var _8
     call baml.String.from
     store_var _7
-    load_var _4
     bin_op +
     load_const "|value="
     bin_op +
@@ -1511,7 +1509,6 @@ function env_ref_clients.resolve_credential_arms_expected() -> string {
     load_type string
     load_var home
     call baml.String.from
-    store_var _9
     load_type string
     load_var home
     call baml.String.from
@@ -1524,7 +1521,6 @@ function env_ref_clients.resolve_credential_arms_expected() -> string {
     load_var home
     call baml.String.from
     store_var _18
-    load_var _9
     bin_op +
     load_const "|"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_desugar/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_desugar/bytecode.snap
@@ -104,12 +104,10 @@ function env_ref_desugar.EnvRefBadClientFn(client: ai.Client | null, on_event: (
     call user.env_ref_desugar.EnvRefBadClientFn@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -196,24 +194,21 @@ function env_ref_desugar.EnvRefBadClientFn@stream(client: ai.stream.StreamingCli
 function env_ref_desugar.EnvRefBadClientThrowsAtCallTime() -> string {
     call user.env_ref_desugar.EnvRefBadClientFn@spec
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type ai.errors.InvalidRequest
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "threw-at-call-time"
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "resolved-unexpectedly"
 
-  L3:
+  L2:
     return
 }
 
@@ -227,8 +222,6 @@ function env_ref_desugar.EnvRefClientId() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -260,12 +253,10 @@ function env_ref_desugar.EnvRefDesugarFn(client: ai.Client | null, on_event: ((a
     call user.env_ref_desugar.EnvRefDesugarFn@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -355,8 +346,6 @@ function env_ref_desugar.EnvRefDesugarFnClientId() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -388,12 +377,10 @@ function env_ref_desugar.EnvRefDynClientFn(client: ai.Client | null, on_event: (
     call user.env_ref_desugar.EnvRefDynClientFn@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -483,8 +470,6 @@ function env_ref_desugar.EnvRefDynClientId() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -505,15 +490,10 @@ function env_ref_desugar.EnvRefGetChain() -> string {
     load_const "BAML_TEST_ENV_REF_UNSET"
     call baml.env.ref
     call baml.env.Ref.get
-    store_var_load_var _1
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "chained-fallback"
-    store_var _1
 
   L0:
-    load_var _1
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
@@ -430,15 +430,21 @@ function errorcontext.ec_hazard_b_main() -> string {
     jump L2
     load_var e
     throw_if_panic
+    load_const 3
+    load_const 3
+    mul_int
+    load_const 3
+    add_int
+    pop 1
     call user.errorcontext.ec_hazard_b_fail_inner
     jump L2
     load_var e2
     throw_if_panic
-    load_var _10
+    load_var _11
     call baml.errors.Context.root_cause
     load_field .error
-    store_var _13
-    load_var _13
+    store_var _14
+    load_var _14
     narrow_bind string, slot=5
     pop_jump_if_false L0
     jump L1
@@ -448,7 +454,7 @@ function errorcontext.ec_hazard_b_main() -> string {
     jump L2
 
   L1:
-    load_var _13
+    load_var _14
 
   L2:
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
@@ -97,7 +97,7 @@ function errorcontext.ec_deferbody_fail_low() -> string {
 
 function errorcontext.ec_deferbody_main() -> string {
     call user.errorcontext.ec_deferbody_mid
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var _2
@@ -106,17 +106,14 @@ function errorcontext.ec_deferbody_main() -> string {
     store_var _5
     load_var _5
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "LOST: cause chain wiped by the defer re-raise"
     jump L1
 
   L0:
-    load_const "LOST: cause chain wiped by the defer re-raise"
-    jump L2
-
-  L1:
     load_var _5
 
-  L2:
+  L1:
     return
 }
 
@@ -150,101 +147,63 @@ function errorcontext.ec_deferthrow_check() -> bool {
     load_var rendered
     load_const "origin"
     call baml.String.index_of
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const -1
-    store_var _3
 
   L0:
-    load_var _3
     store_var origin_at
     load_var rendered
     load_const "wrap"
     call baml.String.index_of
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L1
     load_const -1
-    store_var _7
 
   L1:
-    load_var _7
     store_var wrap_at
     load_var rendered
     load_const "cleanup"
     call baml.String.index_of
-    store_var_load_var _11
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L2
     load_const -1
-    store_var _11
 
   L2:
-    load_var _11
     store_var cleanup_at
     load_var origin_at
     load_const 0
     cmp_int_op >=
-    jump_if_false L3
-    pop 1
+    jump_if_false_or_pop L3
     load_var wrap_at
+    load_const 0
+    cmp_int_op >=
+    jump_if_false_or_pop L3
+    load_var cleanup_at
     load_const 0
     cmp_int_op >=
 
   L3:
-    jump_if_false L4
-    pop 1
-    jump L5
+    store_var all_present
+    load_var2 2 3
+    cmp_int_op <
+    jump_if_false_or_pop L4
+    load_var2 3 4
+    cmp_int_op <
 
   L4:
-    store_var all_present
-    jump L6
-
-  L5:
-    load_var cleanup_at
-    load_const 0
-    cmp_int_op >=
-    store_var all_present
-
-  L6:
-    load_var2 2 4
-    cmp_int_op <
-    jump_if_false L7
-    pop 1
-    jump L8
-
-  L7:
     store_var ordered
-    jump L9
-
-  L8:
-    load_var2 4 6
-    cmp_int_op <
-    store_var ordered
-
-  L9:
     load_var rendered
     load_const "During handling of the above error, another error occurred"
     call baml.String.split
     container_len
     store_var pieces
     load_var all_present
-    jump_if_false L10
-    pop 1
+    jump_if_false_or_pop L5
     load_var ordered
-
-  L10:
-    jump_if_false L11
-    pop 1
+    jump_if_false_or_pop L5
     load_var pieces
     load_const 3
     cmp_int_op ==
 
-  L11:
+  L5:
     return
 }
 
@@ -290,7 +249,7 @@ function errorcontext.ec_deferunwind_fail_low() -> string {
 
 function errorcontext.ec_deferunwind_main() -> string {
     call user.errorcontext.ec_deferunwind_mid
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var _2
@@ -299,17 +258,14 @@ function errorcontext.ec_deferunwind_main() -> string {
     store_var _5
     load_var _5
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "LOST: cause chain wiped by the defer re-raise"
     jump L1
 
   L0:
-    load_const "LOST: cause chain wiped by the defer re-raise"
-    jump L2
-
-  L1:
     load_var _5
 
-  L2:
+  L1:
     return
 }
 
@@ -348,24 +304,21 @@ function errorcontext.ec_gap_main() -> string {
 
   L0:
     call user.errorcontext.ec_gap_fail_c
-    jump L3
+    jump L2
     load_var e2
     throw_if_panic
     load_var _7
     load_field .cause
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_const "MISCHAINED: gap over-covered"
     jump L2
 
   L1:
-    load_const "MISCHAINED: gap over-covered"
-    jump L3
-
-  L2:
     load_var recovered
 
-  L3:
+  L2:
     return
     load_var _4
     rethrow
@@ -383,11 +336,11 @@ function errorcontext.ec_hazard_a_fail_outer() -> string {
 
 function errorcontext.ec_hazard_a_main() -> string {
     call user.errorcontext.ec_hazard_a_fail_outer
-    jump L3
+    jump L2
     load_var e
     throw_if_panic
     call user.errorcontext.ec_hazard_a_fail_inner
-    jump L3
+    jump L2
     load_var e2
     throw_if_panic
     load_var _6
@@ -401,17 +354,14 @@ function errorcontext.ec_hazard_a_main() -> string {
     store_var _9
     load_var _9
     narrow_bind string, slot=7
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_const "MISSED: enclosing handled error not found in chain"
     jump L2
 
   L1:
-    load_const "MISSED: enclosing handled error not found in chain"
-    jump L3
-
-  L2:
     load_var _9
 
-  L3:
+  L2:
     return
 }
 
@@ -427,36 +377,27 @@ function errorcontext.ec_hazard_b_fail_outer() -> string {
 
 function errorcontext.ec_hazard_b_main() -> string {
     call user.errorcontext.ec_hazard_b_fail_outer
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
-    load_const 3
-    load_const 3
-    mul_int
-    load_const 3
-    add_int
-    pop 1
     call user.errorcontext.ec_hazard_b_fail_inner
-    jump L2
+    jump L1
     load_var e2
     throw_if_panic
-    load_var _11
+    load_var _4
     call baml.errors.Context.root_cause
     load_field .error
-    store_var _14
-    load_var _14
+    store_var _7
+    load_var _7
     narrow_bind string, slot=5
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "GARBAGE: outer context slot was recolored before the inner throw"
     jump L1
 
   L0:
-    load_const "GARBAGE: outer context slot was recolored before the inner throw"
-    jump L2
+    load_var _7
 
   L1:
-    load_var _14
-
-  L2:
     return
 }
 
@@ -472,11 +413,11 @@ function errorcontext.ec_nested_fail_b() -> string {
 
 function errorcontext.ec_nested_main() -> string {
     call user.errorcontext.ec_nested_fail_a
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     call user.errorcontext.ec_nested_fail_b
-    jump L2
+    jump L1
     load_var e2
     throw_if_panic
     load_var _4
@@ -485,17 +426,14 @@ function errorcontext.ec_nested_main() -> string {
     store_var _7
     load_var _7
     narrow_bind string, slot=5
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no cause found"
     jump L1
 
   L0:
-    load_const "no cause found"
-    jump L2
-
-  L1:
     load_var _7
 
-  L2:
+  L1:
     return
 }
 
@@ -506,20 +444,17 @@ function errorcontext.ec_rethrow_fail_b() -> string {
 
 function errorcontext.ec_rethrow_main() -> string {
     call user.errorcontext.ec_rethrow_fail_b
-    jump L2
+    jump L1
     load_var inner
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var inner
     rethrow
 
-  L1:
+  L0:
     load_const "unreachable"
 
-  L2:
+  L1:
     return
     load_var e2
     throw_if_panic
@@ -527,21 +462,18 @@ function errorcontext.ec_rethrow_main() -> string {
     load_field .cause
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_const "MISCHAINED: rethrow self-linked"
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_const "no cause"
-    jump L2
+    jump L1
 }
 
 function errorcontext.ec_sibling_main() -> string {
     call user.errorcontext.ec_sibling_scope
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var _2
@@ -550,17 +482,14 @@ function errorcontext.ec_sibling_main() -> string {
     store_var _5
     load_var _5
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no root cause found"
     jump L1
 
   L0:
-    load_const "no root cause found"
-    jump L2
-
-  L1:
     load_var _5
 
-  L2:
+  L1:
     return
 }
 
@@ -582,7 +511,7 @@ function errorcontext.ec_single_boom() -> string {
 
 function errorcontext.ec_single_main() -> string {
     call user.errorcontext.ec_single_boom
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var _2
@@ -591,17 +520,14 @@ function errorcontext.ec_single_main() -> string {
     store_var _5
     load_var _5
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "unexpected non-string error"
     jump L1
 
   L0:
-    load_const "unexpected non-string error"
-    jump L2
-
-  L1:
     load_var _5
 
-  L2:
+  L1:
     return
 }
 
@@ -612,7 +538,7 @@ function errorcontext.ec_stackdefers_fail_low() -> string {
 
 function errorcontext.ec_stackdefers_main() -> string {
     call user.errorcontext.ec_stackdefers_mid
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var _2
@@ -621,17 +547,14 @@ function errorcontext.ec_stackdefers_main() -> string {
     store_var _5
     load_var _5
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "LOST: cause chain wiped by a stacked defer re-raise"
     jump L1
 
   L0:
-    load_const "LOST: cause chain wiped by a stacked defer re-raise"
-    jump L2
-
-  L1:
     load_var _5
 
-  L2:
+  L1:
     return
 }
 
@@ -665,16 +588,12 @@ function errorcontext.ec_tostring_check() -> bool {
     call baml.String.includes
     store_var has_wrap
     load_var has_sep
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var has_origin
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var has_wrap
 
-  L1:
+  L0:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_exceptions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_exceptions/bytecode.snap
@@ -3758,19 +3758,33 @@ function exceptions.s8_risky_6(mode: int) -> int {
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
-    jump L2
+    jump L4
 
   L0:
     load_var mode
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L1
+    jump L2
 
   L1:
+    load_const null
+    store_var _4
+    jump L3
+
+  L2:
+    load_const 1
+    load_const 0
+    div_int
+    store_var _4
+    load_var _4
+    pop 1
+
+  L3:
     load_const "fallback"
     throw
 
-  L2:
+  L4:
     load_const 500
     init_instance user.exceptions.AppError .code
     throw
@@ -3816,19 +3830,33 @@ function exceptions.s9_risky_10(mode: int) -> int {
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
-    jump L2
+    jump L4
 
   L0:
     load_var mode
     load_const 1
     cmp_int_op ==
     pop_jump_if_false L1
+    jump L2
 
   L1:
+    load_const null
+    store_var _4
+    jump L3
+
+  L2:
+    load_const 1
+    load_const 0
+    div_int
+    store_var _4
+    load_var _4
+    pop 1
+
+  L3:
     load_const "fallback"
     throw
 
-  L2:
+  L4:
     load_const 7
     init_instance user.exceptions.AppError .code
     throw
@@ -4022,8 +4050,22 @@ function exceptions.s9c_risky_21(mode: int) -> int {
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
+    jump L1
 
   L0:
+    load_const null
+    store_var _2
+    jump L2
+
+  L1:
+    load_const 1
+    load_const 0
+    div_int
+    store_var _2
+    load_var _2
+    pop 1
+
+  L2:
     load_const "fallback"
     throw
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_exceptions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_exceptions/bytecode.snap
@@ -737,194 +737,158 @@ function exceptions.$init_test_ns_exceptions_exceptions(registry: testing.TestCo
 function exceptions.bare_class_dispatch_first_fn() -> int {
     load_const 0
     call user.exceptions.s3b_fails_19
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.ParseError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.bare_class_dispatch_second_fn() -> int {
     load_const 1
     call user.exceptions.s3b_fails_19
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.ParseError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.bare_class_plus_wildcard_fn() -> int {
     load_const 0
     call user.exceptions.s3b_fails_21
-    jump L2
+    jump L1
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.bare_class_plus_wildcard_wildcard_fires_fn() -> int {
     load_const 1
     call user.exceptions.s3b_fails_21
-    jump L2
+    jump L1
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.bare_class_single_arm_fn() -> int {
     call user.exceptions.s3b_fails_18
-    jump L2
+    jump L1
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_division_by_zero_fn() -> int {
     call user.exceptions.s5_divides_1
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_four_literal_arms_fn() -> int {
     load_const 1
     call user.exceptions.s15_fails_lits
-    jump L8
+    jump L4
     load_var e
     is_type "boom"
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var e
     is_type "bang"
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var e
     is_type "crash"
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     is_type "other"
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 0
-    jump L8
+    jump L4
 
-  L4:
+  L0:
     load_const 40
-    jump L8
+    jump L4
 
-  L5:
+  L1:
     load_const 30
-    jump L8
+    jump L4
 
-  L6:
+  L2:
     load_const 20
-    jump L8
+    jump L4
 
-  L7:
+  L3:
     load_const 10
 
-  L8:
+  L4:
     return
 }
 
@@ -1094,100 +1058,85 @@ function exceptions.catch_four_user_classes_instanceof_chain_fn() -> int {
 
 function exceptions.catch_index_out_of_bounds_fn() -> int {
     call user.exceptions.s5_oob_1
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_integer_overflow_add_fn() -> int {
     call baml.Int.max_value
     call user.exceptions.s5_add_overflow
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_integer_overflow_mul_fn() -> int {
     call baml.Int.max_value
     call user.exceptions.s5_mul_overflow
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_integer_overflow_neg_fn() -> int {
     call baml.Int.min_value
     call user.exceptions.s5_neg_overflow
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_integer_overflow_sub_fn() -> int {
     call baml.Int.min_value
     call user.exceptions.s5_sub_overflow
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -1238,205 +1187,169 @@ function exceptions.catch_literal_int_match_fn() -> int {
 
 function exceptions.catch_literal_string_match_fn() -> int {
     call user.exceptions.s1_fails_1
-    jump L2
+    jump L1
     load_var e
     is_type "boom"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_literal_string_no_match_falls_to_wildcard_fn() -> int {
     call user.exceptions.s1_fails_2
-    jump L2
+    jump L1
     load_var e
     is_type "boom"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_map_key_not_found_fn() -> int {
     call user.exceptions.s5_bad_1
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.MapKeyNotFound
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_mixed_literal_and_typed_no_switch_fn() -> int {
     load_const 0
     call user.exceptions.s16_fails_lit_typed
-    jump L4
+    jump L2
     load_var e
     is_type "boom"
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.AppError2
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 3
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.catch_mixed_named_and_anonymous_bindings_fn() -> string {
     call user.exceptions.s15_fails_mixed
-    jump L8
+    jump L4
     load_var e
     store_var _2
     load_var _2
     narrow_bind exceptions.NetErr, slot=2
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var e
     store_var _3
     load_var _3
     narrow_bind exceptions.AuthErr, slot=3
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var e
     store_var _4
     load_var _4
     narrow_bind exceptions.NotFoundErr, slot=4
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.RateLimitErr
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const "unknown"
-    jump L8
+    jump L4
 
-  L4:
+  L0:
     load_const "rate limited"
-    jump L8
+    jump L4
 
-  L5:
+  L1:
     load_var _4
     load_field .path
-    jump L8
+    jump L4
 
-  L6:
+  L2:
     load_var _3
     load_field .reason
-    jump L8
+    jump L4
 
-  L7:
+  L3:
     load_var _2
     load_field .url
 
-  L8:
+  L4:
     return
 }
 
 function exceptions.catch_multiple_literals_dispatch_fn() -> int {
     load_const 1
     call user.exceptions.s1_fails_4
-    jump L4
+    jump L2
     load_var e
     is_type "alpha"
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type "beta"
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 3
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.catch_negative_index_as_index_out_of_bounds_fn() -> int {
     call user.exceptions.s5_bad_2
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -1444,910 +1357,736 @@ function exceptions.catch_negative_shift_fn() -> int {
     load_const 1
     load_const -1
     call user.exceptions.s5_shl
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.NegativeBitShift
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_three_type_arms_bool_throw_fn() -> int {
     call user.exceptions.s15_fails_opt_3
-    jump L6
+    jump L3
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type bool
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 0
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.catch_three_user_classes_plus_wildcard_fn() -> int {
     load_const 2
     call user.exceptions.s3_api_1
-    jump L6
+    jump L3
     load_var e
     is_type exceptions.AuthError
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type exceptions.NotFound
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.RateLimit
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 4
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.catch_two_typed_arms_sequential_chain_fn() -> int {
     load_const 1
     call user.exceptions.s16_fails_chain
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.NetworkError3
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.ParseError3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.catch_two_user_classes_dispatch_first_fn() -> int {
     load_const 0
     call user.exceptions.s3_fails_13
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.ParseError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.catch_two_user_classes_dispatch_second_fn() -> int {
     load_const 1
     call user.exceptions.s3_fails_13
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.ParseError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.catch_user_class_plus_wildcard_fn() -> int {
     load_const 1
     call user.exceptions.s3_fails_15
-    jump L2
+    jump L1
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_user_class_single_arm_fn() -> int {
     call user.exceptions.s3_fails_12
-    jump L2
+    jump L1
     load_var e
     is_type exceptions.NetworkError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.catch_without_stack_trace_still_works_fn() -> string {
     call user.exceptions.s17_inner_st
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.four_arms_division_by_zero_fires_fn() -> int {
     load_const 0
     call user.exceptions.s10_four_arms_risky
-    jump L6
+    jump L3
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 4
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.four_arms_index_out_of_bounds_fires_fn() -> int {
     load_const 1
     call user.exceptions.s10_four_arms_risky
-    jump L6
+    jump L3
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 4
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.four_arms_no_error_fn() -> int {
     load_const 4
     call user.exceptions.s10_four_arms_no_error_risky
-    jump L6
+    jump L3
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 4
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.four_arms_user_class_fires_fn() -> int {
     load_const 2
     call user.exceptions.s10_four_arms_risky
-    jump L6
+    jump L3
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 4
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.four_arms_wildcard_fires_fn() -> int {
     load_const 3
     call user.exceptions.s10_four_arms_risky
-    jump L6
+    jump L3
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 4
-    jump L6
+    jump L3
 
-  L3:
+  L0:
     load_const 3
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const 2
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const 1
 
-  L6:
+  L3:
     return
 }
 
 function exceptions.mixed_union_alias_plus_wildcard_error_fires_fn() -> int {
     load_const 0
     call user.exceptions.s9_risky_14
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.mixed_union_alias_plus_wildcard_handles_both_domains_fn() -> int {
     load_const 1
     call user.exceptions.s9_risky_13
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.mixed_union_arm_plus_wildcard_fallback_error_fires_fn() -> int {
     load_const 2
     call user.exceptions.s9_risky_10
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.mixed_union_arm_plus_wildcard_panic_fires_fn() -> int {
     load_const 1
     call user.exceptions.s9_risky_9
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.mixed_union_arm_plus_wildcard_user_error_fires_fn() -> int {
     load_const 0
     call user.exceptions.s9_risky_10
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.mixed_union_no_wildcard_error_fires_fn() -> int {
     load_const 0
     call user.exceptions.s9b_risky_15
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.mixed_union_no_wildcard_panic_fires_fn() -> int {
     load_const 1
     call user.exceptions.s9b_risky_15
-    jump L3
+    jump L1
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.named_binding_int_access_value_fn() -> int {
     load_const 1
     call user.exceptions.s2b_fails_11
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     store_var _3
     load_var _3
     narrow_bind int, slot=2
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_var _3
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const -1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.named_binding_string_access_value_fn() -> string {
     load_const 0
     call user.exceptions.s2b_fails_10
-    jump L4
+    jump L2
     load_var e
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const "was int"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _2
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.named_class_binding_access_field_fn() -> string {
     call user.exceptions.s3a_fails_16
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind exceptions.NetworkError, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _2
     load_field .url
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.named_class_binding_dispatch_access_fields_fn() -> string {
     load_const 1
     call user.exceptions.s3a_fails_17
-    jump L4
+    jump L2
     load_var e
     store_var _2
     load_var _2
     narrow_bind exceptions.NetworkError, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     store_var _3
     load_var _3
     narrow_bind exceptions.ParseError, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_var _3
     load_field .message
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _2
     load_field .url
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.named_panic_binding_division_by_zero_field_fn() -> int | bigint {
     call user.exceptions.s5b_divides_2
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind baml.panics.DivisionByZero, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _2
     load_field .dividend
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.named_panic_binding_index_out_of_bounds_fields_fn() -> int {
     call user.exceptions.s5b_oob_2
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind baml.panics.IndexOutOfBounds, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _2
     load_field .index
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.named_panic_binding_index_out_of_bounds_length_fn() -> int {
     call user.exceptions.s5b_oob_2
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind baml.panics.IndexOutOfBounds, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _2
     load_field .length
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.named_panic_binding_integer_overflow_message_fn() -> string {
     call baml.Int.max_value
     call user.exceptions.s5b_overflow_to_string
-    jump L2
+    jump L1
     load_var e
     store_var _3
     load_var _3
     narrow_bind baml.panics.IntegerOverflow, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _3
     load_field .message
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.named_panic_binding_map_key_not_found_field_fn() -> string {
     call user.exceptions.s5b_bad_3
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind baml.panics.MapKeyNotFound, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _2
     load_field .key
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.named_wrapper_value_catches_callback_throw_fn() -> string {
     load_const user.exceptions.s17_risky_cb
     call user.exceptions.s17_forward_cb
-    jump L2
+    jump L1
     load_var e
     is_type "boom"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const "other"
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "caught"
 
-  L2:
+  L1:
     return
 }
 
@@ -2415,150 +2154,123 @@ function exceptions.panic_alias_plus_wildcard_dispatch_fn() -> int {
 function exceptions.panic_arm_plus_wildcard_no_error_fn() -> int {
     load_const 5
     call user.exceptions.s7_risky_5
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const -2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.panic_arm_plus_wildcard_panic_fires_fn() -> int {
     load_const 0
     call user.exceptions.s7_risky_3
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.panic_arm_plus_wildcard_user_error_fires_fn() -> int {
     load_const 999
     call user.exceptions.s7_risky_3
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.panic_union_plus_wildcard_division_fires_fn() -> int {
     load_const 0
     call user.exceptions.s9c_risky_19
-    jump L3
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.panic_union_plus_wildcard_error_falls_to_wildcard_fn() -> int {
     load_const 1
     call user.exceptions.s9c_risky_21
-    jump L3
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function exceptions.panic_union_plus_wildcard_index_fires_fn() -> int {
     load_const 1
     call user.exceptions.s9c_risky_19
-    jump L3
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 99
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
@@ -2582,51 +2294,39 @@ function exceptions.s10_four_arms_no_error_risky(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var mode
     load_const 3
     cmp_int_op ==
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const 99
     jump L4
 
-  L3:
-    load_const 99
-    jump L8
-
-  L4:
+  L0:
     load_const "unknown"
     throw
 
-  L5:
+  L1:
     load_const 404
     init_instance user.exceptions.AppError .code
     throw
 
-  L6:
+  L2:
     call user.exceptions.s10_do_oob_1
-    jump L8
+    jump L4
 
-  L7:
+  L3:
     call user.exceptions.s10_do_div_4
 
-  L8:
+  L4:
     return
 }
 
@@ -2634,40 +2334,31 @@ function exceptions.s10_four_arms_risky(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const "unknown"
     throw
 
-  L3:
+  L0:
     load_const 404
     init_instance user.exceptions.AppError .code
     throw
 
-  L4:
+  L1:
     call user.exceptions.s10_do_oob_1
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     call user.exceptions.s10_do_div_4
 
-  L6:
+  L3:
     return
 }
 
@@ -2705,16 +2396,13 @@ function exceptions.s12_risky_22(x: int) -> int {
     load_var x
     load_const 100
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_var x
     div_int
     return
 
-  L1:
+  L0:
     load_const "too big"
     throw
 }
@@ -2760,21 +2448,14 @@ function exceptions.s13_middle_1() -> int {
 function exceptions.s13_middle_2() -> int {
     call user.exceptions.s13_divides_3
     store_var x
-    jump L2
+    jump L0
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
-    load_const -1
-    store_var x
-
-  L2:
+  L0:
     load_const "recovered but failing"
     throw
 }
@@ -2806,50 +2487,38 @@ function exceptions.s15_api_opt(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var mode
     load_const 3
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_const "unknown"
     throw
 
-  L4:
+  L0:
     load_const 5000
     init_instance user.exceptions.Timeout .ms
     throw
 
-  L5:
+  L1:
     load_const 30
     init_instance user.exceptions.RateLimit .retryAfter
     throw
 
-  L6:
+  L2:
     load_const "/users"
     init_instance user.exceptions.NotFound .path
     throw
 
-  L7:
+  L3:
     load_const "expired"
     init_instance user.exceptions.AuthError .reason
     throw
@@ -2859,36 +2528,27 @@ function exceptions.s15_fails_lits(x: int) -> int {
     load_var x
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var x
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const "other"
     throw
 
-  L3:
+  L0:
     load_const "crash"
     throw
 
-  L4:
+  L1:
     load_const "bang"
     throw
 
-  L5:
+  L2:
     load_const "boom"
     throw
 }
@@ -2925,15 +2585,12 @@ function exceptions.s16_fails_chain(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "bad"
     init_instance user.exceptions.ParseError3 .msg
     throw
 
-  L1:
+  L0:
     load_const "http://x"
     init_instance user.exceptions.NetworkError3 .url
     throw
@@ -2943,15 +2600,12 @@ function exceptions.s16_fails_lit_typed(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 404
     init_instance user.exceptions.AppError2 .code
     throw
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -2960,39 +2614,30 @@ function exceptions.s16_risky_jump(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const 4
     init_instance user.exceptions.ErrD .x
     throw
 
-  L3:
+  L0:
     load_const 3
     init_instance user.exceptions.ErrC .x
     throw
 
-  L4:
+  L1:
     load_const 2
     init_instance user.exceptions.ErrB .x
     throw
 
-  L5:
+  L2:
     load_const 1
     init_instance user.exceptions.ErrA .x
     throw
@@ -3002,50 +2647,38 @@ function exceptions.s16_risky_jump2(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var mode
     load_const 3
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_const "unknown"
     throw
 
-  L4:
+  L0:
     load_const 4
     init_instance user.exceptions.ErrD .x
     throw
 
-  L5:
+  L1:
     load_const 3
     init_instance user.exceptions.ErrC .x
     throw
 
-  L6:
+  L2:
     load_const 2
     init_instance user.exceptions.ErrB .x
     throw
 
-  L7:
+  L3:
     load_const 1
     init_instance user.exceptions.ErrA .x
     throw
@@ -3099,25 +2732,19 @@ function exceptions.s1_fails_4(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "gamma"
     throw
 
-  L2:
+  L0:
     load_const "beta"
     throw
 
-  L3:
+  L1:
     load_const "alpha"
     throw
 }
@@ -3129,14 +2756,11 @@ function exceptions.s20_defer_guard_throw_fn(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L4
     load_var n
     call user.exceptions.s20_may_throw
     store_var r
-    jump L1
+    jump L0
     load_type string
     load_var log
     load_const "deferred"
@@ -3148,36 +2772,33 @@ function exceptions.s20_defer_guard_throw_fn(n: int) -> string {
     throw_if_panic
     load_const "caught"
     store_var r
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_type string
     load_var log
     load_const "deferred"
     call baml.Array.push
     pop 1
 
-  L2:
+  L1:
     load_var log
     container_len
     store_var _14
     load_var _14
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_const "defer-did-not-run"
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_var r
 
-  L5:
+  L3:
     return
 
-  L6:
+  L4:
     load_const "guard"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -3187,27 +2808,24 @@ function exceptions.s20_div_panic_beside_call_fn(n: int) -> int {
     load_var n
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var n
     call user.exceptions.s20_may_throw
     pop 1
-    jump L1
+    jump L0
     load_const -1
-    jump L3
+    jump L2
+
+  L0:
+    load_const 7
+    jump L2
 
   L1:
-    load_const 7
-    jump L3
-
-  L2:
     load_const 100
     load_var n
     div_int
 
-  L3:
+  L2:
     return
 }
 
@@ -3215,21 +2833,18 @@ function exceptions.s20_guard_throw_plus_call_fn(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var n
     call user.exceptions.s20_may_throw
-    jump L1
+    jump L0
     load_var e
     throw_if_panic
     load_const "caught"
 
-  L1:
+  L0:
     return
 
-  L2:
+  L1:
     load_const "guard"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -3239,41 +2854,32 @@ function exceptions.s20_guard_throw_typed_catch_fn(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_var n
     call user.exceptions.s20_may_throw
-    jump L5
+    jump L2
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const "other"
-    jump L5
+    jump L2
 
-  L3:
+  L0:
     load_const "io-caught"
-    jump L5
+    jump L2
 
-  L4:
+  L1:
     load_const "guard-caught"
 
-  L5:
+  L2:
     return
 
-  L6:
+  L3:
     load_const "guard"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -3283,22 +2889,19 @@ function exceptions.s20_index_panic_beside_call_fn(n: int) -> int {
     load_var n
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var n
     call user.exceptions.s20_may_throw
     pop 1
-    jump L1
+    jump L0
     load_const -1
-    jump L3
+    jump L2
+
+  L0:
+    load_const 7
+    jump L2
 
   L1:
-    load_const 7
-    jump L3
-
-  L2:
     load_const 1
     load_type int
     alloc_array 1
@@ -3307,7 +2910,7 @@ function exceptions.s20_index_panic_beside_call_fn(n: int) -> int {
     add_int
     load_array_element
 
-  L3:
+  L2:
     return
 }
 
@@ -3315,14 +2918,11 @@ function exceptions.s20_may_throw(n: int) -> string {
     load_var n
     load_const 42
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "ok"
     return
 
-  L1:
+  L0:
     load_const "io"
     init_instance baml.errors.Io .message
     throw
@@ -3342,14 +2942,11 @@ function exceptions.s2_fails_7(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 42
     throw
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -3358,14 +2955,11 @@ function exceptions.s2_fails_9(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 42
     throw
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -3374,14 +2968,11 @@ function exceptions.s2b_fails_10(mode: int) -> string {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 42
     throw
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -3390,14 +2981,11 @@ function exceptions.s2b_fails_11(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 42
     throw
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -3406,38 +2994,29 @@ function exceptions.s3_api_1(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const "unknown"
     throw
 
-  L3:
+  L0:
     load_const 30
     init_instance user.exceptions.RateLimit .retryAfter
     throw
 
-  L4:
+  L1:
     load_const "/users"
     init_instance user.exceptions.NotFound .path
     throw
 
-  L5:
+  L2:
     load_const "expired"
     init_instance user.exceptions.AuthError .reason
     throw
@@ -3453,15 +3032,12 @@ function exceptions.s3_fails_13(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "bad json"
     init_instance user.exceptions.ParseError .message
     throw
 
-  L1:
+  L0:
     load_const "http://x"
     init_instance user.exceptions.NetworkError .url
     throw
@@ -3471,14 +3047,11 @@ function exceptions.s3_fails_15(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "plain string error"
     throw
 
-  L1:
+  L0:
     load_const "http://x"
     init_instance user.exceptions.NetworkError .url
     throw
@@ -3494,15 +3067,12 @@ function exceptions.s3a_fails_17(mode: int) -> string {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "bad json"
     init_instance user.exceptions.ParseError .message
     throw
 
-  L1:
+  L0:
     load_const "http://x"
     init_instance user.exceptions.NetworkError .url
     throw
@@ -3518,15 +3088,12 @@ function exceptions.s3b_fails_19(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "bad"
     init_instance user.exceptions.ParseError .message
     throw
 
-  L1:
+  L0:
     load_const "http://x"
     init_instance user.exceptions.NetworkError .url
     throw
@@ -3536,14 +3103,11 @@ function exceptions.s3b_fails_21(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "plain string"
     throw
 
-  L1:
+  L0:
     load_const "http://x"
     init_instance user.exceptions.NetworkError .url
     throw
@@ -3656,17 +3220,14 @@ function exceptions.s5b_overflow_to_string(x: int) -> string {
     add_int
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "non-positive"
     jump L1
 
   L0:
-    load_const "non-positive"
-    jump L2
-
-  L1:
     load_const "positive"
 
-  L2:
+  L1:
     return
 }
 
@@ -3674,16 +3235,13 @@ function exceptions.s6_risky_1(x: int) -> int {
     load_var x
     load_const 100
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_var x
     div_int
     return
 
-  L1:
+  L0:
     load_const "too big"
     throw
 }
@@ -3692,10 +3250,7 @@ function exceptions.s6_risky_2(x: int) -> int {
     load_var x
     load_const 100
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_const 2
     load_const 3
@@ -3705,7 +3260,7 @@ function exceptions.s6_risky_2(x: int) -> int {
     load_array_element
     return
 
-  L1:
+  L0:
     load_const "too big"
     throw
 }
@@ -3714,16 +3269,13 @@ function exceptions.s7_risky_3(x: int) -> int {
     load_var x
     load_const 100
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_var x
     div_int
     return
 
-  L1:
+  L0:
     load_const "too big"
     throw
 }
@@ -3732,16 +3284,13 @@ function exceptions.s7_risky_5(x: int) -> int {
     load_var x
     load_const 100
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1000
     load_var x
     div_int
     return
 
-  L1:
+  L0:
     load_const "too big"
     throw
 }
@@ -3757,34 +3306,21 @@ function exceptions.s8_risky_6(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const null
-    store_var _4
-    jump L3
-
-  L2:
+    pop_jump_if_false L0
     load_const 1
     load_const 0
     div_int
-    store_var _4
-    load_var _4
     pop 1
 
-  L3:
+  L0:
     load_const "fallback"
     throw
 
-  L4:
+  L1:
     load_const 500
     init_instance user.exceptions.AppError .code
     throw
@@ -3794,25 +3330,19 @@ function exceptions.s8_risky_7(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "fallback"
     throw
 
-  L2:
+  L0:
     call user.exceptions.s8_do_div_1
     return
 
-  L3:
+  L1:
     load_const 500
     init_instance user.exceptions.AppError .code
     throw
@@ -3829,34 +3359,21 @@ function exceptions.s9_risky_10(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const null
-    store_var _4
-    jump L3
-
-  L2:
+    pop_jump_if_false L0
     load_const 1
     load_const 0
     div_int
-    store_var _4
-    load_var _4
     pop 1
 
-  L3:
+  L0:
     load_const "fallback"
     throw
 
-  L4:
+  L1:
     load_const 7
     init_instance user.exceptions.AppError .code
     throw
@@ -3866,10 +3383,7 @@ function exceptions.s9_risky_12(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_type int
     alloc_array 1
@@ -3877,7 +3391,7 @@ function exceptions.s9_risky_12(mode: int) -> int {
     load_array_element
     return
 
-  L1:
+  L0:
     load_const "fallback"
     throw
 }
@@ -3886,25 +3400,19 @@ function exceptions.s9_risky_13(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "fallback"
     throw
 
-  L2:
+  L0:
     call user.exceptions.s9_do_div_2
     return
 
-  L3:
+  L1:
     load_const 7
     init_instance user.exceptions.AppError .code
     throw
@@ -3914,16 +3422,13 @@ function exceptions.s9_risky_14(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_const 0
     div_int
     return
 
-  L1:
+  L0:
     load_const 7
     init_instance user.exceptions.AppError .code
     throw
@@ -3933,42 +3438,33 @@ function exceptions.s9_risky_9(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var mode
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const 1
     load_type int
     alloc_array 1
     load_const 5
     load_array_element
-    jump L5
+    jump L2
 
-  L3:
+  L0:
     load_const "fallback"
     throw
 
-  L4:
+  L1:
     call user.exceptions.s9_do_div_2
 
-  L5:
+  L2:
     return
 
-  L6:
+  L3:
     load_const 7
     init_instance user.exceptions.AppError .code
     throw
@@ -3978,14 +3474,11 @@ function exceptions.s9b_risky_15(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     call user.exceptions.s9_do_div_2
     return
 
-  L1:
+  L0:
     load_const 7
     init_instance user.exceptions.AppError .code
     throw
@@ -4016,32 +3509,26 @@ function exceptions.s9c_risky_19(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "fallback"
     throw
 
-  L2:
+  L0:
     load_const 1
     load_type int
     alloc_array 1
     load_const 5
     load_array_element
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     call user.exceptions.s9c_do_div_3
 
-  L4:
+  L2:
     return
 }
 
@@ -4050,22 +3537,12 @@ function exceptions.s9c_risky_21(mode: int) -> int {
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const null
-    store_var _2
-    jump L2
-
-  L1:
     load_const 1
     load_const 0
     div_int
-    store_var _2
-    load_var _2
     pop 1
 
-  L2:
+  L0:
     load_const "fallback"
     throw
 }
@@ -4097,215 +3574,176 @@ function exceptions.sequential_catches_both_recover_fn() -> int {
 function exceptions.typed_binding_dispatch_int_vs_string_fn() -> int {
     load_const 1
     call user.exceptions.s2_fails_7
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.typed_binding_dispatch_string_vs_int_fn() -> int {
     load_const 0
     call user.exceptions.s2_fails_7
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.typed_binding_int_fn() -> int {
     call user.exceptions.s2_fails_6
-    jump L2
+    jump L1
     load_var e
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.typed_binding_plus_wildcard_fn() -> int {
     load_const 1
     call user.exceptions.s2_fails_9
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.typed_binding_string_fn() -> int {
     call user.exceptions.s2_fails_5
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function exceptions.user_class_plus_panic_plus_wildcard_class_fires_fn() -> int {
     load_const 0
     call user.exceptions.s8_risky_6
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 3
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.user_class_plus_panic_plus_wildcard_panic_fires_fn() -> int {
     load_const 1
     call user.exceptions.s8_risky_7
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 3
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function exceptions.user_class_plus_panic_plus_wildcard_string_fires_fn() -> int {
     load_const 2
     call user.exceptions.s8_risky_7
-    jump L4
+    jump L2
     load_var e
     is_type exceptions.AppError
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 3
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
@@ -31,12 +31,10 @@ function fixtures.anyfunction_reflect.RuntimeClassify(input: string, client: ai.
     call user.fixtures.anyfunction_reflect.RuntimeClassify@spec
     store_var _9
     load_type #0
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -85,10 +83,10 @@ function fixtures.anyfunction_reflect.RuntimeClassify@spec(input: string) -> ai.
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.anyfunction_reflect.RuntimeEnumClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "RuntimeClassify"
     load_deref ?1
     load_const "input"
@@ -134,8 +132,6 @@ function fixtures.anyfunction_reflect.RuntimeClassify@stream(input: string, clie
 }
 
 function fixtures.anyfunction_reflect.bare_and_pinned() -> int {
-    load_const user.fixtures.anyfunction_reflect.web_search
-    store_var g
     load_const 0
     return
 }
@@ -195,7 +191,6 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_var sig
     load_field .errors
     load_type baml.ToString
@@ -210,7 +205,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_var _10
     call baml.String.from
     store_var _9
-    load_var2 4 5
+    load_var _7
     bin_op +
     load_var _9
     bin_op +
@@ -230,13 +225,10 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _15
     store_var arg
-    load_var2 3 10
+    load_var2 3 9
     load_field .name
     bin_op +
     store_var _19
@@ -246,12 +238,12 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _22
-    load_var2 11 12
+    load_var2 10 11
     bin_op +
     store_var parts
     jump L0
 
-  L2:
+  L1:
     load_type string
     load_type reflect.Arg
     load_var sig
@@ -262,7 +254,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     virtual_call nargs=1 ntypeargs=0
     store_var _28
 
-  L3:
+  L2:
     load_var _28
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -270,10 +262,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     store_var _29
     load_var _29
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var _29
     store_var key
     load_type string
@@ -287,8 +276,8 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_const null
     call baml.ops.equals_equals
     unary_op !
-    pop_jump_if_false L3
-    load_var2 3 15
+    pop_jump_if_false L2
+    load_var2 3 14
     bin_op +
     store_var _41
     load_var opt
@@ -297,12 +286,12 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _44
-    load_var2 17 18
+    load_var2 16 17
     bin_op +
     store_var parts
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var parts
     return
 }
@@ -318,66 +307,43 @@ function fixtures.anyfunction_reflect.typed_dispatch(name: string, args: map<str
     load_var f
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L10
-
-  L3:
+    pop_jump_if_true L3
     load_type string | fixtures.anyfunction_reflect.Doc[]
     load_type fixtures.anyfunction_reflect.ToolError
     load_var2 4 2
     call reflect.call_any
-    jump L11
+    jump L4
     load_var e
     is_type fixtures.anyfunction_reflect.ToolError
-    pop_jump_if_false L4
-    jump L9
-
-  L4:
+    pop_jump_if_true L2
     load_var e
     is_type reflect.InvalidArgumentError
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L1
     load_var e
     is_type reflect.errors.CompilationError
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L7:
+  L0:
     load_const "uncompiled-generic"
-    jump L11
+    jump L4
 
-  L8:
+  L1:
     load_const "bad-args"
-    jump L11
+    jump L4
 
-  L9:
+  L2:
     load_const "tool-error:"
     load_var e
     load_field .message
     bin_op +
-    jump L11
+    jump L4
 
-  L10:
+  L3:
     load_const "no-such-tool"
 
-  L11:
+  L4:
     return
 }
 
@@ -385,17 +351,14 @@ function fixtures.anyfunction_reflect.web_search(q: string) -> fixtures.anyfunct
     load_var q
     load_const "boom"
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var q
     init_instance user.fixtures.anyfunction_reflect.Doc .title
     load_type fixtures.anyfunction_reflect.Doc
     alloc_array 1
     return
 
-  L1:
+  L0:
     load_const "no results"
     init_instance user.fixtures.anyfunction_reflect.ToolError .message
     throw

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/bytecode.snap
@@ -196,7 +196,6 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _7
     load_var sig
     load_field .args
     container_len
@@ -205,7 +204,6 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_var _10
     call baml.String.from
     store_var _9
-    load_var _7
     bin_op +
     load_var _9
     bin_op +
@@ -228,7 +226,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     pop_jump_if_true L1
     load_var _15
     store_var arg
-    load_var2 3 9
+    load_var2 3 8
     load_field .name
     bin_op +
     store_var _19
@@ -238,7 +236,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _22
-    load_var2 10 11
+    load_var2 9 10
     bin_op +
     store_var parts
     jump L0
@@ -277,7 +275,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     call baml.ops.equals_equals
     unary_op !
     pop_jump_if_false L2
-    load_var2 3 14
+    load_var2 3 13
     bin_op +
     store_var _41
     load_var opt
@@ -286,7 +284,7 @@ function fixtures.anyfunction_reflect.signature_access(f: reflect.AnyFunction<Re
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _44
-    load_var2 16 17
+    load_var2 15 16
     bin_op +
     store_var parts
     jump L2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_anyfunction_reflect/mir.snap
@@ -48,10 +48,8 @@ fn user.fixtures.anyfunction_reflect.current_time() -> string {
 fn user.fixtures.anyfunction_reflect.bare_and_pinned() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: reflect.AnyFunction<Returns = string | fixtures.anyfunction_reflect.Doc[], Throws = fixtures.anyfunction_reflect.ToolError> // g
 
     bb0: {
-        _1 = const fn user.fixtures.anyfunction_reflect.web_search;
         _0 = const 0_i64;
         goto -> bb1;
     }
@@ -277,71 +275,62 @@ fn user.fixtures.anyfunction_reflect.typed_dispatch(name: string, args: map<stri
 
     bb2: {
         _8 = copy _4 == const null;
-        branch copy _8 -> [bb4, bb3];
+        _7 = copy _8;
+        goto -> bb3;
     }
 
     bb3: {
-        _7 = const false;
-        goto -> bb5;
+        branch copy _7 -> [bb5, bb4];
     }
 
     bb4: {
-        _7 = const true;
-        goto -> bb5;
-    }
-
-    bb5: {
-        branch copy _7 -> [bb7, bb6];
-    }
-
-    bb6: {
         _10 = copy _4;
         _11 = load_type(string | fixtures.anyfunction_reflect.Doc[]);
         _12 = load_type(fixtures.anyfunction_reflect.ToolError);
-        _0 = call const fn reflect.call_any<copy _11, copy _12>(copy _10, copy _2) -> [bb15, unwind: bb8];
+        _0 = call const fn reflect.call_any<copy _11, copy _12>(copy _10, copy _2) -> [bb13, unwind: bb6];
+    }
+
+    bb5: {
+        _0 = const "no-such-tool";
+        goto -> bb13;
+    }
+
+    bb6: {
+        _13 = is_type(copy _9, fixtures.anyfunction_reflect.ToolError);
+        branch copy _13 -> [bb12, bb7];
     }
 
     bb7: {
-        _0 = const "no-such-tool";
-        goto -> bb15;
+        _14 = is_type(copy _9, reflect.InvalidArgumentError);
+        branch copy _14 -> [bb11, bb8];
     }
 
     bb8: {
-        _13 = is_type(copy _9, fixtures.anyfunction_reflect.ToolError);
-        branch copy _13 -> [bb14, bb9];
+        _15 = is_type(copy _9, reflect.errors.CompilationError);
+        branch copy _15 -> [bb10, bb9];
     }
 
     bb9: {
-        _14 = is_type(copy _9, reflect.InvalidArgumentError);
-        branch copy _14 -> [bb13, bb10];
-    }
-
-    bb10: {
-        _15 = is_type(copy _9, reflect.errors.CompilationError);
-        branch copy _15 -> [bb12, bb11];
-    }
-
-    bb11: {
         rethrow copy _9;
     }
 
-    bb12: {
+    bb10: {
         _0 = const "uncompiled-generic";
-        goto -> bb15;
+        goto -> bb13;
+    }
+
+    bb11: {
+        _0 = const "bad-args";
+        goto -> bb13;
+    }
+
+    bb12: {
+        _16 = copy _9.0;
+        _0 = const "tool-error:" + copy _16;
+        goto -> bb13;
     }
 
     bb13: {
-        _0 = const "bad-args";
-        goto -> bb15;
-    }
-
-    bb14: {
-        _16 = copy _9.0;
-        _0 = const "tool-error:" + copy _16;
-        goto -> bb15;
-    }
-
-    bb15: {
         return;
     }
 }
@@ -485,24 +474,26 @@ fn user.fixtures.anyfunction_reflect.RuntimeClassify@spec(input: string) -> ai.F
     let _0: ai.FunctionSpec<T> // _0 // return
     let _1: string // input // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "input": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0]<1 type_args>(copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "input": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0]<1 type_args>(copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.anyfunction_reflect.RuntimeEnumClient) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.anyfunction_reflect.RuntimeEnumClient) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<#0> { const "RuntimeClassify", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<#0> { const "RuntimeClassify", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -566,7 +557,6 @@ fn .<lambda(RuntimeClassify@spec, 0)>( __spec_output_format: ai.OutputFormat) ->
     }
 
     bb1: {
-        _7 = const "";
         _14 = copy _6;
         _15 = copy capture[0];
         _16 = load_type(unknown);

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_arm_header_comments/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_arm_header_comments/bytecode.snap
@@ -9,24 +9,21 @@ function fixtures.arm_header_comments._thrower() -> int {
 
 function fixtures.arm_header_comments.catch_with_headers() -> int {
     call user.fixtures.arm_header_comments._thrower
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind baml.errors.ParseError, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const 0
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.backtick_decl_slots.Greet(name: string, client: ai.Client | nu
     call user.fixtures.backtick_decl_slots.Greet@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function fixtures.backtick_decl_slots.Greet@spec(name: string) -> ai.FunctionSpe
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.backtick_decl_slots.Fast
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "Greet"
     load_deref ?1
     load_const "name"
@@ -129,11 +127,11 @@ function fixtures.backtick_decl_slots.Greet@stream(name: string, client: ai.stre
 }
 
 function fixtures.backtick_decl_slots.Header(title: string) -> string {
+    load_const "# "
     load_type string
     load_var title
     call baml.String.from
     store_var _2
-    load_const "# "
     load_var _2
     bin_op +
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/bytecode.snap
@@ -131,8 +131,6 @@ function fixtures.backtick_decl_slots.Header(title: string) -> string {
     load_type string
     load_var title
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/mir.snap
@@ -167,69 +167,72 @@ fn .<lambda(Greet@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: "."
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: "."
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "Say hello to ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "Say hello to ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _6 = const ".";
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _7 = const ".";
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -241,9 +244,9 @@ fn .<lambda(Greet@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_decl_slots/mir.snap
@@ -135,24 +135,26 @@ fn user.fixtures.backtick_decl_slots.Greet@spec(name: string) -> ai.FunctionSpec
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // name // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "name": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "name": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.backtick_decl_slots.Fast) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.backtick_decl_slots.Fast) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "Greet", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "Greet", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -167,72 +169,68 @@ fn .<lambda(Greet@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: "."
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: "."
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "Say hello to ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "Say hello to ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _7 = const ".";
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _6 = const ".";
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -244,9 +242,9 @@ fn .<lambda(Greet@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 
@@ -303,14 +301,16 @@ fn user.fixtures.backtick_decl_slots.Header(title: string) -> string {
     let _1: string // title // param
     let _2: string
     let _3: reflect.Type
+    let _4: string
 
     bb0: {
         _3 = load_type(string);
+        _4 = const "# ";
         _2 = call const fn baml.String.from<copy _3>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _0 = const "# " + copy _2;
+        _0 = copy _4 + copy _2;
         goto -> bb2;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_dedent/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_dedent/bytecode.snap
@@ -28,10 +28,7 @@ function fixtures.backtick_dedent.ForLoopVerbatim(xs: string[]) -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _8
     load_type string
@@ -48,17 +45,17 @@ function fixtures.backtick_dedent.ForLoopVerbatim(xs: string[]) -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
 
 function fixtures.backtick_dedent.MultilineInterpVerbatim() -> string {
+    load_const "value: "
     load_type string
     load_const "x"
     call baml.String.from
     store_var _1
-    load_const "value: "
     load_var _1
     bin_op +
     return
@@ -75,6 +72,7 @@ function fixtures.backtick_dedent.WithBlankLines() -> string {
 }
 
 function fixtures.backtick_dedent.WithInterps(name: string, count: int) -> string {
+    load_const "name:  "
     load_type string
     load_var name
     call baml.String.from
@@ -83,7 +81,6 @@ function fixtures.backtick_dedent.WithInterps(name: string, count: int) -> strin
     load_var count
     call baml.String.from
     store_var _7
-    load_const "name:  "
     load_var _5
     bin_op +
     load_const "\ncount: "

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_dedent/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_dedent/bytecode.snap
@@ -55,8 +55,6 @@ function fixtures.backtick_dedent.MultilineInterpVerbatim() -> string {
     load_type string
     load_const "x"
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -76,12 +74,10 @@ function fixtures.backtick_dedent.WithInterps(name: string, count: int) -> strin
     load_type string
     load_var name
     call baml.String.from
-    store_var _5
     load_type int
     load_var count
     call baml.String.from
     store_var _7
-    load_var _5
     bin_op +
     load_const "\ncount: "
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_dedent/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_dedent/mir.snap
@@ -55,14 +55,16 @@ fn user.fixtures.backtick_dedent.WithInterps(name: string, count: int) -> string
     let _6: reflect.Type
     let _7: string
     let _8: reflect.Type
+    let _9: string
 
     bb0: {
         _6 = load_type(string);
+        _9 = const "name:  ";
         _5 = call const fn baml.String.from<copy _6>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = const "name:  " + copy _5;
+        _4 = copy _9 + copy _5;
         _3 = copy _4 + const "\ncount: ";
         _8 = load_type(int);
         _7 = call const fn baml.String.from<copy _8>(copy _2) -> [bb2];
@@ -108,6 +110,7 @@ fn user.fixtures.backtick_dedent.ForLoopVerbatim(xs: string[]) -> string {
     let _11: string
     let _12: string
     let _13: reflect.Type
+    let _14: string
 
     bb0: {
         _2 = const "";
@@ -130,11 +133,12 @@ fn user.fixtures.backtick_dedent.ForLoopVerbatim(xs: string[]) -> string {
         _8 = copy _2;
         _12 = copy _7;
         _13 = load_type(string);
+        _14 = const "- ";
         _11 = call const fn baml.String.from<copy _13>(copy _12) -> [bb4];
     }
 
     bb4: {
-        _10 = const "- " + copy _11;
+        _10 = copy _14 + copy _11;
         _9 = copy _10 + const "\n";
         _2 = copy _8 + copy _9;
         goto -> bb1;
@@ -155,14 +159,16 @@ fn user.fixtures.backtick_dedent.MultilineInterpVerbatim() -> string {
     let _0: string // _0 // return
     let _1: string
     let _2: reflect.Type
+    let _3: string
 
     bb0: {
         _2 = load_type(string);
+        _3 = const "value: ";
         _1 = call const fn baml.String.from<copy _2>(const "x") -> [bb1];
     }
 
     bb1: {
-        _0 = const "value: " + copy _1;
+        _0 = copy _3 + copy _1;
         goto -> bb2;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_strings/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_strings/bytecode.snap
@@ -26,39 +26,36 @@ function fixtures.backtick_strings.BacktickInCondition() -> int {
     call baml.String.length
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function fixtures.backtick_strings.BacktickInterpBlockBody(items: int[]) -> string {
+    load_const "head: "
     load_type int
     load_var items
     load_const 0
     load_array_element
     call baml.String.from
     store_var _2
-    load_const "head: "
     load_var _2
     bin_op +
     return
 }
 
 function fixtures.backtick_strings.BacktickInterpBool(b: bool) -> string {
+    load_const "flag: "
     load_type bool
     load_var b
     call baml.String.from
     store_var _2
-    load_const "flag: "
     load_var _2
     bin_op +
     return
@@ -68,39 +65,40 @@ function fixtures.backtick_strings.BacktickInterpCallsFn() -> string {
     load_const 3
     call user.fixtures.backtick_strings.bangs
     store_var _2
+    load_const "done"
     load_type string
     load_var _2
     call baml.String.from
     store_var _1
-    load_const "done"
     load_var _1
     bin_op +
     return
 }
 
 function fixtures.backtick_strings.BacktickInterpFloat(x: float) -> string {
+    load_const "ratio: "
     load_type float
     load_var x
     call baml.String.from
     store_var _2
-    load_const "ratio: "
     load_var _2
     bin_op +
     return
 }
 
 function fixtures.backtick_strings.BacktickInterpInt(n: int) -> string {
+    load_const "count: "
     load_type int
     load_var n
     call baml.String.from
     store_var _2
-    load_const "count: "
     load_var _2
     bin_op +
     return
 }
 
 function fixtures.backtick_strings.BacktickInterpMultiline(name: string, count: int) -> string {
+    load_const "name:  "
     load_type string
     load_var name
     call baml.String.from
@@ -109,7 +107,6 @@ function fixtures.backtick_strings.BacktickInterpMultiline(name: string, count: 
     load_var count
     call baml.String.from
     store_var _7
-    load_const "name:  "
     load_var _5
     bin_op +
     load_const "\ncount: "
@@ -123,12 +120,10 @@ function fixtures.backtick_strings.BacktickInterpMultiple(first: string, last: s
     load_type string
     load_var first
     call baml.String.from
-    store_var _4
     load_type string
     load_var last
     call baml.String.from
     store_var _6
-    load_var _4
     load_const " "
     bin_op +
     load_var _6
@@ -137,11 +132,11 @@ function fixtures.backtick_strings.BacktickInterpMultiple(first: string, last: s
 }
 
 function fixtures.backtick_strings.BacktickInterpSimple(name: string) -> string {
+    load_const "Hello, "
     load_type string
     load_var name
     call baml.String.from
     store_var _3
-    load_const "Hello, "
     load_var _3
     bin_op +
     load_const "!"
@@ -172,10 +167,7 @@ function fixtures.backtick_strings.BacktickM3ForLoop(xs: string[]) -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var  __m3_for
     store_var _8
     load_type string
@@ -192,24 +184,21 @@ function fixtures.backtick_strings.BacktickM3ForLoop(xs: string[]) -> string {
     store_var  __m3_for
     jump L0
 
-  L2:
+  L1:
     load_var  __m3_for
     return
 }
 
 function fixtures.backtick_strings.BacktickM3IfBlock(show: bool) -> string {
     load_var show
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
     jump L1
 
   L0:
-    load_const ""
-    jump L2
-
-  L1:
     load_const "hello"
 
-  L2:
+  L1:
     return
 }
 
@@ -217,28 +206,22 @@ function fixtures.backtick_strings.BacktickM3IfElseChain(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var n
     load_const 0
     cmp_int_op <
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "zero"
+    jump L2
+
+  L0:
+    load_const "neg"
     jump L2
 
   L1:
-    load_const "zero"
-    jump L4
-
-  L2:
-    load_const "neg"
-    jump L4
-
-  L3:
     load_const "pos"
 
-  L4:
+  L2:
     return
 }
 
@@ -281,23 +264,18 @@ function fixtures.backtick_strings.bangs(n: int) -> string {
     load_var n
     load_const 0
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
+    load_const "!"
     load_var n
     load_const 1
     sub_int
     call user.fixtures.backtick_strings.bangs
-    store_var _3
-    load_const "!"
-    load_var _3
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const ""
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_strings/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_strings/bytecode.snap
@@ -44,8 +44,6 @@ function fixtures.backtick_strings.BacktickInterpBlockBody(items: int[]) -> stri
     load_const 0
     load_array_element
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -55,8 +53,6 @@ function fixtures.backtick_strings.BacktickInterpBool(b: bool) -> string {
     load_type bool
     load_var b
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -69,8 +65,6 @@ function fixtures.backtick_strings.BacktickInterpCallsFn() -> string {
     load_type string
     load_var _2
     call baml.String.from
-    store_var _1
-    load_var _1
     bin_op +
     return
 }
@@ -80,8 +74,6 @@ function fixtures.backtick_strings.BacktickInterpFloat(x: float) -> string {
     load_type float
     load_var x
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -91,8 +83,6 @@ function fixtures.backtick_strings.BacktickInterpInt(n: int) -> string {
     load_type int
     load_var n
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -102,12 +92,10 @@ function fixtures.backtick_strings.BacktickInterpMultiline(name: string, count: 
     load_type string
     load_var name
     call baml.String.from
-    store_var _5
     load_type int
     load_var count
     call baml.String.from
     store_var _7
-    load_var _5
     bin_op +
     load_const "\ncount: "
     bin_op +
@@ -136,8 +124,6 @@ function fixtures.backtick_strings.BacktickInterpSimple(name: string) -> string 
     load_type string
     load_var name
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     load_const "!"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_strings/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_backtick_strings/mir.snap
@@ -193,14 +193,16 @@ fn user.fixtures.backtick_strings.BacktickInterpSimple(name: string) -> string {
     let _2: string
     let _3: string
     let _4: reflect.Type
+    let _5: string
 
     bb0: {
         _4 = load_type(string);
+        _5 = const "Hello, ";
         _3 = call const fn baml.String.from<copy _4>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _2 = const "Hello, " + copy _3;
+        _2 = copy _5 + copy _3;
         _0 = copy _2 + const "!";
         goto -> bb2;
     }
@@ -248,14 +250,16 @@ fn user.fixtures.backtick_strings.BacktickInterpInt(n: int) -> string {
     let _1: int // n // param
     let _2: string
     let _3: reflect.Type
+    let _4: string
 
     bb0: {
         _3 = load_type(int);
+        _4 = const "count: ";
         _2 = call const fn baml.String.from<copy _3>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _0 = const "count: " + copy _2;
+        _0 = copy _4 + copy _2;
         goto -> bb2;
     }
 
@@ -270,14 +274,16 @@ fn user.fixtures.backtick_strings.BacktickInterpBool(b: bool) -> string {
     let _1: bool // b // param
     let _2: string
     let _3: reflect.Type
+    let _4: string
 
     bb0: {
         _3 = load_type(bool);
+        _4 = const "flag: ";
         _2 = call const fn baml.String.from<copy _3>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _0 = const "flag: " + copy _2;
+        _0 = copy _4 + copy _2;
         goto -> bb2;
     }
 
@@ -292,14 +298,16 @@ fn user.fixtures.backtick_strings.BacktickInterpFloat(x: float) -> string {
     let _1: float // x // param
     let _2: string
     let _3: reflect.Type
+    let _4: string
 
     bb0: {
         _3 = load_type(float);
+        _4 = const "ratio: ";
         _2 = call const fn baml.String.from<copy _3>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _0 = const "ratio: " + copy _2;
+        _0 = copy _4 + copy _2;
         goto -> bb2;
     }
 
@@ -318,6 +326,7 @@ fn user.fixtures.backtick_strings.BacktickInterpBlockBody(items: int[]) -> strin
     let _5: int[]
     let _6: 0
     let _7: reflect.Type
+    let _8: string
 
     bb0: {
         _5 = copy _1;
@@ -325,11 +334,12 @@ fn user.fixtures.backtick_strings.BacktickInterpBlockBody(items: int[]) -> strin
         _4 = copy _5[_6];
         _3 = copy _4;
         _7 = load_type(int);
+        _8 = const "head: ";
         _2 = call const fn baml.String.from<copy _7>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _0 = const "head: " + copy _2;
+        _0 = copy _8 + copy _2;
         goto -> bb2;
     }
 
@@ -345,6 +355,7 @@ fn user.fixtures.backtick_strings.bangs(n: int) -> string {
     let _2: bool
     let _3: string
     let _4: int
+    let _5: string
 
     bb0: {
         _2 = copy _1 <= const 0_i64;
@@ -353,11 +364,12 @@ fn user.fixtures.backtick_strings.bangs(n: int) -> string {
 
     bb1: {
         _4 = copy _1 - const 1_i64;
+        _5 = const "!";
         _3 = call const fn user.fixtures.backtick_strings.bangs(copy _4) -> [bb2];
     }
 
     bb2: {
-        _0 = const "!" + copy _3;
+        _0 = copy _5 + copy _3;
         goto -> bb4;
     }
 
@@ -377,6 +389,7 @@ fn user.fixtures.backtick_strings.BacktickInterpCallsFn() -> string {
     let _1: string
     let _2: string
     let _3: reflect.Type
+    let _4: string
 
     bb0: {
         _2 = call const fn user.fixtures.backtick_strings.bangs(const 3_i64) -> [bb1];
@@ -384,11 +397,12 @@ fn user.fixtures.backtick_strings.BacktickInterpCallsFn() -> string {
 
     bb1: {
         _3 = load_type(string);
+        _4 = const "done";
         _1 = call const fn baml.String.from<copy _3>(copy _2) -> [bb2];
     }
 
     bb2: {
-        _0 = const "done" + copy _1;
+        _0 = copy _4 + copy _1;
         goto -> bb3;
     }
 
@@ -408,14 +422,16 @@ fn user.fixtures.backtick_strings.BacktickInterpMultiline(name: string, count: i
     let _6: reflect.Type
     let _7: string
     let _8: reflect.Type
+    let _9: string
 
     bb0: {
         _6 = load_type(string);
+        _9 = const "name:  ";
         _5 = call const fn baml.String.from<copy _6>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = const "name:  " + copy _5;
+        _4 = copy _9 + copy _5;
         _3 = copy _4 + const "\ncount: ";
         _8 = load_type(int);
         _7 = call const fn baml.String.from<copy _8>(copy _2) -> [bb2];
@@ -461,6 +477,7 @@ fn user.fixtures.backtick_strings.BacktickM3ForLoop(xs: string[]) -> string {
     let _11: string
     let _12: string
     let _13: reflect.Type
+    let _14: string
 
     bb0: {
         _2 = const "";
@@ -483,11 +500,12 @@ fn user.fixtures.backtick_strings.BacktickM3ForLoop(xs: string[]) -> string {
         _8 = copy _2;
         _12 = copy _7;
         _13 = load_type(string);
+        _14 = const "- ";
         _11 = call const fn baml.String.from<copy _13>(copy _12) -> [bb4];
     }
 
     bb4: {
-        _10 = const "- " + copy _11;
+        _10 = copy _14 + copy _11;
         _9 = copy _10 + const "\n";
         _2 = copy _8 + copy _9;
         goto -> bb1;

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_byte_string_literals/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_byte_string_literals/bytecode.snap
@@ -47,17 +47,14 @@ function fixtures.byte_string_literals.ByteStringInCondition() -> int {
     load_var _2
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_all_keyword/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_all_keyword/bytecode.snap
@@ -4,30 +4,24 @@ source: crates/baml_tests/src/corpus.rs
 function fixtures.catch_all_keyword.CatchAllTyped(x: int) -> string {
     load_var x
     call user.fixtures.catch_all_keyword.MayFailIntOrString
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const "caught int"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "caught string"
 
-  L4:
+  L2:
     return
 }
 
@@ -46,22 +40,19 @@ function fixtures.catch_all_keyword.CatchAllWildcard(x: int) -> string {
 function fixtures.catch_all_keyword.CatchThenCatchAll(x: int) -> string {
     load_var x
     call user.fixtures.catch_all_keyword.MayFailIntOrString
-    jump L2
+    jump L1
     load_var _2
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _2
     throw_if_panic
     load_const "caught rest"
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "caught string"
 
-  L2:
+  L1:
     return
 }
 
@@ -95,19 +86,16 @@ function fixtures.catch_all_keyword.MayFailIntOrString(x: int) -> string {
 function fixtures.catch_all_keyword.PartialCatch(x: int) -> string {
     load_var x
     call user.fixtures.catch_all_keyword.MayFailIntOrString
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "caught string"
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_all_panics/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_all_panics/bytecode.snap
@@ -4,30 +4,24 @@ source: crates/baml_tests/src/corpus.rs
 function fixtures.catch_all_panics.CatchAllPanicsTyped(x: int) -> string {
     load_var x
     call user.fixtures.catch_all_panics.MayFailIntOrString
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const "caught int"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "caught string"
 
-  L4:
+  L2:
     return
 }
 
@@ -44,20 +38,17 @@ function fixtures.catch_all_panics.CatchAllPanicsWildcard(x: int) -> string {
 function fixtures.catch_all_panics.CatchThenCatchAllPanics(x: int) -> string {
     load_var x
     call user.fixtures.catch_all_panics.MayFailIntOrString
-    jump L2
+    jump L1
     load_var _2
     is_type string
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "caught rest"
     jump L1
 
   L0:
-    load_const "caught rest"
-    jump L2
-
-  L1:
     load_const "caught string"
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_arm_return/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_arm_return/bytecode.snap
@@ -5,14 +5,11 @@ function fixtures.catch_arm_return.may_throw(x: int) -> int {
     load_var x
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     return
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_interface_refinement/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_interface_refinement/bytecode.snap
@@ -14,63 +14,49 @@ function fixtures.catch_interface_refinement.<(user.fixtures.catch_interface_ref
 function fixtures.catch_interface_refinement.app(mode: int) -> string {
     load_var mode
     call user.fixtures.catch_interface_refinement.provider_call
-    jump L8
+    jump L4
     load_var e
     store_var _3
     load_var _3
     narrow_bind fixtures.catch_interface_refinement.QuotaExceeded, slot=3
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var e
     store_var _4
     load_var _4
     narrow_bind fixtures.catch_interface_refinement.Failure, slot=4
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     store_var _5
     load_var _5
     narrow_bind baml.errors.UnknownError, slot=5
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L3:
+  L0:
     load_const "unknown"
-    jump L8
+    jump L4
 
-  L4:
+  L1:
     load_var _4
     load_type fixtures.catch_interface_refinement.Failure
     load_const "is_transient"
     virtual_call nargs=1 ntypeargs=0
-    store_var _9
-    load_var _9
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L2
     load_const "fail"
-    jump L8
+    jump L4
 
-  L6:
+  L2:
     load_const "retry"
-    jump L8
+    jump L4
 
-  L7:
+  L3:
     load_const "quota: "
     load_var _3
     load_field .quota_name
     bin_op +
 
-  L8:
+  L4:
     return
 }
 
@@ -79,17 +65,14 @@ function fixtures.catch_interface_refinement.local_throw() -> string {
     init_instance user.fixtures.catch_interface_refinement.Throttled .retry_after_ms
     throw
     load_var e
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     narrow_bind fixtures.catch_interface_refinement.Failure, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "classified"
     return
 }
@@ -98,17 +81,11 @@ function fixtures.catch_interface_refinement.provider_call(mode: int) -> string 
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var mode
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "socket reset"
     load_const "transport"
     load_type string
@@ -116,12 +93,12 @@ function fixtures.catch_interface_refinement.provider_call(mode: int) -> string 
     init_instance baml.errors.UnknownError .data, .message
     throw
 
-  L2:
+  L0:
     load_const "daily"
     init_instance user.fixtures.catch_interface_refinement.QuotaExceeded .quota_name
     throw
 
-  L3:
+  L1:
     load_const 250
     init_instance user.fixtures.catch_interface_refinement.Throttled .retry_after_ms
     throw

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_interface_refinement/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_interface_refinement/mir.snap
@@ -155,36 +155,30 @@ fn user.fixtures.catch_interface_refinement.app(mode: int) -> string {
 fn user.fixtures.catch_interface_refinement.local_throw() -> string {
     // Locals:
     let _0: string // _0 // return
-    let _1: string // r
-    let _2: unknown // e
-    let _3: fixtures.catch_interface_refinement.Throttled
-    let _4: unknown
+    let _1: unknown // e
+    let _2: fixtures.catch_interface_refinement.Throttled
+    let _3: unknown
 
     bb0: {
-        _3 = user.fixtures.catch_interface_refinement.Throttled { const 1_i64 };
-        throw copy _3;
+        _2 = user.fixtures.catch_interface_refinement.Throttled { const 1_i64 };
+        throw copy _2;
     }
 
     bb1: {
-        _4 = copy _2;
-        _4 = narrow_bind copy _4 as Interface(QualifiedTypeName { pkg: Local, namespace: ["fixtures", "catch_interface_refinement"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb3, bb2];
+        _3 = copy _1;
+        _3 = narrow_bind copy _3 as Interface(QualifiedTypeName { pkg: Local, namespace: ["fixtures", "catch_interface_refinement"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb3, bb2];
     }
 
     bb2: {
-        rethrow copy _2;
+        rethrow copy _1;
     }
 
     bb3: {
-        _1 = const "classified";
+        _0 = const "classified";
         goto -> bb4;
     }
 
     bb4: {
-        _0 = copy _1;
-        goto -> bb5;
-    }
-
-    bb5: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_throw/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_catch_throw/bytecode.snap
@@ -33,80 +33,65 @@ function fixtures.catch_throw.CatchAndRethrow(x: int) -> string {
 function fixtures.catch_throw.CatchWithFallback(x: int) -> string {
     load_var x
     call user.fixtures.catch_throw.MayFailIntOrString
-    jump L4
+    jump L2
     load_var _2
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _2
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _2
     rethrow
 
-  L2:
+  L0:
     load_const "caught int fallback"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "caught string"
 
-  L4:
+  L2:
     return
 }
 
 function fixtures.catch_throw.CatchWithTypedArm(x: int) -> string {
     load_var x
     call user.fixtures.catch_throw.MayFail
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "caught string"
 
-  L2:
+  L1:
     return
 }
 
 function fixtures.catch_throw.ChainedCatchClauses(x: int) -> string {
     load_var x
     call user.fixtures.catch_throw.MayFailIntOrString
-    jump L4
+    jump L2
     load_var _2
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _2
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _2
     rethrow
 
-  L2:
+  L0:
     load_const "second handler"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "first handler"
 
-  L4:
+  L2:
     return
 }
 
@@ -156,30 +141,24 @@ function fixtures.catch_throw.MayFailIntOrString(x: int) -> string {
 function fixtures.catch_throw.MultipleCatchArms(x: int) -> string {
     load_var x
     call user.fixtures.catch_throw.MayFailIntOrString
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const "caught int"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "caught string"
 
-  L4:
+  L2:
     return
 }
 
@@ -208,20 +187,17 @@ function fixtures.catch_throw.NestedCatch(x: int) -> string {
 function fixtures.catch_throw.SingleCatchTyped(x: int) -> string {
     load_var x
     call user.fixtures.catch_throw.MayFail
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "caught string"
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_closure_loop_variable/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_closure_loop_variable/bytecode.snap
@@ -27,10 +27,7 @@ function fixtures.closure_loop_variable.sum_array(arr: int[]) -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const null
     make_cell
     store_var i
@@ -44,14 +41,14 @@ function fixtures.closure_loop_variable.sum_array(arr: int[]) -> int {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var total
     load_type baml.iter.Iterable<Error = never, Item = () -> void throws never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
-  L3:
+  L2:
     load_var _13
     load_type baml.iter.Iterator<Error = never, Item = () -> void throws never>
     load_const "next"
@@ -59,16 +56,13 @@ function fixtures.closure_loop_variable.sum_array(arr: int[]) -> int {
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var _14
     call_indirect
     pop 1
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_deref ?2
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_closures/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_closures/bytecode.snap
@@ -12,19 +12,16 @@ function fixtures.closures.Calculator.compute(self: fixtures.closures.Calculator
     load_field .op
     load_const "add"
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var2 2 3
+    mul_int
     jump L1
 
   L0:
     load_var2 2 3
-    mul_int
-    jump L2
-
-  L1:
-    load_var2 2 3
     add_int
 
-  L2:
+  L1:
     return
 }
 
@@ -85,8 +82,7 @@ function fixtures.closures.RangeCheck.is_valid(self: fixtures.closures.RangeChec
     load_var2 2 1
     load_field .min
     cmp_int_op >=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var2 2 1
     load_field .max
     cmp_int_op <=

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_closures/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_closures/mir.snap
@@ -26,22 +26,28 @@ fn user.fixtures.closures.RangeCheck.is_valid(self: fixtures.closures.RangeCheck
     let _1: fixtures.closures.RangeCheck // self // param
     let _2: int // n // param
     let _3: bool
-    let _4: int
+    let _4: bool
     let _5: int
+    let _6: int
 
     bb0: {
-        _4 = copy _1.0;
-        _3 = copy _2 >= copy _4;
-        _0 = short_circuit(&&) copy _3 -> [eval: bb1, join: bb2];
+        _5 = copy _1.0;
+        _4 = copy _2 >= copy _5;
+        _3 = short_circuit(&&) copy _4 -> [eval: bb1, join: bb2];
     }
 
     bb1: {
-        _5 = copy _1.1;
-        _0 = copy _2 <= copy _5;
+        _6 = copy _1.1;
+        _3 = copy _2 <= copy _6;
         goto -> bb2;
     }
 
     bb2: {
+        _0 = copy _3;
+        goto -> bb3;
+    }
+
+    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/bytecode.snap
@@ -29,12 +29,10 @@ function fixtures.comment_in_type.CommentAfterArrow(client: ai.Client | null, on
     call user.fixtures.comment_in_type.CommentAfterArrow@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -147,12 +145,10 @@ function fixtures.comment_in_type.FunctionWithComments(a: string, b: int, client
     call user.fixtures.comment_in_type.FunctionWithComments@spec
     store_var _10
     load_type string
-    load_var2 6 7
+    load_var2 5 6
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _7
-    load_var _7
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/mir.snap
@@ -171,45 +171,48 @@ fn .<lambda(FunctionWithComments@spec, 0)>( __spec_output_format: ai.OutputForma
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: string[]
-    let _13: unknown[]
-    let _14: string[]
-    let _15: baml.TaggedString
-    let _16: unknown[]
-    let _17: baml.TaggedString
-    let _18: ai.errors.PromptRenderError
-    let _19: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: string[]
+    let _14: unknown[]
+    let _15: string[]
+    let _16: baml.TaggedString
+    let _17: unknown[]
+    let _18: baml.TaggedString
+    let _19: ai.errors.PromptRenderError
+    let _20: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "test";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb3];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "test";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb3];
     }
 
     bb1: {
-        _12 = copy _4;
         _13 = copy _5;
-        _3 = baml.TaggedString { copy _12, copy _13 };
-        _15 = copy _3;
-        _14 = copy _15.0;
-        _17 = copy _3;
-        _16 = copy _17.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _14, copy _16) -> [bb2, unwind: bb3];
+        _14 = copy _6;
+        _4 = baml.TaggedString { copy _13, copy _14 };
+        _16 = copy _4;
+        _15 = copy _16.0;
+        _18 = copy _4;
+        _17 = copy _18.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _15, copy _17) -> [bb2, unwind: bb3];
     }
 
     bb2: {
@@ -221,9 +224,9 @@ fn .<lambda(FunctionWithComments@spec, 0)>( __spec_output_format: ai.OutputForma
     }
 
     bb4: {
-        _19 = copy _2;
-        _18 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _19 };
-        throw copy _18;
+        _20 = copy _2;
+        _19 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _20 };
+        throw copy _19;
     }
 }
 
@@ -436,45 +439,48 @@ fn .<lambda(CommentAfterArrow@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: string[]
-    let _13: unknown[]
-    let _14: string[]
-    let _15: baml.TaggedString
-    let _16: unknown[]
-    let _17: baml.TaggedString
-    let _18: ai.errors.PromptRenderError
-    let _19: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: string[]
+    let _14: unknown[]
+    let _15: string[]
+    let _16: baml.TaggedString
+    let _17: unknown[]
+    let _18: baml.TaggedString
+    let _19: ai.errors.PromptRenderError
+    let _20: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "test";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb3];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "test";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb3];
     }
 
     bb1: {
-        _12 = copy _4;
         _13 = copy _5;
-        _3 = baml.TaggedString { copy _12, copy _13 };
-        _15 = copy _3;
-        _14 = copy _15.0;
-        _17 = copy _3;
-        _16 = copy _17.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _14, copy _16) -> [bb2, unwind: bb3];
+        _14 = copy _6;
+        _4 = baml.TaggedString { copy _13, copy _14 };
+        _16 = copy _4;
+        _15 = copy _16.0;
+        _18 = copy _4;
+        _17 = copy _18.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _15, copy _17) -> [bb2, unwind: bb3];
     }
 
     bb2: {
@@ -486,9 +492,9 @@ fn .<lambda(CommentAfterArrow@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     }
 
     bb4: {
-        _19 = copy _2;
-        _18 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _19 };
-        throw copy _18;
+        _20 = copy _2;
+        _19 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _20 };
+        throw copy _19;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_comment_in_type/mir.snap
@@ -171,48 +171,45 @@ fn .<lambda(FunctionWithComments@spec, 0)>( __spec_output_format: ai.OutputForma
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: string[]
-    let _14: unknown[]
-    let _15: string[]
-    let _16: baml.TaggedString
-    let _17: unknown[]
-    let _18: baml.TaggedString
-    let _19: ai.errors.PromptRenderError
-    let _20: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: string[]
+    let _13: unknown[]
+    let _14: string[]
+    let _15: baml.TaggedString
+    let _16: unknown[]
+    let _17: baml.TaggedString
+    let _18: ai.errors.PromptRenderError
+    let _19: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "test";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb3];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "test";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb3];
     }
 
     bb1: {
+        _12 = copy _4;
         _13 = copy _5;
-        _14 = copy _6;
-        _4 = baml.TaggedString { copy _13, copy _14 };
-        _16 = copy _4;
-        _15 = copy _16.0;
-        _18 = copy _4;
-        _17 = copy _18.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _15, copy _17) -> [bb2, unwind: bb3];
+        _3 = baml.TaggedString { copy _12, copy _13 };
+        _15 = copy _3;
+        _14 = copy _15.0;
+        _17 = copy _3;
+        _16 = copy _17.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _14, copy _16) -> [bb2, unwind: bb3];
     }
 
     bb2: {
@@ -224,9 +221,9 @@ fn .<lambda(FunctionWithComments@spec, 0)>( __spec_output_format: ai.OutputForma
     }
 
     bb4: {
-        _20 = copy _2;
-        _19 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _20 };
-        throw copy _19;
+        _19 = copy _2;
+        _18 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _19 };
+        throw copy _18;
     }
 }
 
@@ -439,48 +436,45 @@ fn .<lambda(CommentAfterArrow@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: string[]
-    let _14: unknown[]
-    let _15: string[]
-    let _16: baml.TaggedString
-    let _17: unknown[]
-    let _18: baml.TaggedString
-    let _19: ai.errors.PromptRenderError
-    let _20: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: string[]
+    let _13: unknown[]
+    let _14: string[]
+    let _15: baml.TaggedString
+    let _16: unknown[]
+    let _17: baml.TaggedString
+    let _18: ai.errors.PromptRenderError
+    let _19: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "test";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb3];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "test";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb3];
     }
 
     bb1: {
+        _12 = copy _4;
         _13 = copy _5;
-        _14 = copy _6;
-        _4 = baml.TaggedString { copy _13, copy _14 };
-        _16 = copy _4;
-        _15 = copy _16.0;
-        _18 = copy _4;
-        _17 = copy _18.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _15, copy _17) -> [bb2, unwind: bb3];
+        _3 = baml.TaggedString { copy _12, copy _13 };
+        _15 = copy _3;
+        _14 = copy _15.0;
+        _17 = copy _3;
+        _16 = copy _17.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _14, copy _16) -> [bb2, unwind: bb3];
     }
 
     bb2: {
@@ -492,9 +486,9 @@ fn .<lambda(CommentAfterArrow@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     }
 
     bb4: {
-        _20 = copy _2;
-        _19 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _20 };
-        throw copy _19;
+        _19 = copy _2;
+        _18 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _19 };
+        throw copy _18;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_function_call/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_function_call/bytecode.snap
@@ -43,16 +43,13 @@ function fixtures.function_call.array_length() -> int {
 
 function fixtures.function_call.param_in_if_statement(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_generic_intersection_bounds/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_generic_intersection_bounds/bytecode.snap
@@ -64,17 +64,14 @@ function fixtures.generic_intersection_bounds.field_into_switch(item: #0) -> int
     load_type fixtures.generic_intersection_bounds.Named
     virtual_load_field .name
     is_type "a"
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -83,8 +80,6 @@ function fixtures.generic_intersection_bounds.label_of(item: #0) -> string {
     load_type fixtures.generic_intersection_bounds.Tagged<Label = string>
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_generic_match_typevar_arm/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_generic_match_typevar_arm/bytecode.snap
@@ -6,17 +6,14 @@ function fixtures.generic_match_typevar_arm.unwrap_or(o: fixtures.generic_match_
     store_var _3
     load_var _3
     narrow_bind fixtures.generic_match_typevar_arm.Opt<...>, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var default
     jump L1
 
   L0:
-    load_var default
-    jump L2
-
-  L1:
     load_var _3
     load_field .value
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_is_operator/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_is_operator/bytecode.snap
@@ -4,117 +4,52 @@ source: crates/baml_tests/src/corpus.rs
 function fixtures.is_operator.both_ints(a: int | string, b: int | string) -> bool {
     load_var a
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    jump_if_false L5
-    pop 1
+    jump_if_false_or_pop L0
     load_var b
     is_type int
-    pop_jump_if_false L3
-    jump L4
 
-  L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
+  L0:
     return
 }
 
 function fixtures.is_operator.classify(v: int | string) -> string {
     load_var v
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "text"
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const "text"
-    jump L5
-
-  L4:
     load_const "number"
 
-  L5:
+  L1:
     return
 }
 
 function fixtures.is_operator.is_int(v: int | string) -> bool {
     load_var v
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function fixtures.is_operator.is_int_or_bool(v: int | string | bool) -> bool {
     load_var v
     is_type int
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     is_type bool
-    pop_jump_if_false L1
-    jump L2
+    jump L1
 
-  L1:
-    load_const false
-    jump L3
-
-  L2:
+  L0:
     load_const true
 
-  L3:
+  L1:
     return
 }
 
 function fixtures.is_operator.is_not_string(v: int | string) -> bool {
     load_var v
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     unary_op !
     return
 }
@@ -122,16 +57,5 @@ function fixtures.is_operator.is_not_string(v: int | string) -> bool {
 function fixtures.is_operator.is_zero(n: int) -> bool {
     load_var n
     is_type 0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_is_operator/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_is_operator/mir.snap
@@ -10,20 +10,11 @@ fn user.fixtures.is_operator.is_int(v: int | string) -> bool {
 
     bb0: {
         _2 = is_type(copy _1, int);
-        branch copy _2 -> [bb2, bb1];
+        _0 = copy _2;
+        goto -> bb1;
     }
 
     bb1: {
-        _0 = const false;
-        goto -> bb3;
-    }
-
-    bb2: {
-        _0 = const true;
-        goto -> bb3;
-    }
-
-    bb3: {
         return;
     }
 }
@@ -37,25 +28,16 @@ fn user.fixtures.is_operator.is_not_string(v: int | string) -> bool {
 
     bb0: {
         _3 = is_type(copy _1, string);
-        branch copy _3 -> [bb2, bb1];
+        _2 = copy _3;
+        goto -> bb1;
     }
 
     bb1: {
-        _2 = const false;
-        goto -> bb3;
+        _0 = !copy _2;
+        goto -> bb2;
     }
 
     bb2: {
-        _2 = const true;
-        goto -> bb3;
-    }
-
-    bb3: {
-        _0 = !copy _2;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }
@@ -69,25 +51,21 @@ fn user.fixtures.is_operator.is_int_or_bool(v: int | string | bool) -> bool {
 
     bb0: {
         _2 = is_type(copy _1, int);
-        branch copy _2 -> [bb3, bb1];
+        branch copy _2 -> [bb2, bb1];
     }
 
     bb1: {
         _3 = is_type(copy _1, bool);
-        branch copy _3 -> [bb3, bb2];
+        _0 = copy _3;
+        goto -> bb3;
     }
 
     bb2: {
-        _0 = const false;
-        goto -> bb4;
+        _0 = const true;
+        goto -> bb3;
     }
 
     bb3: {
-        _0 = const true;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }
@@ -101,34 +79,25 @@ fn user.fixtures.is_operator.classify(v: int | string) -> string {
 
     bb0: {
         _3 = is_type(copy _1, int);
-        branch copy _3 -> [bb2, bb1];
+        _2 = copy _3;
+        goto -> bb1;
     }
 
     bb1: {
-        _2 = const false;
-        goto -> bb3;
+        branch copy _2 -> [bb3, bb2];
     }
 
     bb2: {
-        _2 = const true;
-        goto -> bb3;
+        _0 = const "text";
+        goto -> bb4;
     }
 
     bb3: {
-        branch copy _2 -> [bb5, bb4];
+        _0 = const "number";
+        goto -> bb4;
     }
 
     bb4: {
-        _0 = const "text";
-        goto -> bb6;
-    }
-
-    bb5: {
-        _0 = const "number";
-        goto -> bb6;
-    }
-
-    bb6: {
         return;
     }
 }
@@ -141,42 +110,30 @@ fn user.fixtures.is_operator.both_ints(a: int | string, b: int | string) -> bool
     let _3: bool
     let _4: bool
     let _5: bool
+    let _6: bool
 
     bb0: {
-        _4 = is_type(copy _1, int);
-        branch copy _4 -> [bb2, bb1];
+        _5 = is_type(copy _1, int);
+        _4 = copy _5;
+        goto -> bb1;
     }
 
     bb1: {
-        _3 = const false;
-        goto -> bb3;
+        _3 = short_circuit(&&) copy _4 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _3 = const true;
+        _6 = is_type(copy _2, int);
+        _3 = copy _6;
         goto -> bb3;
     }
 
     bb3: {
-        _0 = short_circuit(&&) copy _3 -> [eval: bb4, join: bb7];
+        _0 = copy _3;
+        goto -> bb4;
     }
 
     bb4: {
-        _5 = is_type(copy _2, int);
-        branch copy _5 -> [bb6, bb5];
-    }
-
-    bb5: {
-        _0 = const false;
-        goto -> bb7;
-    }
-
-    bb6: {
-        _0 = const true;
-        goto -> bb7;
-    }
-
-    bb7: {
         return;
     }
 }
@@ -189,20 +146,11 @@ fn user.fixtures.is_operator.is_zero(n: int) -> bool {
 
     bb0: {
         _2 = is_type(copy _1, 0);
-        branch copy _2 -> [bb2, bb1];
+        _0 = copy _2;
+        goto -> bb1;
     }
 
     bb1: {
-        _0 = const false;
-        goto -> bb3;
-    }
-
-    bb2: {
-        _0 = const true;
-        goto -> bb3;
-    }
-
-    bb3: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_alias_basic/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_alias_basic/bytecode.snap
@@ -11,77 +11,59 @@ function fixtures.json_alias_basic.MatchJson(j: baml.json.json) -> string {
     load_var j
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L11
-
-  L0:
+    pop_jump_if_true L5
     load_var j
     store_var _3
     load_var _3
     narrow_bind bool, slot=2
-    pop_jump_if_false L1
-    jump L10
-
-  L1:
+    pop_jump_if_true L4
     load_var j
     store_var _4
     load_var _4
     narrow_bind int, slot=3
-    pop_jump_if_false L2
-    jump L9
-
-  L2:
+    pop_jump_if_true L3
     load_var j
     store_var _5
     load_var _5
     narrow_bind float, slot=4
-    pop_jump_if_false L3
-    jump L8
-
-  L3:
+    pop_jump_if_true L2
     load_var j
     store_var _6
     load_var _6
     narrow_bind string, slot=5
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L1
     load_var j
     store_var _7
     load_var _7
     narrow_bind baml.json.json[], slot=6
-    pop_jump_if_false L5
+    pop_jump_if_true L0
+    load_const "map"
+    jump L6
+
+  L0:
+    load_const "array"
+    jump L6
+
+  L1:
+    load_const "string"
+    jump L6
+
+  L2:
+    load_const "float"
+    jump L6
+
+  L3:
+    load_const "int"
+    jump L6
+
+  L4:
+    load_const "bool"
     jump L6
 
   L5:
-    load_const "map"
-    jump L12
-
-  L6:
-    load_const "array"
-    jump L12
-
-  L7:
-    load_const "string"
-    jump L12
-
-  L8:
-    load_const "float"
-    jump L12
-
-  L9:
-    load_const "int"
-    jump L12
-
-  L10:
-    load_const "bool"
-    jump L12
-
-  L11:
     load_const "null"
 
-  L12:
+  L6:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_llm_return_type/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_llm_return_type/bytecode.snap
@@ -29,12 +29,10 @@ function fixtures.json_llm_return_type.ExtractAny(client: ai.Client | null, on_e
     call user.fixtures.json_llm_return_type.ExtractAny@spec
     store_var _8
     load_type baml.json.json
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_parse_stringify_intrinsics/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_json_parse_stringify_intrinsics/bytecode.snap
@@ -9,79 +9,61 @@ function fixtures.json_parse_stringify_intrinsics.match_parsed(s: string) -> str
     store_var _3
     load_var _3
     narrow_bind baml.json.json[], slot=3
-    pop_jump_if_false L0
-    jump L11
-
-  L0:
+    pop_jump_if_true L5
     load_var j
     store_var _6
     load_var _6
     narrow_bind map<string, baml.json.json>, slot=4
-    pop_jump_if_false L1
-    jump L10
-
-  L1:
+    pop_jump_if_true L4
     load_var j
     store_var _9
     load_var _9
     narrow_bind int, slot=5
-    pop_jump_if_false L2
-    jump L9
-
-  L2:
+    pop_jump_if_true L3
     load_var j
     store_var _10
     load_var _10
     narrow_bind float, slot=6
-    pop_jump_if_false L3
-    jump L8
-
-  L3:
+    pop_jump_if_true L2
     load_var j
     store_var _11
     load_var _11
     narrow_bind bool, slot=7
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L1
     load_var j
     store_var _12
     load_var _12
     narrow_bind string, slot=8
-    pop_jump_if_false L5
+    pop_jump_if_true L0
+    load_const "null"
+    jump L6
+
+  L0:
+    load_var _12
+    jump L6
+
+  L1:
+    load_const "bool"
+    jump L6
+
+  L2:
+    load_const "float"
+    jump L6
+
+  L3:
+    load_const "int"
+    jump L6
+
+  L4:
+    load_var _6
+    call baml.json.stringify
     jump L6
 
   L5:
-    load_const "null"
-    jump L12
-
-  L6:
-    load_var _12
-    jump L12
-
-  L7:
-    load_const "bool"
-    jump L12
-
-  L8:
-    load_const "float"
-    jump L12
-
-  L9:
-    load_const "int"
-    jump L12
-
-  L10:
-    load_var _6
-    call baml.json.stringify
-    jump L12
-
-  L11:
     load_var _3
     call baml.json.stringify
 
-  L12:
+  L6:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lambda_advanced/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lambda_advanced/bytecode.snap
@@ -171,30 +171,24 @@ function fixtures.lambda_advanced.test_lambda_calling_lambda() -> int {
 function fixtures.lambda_advanced.test_lambda_in_match_inferred() -> int {
     load_const "double"
     is_type "double"
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_const "double"
     is_type "negate"
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    make_closure .<lambda(test_lambda_in_match_inferred, 2)>, 0
+    store_var f
+    jump L2
+
+  L0:
+    make_closure .<lambda(test_lambda_in_match_inferred, 1)>, 0
+    store_var f
     jump L2
 
   L1:
-    make_closure .<lambda(test_lambda_in_match_inferred, 2)>, 0
-    store_var f
-    jump L4
-
-  L2:
-    make_closure .<lambda(test_lambda_in_match_inferred, 1)>, 0
-    store_var f
-    jump L4
-
-  L3:
     make_closure .<lambda(test_lambda_in_match_inferred, 0)>, 0
     store_var f
 
-  L4:
+  L2:
     load_const 21
     load_var f
     call_indirect
@@ -370,16 +364,13 @@ function fixtures.lambda_advanced.test_shadowing() -> string {
     store_var _10
     load_var _10
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L2
     load_var _10
     store_var y
     load_const 0
     store_var i
 
-  L2:
+  L1:
     load_var2 5 4
     cmp_int_op <
     pop_jump_if_false L0
@@ -391,9 +382,9 @@ function fixtures.lambda_advanced.test_shadowing() -> string {
     load_const 1
     add_int
     store_var i
-    jump L2
+    jump L1
 
-  L3:
+  L2:
     load_var x
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lambda_advanced/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lambda_advanced/mir.snap
@@ -526,16 +526,12 @@ fn .<lambda(test_map_multi_statement, 0)>(x: int) -> int {
     let _0: int // _0 // return
     let _1: int // x // param
     let _2: int // doubled
-    let _3: int // offset
-    let _4: int
-    let _5: int
+    let _3: int
 
     bb0: {
         _2 = copy _1 * const 2_i64;
-        _3 = const 100_i64;
-        _4 = copy _2;
-        _5 = copy _3;
-        _0 = copy _4 + copy _5;
+        _3 = copy _2;
+        _0 = copy _3 + const 100_i64;
         goto -> bb1;
     }
 
@@ -1213,41 +1209,39 @@ fn .<lambda(test_two_transforms_inferred, 2)>(x: int) -> int {
 fn user.fixtures.lambda_advanced.test_lambda_in_match_inferred() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: string // op
-    let _2: (int) -> int throws never // f
+    let _1: (int) -> int throws never // f
+    let _2: bool
     let _3: bool
-    let _4: bool
-    let _5: (int) -> int throws never
+    let _4: (int) -> int throws never
 
     bb0: {
-        _1 = const "double";
-        _3 = is_type(copy _1, "double");
-        branch copy _3 -> [bb4, bb1];
+        _2 = is_type(const "double", "double");
+        branch copy _2 -> [bb4, bb1];
     }
 
     bb1: {
-        _4 = is_type(copy _1, "negate");
-        branch copy _4 -> [bb3, bb2];
+        _3 = is_type(const "double", "negate");
+        branch copy _3 -> [bb3, bb2];
     }
 
     bb2: {
-        _2 = make_closure lambda[2]();
+        _1 = make_closure lambda[2]();
         goto -> bb5;
     }
 
     bb3: {
-        _2 = make_closure lambda[1]();
+        _1 = make_closure lambda[1]();
         goto -> bb5;
     }
 
     bb4: {
-        _2 = make_closure lambda[0]();
+        _1 = make_closure lambda[0]();
         goto -> bb5;
     }
 
     bb5: {
-        _5 = copy _2;
-        _0 = call copy _5(const 21_i64) -> [bb6];
+        _4 = copy _1;
+        _0 = call copy _4(const 21_i64) -> [bb6];
     }
 
     bb6: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lambda_fat_arrow/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lambda_fat_arrow/bytecode.snap
@@ -39,11 +39,9 @@ function fixtures.lambda_fat_arrow.test_mixed() -> int {
     load_const 0
     make_closure .<lambda(test_mixed, 0)>, 0
     call_indirect
-    store_var _3
     load_const 0
     make_closure .<lambda(test_mixed, 1)>, 0
     call_indirect
-    load_var _3
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lexical_scoping/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lexical_scoping/bytecode.snap
@@ -3,17 +3,14 @@ source: crates/baml_tests/src/corpus.rs
 ---
 function fixtures.lexical_scoping.branch_locals(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -55,33 +52,28 @@ function fixtures.lexical_scoping.for_loop_restores_outer() -> int {
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
+    store_var _2
 
   L0:
-    load_var _3
+    load_var _2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var _4
+    pop_jump_if_true L1
+    load_var _3
     store_var x
     jump L0
 
-  L2:
+  L1:
     load_const 1
     return
 }
 
 function fixtures.lexical_scoping.initializer_uses_previous() -> int {
-    load_const 1
-    load_const 1
-    add_int
+    load_const 2
     return
 }
 
@@ -98,10 +90,6 @@ function fixtures.lexical_scoping.nested_lambda_capture() -> int {
 }
 
 function fixtures.lexical_scoping.nested_outer_restored() -> int {
-    load_const 2
-    store_var x
-    load_const 3
-    store_var x
     load_const 1
     return
 }
@@ -127,14 +115,11 @@ function fixtures.lexical_scoping.while_body_restores_outer() -> int {
     load_const true
 
   L0:
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 1
     return
 
-  L2:
+  L1:
     load_const false
     jump L0
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lexical_scoping/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_lexical_scoping/mir.snap
@@ -6,22 +6,18 @@ fn user.fixtures.lexical_scoping.branch_locals(b: bool) -> int {
     // Locals:
     let _0: int // _0 // return
     let _1: bool // b // param
-    let _2: int // a
-    let _3: int // a
 
     bb0: {
         branch copy _1 -> [bb2, bb1];
     }
 
     bb1: {
-        _3 = const 2_i64;
-        _0 = copy _3;
+        _0 = const 2_i64;
         goto -> bb3;
     }
 
     bb2: {
-        _2 = const 1_i64;
-        _0 = copy _2;
+        _0 = const 1_i64;
         goto -> bb3;
     }
 
@@ -33,11 +29,9 @@ fn user.fixtures.lexical_scoping.branch_locals(b: bool) -> int {
 fn user.fixtures.lexical_scoping.same_scope_shadow() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
 
     bb0: {
-        _1 = const 2_i64;
-        _0 = copy _1;
+        _0 = const 2_i64;
         goto -> bb1;
     }
 
@@ -49,15 +43,9 @@ fn user.fixtures.lexical_scoping.same_scope_shadow() -> int {
 fn user.fixtures.lexical_scoping.initializer_uses_previous() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
-    let _2: int // x
-    let _3: int
 
     bb0: {
-        _1 = const 1_i64;
-        _3 = copy _1;
-        _2 = copy _3 + const 1_i64;
-        _0 = copy _2;
+        _0 = const 2_i64;
         goto -> bb1;
     }
 
@@ -86,11 +74,9 @@ fn user.fixtures.lexical_scoping.shadow_param(x: int) -> int {
 fn user.fixtures.lexical_scoping.outer_restored() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
 
     bb0: {
-        _1 = const 1_i64;
-        _0 = copy _1;
+        _0 = const 1_i64;
         goto -> bb1;
     }
 
@@ -102,11 +88,9 @@ fn user.fixtures.lexical_scoping.outer_restored() -> int {
 fn user.fixtures.lexical_scoping.declared_type_restored() -> string {
     // Locals:
     let _0: string // _0 // return
-    let _1: string // x
 
     bb0: {
-        _1 = const "outer";
-        _0 = copy _1;
+        _0 = const "outer";
         goto -> bb1;
     }
 
@@ -118,38 +102,36 @@ fn user.fixtures.lexical_scoping.declared_type_restored() -> string {
 fn user.fixtures.lexical_scoping.for_loop_restores_outer() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
-    let _2: int[]
-    let _3: baml.iter.Iterator<Error = never, Item = int>
-    let _4: unknown
-    let _5: bool
-    let _6: int
-    let _7: int // x
+    let _1: int[]
+    let _2: baml.iter.Iterator<Error = never, Item = int>
+    let _3: unknown
+    let _4: bool
+    let _5: int
+    let _6: int // x
 
     bb0: {
-        _1 = const 1_i64;
-        _2 = [const 2_i64, const 3_i64]: int[];
-        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _2) -> [bb1];
+        _1 = [const 2_i64, const 3_i64]: int[];
+        _2 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
+        _3 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _2) -> [bb2];
     }
 
     bb2: {
-        _5 = is_type(copy _4, baml.iter.Done);
-        branch copy _5 -> [bb4, bb3];
+        _4 = is_type(copy _3, baml.iter.Done);
+        branch copy _4 -> [bb4, bb3];
     }
 
     bb3: {
-        _6 = copy _4;
-        fresh_cell(_7);
-        _7 = copy _6;
+        _5 = copy _3;
+        fresh_cell(_6);
+        _6 = copy _5;
         goto -> bb1;
     }
 
     bb4: {
-        _0 = copy _1;
+        _0 = const 1_i64;
         goto -> bb5;
     }
 
@@ -161,15 +143,9 @@ fn user.fixtures.lexical_scoping.for_loop_restores_outer() -> int {
 fn user.fixtures.lexical_scoping.nested_outer_restored() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
-    let _2: int // x
-    let _3: int // x
 
     bb0: {
-        _1 = const 1_i64;
-        _2 = const 2_i64;
-        _3 = const 3_i64;
-        _0 = copy _1;
+        _0 = const 1_i64;
         goto -> bb1;
     }
 
@@ -301,23 +277,21 @@ fn .<lambda(<lambda(nested_lambda_capture, 0)>, 1)>() -> int {
 fn user.fixtures.lexical_scoping.while_body_restores_outer() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
-    let _2: bool // once
-    let _3: bool
+    let _1: bool // once
+    let _2: bool
 
     bb0: {
-        _1 = const 1_i64;
-        _2 = const true;
+        _1 = const true;
         goto -> bb1;
     }
 
     bb1: {
-        _3 = copy _2;
-        branch copy _3 -> [bb4, bb2];
+        _2 = copy _1;
+        branch copy _2 -> [bb4, bb2];
     }
 
     bb2: {
-        _0 = copy _1;
+        _0 = const 1_i64;
         goto -> bb3;
     }
 
@@ -326,7 +300,7 @@ fn user.fixtures.lexical_scoping.while_body_restores_outer() -> int {
     }
 
     bb4: {
-        _2 = const false;
+        _1 = const false;
         goto -> bb1;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_literal_union_arithmetic/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_literal_union_arithmetic/bytecode.snap
@@ -2,57 +2,12 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 function fixtures.literal_union_arithmetic.bothSidesUnion() -> int {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const 2
-    store_var _1
-    jump L2
-
-  L1:
-    load_const 1
-    store_var _1
-
-  L2:
-    load_const false
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 4
-    store_var _2
-    jump L5
-
-  L4:
-    load_const 3
-    store_var _2
-
-  L5:
-    load_var2 1 2
-    bin_op +
+    load_const 5
     return
 }
 
 function fixtures.literal_union_arithmetic.ifElseAdd() -> int {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
     load_const 3
-    store_var _1
-    jump L2
-
-  L1:
-    load_const 2
-    store_var _1
-
-  L2:
-    load_const 1
-    load_var _1
-    bin_op +
     return
 }
 
@@ -66,44 +21,41 @@ function fixtures.literal_union_arithmetic.loopMatchAccum() -> int {
     load_var i
     load_const 3
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var sum
     return
 
-  L2:
+  L1:
     load_var sum
     store_var _5
     load_var i
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L6
+    pop_jump_if_false L2
+    jump L5
 
-  L3:
+  L2:
     load_var i
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L4
-    jump L5
+    pop_jump_if_false L3
+    jump L4
 
-  L4:
+  L3:
     load_const 30
     store_var _6
-    jump L7
+    jump L6
 
-  L5:
+  L4:
     load_const 20
     store_var _6
-    jump L7
+    jump L6
 
-  L6:
+  L5:
     load_const 10
     store_var _6
 
-  L7:
+  L6:
     load_var2 3 4
     bin_op +
     store_var sum
@@ -146,22 +98,6 @@ function fixtures.literal_union_arithmetic.matchAdd(x: int) -> int {
 }
 
 function fixtures.literal_union_arithmetic.subtractUnion() -> int {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const 3
-    store_var _1
-    jump L2
-
-  L1:
-    load_const 7
-    store_var _1
-
-  L2:
-    load_const 100
-    load_var _1
-    bin_op -
+    load_const 93
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_literal_union_arithmetic/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_literal_union_arithmetic/mir.snap
@@ -5,28 +5,17 @@ source: crates/baml_tests/src/corpus.rs
 fn user.fixtures.literal_union_arithmetic.ifElseAdd() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: 2 | 3
 
     bb0: {
-        branch const true -> [bb2, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _1 = const 3_i64;
-        goto -> bb3;
+        _0 = const 3_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        _1 = const 2_i64;
-        goto -> bb3;
-    }
-
-    bb3: {
-        _0 = const 1_i64 + copy _1;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }
@@ -69,43 +58,17 @@ fn user.fixtures.literal_union_arithmetic.matchAdd(x: int) -> int {
 fn user.fixtures.literal_union_arithmetic.bothSidesUnion() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: 1 | 2
-    let _2: 3 | 4
 
     bb0: {
-        branch const true -> [bb2, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _1 = const 2_i64;
-        goto -> bb3;
+        _0 = const 5_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        _1 = const 1_i64;
-        goto -> bb3;
-    }
-
-    bb3: {
-        branch const false -> [bb5, bb4];
-    }
-
-    bb4: {
-        _2 = const 4_i64;
-        goto -> bb6;
-    }
-
-    bb5: {
-        _2 = const 3_i64;
-        goto -> bb6;
-    }
-
-    bb6: {
-        _0 = copy _1 + copy _2;
-        goto -> bb7;
-    }
-
-    bb7: {
         return;
     }
 }
@@ -113,28 +76,17 @@ fn user.fixtures.literal_union_arithmetic.bothSidesUnion() -> int {
 fn user.fixtures.literal_union_arithmetic.subtractUnion() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: 3 | 7
 
     bb0: {
-        branch const true -> [bb2, bb1];
+        goto -> bb1;
     }
 
     bb1: {
-        _1 = const 3_i64;
-        goto -> bb3;
+        _0 = const 93_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        _1 = const 7_i64;
-        goto -> bb3;
-    }
-
-    bb3: {
-        _0 = const 100_i64 - copy _1;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_literal_union_widening/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_literal_union_widening/mir.snap
@@ -57,11 +57,9 @@ fn user.fixtures.literal_union_widening.nestedArray() -> int[][] {
 fn user.fixtures.literal_union_widening.annotatedLiteralUnion() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: 1 | 2 // x
 
     bb0: {
-        _1 = const 1_i64;
-        _0 = copy _1;
+        _0 = const 1_i64;
         goto -> bb1;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.llm_image_outputs.GenerateImage(prompt: string, client: ai.Cli
     call user.fixtures.llm_image_outputs.GenerateImage@spec
     store_var _9
     load_type image
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,7 +80,7 @@ function fixtures.llm_image_outputs.GenerateImage@spec(prompt: string) -> ai.Fun
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-image-1"
     load_const <omitted>
     load_const <omitted>
@@ -101,7 +99,7 @@ function fixtures.llm_image_outputs.GenerateImage@spec(prompt: string) -> ai.Fun
     load_const <omitted>
     load_const <omitted>
     call openai.ImageClient.new
-    store_var _6
+    store_var _7
     load_const "GenerateImage"
     load_deref ?1
     load_const "prompt"
@@ -173,12 +171,10 @@ function fixtures.llm_image_outputs.GenerateImageSet(prompt: string, client: ai.
     call user.fixtures.llm_image_outputs.GenerateImageSet@spec
     store_var _9
     load_type image[]
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -225,7 +221,7 @@ function fixtures.llm_image_outputs.GenerateImageSet@spec(prompt: string) -> ai.
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-image-1"
     load_const <omitted>
     load_const <omitted>
@@ -244,7 +240,7 @@ function fixtures.llm_image_outputs.GenerateImageSet@spec(prompt: string) -> ai.
     load_const <omitted>
     load_const <omitted>
     call openai.ImageClient.new
-    store_var _6
+    store_var _7
     load_const "GenerateImageSet"
     load_deref ?1
     load_const "prompt"
@@ -316,12 +312,10 @@ function fixtures.llm_image_outputs.GenerateMixedImageNarrative(prompt: string, 
     call user.fixtures.llm_image_outputs.GenerateMixedImageNarrative@spec
     store_var _9
     load_type (string | image)[]
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -368,7 +362,7 @@ function fixtures.llm_image_outputs.GenerateMixedImageNarrative@spec(prompt: str
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4.1"
     load_const <omitted>
     load_const <omitted>
@@ -387,7 +381,7 @@ function fixtures.llm_image_outputs.GenerateMixedImageNarrative@spec(prompt: str
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _6
+    store_var _7
     load_const "GenerateMixedImageNarrative"
     load_deref ?1
     load_const "prompt"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/mir.snap
@@ -167,68 +167,71 @@ fn .<lambda(GenerateImage@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "Generate an image for this prompt:\n";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "Generate an image for this prompt:\n";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -240,9 +243,9 @@ fn .<lambda(GenerateImage@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 
@@ -458,68 +461,71 @@ fn .<lambda(GenerateImageSet@spec, 0)>( __spec_output_format: ai.OutputFormat) -
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "Generate multiple distinct image outputs for this prompt:\n";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "Generate multiple distinct image outputs for this prompt:\n";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -531,9 +537,9 @@ fn .<lambda(GenerateImageSet@spec, 0)>( __spec_output_format: ai.OutputFormat) -
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_image_outputs/mir.snap
@@ -135,24 +135,26 @@ fn user.fixtures.llm_image_outputs.GenerateImage@spec(prompt: string) -> ai.Func
     let _0: ai.FunctionSpec<image> // _0 // return
     let _1: string // prompt // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: openai.ImageClient
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: openai.ImageClient
 
     bb0: {
-        _2 = { const "prompt": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "prompt": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn openai.ImageClient.new(const "gpt-image-1", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
+        _7 = call const fn openai.ImageClient.new(const "gpt-image-1", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<image> { const "GenerateImage", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<image> { const "GenerateImage", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -167,71 +169,68 @@ fn .<lambda(GenerateImage@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "Generate an image for this prompt:\n";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "Generate an image for this prompt:\n";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -243,9 +242,9 @@ fn .<lambda(GenerateImage@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 
@@ -429,24 +428,26 @@ fn user.fixtures.llm_image_outputs.GenerateImageSet@spec(prompt: string) -> ai.F
     let _0: ai.FunctionSpec<image[]> // _0 // return
     let _1: string // prompt // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: openai.ImageClient
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: openai.ImageClient
 
     bb0: {
-        _2 = { const "prompt": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "prompt": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn openai.ImageClient.new(const "gpt-image-1", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
+        _7 = call const fn openai.ImageClient.new(const "gpt-image-1", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<image[]> { const "GenerateImageSet", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<image[]> { const "GenerateImageSet", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -461,71 +462,68 @@ fn .<lambda(GenerateImageSet@spec, 0)>( __spec_output_format: ai.OutputFormat) -
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "Generate multiple distinct image outputs for this prompt:\n";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "Generate multiple distinct image outputs for this prompt:\n";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -537,9 +535,9 @@ fn .<lambda(GenerateImageSet@spec, 0)>( __spec_output_format: ai.OutputFormat) -
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 
@@ -723,24 +721,26 @@ fn user.fixtures.llm_image_outputs.GenerateMixedImageNarrative@spec(prompt: stri
     let _0: ai.FunctionSpec<(string | image)[]> // _0 // return
     let _1: string // prompt // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: openai.ResponsesClient
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: openai.ResponsesClient
 
     bb0: {
-        _2 = { const "prompt": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "prompt": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn openai.ResponsesClient.new(const "gpt-4.1", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
+        _7 = call const fn openai.ResponsesClient.new(const "gpt-4.1", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<(image | string)[]> { const "GenerateMixedImageNarrative", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<(image | string)[]> { const "GenerateMixedImageNarrative", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -804,7 +804,6 @@ fn .<lambda(GenerateMixedImageNarrative@spec, 0)>( __spec_output_format: ai.Outp
     }
 
     bb1: {
-        _7 = const "";
         _14 = copy _6;
         _15 = copy capture[0];
         _16 = load_type(unknown);

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.llm_parse_catchable_parse_error.ExtractInvoice(text: string, c
     call user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@spec
     store_var _9
     load_type fixtures.llm_parse_catchable_parse_error.Invoice
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function fixtures.llm_parse_catchable_parse_error.ExtractInvoice@spec(text: stri
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.llm_parse_catchable_parse_error.GPT4o
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "ExtractInvoice"
     load_deref ?1
     load_const "text"
@@ -131,22 +129,16 @@ function fixtures.llm_parse_catchable_parse_error.ExtractInvoice@stream(text: st
 function fixtures.llm_parse_catchable_parse_error.TryExtract(json: string) -> fixtures.llm_parse_catchable_parse_error.Invoice | null {
     load_var json
     call user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@parse
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/bytecode.snap
@@ -142,6 +142,9 @@ function fixtures.llm_parse_catchable_parse_error.TryExtract(json: string) -> fi
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_const null
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/mir.snap
@@ -135,24 +135,26 @@ fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@spec(text: strin
     let _0: ai.FunctionSpec<fixtures.llm_parse_catchable_parse_error.Invoice> // _0 // return
     let _1: string // text // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "text": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "text": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.llm_parse_catchable_parse_error.GPT4o) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.llm_parse_catchable_parse_error.GPT4o) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<fixtures.llm_parse_catchable_parse_error.Invoice> { const "ExtractInvoice", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<fixtures.llm_parse_catchable_parse_error.Invoice> { const "ExtractInvoice", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -167,71 +169,68 @@ fn .<lambda(ExtractInvoice@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "extract an invoice from ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "extract an invoice from ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -243,9 +242,9 @@ fn .<lambda(ExtractInvoice@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 
@@ -302,11 +301,9 @@ fn user.fixtures.llm_parse_catchable_parse_error.TryExtract(json: string) -> nul
     let _1: string // json // param
     let _2: unknown // _
     let _3: bool
-    let _4: string
-    let _5: string
 
     bb0: {
-        _0 = call const fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@parse(copy _1) -> [bb5, unwind: bb1];
+        _0 = call const fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@parse(copy _1) -> [bb4, unwind: bb1];
     }
 
     bb1: {
@@ -319,18 +316,11 @@ fn user.fixtures.llm_parse_catchable_parse_error.TryExtract(json: string) -> nul
     }
 
     bb3: {
-        _4 = copy _2.0;
-        drop(_4);
+        _0 = const null;
         goto -> bb4;
     }
 
     bb4: {
-        _5 = copy _2.0;
-        _0 = const null;
-        goto -> bb5;
-    }
-
-    bb5: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_parse_catchable_parse_error/mir.snap
@@ -167,68 +167,71 @@ fn .<lambda(ExtractInvoice@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "extract an invoice from ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "extract an invoice from ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -240,9 +243,9 @@ fn .<lambda(ExtractInvoice@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 
@@ -300,9 +303,10 @@ fn user.fixtures.llm_parse_catchable_parse_error.TryExtract(json: string) -> nul
     let _2: unknown // _
     let _3: bool
     let _4: string
+    let _5: string
 
     bb0: {
-        _0 = call const fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@parse(copy _1) -> [bb4, unwind: bb1];
+        _0 = call const fn user.fixtures.llm_parse_catchable_parse_error.ExtractInvoice@parse(copy _1) -> [bb5, unwind: bb1];
     }
 
     bb1: {
@@ -316,11 +320,17 @@ fn user.fixtures.llm_parse_catchable_parse_error.TryExtract(json: string) -> nul
 
     bb3: {
         _4 = copy _2.0;
-        _0 = const null;
+        drop(_4);
         goto -> bb4;
     }
 
     bb4: {
+        _5 = copy _2.0;
+        _0 = const null;
+        goto -> bb5;
+    }
+
+    bb5: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.llm_quoted_prompt.BacktickPrompt(topic: string, client: ai.Cli
     call user.fixtures.llm_quoted_prompt.BacktickPrompt@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function fixtures.llm_quoted_prompt.BacktickPrompt@spec(topic: string) -> ai.Fun
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.llm_quoted_prompt.QuotedPromptClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "BacktickPrompt"
     load_deref ?1
     load_const "topic"
@@ -157,12 +155,10 @@ function fixtures.llm_quoted_prompt.QuotedPrompt(topic: string, client: ai.Clien
     call user.fixtures.llm_quoted_prompt.QuotedPrompt@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/mir.snap
@@ -167,48 +167,45 @@ fn .<lambda(QuotedPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: string[]
-    let _14: unknown[]
-    let _15: string[]
-    let _16: baml.TaggedString
-    let _17: unknown[]
-    let _18: baml.TaggedString
-    let _19: ai.errors.PromptRenderError
-    let _20: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: string[]
+    let _13: unknown[]
+    let _14: string[]
+    let _15: baml.TaggedString
+    let _16: unknown[]
+    let _17: baml.TaggedString
+    let _18: ai.errors.PromptRenderError
+    let _19: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "Write one sentence. Escapes decode:\n\tdone. Interpolation stays literal: ${topic}";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb3];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "Write one sentence. Escapes decode:\n\tdone. Interpolation stays literal: ${topic}";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb3];
     }
 
     bb1: {
+        _12 = copy _4;
         _13 = copy _5;
-        _14 = copy _6;
-        _4 = baml.TaggedString { copy _13, copy _14 };
-        _16 = copy _4;
-        _15 = copy _16.0;
-        _18 = copy _4;
-        _17 = copy _18.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _15, copy _17) -> [bb2, unwind: bb3];
+        _3 = baml.TaggedString { copy _12, copy _13 };
+        _15 = copy _3;
+        _14 = copy _15.0;
+        _17 = copy _3;
+        _16 = copy _17.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _14, copy _16) -> [bb2, unwind: bb3];
     }
 
     bb2: {
@@ -220,9 +217,9 @@ fn .<lambda(QuotedPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai
     }
 
     bb4: {
-        _20 = copy _2;
-        _19 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _20 };
-        throw copy _19;
+        _19 = copy _2;
+        _18 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _19 };
+        throw copy _18;
     }
 }
 
@@ -406,24 +403,26 @@ fn user.fixtures.llm_quoted_prompt.BacktickPrompt@spec(topic: string) -> ai.Func
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // topic // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "topic": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "topic": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.llm_quoted_prompt.QuotedPromptClient) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.llm_quoted_prompt.QuotedPromptClient) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "BacktickPrompt", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "BacktickPrompt", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -487,7 +486,6 @@ fn .<lambda(BacktickPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 
     bb1: {
-        _7 = const "";
         _14 = copy _6;
         _15 = copy capture[0];
         _16 = load_type(unknown);

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_quoted_prompt/mir.snap
@@ -167,45 +167,48 @@ fn .<lambda(QuotedPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: string[]
-    let _13: unknown[]
-    let _14: string[]
-    let _15: baml.TaggedString
-    let _16: unknown[]
-    let _17: baml.TaggedString
-    let _18: ai.errors.PromptRenderError
-    let _19: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: string[]
+    let _14: unknown[]
+    let _15: string[]
+    let _16: baml.TaggedString
+    let _17: unknown[]
+    let _18: baml.TaggedString
+    let _19: ai.errors.PromptRenderError
+    let _20: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "Write one sentence. Escapes decode:\n\tdone. Interpolation stays literal: ${topic}";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb3];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "Write one sentence. Escapes decode:\n\tdone. Interpolation stays literal: ${topic}";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb3];
     }
 
     bb1: {
-        _12 = copy _4;
         _13 = copy _5;
-        _3 = baml.TaggedString { copy _12, copy _13 };
-        _15 = copy _3;
-        _14 = copy _15.0;
-        _17 = copy _3;
-        _16 = copy _17.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _14, copy _16) -> [bb2, unwind: bb3];
+        _14 = copy _6;
+        _4 = baml.TaggedString { copy _13, copy _14 };
+        _16 = copy _4;
+        _15 = copy _16.0;
+        _18 = copy _4;
+        _17 = copy _18.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _15, copy _17) -> [bb2, unwind: bb3];
     }
 
     bb2: {
@@ -217,9 +220,9 @@ fn .<lambda(QuotedPrompt@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai
     }
 
     bb4: {
-        _19 = copy _2;
-        _18 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _19 };
-        throw copy _18;
+        _20 = copy _2;
+        _19 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _20 };
+        throw copy _19;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.llm_spec_mode.NamedTools(q: string, client: ai.Client | null, 
     call user.fixtures.llm_spec_mode.NamedTools@spec
     store_var _9
     load_type fixtures.llm_spec_mode.Answer
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -81,7 +79,7 @@ function fixtures.llm_spec_mode.NamedTools@spec(q: string) -> ai.FunctionSpec<fi
     store_var ?1
     call user.fixtures.llm_spec_mode.more_tools
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "claude-haiku-4-5"
     load_const <omitted>
     load_const <omitted>
@@ -99,7 +97,7 @@ function fixtures.llm_spec_mode.NamedTools@spec(q: string) -> ai.FunctionSpec<fi
     load_const <omitted>
     load_const <omitted>
     call anthropic.Client.new
-    store_var _6
+    store_var _7
     load_const "NamedTools"
     load_deref ?1
     load_const "q"
@@ -143,12 +141,10 @@ function fixtures.llm_spec_mode.PlainChat(q: string, client: ai.Client | null, o
     call user.fixtures.llm_spec_mode.PlainChat@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -195,7 +191,7 @@ function fixtures.llm_spec_mode.PlainChat@spec(q: string) -> ai.FunctionSpec<str
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4o-mini"
     load_const <omitted>
     load_const <omitted>
@@ -214,7 +210,7 @@ function fixtures.llm_spec_mode.PlainChat@spec(q: string) -> ai.FunctionSpec<str
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _6
+    store_var _7
     load_const "PlainChat"
     load_deref ?1
     load_const "q"
@@ -286,12 +282,10 @@ function fixtures.llm_spec_mode.SpecAgent(q: string, client: ai.Client | null, o
     call user.fixtures.llm_spec_mode.SpecAgent@spec
     store_var _9
     load_type fixtures.llm_spec_mode.Answer
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -343,7 +337,7 @@ function fixtures.llm_spec_mode.SpecAgent@spec(q: string) -> ai.FunctionSpec<fix
     load_type ai.tools.Tool
     alloc_array 1
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4o-mini"
     load_const <omitted>
     load_const <omitted>
@@ -362,7 +356,7 @@ function fixtures.llm_spec_mode.SpecAgent@spec(q: string) -> ai.FunctionSpec<fix
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _7
+    store_var _8
     load_const "SpecAgent"
     load_deref ?1
     load_const "q"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_llm_spec_mode/mir.snap
@@ -169,24 +169,26 @@ fn user.fixtures.llm_spec_mode.PlainChat@spec(q: string) -> ai.FunctionSpec<stri
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // q // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: openai.ResponsesClient
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: openai.ResponsesClient
 
     bb0: {
-        _2 = { const "q": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "q": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn openai.ResponsesClient.new(const "gpt-4o-mini", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
+        _7 = call const fn openai.ResponsesClient.new(const "gpt-4o-mini", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "PlainChat", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "PlainChat", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -250,7 +252,6 @@ fn .<lambda(PlainChat@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pr
     }
 
     bb1: {
-        _7 = const "";
         _14 = copy _6;
         _15 = copy capture[0];
         _16 = load_type(unknown);
@@ -489,29 +490,31 @@ fn user.fixtures.llm_spec_mode.SpecAgent@spec(q: string) -> ai.FunctionSpec<fixt
     let _0: ai.FunctionSpec<fixtures.llm_spec_mode.Answer> // _0 // return
     let _1: string // q // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.tools.Tool
-    let _7: openai.ResponsesClient
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.tools.Tool
+    let _8: openai.ResponsesClient
 
     bb0: {
-        _2 = { const "q": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _6 = call const fn ai.tools.tool(const fn user.fixtures.llm_spec_mode.double_it, const <omitted>, const <omitted>, const <omitted>) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "q": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _7 = call const fn ai.tools.tool(const fn user.fixtures.llm_spec_mode.double_it, const <omitted>, const <omitted>, const <omitted>) -> [bb1];
     }
 
     bb1: {
-        _5 = [copy _6]: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb2];
+        _6 = [copy _7]: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb2];
     }
 
     bb2: {
-        _7 = call const fn openai.ResponsesClient.new(const "gpt-4o-mini", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb3];
+        _8 = call const fn openai.ResponsesClient.new(const "gpt-4o-mini", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb3];
     }
 
     bb3: {
-        _0 = ai.FunctionSpec<fixtures.llm_spec_mode.Answer> { const "SpecAgent", copy _2, copy _3, copy _4, copy _7 };
+        _0 = ai.FunctionSpec<fixtures.llm_spec_mode.Answer> { const "SpecAgent", copy _2, copy _4, copy _5, copy _8 };
         goto -> bb4;
     }
 
@@ -572,7 +575,6 @@ fn .<lambda(SpecAgent@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pr
     }
 
     bb1: {
-        _7 = const "";
         _13 = copy _6;
         _14 = copy capture[0];
         _15 = load_type(unknown);
@@ -764,27 +766,29 @@ fn user.fixtures.llm_spec_mode.NamedTools@spec(q: string) -> ai.FunctionSpec<fix
     let _0: ai.FunctionSpec<fixtures.llm_spec_mode.Answer> // _0 // return
     let _1: string // q // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: anthropic.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: anthropic.Client
 
     bb0: {
-        _2 = { const "q": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = call const fn user.fixtures.llm_spec_mode.more_tools() -> [bb1];
+        _3 = copy _1;
+        _2 = { const "q": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = call const fn user.fixtures.llm_spec_mode.more_tools() -> [bb1];
     }
 
     bb1: {
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb2];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb2];
     }
 
     bb2: {
-        _6 = call const fn anthropic.Client.new(const "claude-haiku-4-5", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb3];
+        _7 = call const fn anthropic.Client.new(const "claude-haiku-4-5", const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>, const <omitted>) -> [bb3];
     }
 
     bb3: {
-        _0 = ai.FunctionSpec<fixtures.llm_spec_mode.Answer> { const "NamedTools", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<fixtures.llm_spec_mode.Answer> { const "NamedTools", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb4;
     }
 
@@ -845,7 +849,6 @@ fn .<lambda(NamedTools@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.P
     }
 
     bb1: {
-        _7 = const "";
         _13 = copy _6;
         _14 = copy capture[0];
         _15 = load_type(unknown);

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_method_explicit_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_method_explicit_type_args/bytecode.snap
@@ -11,14 +11,9 @@ function fixtures.method_explicit_type_args.use_method_type_args() -> int {
     load_const "x"
     init_instance user.fixtures.method_explicit_type_args.Foo .tag
     call user.fixtures.method_explicit_type_args.Foo.zero
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const 5
-    store_var _3
 
   L0:
-    load_var _3
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_method_explicit_type_args/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_method_explicit_type_args/mir.snap
@@ -25,7 +25,6 @@ fn user.fixtures.method_explicit_type_args.use_method_type_args() -> int {
     let _3: int
     let _4: int | null
     let _5: reflect.Type
-    let _6: bool
 
     bb0: {
         _1 = user.fixtures.method_explicit_type_args.Foo { const "x" };
@@ -34,9 +33,7 @@ fn user.fixtures.method_explicit_type_args.use_method_type_args() -> int {
     }
 
     bb1: {
-        _3 = copy _4;
-        _6 = copy _3 == const null;
-        branch copy _6 -> [bb2, bb3];
+        _3 = short_circuit(??) copy _4 -> [eval: bb2, join: bb3];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.o1_allowed_roles.AskGpt4o(question: string, client: ai.Client 
     call user.fixtures.o1_allowed_roles.AskGpt4o@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function fixtures.o1_allowed_roles.AskGpt4o@spec(question: string) -> ai.Functio
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.o1_allowed_roles.Gpt4oClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "AskGpt4o"
     load_deref ?1
     load_const "question"
@@ -157,12 +155,10 @@ function fixtures.o1_allowed_roles.AskO1(question: string, client: ai.Client | n
     call user.fixtures.o1_allowed_roles.AskO1@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -209,10 +205,10 @@ function fixtures.o1_allowed_roles.AskO1@spec(question: string) -> ai.FunctionSp
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.o1_allowed_roles.O1Client
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "AskO1"
     load_deref ?1
     load_const "question"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/mir.snap
@@ -167,65 +167,68 @@ fn .<lambda(AskO1@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: int
-    let _8: string[]
-    let _9: string
-    let _10: reflect.Type
-    let _11: int
-    let _12: unknown[]
-    let _13: string
-    let _14: reflect.Type
-    let _15: int
-    let _16: string[]
-    let _17: ""
-    let _18: reflect.Type
-    let _19: string[]
-    let _20: unknown[]
-    let _21: string[]
-    let _22: baml.TaggedString
-    let _23: unknown[]
-    let _24: baml.TaggedString
-    let _25: ai.errors.PromptRenderError
-    let _26: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _8 = copy _4;
-        _9 = copy _6;
-        _10 = load_type(string);
-        _7 = call const fn baml.Array.push<copy _10>(copy _8, copy _9) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _9 = copy _5;
+        _10 = copy _7;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _12 = copy _5;
-        _13 = copy capture[0];
-        _14 = load_type(unknown);
-        _11 = call const fn baml.Array.push<copy _14>(copy _12, copy _13) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _13 = copy _6;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _16 = copy _4;
-        _17 = copy _6;
-        _18 = load_type(string);
-        _15 = call const fn baml.Array.push<copy _18>(copy _16, copy _17) -> [bb3, unwind: bb5];
+        _17 = copy _5;
+        _18 = copy _7;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _19 = copy _4;
         _20 = copy _5;
-        _3 = baml.TaggedString { copy _19, copy _20 };
-        _22 = copy _3;
-        _21 = copy _22.0;
-        _24 = copy _3;
-        _23 = copy _24.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _21, copy _23) -> [bb4, unwind: bb5];
+        _21 = copy _6;
+        _4 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _4;
+        _22 = copy _23.0;
+        _25 = copy _4;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -237,9 +240,9 @@ fn .<lambda(AskO1@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     }
 
     bb6: {
-        _26 = copy _2;
-        _25 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _26 };
-        throw copy _25;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 
@@ -455,65 +458,68 @@ fn .<lambda(AskGpt4o@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: int
-    let _8: string[]
-    let _9: string
-    let _10: reflect.Type
-    let _11: int
-    let _12: unknown[]
-    let _13: string
-    let _14: reflect.Type
-    let _15: int
-    let _16: string[]
-    let _17: ""
-    let _18: reflect.Type
-    let _19: string[]
-    let _20: unknown[]
-    let _21: string[]
-    let _22: baml.TaggedString
-    let _23: unknown[]
-    let _24: baml.TaggedString
-    let _25: ai.errors.PromptRenderError
-    let _26: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _8 = copy _4;
-        _9 = copy _6;
-        _10 = load_type(string);
-        _7 = call const fn baml.Array.push<copy _10>(copy _8, copy _9) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _9 = copy _5;
+        _10 = copy _7;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _12 = copy _5;
-        _13 = copy capture[0];
-        _14 = load_type(unknown);
-        _11 = call const fn baml.Array.push<copy _14>(copy _12, copy _13) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _13 = copy _6;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _16 = copy _4;
-        _17 = copy _6;
-        _18 = load_type(string);
-        _15 = call const fn baml.Array.push<copy _18>(copy _16, copy _17) -> [bb3, unwind: bb5];
+        _17 = copy _5;
+        _18 = copy _7;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _19 = copy _4;
         _20 = copy _5;
-        _3 = baml.TaggedString { copy _19, copy _20 };
-        _22 = copy _3;
-        _21 = copy _22.0;
-        _24 = copy _3;
-        _23 = copy _24.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _21, copy _23) -> [bb4, unwind: bb5];
+        _21 = copy _6;
+        _4 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _4;
+        _22 = copy _23.0;
+        _25 = copy _4;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -525,9 +531,9 @@ fn .<lambda(AskGpt4o@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     }
 
     bb6: {
-        _26 = copy _2;
-        _25 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _26 };
-        throw copy _25;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_o1_allowed_roles/mir.snap
@@ -135,24 +135,26 @@ fn user.fixtures.o1_allowed_roles.AskO1@spec(question: string) -> ai.FunctionSpe
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // question // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "question": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "question": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.o1_allowed_roles.O1Client) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.o1_allowed_roles.O1Client) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "AskO1", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "AskO1", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -167,68 +169,65 @@ fn .<lambda(AskO1@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: int
+    let _8: string[]
+    let _9: string
+    let _10: reflect.Type
+    let _11: int
+    let _12: unknown[]
+    let _13: string
+    let _14: reflect.Type
+    let _15: int
+    let _16: string[]
+    let _17: ""
+    let _18: reflect.Type
+    let _19: string[]
+    let _20: unknown[]
+    let _21: string[]
+    let _22: baml.TaggedString
+    let _23: unknown[]
+    let _24: baml.TaggedString
+    let _25: ai.errors.PromptRenderError
+    let _26: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _9 = copy _5;
-        _10 = copy _7;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _8 = copy _4;
+        _9 = copy _6;
+        _10 = load_type(string);
+        _7 = call const fn baml.Array.push<copy _10>(copy _8, copy _9) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _13 = copy _6;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _12 = copy _5;
+        _13 = copy capture[0];
+        _14 = load_type(unknown);
+        _11 = call const fn baml.Array.push<copy _14>(copy _12, copy _13) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _5;
-        _18 = copy _7;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _16 = copy _4;
+        _17 = copy _6;
+        _18 = load_type(string);
+        _15 = call const fn baml.Array.push<copy _18>(copy _16, copy _17) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _19 = copy _4;
         _20 = copy _5;
-        _21 = copy _6;
-        _4 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _4;
-        _22 = copy _23.0;
-        _25 = copy _4;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _19, copy _20 };
+        _22 = copy _3;
+        _21 = copy _22.0;
+        _24 = copy _3;
+        _23 = copy _24.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _21, copy _23) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -240,9 +239,9 @@ fn .<lambda(AskO1@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prompt
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _26 = copy _2;
+        _25 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _26 };
+        throw copy _25;
     }
 }
 
@@ -426,24 +425,26 @@ fn user.fixtures.o1_allowed_roles.AskGpt4o@spec(question: string) -> ai.Function
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // question // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "question": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "question": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.o1_allowed_roles.Gpt4oClient) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.o1_allowed_roles.Gpt4oClient) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "AskGpt4o", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "AskGpt4o", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -458,68 +459,65 @@ fn .<lambda(AskGpt4o@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: int
+    let _8: string[]
+    let _9: string
+    let _10: reflect.Type
+    let _11: int
+    let _12: unknown[]
+    let _13: string
+    let _14: reflect.Type
+    let _15: int
+    let _16: string[]
+    let _17: ""
+    let _18: reflect.Type
+    let _19: string[]
+    let _20: unknown[]
+    let _21: string[]
+    let _22: baml.TaggedString
+    let _23: unknown[]
+    let _24: baml.TaggedString
+    let _25: ai.errors.PromptRenderError
+    let _26: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _9 = copy _5;
-        _10 = copy _7;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _8 = copy _4;
+        _9 = copy _6;
+        _10 = load_type(string);
+        _7 = call const fn baml.Array.push<copy _10>(copy _8, copy _9) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _13 = copy _6;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _12 = copy _5;
+        _13 = copy capture[0];
+        _14 = load_type(unknown);
+        _11 = call const fn baml.Array.push<copy _14>(copy _12, copy _13) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _5;
-        _18 = copy _7;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _16 = copy _4;
+        _17 = copy _6;
+        _18 = load_type(string);
+        _15 = call const fn baml.Array.push<copy _18>(copy _16, copy _17) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _19 = copy _4;
         _20 = copy _5;
-        _21 = copy _6;
-        _4 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _4;
-        _22 = copy _23.0;
-        _25 = copy _4;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _19, copy _20 };
+        _22 = copy _3;
+        _21 = copy _22.0;
+        _24 = copy _3;
+        _23 = copy _24.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _21, copy _23) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -531,9 +529,9 @@ fn .<lambda(AskGpt4o@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _26 = copy _2;
+        _25 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _26 };
+        throw copy _25;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/bytecode.snap
@@ -31,12 +31,10 @@ function fixtures.optional_function_parameters.AskDocs(query: string, max_result
     call user.fixtures.optional_function_parameters.AskDocs@spec
     store_var _11
     load_type string
-    load_var2 7 8
+    load_var2 6 7
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _8
-    load_var _8
     load_field .value
     return
 }
@@ -91,10 +89,10 @@ function fixtures.optional_function_parameters.AskDocs@spec(query: string, max_r
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _6
+    store_var _9
     load_global user.fixtures.optional_function_parameters.TestClient
     call ai.clients.resolve
-    store_var _8
+    store_var _11
     load_const "AskDocs"
     load_deref ?1
     load_deref ?2
@@ -168,19 +166,16 @@ function fixtures.optional_function_parameters.HostEntry(query: string, max_resu
     load_var filter
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L2
+    pop_jump_if_true L2
+    load_var max_results
+    load_const 100
+    add_int
     jump L3
 
   L2:
     load_var max_results
-    load_const 100
-    add_int
-    jump L4
 
   L3:
-    load_var max_results
-
-  L4:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/mir.snap
@@ -405,113 +405,116 @@ fn .<lambda(AskDocs@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prom
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: int
-    let _8: string[]
-    let _9: string
-    let _10: reflect.Type
-    let _11: int
-    let _12: unknown[]
-    let _13: string
-    let _14: reflect.Type
-    let _15: int
-    let _16: string[]
-    let _17: " "
-    let _18: reflect.Type
-    let _19: int
-    let _20: unknown[]
-    let _21: int
-    let _22: reflect.Type
-    let _23: int
-    let _24: string[]
-    let _25: " "
-    let _26: reflect.Type
-    let _27: int
-    let _28: unknown[]
-    let _29: string
-    let _30: reflect.Type
-    let _31: int
-    let _32: string[]
-    let _33: ""
-    let _34: reflect.Type
-    let _35: string[]
-    let _36: unknown[]
-    let _37: string[]
-    let _38: baml.TaggedString
-    let _39: unknown[]
-    let _40: baml.TaggedString
-    let _41: ai.errors.PromptRenderError
-    let _42: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: " "
+    let _19: reflect.Type
+    let _20: int
+    let _21: unknown[]
+    let _22: int
+    let _23: reflect.Type
+    let _24: int
+    let _25: string[]
+    let _26: " "
+    let _27: reflect.Type
+    let _28: int
+    let _29: unknown[]
+    let _30: string
+    let _31: reflect.Type
+    let _32: int
+    let _33: string[]
+    let _34: ""
+    let _35: reflect.Type
+    let _36: string[]
+    let _37: unknown[]
+    let _38: string[]
+    let _39: baml.TaggedString
+    let _40: unknown[]
+    let _41: baml.TaggedString
+    let _42: ai.errors.PromptRenderError
+    let _43: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _8 = copy _4;
-        _9 = copy _6;
-        _10 = load_type(string);
-        _7 = call const fn baml.Array.push<copy _10>(copy _8, copy _9) -> [bb1, unwind: bb9];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _9 = copy _5;
+        _10 = copy _7;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb9];
     }
 
     bb1: {
-        _6 = const "";
-        _12 = copy _5;
-        _13 = copy capture[0];
-        _14 = load_type(unknown);
-        _11 = call const fn baml.Array.push<copy _14>(copy _12, copy _13) -> [bb2, unwind: bb9];
+        _7 = const "";
+        _13 = copy _6;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb9];
     }
 
     bb2: {
-        _6 = const " ";
-        _16 = copy _4;
-        _17 = copy _6;
-        _18 = load_type(string);
-        _15 = call const fn baml.Array.push<copy _18>(copy _16, copy _17) -> [bb3, unwind: bb9];
+        _7 = const " ";
+        _17 = copy _5;
+        _18 = copy _7;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb9];
     }
 
     bb3: {
-        _6 = const "";
-        _20 = copy _5;
-        _21 = copy capture[1];
-        _22 = load_type(unknown);
-        _19 = call const fn baml.Array.push<copy _22>(copy _20, copy _21) -> [bb4, unwind: bb9];
+        _7 = const "";
+        _21 = copy _6;
+        _22 = copy capture[1];
+        _23 = load_type(unknown);
+        _20 = call const fn baml.Array.push<copy _23>(copy _21, copy _22) -> [bb4, unwind: bb9];
     }
 
     bb4: {
-        _6 = const " ";
-        _24 = copy _4;
-        _25 = copy _6;
-        _26 = load_type(string);
-        _23 = call const fn baml.Array.push<copy _26>(copy _24, copy _25) -> [bb5, unwind: bb9];
+        _7 = const " ";
+        _25 = copy _5;
+        _26 = copy _7;
+        _27 = load_type(string);
+        _24 = call const fn baml.Array.push<copy _27>(copy _25, copy _26) -> [bb5, unwind: bb9];
     }
 
     bb5: {
-        _6 = const "";
-        _28 = copy _5;
-        _29 = copy capture[2];
-        _30 = load_type(unknown);
-        _27 = call const fn baml.Array.push<copy _30>(copy _28, copy _29) -> [bb6, unwind: bb9];
+        _7 = const "";
+        _29 = copy _6;
+        _30 = copy capture[2];
+        _31 = load_type(unknown);
+        _28 = call const fn baml.Array.push<copy _31>(copy _29, copy _30) -> [bb6, unwind: bb9];
     }
 
     bb6: {
-        _32 = copy _4;
-        _33 = copy _6;
-        _34 = load_type(string);
-        _31 = call const fn baml.Array.push<copy _34>(copy _32, copy _33) -> [bb7, unwind: bb9];
+        _33 = copy _5;
+        _34 = copy _7;
+        _35 = load_type(string);
+        _32 = call const fn baml.Array.push<copy _35>(copy _33, copy _34) -> [bb7, unwind: bb9];
     }
 
     bb7: {
-        _35 = copy _4;
         _36 = copy _5;
-        _3 = baml.TaggedString { copy _35, copy _36 };
-        _38 = copy _3;
-        _37 = copy _38.0;
-        _40 = copy _3;
-        _39 = copy _40.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _37, copy _39) -> [bb8, unwind: bb9];
+        _37 = copy _6;
+        _4 = baml.TaggedString { copy _36, copy _37 };
+        _39 = copy _4;
+        _38 = copy _39.0;
+        _41 = copy _4;
+        _40 = copy _41.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _38, copy _40) -> [bb8, unwind: bb9];
     }
 
     bb8: {
@@ -523,9 +526,9 @@ fn .<lambda(AskDocs@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prom
     }
 
     bb10: {
-        _42 = copy _2;
-        _41 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _42 };
-        throw copy _41;
+        _43 = copy _2;
+        _42 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _43 };
+        throw copy _42;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_optional_function_parameters/mir.snap
@@ -373,24 +373,30 @@ fn user.fixtures.optional_function_parameters.AskDocs@spec(query: string, max_re
     let _2: int // max_results // param [captured]
     let _3: string // filter // param [captured]
     let _4: map<string, unknown>
-    let _5: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _6: ai.tools.Toolbox
-    let _7: ai.tools.Tool[]
-    let _8: ai.Client
+    let _5: string
+    let _6: int
+    let _7: string
+    let _8: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _9: ai.tools.Toolbox
+    let _10: ai.tools.Tool[]
+    let _11: ai.Client
 
     bb0: {
-        _4 = { const "query": copy _1, const "max_results": copy _2, const "filter": copy _3 }: map<string, unknown>;
-        _5 = make_closure lambda[0](copy _1, copy _2, copy _3);
-        _7 = []: ai.tools.Tool[];
-        _6 = call const fn ai.tools.Toolbox.new(copy _7) -> [bb1];
+        _5 = copy _1;
+        _6 = copy _2;
+        _7 = copy _3;
+        _4 = { const "query": copy _5, const "max_results": copy _6, const "filter": copy _7 }: map<string, unknown>;
+        _8 = make_closure lambda[0](copy _1, copy _2, copy _3);
+        _10 = []: ai.tools.Tool[];
+        _9 = call const fn ai.tools.Toolbox.new(copy _10) -> [bb1];
     }
 
     bb1: {
-        _8 = call const fn ai.clients.resolve(const item user.fixtures.optional_function_parameters.TestClient) -> [bb2];
+        _11 = call const fn ai.clients.resolve(const item user.fixtures.optional_function_parameters.TestClient) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "AskDocs", copy _4, copy _5, copy _6, copy _8 };
+        _0 = ai.FunctionSpec<string> { const "AskDocs", copy _4, copy _8, copy _9, copy _11 };
         goto -> bb3;
     }
 
@@ -405,116 +411,111 @@ fn .<lambda(AskDocs@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prom
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: " "
-    let _19: reflect.Type
-    let _20: int
-    let _21: unknown[]
-    let _22: int
-    let _23: reflect.Type
-    let _24: int
-    let _25: string[]
-    let _26: " "
-    let _27: reflect.Type
-    let _28: int
-    let _29: unknown[]
-    let _30: string
-    let _31: reflect.Type
-    let _32: int
-    let _33: string[]
-    let _34: ""
-    let _35: reflect.Type
-    let _36: string[]
-    let _37: unknown[]
-    let _38: string[]
-    let _39: baml.TaggedString
-    let _40: unknown[]
-    let _41: baml.TaggedString
-    let _42: ai.errors.PromptRenderError
-    let _43: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: int
+    let _8: string[]
+    let _9: string
+    let _10: reflect.Type
+    let _11: int
+    let _12: unknown[]
+    let _13: string
+    let _14: reflect.Type
+    let _15: int
+    let _16: string[]
+    let _17: " "
+    let _18: reflect.Type
+    let _19: int
+    let _20: unknown[]
+    let _21: int
+    let _22: reflect.Type
+    let _23: int
+    let _24: string[]
+    let _25: " "
+    let _26: reflect.Type
+    let _27: int
+    let _28: unknown[]
+    let _29: string
+    let _30: reflect.Type
+    let _31: int
+    let _32: string[]
+    let _33: ""
+    let _34: reflect.Type
+    let _35: string[]
+    let _36: unknown[]
+    let _37: string[]
+    let _38: baml.TaggedString
+    let _39: unknown[]
+    let _40: baml.TaggedString
+    let _41: ai.errors.PromptRenderError
+    let _42: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _9 = copy _5;
-        _10 = copy _7;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb9];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _8 = copy _4;
+        _9 = copy _6;
+        _10 = load_type(string);
+        _7 = call const fn baml.Array.push<copy _10>(copy _8, copy _9) -> [bb1, unwind: bb9];
     }
 
     bb1: {
-        _7 = const "";
-        _13 = copy _6;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb9];
+        _12 = copy _5;
+        _13 = copy capture[0];
+        _14 = load_type(unknown);
+        _11 = call const fn baml.Array.push<copy _14>(copy _12, copy _13) -> [bb2, unwind: bb9];
     }
 
     bb2: {
-        _7 = const " ";
-        _17 = copy _5;
-        _18 = copy _7;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb9];
+        _6 = const " ";
+        _16 = copy _4;
+        _17 = copy _6;
+        _18 = load_type(string);
+        _15 = call const fn baml.Array.push<copy _18>(copy _16, copy _17) -> [bb3, unwind: bb9];
     }
 
     bb3: {
-        _7 = const "";
-        _21 = copy _6;
-        _22 = copy capture[1];
-        _23 = load_type(unknown);
-        _20 = call const fn baml.Array.push<copy _23>(copy _21, copy _22) -> [bb4, unwind: bb9];
+        _20 = copy _5;
+        _21 = copy capture[1];
+        _22 = load_type(unknown);
+        _19 = call const fn baml.Array.push<copy _22>(copy _20, copy _21) -> [bb4, unwind: bb9];
     }
 
     bb4: {
-        _7 = const " ";
-        _25 = copy _5;
-        _26 = copy _7;
-        _27 = load_type(string);
-        _24 = call const fn baml.Array.push<copy _27>(copy _25, copy _26) -> [bb5, unwind: bb9];
+        _6 = const " ";
+        _24 = copy _4;
+        _25 = copy _6;
+        _26 = load_type(string);
+        _23 = call const fn baml.Array.push<copy _26>(copy _24, copy _25) -> [bb5, unwind: bb9];
     }
 
     bb5: {
-        _7 = const "";
-        _29 = copy _6;
-        _30 = copy capture[2];
-        _31 = load_type(unknown);
-        _28 = call const fn baml.Array.push<copy _31>(copy _29, copy _30) -> [bb6, unwind: bb9];
+        _6 = const "";
+        _28 = copy _5;
+        _29 = copy capture[2];
+        _30 = load_type(unknown);
+        _27 = call const fn baml.Array.push<copy _30>(copy _28, copy _29) -> [bb6, unwind: bb9];
     }
 
     bb6: {
-        _33 = copy _5;
-        _34 = copy _7;
-        _35 = load_type(string);
-        _32 = call const fn baml.Array.push<copy _35>(copy _33, copy _34) -> [bb7, unwind: bb9];
+        _32 = copy _4;
+        _33 = copy _6;
+        _34 = load_type(string);
+        _31 = call const fn baml.Array.push<copy _34>(copy _32, copy _33) -> [bb7, unwind: bb9];
     }
 
     bb7: {
+        _35 = copy _4;
         _36 = copy _5;
-        _37 = copy _6;
-        _4 = baml.TaggedString { copy _36, copy _37 };
-        _39 = copy _4;
-        _38 = copy _39.0;
-        _41 = copy _4;
-        _40 = copy _41.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _38, copy _40) -> [bb8, unwind: bb9];
+        _3 = baml.TaggedString { copy _35, copy _36 };
+        _38 = copy _3;
+        _37 = copy _38.0;
+        _40 = copy _3;
+        _39 = copy _40.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _37, copy _39) -> [bb8, unwind: bb9];
     }
 
     bb8: {
@@ -526,9 +527,9 @@ fn .<lambda(AskDocs@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Prom
     }
 
     bb10: {
-        _43 = copy _2;
-        _42 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _43 };
-        throw copy _42;
+        _42 = copy _2;
+        _41 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _42 };
+        throw copy _41;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
@@ -2,30 +2,11 @@
 source: crates/baml_tests/src/corpus.rs
 ---
 function fixtures.parser_expressions.Calculate() -> int {
-    load_const 3
-    load_const 3
-    mul_int
-    store_var b
-    load_const 3
-    load_var b
-    add_int
-    load_var b
-    load_const 2
-    div_int
-    load_const 1
-    sub_int
-    mul_int
+    load_const 36
     return
 }
 
 function fixtures.parser_expressions.FieldAccess(user: fixtures.parser_expressions.User) -> string {
-    load_var user
-    load_field .name
-    pop 1
-    load_var user
-    load_field .profile
-    load_field .bio
-    pop 1
     load_var user
     load_field .profile
     load_field .settings
@@ -67,16 +48,5 @@ function fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressi
 
 function fixtures.parser_expressions.TestPrecedence() -> bool {
     load_const true
-    jump_if_false L0
-    jump L1
-
-  L0:
-    pop 1
-    load_const false
-    jump_if_false L1
-    pop 1
-    load_const false
-
-  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
@@ -20,9 +20,23 @@ function fixtures.parser_expressions.Calculate() -> int {
 
 function fixtures.parser_expressions.FieldAccess(user: fixtures.parser_expressions.User) -> string {
     load_var user
+    load_field .name
+    pop 1
+    load_var user
+    load_field .profile
+    load_field .bio
+    pop 1
+    load_var user
     load_field .profile
     load_field .settings
     load_field .theme
+    store_var theme
+    load_var user
+    load_field .tags
+    load_const 0
+    load_array_element
+    pop 1
+    load_var theme
     return
 }
 
@@ -30,7 +44,24 @@ function fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressi
     load_var users
     load_const 0
     load_array_element
+    pop 1
+    load_var users
+    load_const 1
+    load_array_element
+    pop 1
+    load_var users
+    load_const 0
+    load_array_element
     load_field .name
+    store_var firstName
+    load_var users
+    load_const 0
+    load_array_element
+    load_field .tags
+    load_const 0
+    load_array_element
+    pop 1
+    load_var firstName
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/mir.snap
@@ -5,31 +5,9 @@ source: crates/baml_tests/src/corpus.rs
 fn user.fixtures.parser_expressions.Calculate() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // a
-    let _2: int // b
-    let _3: int
-    let _4: int // c
-    let _5: int
-    let _6: int
-    let _7: int // d
-    let _8: int
-    let _9: int
-    let _10: int
-    let _11: int
 
     bb0: {
-        _1 = const 3_i64;
-        _3 = copy _1;
-        _2 = copy _3 * const 3_i64;
-        _6 = copy _2;
-        _5 = copy _6 / const 2_i64;
-        _4 = copy _5 - const 1_i64;
-        _9 = copy _1;
-        _10 = copy _2;
-        _8 = copy _9 + copy _10;
-        _11 = copy _4;
-        _7 = copy _8 * copy _11;
-        _0 = copy _7;
+        _0 = const 36_i64;
         goto -> bb1;
     }
 
@@ -42,24 +20,18 @@ fn user.fixtures.parser_expressions.FieldAccess(user: fixtures.parser_expression
     // Locals:
     let _0: string // _0 // return
     let _1: fixtures.parser_expressions.User // user // param
-    let _2: string // name
-    let _3: string // bio
-    let _4: string // theme
-    let _5: string // firstTag
-    let _6: string[]
-    let _7: 0
+    let _2: string // theme
+    let _3: string // firstTag
+    let _4: string[]
+    let _5: 0
 
     bb0: {
-        _2 = copy _1.0;
-        drop(_2);
-        _3 = copy _1.1.0;
+        _2 = copy _1.1.1.0;
+        _4 = copy _1.2;
+        _5 = const 0_i64;
+        _3 = copy _4[_5];
         drop(_3);
-        _4 = copy _1.1.1.0;
-        _6 = copy _1.2;
-        _7 = const 0_i64;
-        _5 = copy _6[_7];
-        drop(_5);
-        _0 = copy _4;
+        _0 = copy _2;
         goto -> bb1;
     }
 
@@ -75,43 +47,41 @@ fn user.fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressio
     let _2: fixtures.parser_expressions.IndexUser // first
     let _3: fixtures.parser_expressions.IndexUser[]
     let _4: 0
-    let _5: int // idx
-    let _6: fixtures.parser_expressions.IndexUser // second
-    let _7: fixtures.parser_expressions.IndexUser[]
-    let _8: int
-    let _9: string // firstName
-    let _10: fixtures.parser_expressions.IndexUser
-    let _11: fixtures.parser_expressions.IndexUser[]
-    let _12: 0
-    let _13: string // tag
-    let _14: string[]
-    let _15: fixtures.parser_expressions.IndexUser
-    let _16: fixtures.parser_expressions.IndexUser[]
+    let _5: fixtures.parser_expressions.IndexUser // second
+    let _6: fixtures.parser_expressions.IndexUser[]
+    let _7: int
+    let _8: string // firstName
+    let _9: fixtures.parser_expressions.IndexUser
+    let _10: fixtures.parser_expressions.IndexUser[]
+    let _11: 0
+    let _12: string // tag
+    let _13: string[]
+    let _14: fixtures.parser_expressions.IndexUser
+    let _15: fixtures.parser_expressions.IndexUser[]
+    let _16: 0
     let _17: 0
-    let _18: 0
 
     bb0: {
         _3 = copy _1;
         _4 = const 0_i64;
         _2 = copy _3[_4];
         drop(_2);
-        _5 = const 1_i64;
-        _7 = copy _1;
-        _8 = copy _5;
-        _6 = copy _7[_8];
-        drop(_6);
-        _11 = copy _1;
-        _12 = const 0_i64;
-        _10 = copy _11[_12];
-        _9 = copy _10.0;
-        _16 = copy _1;
+        _6 = copy _1;
+        _7 = const 1_i64;
+        _5 = copy _6[_7];
+        drop(_5);
+        _10 = copy _1;
+        _11 = const 0_i64;
+        _9 = copy _10[_11];
+        _8 = copy _9.0;
+        _15 = copy _1;
+        _16 = const 0_i64;
+        _14 = copy _15[_16];
+        _13 = copy _14.2;
         _17 = const 0_i64;
-        _15 = copy _16[_17];
-        _14 = copy _15.2;
-        _18 = const 0_i64;
-        _13 = copy _14[_18];
-        drop(_13);
-        _0 = copy _9;
+        _12 = copy _13[_17];
+        drop(_12);
+        _0 = copy _8;
         goto -> bb1;
     }
 
@@ -123,31 +93,17 @@ fn user.fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressio
 fn user.fixtures.parser_expressions.TestPrecedence() -> bool {
     // Locals:
     let _0: bool // _0 // return
-    let _1: int // a
-    let _2: int
-    let _3: bool // d
 
     bb0: {
-        _1 = const 14_i64;
-        _2 = copy _1;
-        _3 = short_circuit(||) const true -> [eval: bb1, join: bb3];
+        goto -> bb1;
     }
 
     bb1: {
-        _3 = short_circuit(&&) const false -> [eval: bb2, join: bb3];
+        _0 = const true;
+        goto -> bb2;
     }
 
     bb2: {
-        _3 = const false;
-        goto -> bb3;
-    }
-
-    bb3: {
-        _0 = copy _3;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/mir.snap
@@ -42,15 +42,24 @@ fn user.fixtures.parser_expressions.FieldAccess(user: fixtures.parser_expression
     // Locals:
     let _0: string // _0 // return
     let _1: fixtures.parser_expressions.User // user // param
-    let _2: string // theme
-    let _3: string[]
-    let _4: 0
+    let _2: string // name
+    let _3: string // bio
+    let _4: string // theme
+    let _5: string // firstTag
+    let _6: string[]
+    let _7: 0
 
     bb0: {
-        _2 = copy _1.1.1.0;
-        _3 = copy _1.2;
-        _4 = const 0_i64;
-        _0 = copy _2;
+        _2 = copy _1.0;
+        drop(_2);
+        _3 = copy _1.1.0;
+        drop(_3);
+        _4 = copy _1.1.1.0;
+        _6 = copy _1.2;
+        _7 = const 0_i64;
+        _5 = copy _6[_7];
+        drop(_5);
+        _0 = copy _4;
         goto -> bb1;
     }
 
@@ -63,37 +72,46 @@ fn user.fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressio
     // Locals:
     let _0: string // _0 // return
     let _1: fixtures.parser_expressions.IndexUser[] // users // param
-    let _2: fixtures.parser_expressions.IndexUser[]
-    let _3: 0
-    let _4: int // idx
-    let _5: fixtures.parser_expressions.IndexUser[]
-    let _6: int
-    let _7: string // firstName
-    let _8: fixtures.parser_expressions.IndexUser
-    let _9: fixtures.parser_expressions.IndexUser[]
-    let _10: 0
-    let _11: string[]
-    let _12: fixtures.parser_expressions.IndexUser
-    let _13: fixtures.parser_expressions.IndexUser[]
-    let _14: 0
-    let _15: 0
+    let _2: fixtures.parser_expressions.IndexUser // first
+    let _3: fixtures.parser_expressions.IndexUser[]
+    let _4: 0
+    let _5: int // idx
+    let _6: fixtures.parser_expressions.IndexUser // second
+    let _7: fixtures.parser_expressions.IndexUser[]
+    let _8: int
+    let _9: string // firstName
+    let _10: fixtures.parser_expressions.IndexUser
+    let _11: fixtures.parser_expressions.IndexUser[]
+    let _12: 0
+    let _13: string // tag
+    let _14: string[]
+    let _15: fixtures.parser_expressions.IndexUser
+    let _16: fixtures.parser_expressions.IndexUser[]
+    let _17: 0
+    let _18: 0
 
     bb0: {
-        _2 = copy _1;
-        _3 = const 0_i64;
-        _4 = const 1_i64;
-        _5 = copy _1;
-        _6 = copy _4;
-        _9 = copy _1;
-        _10 = const 0_i64;
-        _8 = copy _9[_10];
-        _7 = copy _8.0;
-        _13 = copy _1;
-        _14 = const 0_i64;
-        _12 = copy _13[_14];
-        _11 = copy _12.2;
-        _15 = const 0_i64;
-        _0 = copy _7;
+        _3 = copy _1;
+        _4 = const 0_i64;
+        _2 = copy _3[_4];
+        drop(_2);
+        _5 = const 1_i64;
+        _7 = copy _1;
+        _8 = copy _5;
+        _6 = copy _7[_8];
+        drop(_6);
+        _11 = copy _1;
+        _12 = const 0_i64;
+        _10 = copy _11[_12];
+        _9 = copy _10.0;
+        _16 = copy _1;
+        _17 = const 0_i64;
+        _15 = copy _16[_17];
+        _14 = copy _15.2;
+        _18 = const 0_i64;
+        _13 = copy _14[_18];
+        drop(_13);
+        _0 = copy _9;
         goto -> bb1;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/bytecode.snap
@@ -5,28 +5,22 @@ function fixtures.parser_statements.ConditionalLogic(age: int) -> string {
     load_var age
     load_const 18
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var age
     load_const 65
     cmp_int_op <
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "senior"
+    jump L2
+
+  L0:
+    load_const "adult"
     jump L2
 
   L1:
-    load_const "senior"
-    jump L4
-
-  L2:
-    load_const "adult"
-    jump L4
-
-  L3:
     load_const "minor"
 
-  L4:
+  L2:
     return
 }
 
@@ -51,14 +45,11 @@ function fixtures.parser_statements.assign_in_loop() -> int {
     load_var i
     load_const 5
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var sum
     return
 
-  L2:
+  L1:
     load_var2 1 2
     add_int
     store_var sum
@@ -70,31 +61,16 @@ function fixtures.parser_statements.assign_in_loop() -> int {
 }
 
 function fixtures.parser_statements.block_with_tail() -> int {
-    load_const 1
-    load_const 2
-    add_int
+    load_const 3
     return
 }
 
 function fixtures.parser_statements.break_in_for() -> int {
-    load_const 0
-    load_const 10
-    cmp_int_op <
-    pop_jump_if_false L0
-
-  L0:
     load_const 1
     return
 }
 
 function fixtures.parser_statements.break_with_locals() -> int {
-  L0:
-    load_const true
-    pop_jump_if_false L1
-    load_const true
-    pop_jump_if_false L0
-
-  L1:
     load_const 4
     return
 }
@@ -109,14 +85,11 @@ function fixtures.parser_statements.c_style_for_loop() -> int {
     load_var i
     load_const 10
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var result
     return
 
-  L2:
+  L1:
     load_var2 1 2
     add_int
     store_var result
@@ -135,14 +108,11 @@ function fixtures.parser_statements.continue_in_for() -> int {
     load_var i
     load_const 10
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 2
     return
 
-  L2:
+  L1:
     load_var i
     load_const 1
     add_int
@@ -152,17 +122,6 @@ function fixtures.parser_statements.continue_in_for() -> int {
 
 function fixtures.parser_statements.continue_with_locals() -> int {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const 5
-    return
-
-  L2:
-    load_const true
-    pop_jump_if_false L0
     jump L0
 }
 
@@ -200,10 +159,6 @@ function fixtures.parser_statements.edge_semicolon_forces_boundary(bar: () -> in
     load_var bar
     call_indirect
     pop 1
-    load_const 0
-    load_type int
-    alloc_array 1
-    pop 1
     load_const 1
     return
 }
@@ -236,45 +191,28 @@ function fixtures.parser_statements.iterator_style_for_loop() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     add_int
     store_var result
     jump L0
 
-  L2:
+  L1:
     load_var result
     return
 }
 
 function fixtures.parser_statements.let_mixed_semicolons() -> int {
-    load_const 1
-    load_const 2
-    add_int
-    load_const 3
-    add_int
-    load_const 4
-    add_int
+    load_const 10
     return
 }
 
 function fixtures.parser_statements.let_no_semicolons() -> int {
-    load_const 1
-    load_const 2
-    add_int
+    load_const 3
     return
 }
 
 function fixtures.parser_statements.let_statements() -> int {
-    load_const 1
-    load_const 2
-    load_const 3
-    load_type int
-    alloc_array 3
-    pop 1
     load_const 1
     load_const 2
     init_instance user.fixtures.parser_statements.Point .x, .y
@@ -303,12 +241,6 @@ function fixtures.parser_statements.multi_assign() -> int {
 }
 
 function fixtures.parser_statements.nested_break() -> int {
-    load_const true
-    pop_jump_if_false L0
-    load_const true
-    pop_jump_if_false L0
-
-  L0:
     load_const 3
     return
 }
@@ -334,10 +266,7 @@ function fixtures.parser_statements.nested_for_loop() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_const 4
     load_const 5
     load_const 6
@@ -348,7 +277,7 @@ function fixtures.parser_statements.nested_for_loop() -> int {
     virtual_call nargs=1 ntypeargs=0
     store_var _9
 
-  L2:
+  L1:
     load_var _9
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
@@ -356,18 +285,15 @@ function fixtures.parser_statements.nested_for_loop() -> int {
     store_var _10
     load_var _10
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L0
-
-  L3:
+    pop_jump_if_true L0
     load_var2 1 3
     load_var _10
     mul_int
     add_int
     store_var result
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_var result
     return
 }
@@ -375,20 +301,9 @@ function fixtures.parser_statements.nested_for_loop() -> int {
 function fixtures.parser_statements.nested_while_loop() -> int {
   L0:
     load_const 0
-    load_const 10
-    cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const 0
-    return
-
-  L2:
-    load_const 0
     store_var j
 
-  L3:
+  L1:
     load_var j
     load_const 10
     cmp_int_op <
@@ -397,36 +312,22 @@ function fixtures.parser_statements.nested_while_loop() -> int {
     load_const 1
     add_int
     store_var j
-    jump L3
+    jump L1
 }
 
 function fixtures.parser_statements.simple_assign() -> int {
-    load_const 1
-    store_var x
     load_const 5
-    store_var x
-    load_var x
     return
 }
 
 function fixtures.parser_statements.simple_break() -> int {
-    load_const true
-    pop_jump_if_false L0
-
-  L0:
     load_const 42
     return
 }
 
 function fixtures.parser_statements.simple_continue() -> int {
   L0:
-    load_const true
-    pop_jump_if_false L1
     jump L0
-
-  L1:
-    load_const 0
-    return
 }
 
 function fixtures.parser_statements.simple_while_loop() -> int {
@@ -437,14 +338,11 @@ function fixtures.parser_statements.simple_while_loop() -> int {
     load_var i
     load_const 10
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var i
     return
 
-  L2:
+  L1:
     load_var i
     load_const 1
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/bytecode.snap
@@ -169,6 +169,8 @@ function fixtures.parser_statements.continue_with_locals() -> int {
 function fixtures.parser_statements.edge_call_then_index(foo: () -> int[] throws never) -> int {
     load_var foo
     call_indirect
+    load_const 0
+    load_array_element
     pop 1
     load_const 1
     return
@@ -197,6 +199,10 @@ function fixtures.parser_statements.edge_let_call_then_index(bar: () -> int[] th
 function fixtures.parser_statements.edge_semicolon_forces_boundary(bar: () -> int[] throws never) -> int {
     load_var bar
     call_indirect
+    pop 1
+    load_const 0
+    load_type int
+    alloc_array 1
     pop 1
     load_const 1
     return
@@ -263,6 +269,12 @@ function fixtures.parser_statements.let_no_semicolons() -> int {
 }
 
 function fixtures.parser_statements.let_statements() -> int {
+    load_const 1
+    load_const 2
+    load_const 3
+    load_type int
+    alloc_array 3
+    pop 1
     load_const 1
     load_const 2
     init_instance user.fixtures.parser_statements.Point .x, .y

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/mir.snap
@@ -5,12 +5,9 @@ source: crates/baml_tests/src/corpus.rs
 fn user.fixtures.parser_statements.simple_assign() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
 
     bb0: {
-        _1 = const 1_i64;
-        _1 = const 5_i64;
-        _0 = copy _1;
+        _0 = const 5_i64;
         goto -> bb1;
     }
 
@@ -125,19 +122,9 @@ fn user.fixtures.parser_statements.assign_in_loop() -> int {
 fn user.fixtures.parser_statements.block_with_tail() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
-    let _2: int // y
-    let _3: int // z
-    let _4: int
-    let _5: int
 
     bb0: {
-        _2 = const 1_i64;
-        _3 = const 2_i64;
-        _4 = copy _2;
-        _5 = copy _3;
-        _1 = copy _4 + copy _5;
-        _0 = copy _1;
+        _0 = const 3_i64;
         goto -> bb1;
     }
 
@@ -149,17 +136,9 @@ fn user.fixtures.parser_statements.block_with_tail() -> int {
 fn user.fixtures.parser_statements.let_no_semicolons() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // x
-    let _2: int // y
-    let _3: int
-    let _4: int
 
     bb0: {
-        _1 = const 1_i64;
-        _2 = const 2_i64;
-        _3 = copy _1;
-        _4 = copy _2;
-        _0 = copy _3 + copy _4;
+        _0 = const 3_i64;
         goto -> bb1;
     }
 
@@ -171,29 +150,9 @@ fn user.fixtures.parser_statements.let_no_semicolons() -> int {
 fn user.fixtures.parser_statements.let_mixed_semicolons() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // a
-    let _2: int // b
-    let _3: int // c
-    let _4: int // d
-    let _5: int
-    let _6: int
-    let _7: int
-    let _8: int
-    let _9: int
-    let _10: int
 
     bb0: {
-        _1 = const 1_i64;
-        _2 = const 2_i64;
-        _3 = const 3_i64;
-        _4 = const 4_i64;
-        _7 = copy _1;
-        _8 = copy _2;
-        _6 = copy _7 + copy _8;
-        _9 = copy _3;
-        _5 = copy _6 + copy _9;
-        _10 = copy _4;
-        _0 = copy _5 + copy _10;
+        _0 = const 10_i64;
         goto -> bb1;
     }
 
@@ -297,15 +256,12 @@ fn user.fixtures.parser_statements.edge_semicolon_forces_boundary(bar: () -> int
     let _0: int // _0 // return
     let _1: () -> int[] throws never // bar // param
     let _2: int[]
-    let _3: int[]
 
     bb0: {
         _2 = call copy _1() -> [bb1];
     }
 
     bb1: {
-        _3 = [const 0_i64]: int[];
-        drop(_3);
         _0 = const 1_i64;
         goto -> bb2;
     }
@@ -324,15 +280,11 @@ fn user.fixtures.parser_statements.simple_break() -> int {
     }
 
     bb1: {
-        branch const true -> [bb2, bb2];
+        _0 = const 42_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        _0 = const 42_i64;
-        goto -> bb3;
-    }
-
-    bb3: {
         return;
     }
 }
@@ -346,43 +298,24 @@ fn user.fixtures.parser_statements.simple_continue() -> int {
     }
 
     bb1: {
-        branch const true -> [bb1, bb2];
-    }
-
-    bb2: {
-        _0 = const 0_i64;
-        goto -> bb3;
-    }
-
-    bb3: {
-        return;
+        goto -> bb1;
     }
 }
 
 fn user.fixtures.parser_statements.break_in_for() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // i
-    let _2: bool
-    let _3: int
 
     bb0: {
-        _1 = const 0_i64;
         goto -> bb1;
     }
 
     bb1: {
-        _3 = copy _1;
-        _2 = copy _3 < const 10_i64;
-        branch copy _2 -> [bb2, bb2];
+        _0 = const 1_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        _0 = const 1_i64;
-        goto -> bb3;
-    }
-
-    bb3: {
         return;
     }
 }
@@ -431,19 +364,11 @@ fn user.fixtures.parser_statements.nested_break() -> int {
     }
 
     bb1: {
-        branch const true -> [bb2, bb3];
+        _0 = const 3_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        branch const true -> [bb3, bb3];
-    }
-
-    bb3: {
-        _0 = const 3_i64;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }
@@ -457,19 +382,11 @@ fn user.fixtures.parser_statements.break_with_locals() -> int {
     }
 
     bb1: {
-        branch const true -> [bb2, bb3];
+        _0 = const 4_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        branch const true -> [bb3, bb1];
-    }
-
-    bb3: {
-        _0 = const 4_i64;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }
@@ -483,20 +400,15 @@ fn user.fixtures.parser_statements.continue_with_locals() -> int {
     }
 
     bb1: {
-        branch const true -> [bb4, bb2];
+        goto -> bb2;
     }
 
     bb2: {
-        _0 = const 5_i64;
         goto -> bb3;
     }
 
     bb3: {
-        return;
-    }
-
-    bb4: {
-        branch const true -> [bb1, bb1];
+        goto -> bb1;
     }
 }
 
@@ -701,18 +613,15 @@ fn user.fixtures.parser_statements.ConditionalLogic(age: int) -> string {
 fn user.fixtures.parser_statements.let_statements() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int[] // z
-    let _2: fixtures.parser_statements.Point // point
+    let _1: fixtures.parser_statements.Point // point
+    let _2: int
     let _3: int
-    let _4: int
 
     bb0: {
-        _1 = [const 1_i64, const 2_i64, const 3_i64]: int[];
-        drop(_1);
-        _2 = user.fixtures.parser_statements.Point { const 1_i64, const 2_i64 };
-        _3 = copy _2.0;
-        _4 = copy _2.1;
-        _0 = copy _3 + copy _4;
+        _1 = user.fixtures.parser_statements.Point { const 1_i64, const 2_i64 };
+        _2 = copy _1.0;
+        _3 = copy _1.1;
+        _0 = copy _2 + copy _3;
         goto -> bb1;
     }
 
@@ -759,48 +668,29 @@ fn user.fixtures.parser_statements.simple_while_loop() -> int {
 fn user.fixtures.parser_statements.nested_while_loop() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // i
+    let _1: int // j
     let _2: bool
     let _3: int
-    let _4: int // j
-    let _5: bool
-    let _6: int
-    let _7: int
+    let _4: int
 
     bb0: {
-        _1 = const 0_i64;
         goto -> bb1;
     }
 
     bb1: {
-        _3 = copy _1;
-        _2 = copy _3 < const 10_i64;
-        branch copy _2 -> [bb4, bb2];
+        _1 = const 0_i64;
+        goto -> bb2;
     }
 
     bb2: {
-        _0 = copy _1;
-        goto -> bb3;
+        _3 = copy _1;
+        _2 = copy _3 < const 10_i64;
+        branch copy _2 -> [bb3, bb1];
     }
 
     bb3: {
-        return;
-    }
-
-    bb4: {
-        _4 = const 0_i64;
-        goto -> bb5;
-    }
-
-    bb5: {
-        _6 = copy _4;
-        _5 = copy _6 < const 10_i64;
-        branch copy _5 -> [bb6, bb1];
-    }
-
-    bb6: {
-        _7 = copy _4;
-        _4 = copy _7 + const 1_i64;
-        goto -> bb5;
+        _4 = copy _1;
+        _1 = copy _4 + const 1_i64;
+        goto -> bb2;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_statements/mir.snap
@@ -231,15 +231,18 @@ fn user.fixtures.parser_statements.edge_call_then_index(foo: () -> int[] throws 
     // Locals:
     let _0: int // _0 // return
     let _1: () -> int[] throws never // foo // param
-    let _2: int[]
-    let _3: 0
+    let _2: int
+    let _3: int[]
+    let _4: 0
 
     bb0: {
-        _2 = call copy _1() -> [bb1];
+        _3 = call copy _1() -> [bb1];
     }
 
     bb1: {
-        _3 = const 0_i64;
+        _4 = const 0_i64;
+        _2 = copy _3[_4];
+        drop(_2);
         _0 = const 1_i64;
         goto -> bb2;
     }
@@ -294,12 +297,15 @@ fn user.fixtures.parser_statements.edge_semicolon_forces_boundary(bar: () -> int
     let _0: int // _0 // return
     let _1: () -> int[] throws never // bar // param
     let _2: int[]
+    let _3: int[]
 
     bb0: {
         _2 = call copy _1() -> [bb1];
     }
 
     bb1: {
+        _3 = [const 0_i64]: int[];
+        drop(_3);
         _0 = const 1_i64;
         goto -> bb2;
     }
@@ -695,15 +701,18 @@ fn user.fixtures.parser_statements.ConditionalLogic(age: int) -> string {
 fn user.fixtures.parser_statements.let_statements() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: fixtures.parser_statements.Point // point
-    let _2: int
+    let _1: int[] // z
+    let _2: fixtures.parser_statements.Point // point
     let _3: int
+    let _4: int
 
     bb0: {
-        _1 = user.fixtures.parser_statements.Point { const 1_i64, const 2_i64 };
-        _2 = copy _1.0;
-        _3 = copy _1.1;
-        _0 = copy _2 + copy _3;
+        _1 = [const 1_i64, const 2_i64, const 3_i64]: int[];
+        drop(_1);
+        _2 = user.fixtures.parser_statements.Point { const 1_i64, const 2_i64 };
+        _3 = copy _2.0;
+        _4 = copy _2.1;
+        _0 = copy _3 + copy _4;
         goto -> bb1;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/bytecode.snap
@@ -42,8 +42,7 @@ function fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQual
     load_var response
     load_field .score
     is_type 0
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var response
@@ -51,9 +50,6 @@ function fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQual
     jump L2
 
   L1:
-    load_var response
-    load_field .score
-    pop 1
     load_const 0
 
   L2:
@@ -78,8 +74,7 @@ function fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatc
     load_var response
     load_field .score
     is_type 0
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var response
@@ -87,9 +82,6 @@ function fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatc
     jump L2
 
   L1:
-    load_var response
-    load_field .score
-    pop 1
     load_const 0
 
   L2:
@@ -118,17 +110,14 @@ function fixtures.patterns_class_destructure_namespaces.GenericTypePatternNamesp
     load_type string
     init_instance<1> user.fixtures.patterns_class_destructure_namespaces.llm.openai.Box .value
     is_type fixtures.patterns_class_destructure_namespaces.llm.openai.Box<...>
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 51
     jump L1
 
   L0:
-    load_const 51
-    jump L2
-
-  L1:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 
@@ -137,17 +126,14 @@ function fixtures.patterns_class_destructure_namespaces.GenericTypePatternQualif
     load_type int
     init_instance<1> user.fixtures.patterns_class_destructure_namespaces.llm.openai.Box .value
     is_type fixtures.patterns_class_destructure_namespaces.llm.openai.Box<...>
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 50
     jump L1
 
   L0:
-    load_const 50
-    jump L2
-
-  L1:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/bytecode.snap
@@ -51,6 +51,9 @@ function fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQual
     jump L2
 
   L1:
+    load_var response
+    load_field .score
+    pop 1
     load_const 0
 
   L2:
@@ -84,6 +87,9 @@ function fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatc
     jump L2
 
   L1:
+    load_var response
+    load_field .score
+    pop 1
     load_const 0
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/mir.snap
@@ -32,7 +32,8 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatch
     let _3: int
     let _4: bool
     let _5: int
-    let _6: int // matched
+    let _6: int
+    let _7: int // matched
 
     bb0: {
         _1 = user.fixtures.patterns_class_destructure_namespaces.llm.openai.Response { const "ok", const 42_i64 };
@@ -47,13 +48,15 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatch
     }
 
     bb2: {
-        _5 = copy _1.1;
-        _6 = copy _5;
-        _0 = copy _6;
+        _6 = copy _1.1;
+        _7 = copy _6;
+        _0 = copy _7;
         goto -> bb4;
     }
 
     bb3: {
+        _5 = copy _1.1;
+        drop(_5);
         _0 = const 0_i64;
         goto -> bb4;
     }
@@ -93,7 +96,8 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQuali
     let _3: int
     let _4: bool
     let _5: int
-    let _6: int // matched
+    let _6: int
+    let _7: int // matched
 
     bb0: {
         _1 = user.fixtures.patterns_class_destructure_namespaces.llm.openai.Response { const "ok", const 46_i64 };
@@ -108,13 +112,15 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQuali
     }
 
     bb2: {
-        _5 = copy _1.1;
-        _6 = copy _5;
-        _0 = copy _6;
+        _6 = copy _1.1;
+        _7 = copy _6;
+        _0 = copy _7;
         goto -> bb4;
     }
 
     bb3: {
+        _5 = copy _1.1;
+        drop(_5);
         _0 = const 0_i64;
         goto -> bb4;
     }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_class_destructure_namespaces/mir.snap
@@ -32,8 +32,7 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatch
     let _3: int
     let _4: bool
     let _5: int
-    let _6: int
-    let _7: int // matched
+    let _6: int // matched
 
     bb0: {
         _1 = user.fixtures.patterns_class_destructure_namespaces.llm.openai.Response { const "ok", const 42_i64 };
@@ -48,15 +47,13 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureQualifiedMatch
     }
 
     bb2: {
-        _6 = copy _1.1;
-        _7 = copy _6;
-        _0 = copy _7;
+        _5 = copy _1.1;
+        _6 = copy _5;
+        _0 = copy _6;
         goto -> bb4;
     }
 
     bb3: {
-        _5 = copy _1.1;
-        drop(_5);
         _0 = const 0_i64;
         goto -> bb4;
     }
@@ -96,8 +93,7 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQuali
     let _3: int
     let _4: bool
     let _5: int
-    let _6: int
-    let _7: int // matched
+    let _6: int // matched
 
     bb0: {
         _1 = user.fixtures.patterns_class_destructure_namespaces.llm.openai.Response { const "ok", const 46_i64 };
@@ -112,15 +108,13 @@ fn user.fixtures.patterns_class_destructure_namespaces.DestructureNamespaceQuali
     }
 
     bb2: {
-        _6 = copy _1.1;
-        _7 = copy _6;
-        _0 = copy _7;
+        _5 = copy _1.1;
+        _6 = copy _5;
+        _0 = copy _6;
         goto -> bb4;
     }
 
     bb3: {
-        _5 = copy _1.1;
-        drop(_5);
         _0 = const 0_i64;
         goto -> bb4;
     }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_new/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_patterns_new/bytecode.snap
@@ -4,17 +4,14 @@ source: crates/baml_tests/src/corpus.rs
 function fixtures.patterns_new.bare_type_arm(v: int | string) -> int {
     load_var v
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -29,105 +26,84 @@ function fixtures.patterns_new.call_optional_callback(cb: ((int) -> int throws n
     load_var cb
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     load_var cb
     call_indirect
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 
 function fixtures.patterns_new.catch_chain_union(mode: int) -> int {
     load_var mode
     call user.fixtures.patterns_new.risky_error
-    jump L3
+    jump L1
     load_var e
     is_type fixtures.patterns_new.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type string
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function fixtures.patterns_new.catch_paren_or_chain(mode: int) -> int {
     load_var mode
     call user.fixtures.patterns_new.risky_error
-    jump L3
+    jump L1
     load_var e
     is_type fixtures.patterns_new.AppError
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     is_type string
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 1
 
-  L3:
+  L1:
     return
 }
 
 function fixtures.patterns_new.catch_widening_chain(mode: int) -> int {
     load_var mode
     call user.fixtures.patterns_new.risky_error
-    jump L4
+    jump L2
     load_var e
     store_var _3
     load_var _3
     narrow_bind string, slot=3
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     store_var _4
     load_var _4
     narrow_bind fixtures.patterns_new.AppError, slot=4
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
@@ -136,17 +112,14 @@ function fixtures.patterns_new.chain_narrow_then_wildcard(v: int | string | bool
     store_var _2
     load_var _2
     narrow_bind int, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_var _2
 
-  L2:
+  L1:
     return
 }
 
@@ -179,10 +152,7 @@ function fixtures.patterns_new.for_let_ascription(items: int[]) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var n
     load_var sum
@@ -191,7 +161,7 @@ function fixtures.patterns_new.for_let_ascription(items: int[]) -> int {
     store_var sum
     jump L0
 
-  L2:
+  L1:
     load_var sum
     return
 }
@@ -213,10 +183,7 @@ function fixtures.patterns_new.for_let_fn_narrow(items: ((int) -> int throws nev
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 0
     load_var _4
     call_indirect
@@ -225,7 +192,7 @@ function fixtures.patterns_new.for_let_fn_narrow(items: ((int) -> int throws nev
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -247,16 +214,13 @@ function fixtures.patterns_new.for_let_with_narrow(items: int[]) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 4
     add_int
     store_var sum
     jump L0
 
-  L2:
+  L1:
     load_var sum
     return
 }
@@ -309,29 +273,23 @@ function fixtures.patterns_new.or_with_repeated_typed_binding(v: int | string) -
     store_var _2
     load_var _2
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var v
     store_var _4
     load_var _4
     narrow_bind int, slot=3
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const 0
+    jump L2
+
+  L0:
+    load_var _4
     jump L2
 
   L1:
-    load_const 0
-    jump L4
-
-  L2:
-    load_var _4
-    jump L4
-
-  L3:
     load_var _2
 
-  L4:
+  L2:
     return
 }
 
@@ -340,22 +298,19 @@ function fixtures.patterns_new.paren_chains_in_or(v: int) -> int {
     store_var _2
     load_var _2
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     store_var _3
     load_var _3
     narrow_bind int, slot=3
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_const 1
-    jump L2
+    jump L1
+
+  L0:
+    load_const 1
 
   L1:
-    load_const 1
-
-  L2:
     return
 }
 
@@ -363,14 +318,11 @@ function fixtures.patterns_new.risky_error(mode: int) -> int {
     load_var mode
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "boom"
     throw
 
-  L1:
+  L0:
     load_const 1
     init_instance user.fixtures.patterns_new.AppError .code
     throw

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/bytecode.snap
@@ -42,9 +42,7 @@ function fixtures.reflect_shadowing.helper(q: string) -> string {
 }
 
 function fixtures.reflect_shadowing.local_shadows_package() -> int {
-    load_const 1
-    load_const 1
-    add_int
+    load_const 2
     return
 }
 
@@ -55,8 +53,6 @@ function fixtures.reflect_shadowing.package_still_reachable() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_reflect_shadowing/mir.snap
@@ -175,13 +175,9 @@ fn user.fixtures.reflect_shadowing.unbound_user_method() -> string {
 fn user.fixtures.reflect_shadowing.local_shadows_package() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // reflect
-    let _2: int
 
     bb0: {
-        _1 = const 1_i64;
-        _2 = copy _1;
-        _0 = copy _2 + const 1_i64;
+        _0 = const 2_i64;
         goto -> bb1;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.retry_policy.UseRetryClient(input: string, client: ai.Client |
     call user.fixtures.retry_policy.UseRetryClient@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function fixtures.retry_policy.UseRetryClient@spec(input: string) -> ai.Function
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.retry_policy.MyClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "UseRetryClient"
     load_deref ?1
     load_const "input"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/mir.snap
@@ -135,24 +135,26 @@ fn user.fixtures.retry_policy.UseRetryClient@spec(input: string) -> ai.FunctionS
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // input // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "input": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "input": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.retry_policy.MyClient) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.retry_policy.MyClient) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "UseRetryClient", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "UseRetryClient", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -167,71 +169,68 @@ fn .<lambda(UseRetryClient@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "echo ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "echo ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -243,9 +242,9 @@ fn .<lambda(UseRetryClient@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_retry_policy/mir.snap
@@ -167,68 +167,71 @@ fn .<lambda(UseRetryClient@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "echo ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "echo ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -240,9 +243,9 @@ fn .<lambda(UseRetryClient@spec, 0)>( __spec_output_format: ai.OutputFormat) -> 
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/bytecode.snap
@@ -3,16 +3,12 @@ source: crates/baml_tests/src/corpus.rs
 ---
 function fixtures.short_circuit_locals.chained_and(a: bool, b: bool, c: bool) -> bool {
     load_var a
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var b
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var c
 
-  L1:
+  L0:
     return
 }
 
@@ -20,21 +16,15 @@ function fixtures.short_circuit_locals.conditional_short_circuit(a: bool, b: boo
     load_const false
     store_var x
     load_var cond
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_var a
-    jump_if_false L0
-    pop 1
-    jump L1
+    jump_if_false_or_pop L0
+    load_var b
 
   L0:
     store_var x
-    jump L2
 
   L1:
-    load_var b
-    store_var x
-
-  L2:
     load_var x
     return
 }
@@ -58,28 +48,19 @@ function fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: 
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var _7
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L4
+    pop_jump_if_false L2
     load_var a
-    jump_if_false L2
-    pop 1
-    jump L3
+    jump_if_false_or_pop L1
+    load_var b
+
+  L1:
+    store_var x
 
   L2:
-    store_var x
-    jump L4
-
-  L3:
-    load_var b
-    store_var x
-
-  L4:
     load_var x
     pop_jump_if_false L0
     load_var hits
@@ -88,7 +69,7 @@ function fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: 
     store_var hits
     jump L0
 
-  L5:
+  L3:
     load_var hits
     return
 }
@@ -110,53 +91,39 @@ function fixtures.short_circuit_locals.initialized_local_in_branch_loop(items: i
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
-    load_const 0
-    store_var x
+    pop_jump_if_true L3
     load_var _4
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L1
+    load_const 2
+    jump L2
+
+  L1:
+    load_const 1
 
   L2:
-    load_const 2
-    store_var x
-    jump L4
-
-  L3:
-    load_const 1
-    store_var x
-
-  L4:
-    load_var2 5 2
+    load_var total
     bin_op +
     store_var total
     jump L0
 
-  L5:
+  L3:
     load_var total
     return
 }
 
 function fixtures.short_circuit_locals.mixed_join(a: bool, b: bool, cond: bool) -> bool {
     load_var cond
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_var a
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L1
     load_var b
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/mir.snap
@@ -10,26 +10,30 @@ fn user.fixtures.short_circuit_locals.chained_and(a: bool, b: bool, c: bool) -> 
     let _3: bool // c // param
     let _4: bool // ok
     let _5: bool
+    let _6: bool
+    let _7: bool
 
     bb0: {
-        _5 = short_circuit(&&) copy _1 -> [eval: bb1, join: bb2];
+        _7 = short_circuit(&&) copy _1 -> [eval: bb1, join: bb2];
     }
 
     bb1: {
-        _5 = copy _2;
+        _7 = copy _2;
         goto -> bb2;
     }
 
     bb2: {
-        _4 = short_circuit(&&) copy _5 -> [eval: bb3, join: bb4];
+        _6 = copy _7;
+        _5 = short_circuit(&&) copy _6 -> [eval: bb3, join: bb4];
     }
 
     bb3: {
-        _4 = copy _3;
+        _5 = copy _3;
         goto -> bb4;
     }
 
     bb4: {
+        _4 = copy _5;
         _0 = copy _4;
         goto -> bb5;
     }
@@ -46,27 +50,33 @@ fn user.fixtures.short_circuit_locals.conditional_short_circuit(a: bool, b: bool
     let _2: bool // b // param
     let _3: bool // cond // param
     let _4: bool // x
+    let _5: bool
 
     bb0: {
         _4 = const false;
-        branch copy _3 -> [bb1, bb3];
+        branch copy _3 -> [bb1, bb4];
     }
 
     bb1: {
-        _4 = short_circuit(&&) copy _1 -> [eval: bb2, join: bb3];
+        _5 = short_circuit(&&) copy _1 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _4 = copy _2;
+        _5 = copy _2;
         goto -> bb3;
     }
 
     bb3: {
-        _0 = copy _4;
+        _4 = copy _5;
         goto -> bb4;
     }
 
     bb4: {
+        _0 = copy _4;
+        goto -> bb5;
+    }
+
+    bb5: {
         return;
     }
 }
@@ -87,7 +97,8 @@ fn user.fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: i
     let _11: bool
     let _12: int
     let _13: bool
-    let _14: int
+    let _14: bool
+    let _15: int
 
     bb0: {
         _4 = const false;
@@ -101,7 +112,7 @@ fn user.fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: i
 
     bb2: {
         _8 = is_type(copy _7, baml.iter.Done);
-        branch copy _8 -> [bb8, bb3];
+        branch copy _8 -> [bb9, bb3];
     }
 
     bb3: {
@@ -110,35 +121,40 @@ fn user.fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: i
         _10 = copy _9;
         _12 = copy _10;
         _11 = copy _12 > const 0_i64;
-        branch copy _11 -> [bb4, bb6];
+        branch copy _11 -> [bb4, bb7];
     }
 
     bb4: {
-        _4 = short_circuit(&&) copy _2 -> [eval: bb5, join: bb6];
+        _13 = short_circuit(&&) copy _2 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
-        _4 = copy _3;
+        _13 = copy _3;
         goto -> bb6;
     }
 
     bb6: {
-        _13 = copy _4;
-        branch copy _13 -> [bb7, bb1];
+        _4 = copy _13;
+        goto -> bb7;
     }
 
     bb7: {
-        _14 = copy _5;
-        _5 = copy _14 + const 1_i64;
-        goto -> bb1;
+        _14 = copy _4;
+        branch copy _14 -> [bb8, bb1];
     }
 
     bb8: {
-        _0 = copy _5;
-        goto -> bb9;
+        _15 = copy _5;
+        _5 = copy _15 + const 1_i64;
+        goto -> bb1;
     }
 
     bb9: {
+        _0 = copy _5;
+        goto -> bb10;
+    }
+
+    bb10: {
         return;
     }
 }
@@ -177,7 +193,6 @@ fn user.fixtures.short_circuit_locals.initialized_local_in_branch_loop(items: in
         _6 = copy _4;
         fresh_cell(_7);
         _7 = copy _6;
-        _8 = const 0_i64;
         _10 = copy _7;
         _9 = copy _10 > const 0_i64;
         branch copy _9 -> [bb5, bb4];
@@ -217,6 +232,7 @@ fn user.fixtures.short_circuit_locals.mixed_join(a: bool, b: bool, cond: bool) -
     let _2: bool // b // param
     let _3: bool // cond // param
     let _4: bool // x
+    let _5: bool
 
     bb0: {
         branch copy _3 -> [bb2, bb1];
@@ -224,24 +240,29 @@ fn user.fixtures.short_circuit_locals.mixed_join(a: bool, b: bool, cond: bool) -
 
     bb1: {
         _4 = const false;
-        goto -> bb4;
+        goto -> bb5;
     }
 
     bb2: {
-        _4 = short_circuit(&&) copy _1 -> [eval: bb3, join: bb4];
+        _5 = short_circuit(&&) copy _1 -> [eval: bb3, join: bb4];
     }
 
     bb3: {
-        _4 = copy _2;
+        _5 = copy _2;
         goto -> bb4;
     }
 
     bb4: {
-        _0 = copy _4;
+        _4 = copy _5;
         goto -> bb5;
     }
 
     bb5: {
+        _0 = copy _4;
+        goto -> bb6;
+    }
+
+    bb6: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/bytecode.snap
@@ -30,12 +30,10 @@ function fixtures.stream_llm_inferred_typeargs.TestFunc(input: string, client: a
     call user.fixtures.stream_llm_inferred_typeargs.TestFunc@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function fixtures.stream_llm_inferred_typeargs.TestFunc@spec(input: string) -> a
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.stream_llm_inferred_typeargs.TestClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "TestFunc"
     load_deref ?1
     load_const "input"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/mir.snap
@@ -167,68 +167,71 @@ fn .<lambda(TestFunc@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "hi ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "hi ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -240,9 +243,9 @@ fn .<lambda(TestFunc@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_stream_llm_inferred_typeargs/mir.snap
@@ -135,24 +135,26 @@ fn user.fixtures.stream_llm_inferred_typeargs.TestFunc@spec(input: string) -> ai
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // input // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "input": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "input": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.stream_llm_inferred_typeargs.TestClient) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.stream_llm_inferred_typeargs.TestClient) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "TestFunc", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "TestFunc", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -167,71 +169,68 @@ fn .<lambda(TestFunc@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "hi ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "hi ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -243,9 +242,9 @@ fn .<lambda(TestFunc@spec, 0)>( __spec_output_format: ai.OutputFormat) -> ai.Pro
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_expr_basic/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_expr_basic/mir.snap
@@ -35,13 +35,9 @@ fn user.fixtures.test_expr_basic.$init_test_ns_fixtures_ns_test_expr_basic_main(
 fn .<lambda($init_test_ns_fixtures_ns_test_expr_basic_main, 0)>() -> void {
     // Locals:
     let _0: void // _0 // return
-    let _1: int // x
-    let _2: int
 
     bb0: {
-        _1 = const 3_i64;
-        _2 = copy _1;
-        _0 = call const fn assert.equal(copy _2, const 3_i64) -> [bb1];
+        _0 = call const fn assert.equal(const 3_i64, const 3_i64) -> [bb1];
     }
 
     bb1: {
@@ -53,13 +49,9 @@ fn .<lambda($init_test_ns_fixtures_ns_test_expr_basic_main, 0)>() -> void {
 fn .<lambda($init_test_ns_fixtures_ns_test_expr_basic_main, 1)>() -> void {
     // Locals:
     let _0: void // _0 // return
-    let _1: string // result
-    let _2: string
 
     bb0: {
-        _1 = const "hello";
-        _2 = copy _1;
-        _0 = call const fn assert.not_null(copy _2) -> [bb1];
+        _0 = call const fn assert.not_null(const "hello") -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_expr_with_runner/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_expr_with_runner/mir.snap
@@ -33,13 +33,9 @@ fn user.fixtures.test_expr_with_runner.$init_test_ns_fixtures_ns_test_expr_with_
 fn .<lambda($init_test_ns_fixtures_ns_test_expr_with_runner_main, 0)>() -> void {
     // Locals:
     let _0: void // _0 // return
-    let _1: string // result
-    let _2: string
 
     bb0: {
-        _1 = const "hello";
-        _2 = copy _1;
-        _0 = call const fn assert.not_null(copy _2) -> [bb1];
+        _0 = call const fn assert.not_null(const "hello") -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_old_and_new/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_old_and_new/mir.snap
@@ -28,13 +28,9 @@ fn user.fixtures.test_old_and_new.$init_test_ns_fixtures_ns_test_old_and_new_mai
 fn .<lambda($init_test_ns_fixtures_ns_test_old_and_new_main, 0)>() -> void {
     // Locals:
     let _0: void // _0 // return
-    let _1: string // result
-    let _2: string
 
     bb0: {
-        _1 = const "hello";
-        _2 = copy _1;
-        _0 = call const fn assert.not_null(copy _2) -> [bb1];
+        _0 = call const fn assert.not_null(const "hello") -> [bb1];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_with_not_keyword/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_test_with_not_keyword/mir.snap
@@ -59,11 +59,9 @@ fn user.fixtures.test_with_not_keyword.make_foo() -> fixtures.test_with_not_keyw
 fn user.fixtures.test_with_not_keyword.use_with_as_var() -> int {
     // Locals:
     let _0: int // _0 // return
-    let _1: int // with
 
     bb0: {
-        _1 = const 42_i64;
-        _0 = copy _1;
+        _0 = const 42_i64;
         goto -> bb1;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_dynamic/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_dynamic/mir.snap
@@ -100,35 +100,20 @@ fn .<lambda($init_test_ns_fixtures_ns_testset_dynamic_main, 2)>(testset: testing
     // Locals:
     let _0: void // _0 // return
     let _1: testing.TestCollector // testset // param
-    let _2: bool // run_slow
-    let _3: void
-    let _4: () -> void throws never
-    let _5: bool
-    let _6: void
-    let _7: () -> void throws never
+    let _2: void
+    let _3: () -> void throws never
 
     bb0: {
-        _2 = const false;
-        _4 = make_closure lambda[0]();
-        _3 = call const fn testing.TestCollector.register_test(copy _1, const "always runs", copy _4, const null) -> [bb1];
+        _3 = make_closure lambda[0]();
+        _2 = call const fn testing.TestCollector.register_test(copy _1, const "always runs", copy _3, const null) -> [bb1];
     }
 
     bb1: {
-        _5 = copy _2;
-        branch copy _5 -> [bb2, bb3];
+        _0 = const null;
+        goto -> bb2;
     }
 
     bb2: {
-        _7 = make_closure lambda[1]();
-        _6 = call const fn testing.TestCollector.register_test(copy _1, const "only when slow", copy _7, const null) -> [bb3];
-    }
-
-    bb3: {
-        _0 = const null;
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/bytecode.snap
@@ -42,12 +42,10 @@ function fixtures.testset_vibes_nested.ClassifySentiment(text: string, client: a
     call user.fixtures.testset_vibes_nested.ClassifySentiment@spec
     store_var _9
     load_type fixtures.testset_vibes_nested.Sentiment
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -81,12 +79,10 @@ function fixtures.testset_vibes_nested.ClassifySentiment2(text: string, client: 
     call user.fixtures.testset_vibes_nested.ClassifySentiment2@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -133,10 +129,10 @@ function fixtures.testset_vibes_nested.ClassifySentiment2@spec(text: string) -> 
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.testset_vibes_nested.GPT4o
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "ClassifySentiment2"
     load_deref ?1
     load_const "text"
@@ -221,10 +217,10 @@ function fixtures.testset_vibes_nested.ClassifySentiment@spec(text: string) -> a
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.fixtures.testset_vibes_nested.GPT4o
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "ClassifySentiment"
     load_deref ?1
     load_const "text"
@@ -277,14 +273,11 @@ function fixtures.testset_vibes_nested.Foo() -> string | image {
     load_var i
     load_const 2
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     return
 
-  L2:
+  L1:
     load_const "hi:  "
     load_var x
     bin_op +
@@ -325,12 +318,10 @@ function fixtures.testset_vibes_nested.GenerateTests(count: int, topic: string, 
     call user.fixtures.testset_vibes_nested.GenerateTests@spec
     store_var _10
     load_type string[]
-    load_var2 6 7
+    load_var2 5 6
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _7
-    load_var _7
     load_field .value
     return
 }
@@ -380,10 +371,10 @@ function fixtures.testset_vibes_nested.GenerateTests@spec(count: int, topic: str
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _5
+    store_var _7
     load_global user.fixtures.testset_vibes_nested.GPT4o
     call ai.clients.resolve
-    store_var _7
+    store_var _9
     load_const "GenerateTests"
     load_deref ?1
     load_deref ?2

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/mir.snap
@@ -480,68 +480,71 @@ fn .<lambda(ClassifySentiment@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "classify ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "classify ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -553,9 +556,9 @@ fn .<lambda(ClassifySentiment@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 
@@ -775,92 +778,95 @@ fn .<lambda(GenerateTests@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: int
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: " tests about "
-    let _19: reflect.Type
-    let _20: int
-    let _21: unknown[]
-    let _22: string
-    let _23: reflect.Type
-    let _24: int
-    let _25: string[]
-    let _26: ""
-    let _27: reflect.Type
-    let _28: string[]
-    let _29: unknown[]
-    let _30: string[]
-    let _31: baml.TaggedString
-    let _32: unknown[]
-    let _33: baml.TaggedString
-    let _34: ai.errors.PromptRenderError
-    let _35: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: int
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: " tests about "
+    let _20: reflect.Type
+    let _21: int
+    let _22: unknown[]
+    let _23: string
+    let _24: reflect.Type
+    let _25: int
+    let _26: string[]
+    let _27: ""
+    let _28: reflect.Type
+    let _29: string[]
+    let _30: unknown[]
+    let _31: string[]
+    let _32: baml.TaggedString
+    let _33: unknown[]
+    let _34: baml.TaggedString
+    let _35: ai.errors.PromptRenderError
+    let _36: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "generate ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb7];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "generate ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb7];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb7];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb7];
     }
 
     bb2: {
-        _6 = const " tests about ";
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb7];
+        _7 = const " tests about ";
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb7];
     }
 
     bb3: {
-        _6 = const "";
-        _21 = copy _5;
-        _22 = copy capture[1];
-        _23 = load_type(unknown);
-        _20 = call const fn baml.Array.push<copy _23>(copy _21, copy _22) -> [bb4, unwind: bb7];
+        _7 = const "";
+        _22 = copy _6;
+        _23 = copy capture[1];
+        _24 = load_type(unknown);
+        _21 = call const fn baml.Array.push<copy _24>(copy _22, copy _23) -> [bb4, unwind: bb7];
     }
 
     bb4: {
-        _25 = copy _4;
-        _26 = copy _6;
-        _27 = load_type(string);
-        _24 = call const fn baml.Array.push<copy _27>(copy _25, copy _26) -> [bb5, unwind: bb7];
+        _26 = copy _5;
+        _27 = copy _7;
+        _28 = load_type(string);
+        _25 = call const fn baml.Array.push<copy _28>(copy _26, copy _27) -> [bb5, unwind: bb7];
     }
 
     bb5: {
-        _28 = copy _4;
         _29 = copy _5;
-        _3 = baml.TaggedString { copy _28, copy _29 };
-        _31 = copy _3;
-        _30 = copy _31.0;
-        _33 = copy _3;
-        _32 = copy _33.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _30, copy _32) -> [bb6, unwind: bb7];
+        _30 = copy _6;
+        _4 = baml.TaggedString { copy _29, copy _30 };
+        _32 = copy _4;
+        _31 = copy _32.0;
+        _34 = copy _4;
+        _33 = copy _34.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _31, copy _33) -> [bb6, unwind: bb7];
     }
 
     bb6: {
@@ -872,9 +878,9 @@ fn .<lambda(GenerateTests@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     }
 
     bb8: {
-        _35 = copy _2;
-        _34 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _35 };
-        throw copy _34;
+        _36 = copy _2;
+        _35 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _36 };
+        throw copy _35;
     }
 }
 
@@ -1137,68 +1143,71 @@ fn .<lambda(ClassifySentiment2@spec, 0)>( __spec_output_format: ai.OutputFormat)
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: baml.TaggedString //  __spec_tagged_prompt
-    let _4: string[] //  __tt_parts
-    let _5: unknown[] //  __tt_values
-    let _6: string //  __tt_cur
-    let _7: string
-    let _8: int
-    let _9: string[]
-    let _10: string
-    let _11: reflect.Type
-    let _12: int
-    let _13: unknown[]
-    let _14: string
-    let _15: reflect.Type
-    let _16: int
-    let _17: string[]
-    let _18: ""
-    let _19: reflect.Type
-    let _20: string[]
-    let _21: unknown[]
-    let _22: string[]
-    let _23: baml.TaggedString
-    let _24: unknown[]
-    let _25: baml.TaggedString
-    let _26: ai.errors.PromptRenderError
-    let _27: never
+    let _3: ai.internal.SpecCtx // ctx
+    let _4: baml.TaggedString //  __spec_tagged_prompt
+    let _5: string[] //  __tt_parts
+    let _6: unknown[] //  __tt_values
+    let _7: string //  __tt_cur
+    let _8: string
+    let _9: int
+    let _10: string[]
+    let _11: string
+    let _12: reflect.Type
+    let _13: int
+    let _14: unknown[]
+    let _15: string
+    let _16: reflect.Type
+    let _17: int
+    let _18: string[]
+    let _19: ""
+    let _20: reflect.Type
+    let _21: string[]
+    let _22: unknown[]
+    let _23: string[]
+    let _24: baml.TaggedString
+    let _25: unknown[]
+    let _26: baml.TaggedString
+    let _27: ai.errors.PromptRenderError
+    let _28: never
 
     bb0: {
-        _4 = []: string[];
-        _5 = []: unknown[];
-        _6 = const "";
-        _7 = copy _6;
-        _6 = copy _7 + const "classify ";
-        _9 = copy _4;
-        _10 = copy _6;
-        _11 = load_type(string);
-        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
+        _3 = ai.internal.SpecCtx { copy _1 };
+        drop(_3);
+        _5 = []: string[];
+        _6 = []: unknown[];
+        _7 = const "";
+        _8 = copy _7;
+        _7 = copy _8 + const "classify ";
+        _10 = copy _5;
+        _11 = copy _7;
+        _12 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _6 = const "";
-        _13 = copy _5;
-        _14 = copy capture[0];
-        _15 = load_type(unknown);
-        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
+        _7 = const "";
+        _14 = copy _6;
+        _15 = copy capture[0];
+        _16 = load_type(unknown);
+        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _17 = copy _4;
-        _18 = copy _6;
-        _19 = load_type(string);
-        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
+        _18 = copy _5;
+        _19 = copy _7;
+        _20 = load_type(string);
+        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _20 = copy _4;
         _21 = copy _5;
-        _3 = baml.TaggedString { copy _20, copy _21 };
-        _23 = copy _3;
-        _22 = copy _23.0;
-        _25 = copy _3;
-        _24 = copy _25.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
+        _22 = copy _6;
+        _4 = baml.TaggedString { copy _21, copy _22 };
+        _24 = copy _4;
+        _23 = copy _24.0;
+        _26 = copy _4;
+        _25 = copy _26.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -1210,9 +1219,9 @@ fn .<lambda(ClassifySentiment2@spec, 0)>( __spec_output_format: ai.OutputFormat)
     }
 
     bb6: {
-        _27 = copy _2;
-        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
-        throw copy _26;
+        _28 = copy _2;
+        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
+        throw copy _27;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_testset_vibes_nested/mir.snap
@@ -448,24 +448,26 @@ fn user.fixtures.testset_vibes_nested.ClassifySentiment@spec(text: string) -> ai
     let _0: ai.FunctionSpec<fixtures.testset_vibes_nested.Sentiment> // _0 // return
     let _1: string // text // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "text": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "text": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.testset_vibes_nested.GPT4o) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.testset_vibes_nested.GPT4o) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<fixtures.testset_vibes_nested.Sentiment> { const "ClassifySentiment", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<fixtures.testset_vibes_nested.Sentiment> { const "ClassifySentiment", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -480,71 +482,68 @@ fn .<lambda(ClassifySentiment@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "classify ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "classify ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -556,9 +555,9 @@ fn .<lambda(ClassifySentiment@spec, 0)>( __spec_output_format: ai.OutputFormat) 
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 
@@ -746,24 +745,28 @@ fn user.fixtures.testset_vibes_nested.GenerateTests@spec(count: int, topic: stri
     let _1: int // count // param [captured]
     let _2: string // topic // param [captured]
     let _3: map<string, unknown>
-    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _5: ai.tools.Toolbox
-    let _6: ai.tools.Tool[]
-    let _7: ai.Client
+    let _4: int
+    let _5: string
+    let _6: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _7: ai.tools.Toolbox
+    let _8: ai.tools.Tool[]
+    let _9: ai.Client
 
     bb0: {
-        _3 = { const "count": copy _1, const "topic": copy _2 }: map<string, unknown>;
-        _4 = make_closure lambda[0](copy _1, copy _2);
-        _6 = []: ai.tools.Tool[];
-        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
+        _4 = copy _1;
+        _5 = copy _2;
+        _3 = { const "count": copy _4, const "topic": copy _5 }: map<string, unknown>;
+        _6 = make_closure lambda[0](copy _1, copy _2);
+        _8 = []: ai.tools.Tool[];
+        _7 = call const fn ai.tools.Toolbox.new(copy _8) -> [bb1];
     }
 
     bb1: {
-        _7 = call const fn ai.clients.resolve(const item user.fixtures.testset_vibes_nested.GPT4o) -> [bb2];
+        _9 = call const fn ai.clients.resolve(const item user.fixtures.testset_vibes_nested.GPT4o) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string[]> { const "GenerateTests", copy _3, copy _4, copy _5, copy _7 };
+        _0 = ai.FunctionSpec<string[]> { const "GenerateTests", copy _3, copy _6, copy _7, copy _9 };
         goto -> bb3;
     }
 
@@ -778,95 +781,91 @@ fn .<lambda(GenerateTests@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: int
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: " tests about "
-    let _20: reflect.Type
-    let _21: int
-    let _22: unknown[]
-    let _23: string
-    let _24: reflect.Type
-    let _25: int
-    let _26: string[]
-    let _27: ""
-    let _28: reflect.Type
-    let _29: string[]
-    let _30: unknown[]
-    let _31: string[]
-    let _32: baml.TaggedString
-    let _33: unknown[]
-    let _34: baml.TaggedString
-    let _35: ai.errors.PromptRenderError
-    let _36: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: int
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: " tests about "
+    let _19: reflect.Type
+    let _20: int
+    let _21: unknown[]
+    let _22: string
+    let _23: reflect.Type
+    let _24: int
+    let _25: string[]
+    let _26: ""
+    let _27: reflect.Type
+    let _28: string[]
+    let _29: unknown[]
+    let _30: string[]
+    let _31: baml.TaggedString
+    let _32: unknown[]
+    let _33: baml.TaggedString
+    let _34: ai.errors.PromptRenderError
+    let _35: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "generate ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb7];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "generate ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb7];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb7];
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb7];
     }
 
     bb2: {
-        _7 = const " tests about ";
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb7];
+        _6 = const " tests about ";
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb7];
     }
 
     bb3: {
-        _7 = const "";
-        _22 = copy _6;
-        _23 = copy capture[1];
-        _24 = load_type(unknown);
-        _21 = call const fn baml.Array.push<copy _24>(copy _22, copy _23) -> [bb4, unwind: bb7];
+        _6 = const "";
+        _21 = copy _5;
+        _22 = copy capture[1];
+        _23 = load_type(unknown);
+        _20 = call const fn baml.Array.push<copy _23>(copy _21, copy _22) -> [bb4, unwind: bb7];
     }
 
     bb4: {
-        _26 = copy _5;
-        _27 = copy _7;
-        _28 = load_type(string);
-        _25 = call const fn baml.Array.push<copy _28>(copy _26, copy _27) -> [bb5, unwind: bb7];
+        _25 = copy _4;
+        _26 = copy _6;
+        _27 = load_type(string);
+        _24 = call const fn baml.Array.push<copy _27>(copy _25, copy _26) -> [bb5, unwind: bb7];
     }
 
     bb5: {
+        _28 = copy _4;
         _29 = copy _5;
-        _30 = copy _6;
-        _4 = baml.TaggedString { copy _29, copy _30 };
-        _32 = copy _4;
-        _31 = copy _32.0;
-        _34 = copy _4;
-        _33 = copy _34.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _31, copy _33) -> [bb6, unwind: bb7];
+        _3 = baml.TaggedString { copy _28, copy _29 };
+        _31 = copy _3;
+        _30 = copy _31.0;
+        _33 = copy _3;
+        _32 = copy _33.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _30, copy _32) -> [bb6, unwind: bb7];
     }
 
     bb6: {
@@ -878,9 +877,9 @@ fn .<lambda(GenerateTests@spec, 0)>( __spec_output_format: ai.OutputFormat) -> a
     }
 
     bb8: {
-        _36 = copy _2;
-        _35 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _36 };
-        throw copy _35;
+        _35 = copy _2;
+        _34 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _35 };
+        throw copy _34;
     }
 }
 
@@ -936,25 +935,21 @@ fn user.fixtures.testset_vibes_nested.Foo() -> string | image {
     // Locals:
     let _0: string | image // _0 // return
     let _1: string // x
-    let _2: int // y
-    let _3: int // i
-    let _4: bool
-    let _5: int
-    let _6: int
-    let _7: string
+    let _2: int // i
+    let _3: bool
+    let _4: int
+    let _5: string
 
     bb0: {
         _1 = const "foo";
-        _2 = const 2_i64;
-        _3 = const 0_i64;
+        _2 = const 0_i64;
         goto -> bb1;
     }
 
     bb1: {
-        _5 = copy _3;
-        _6 = copy _2;
-        _4 = copy _5 < copy _6;
-        branch copy _4 -> [bb4, bb2];
+        _4 = copy _2;
+        _3 = copy _4 < const 2_i64;
+        branch copy _3 -> [bb4, bb2];
     }
 
     bb2: {
@@ -967,13 +962,13 @@ fn user.fixtures.testset_vibes_nested.Foo() -> string | image {
     }
 
     bb4: {
-        _7 = copy _1;
-        _1 = const "hi:  " + copy _7;
+        _5 = copy _1;
+        _1 = const "hi:  " + copy _5;
         goto -> bb5;
     }
 
     bb5: {
-        _3 = copy _3 + const 1_i64;
+        _2 = copy _2 + const 1_i64;
         goto -> bb1;
     }
 }
@@ -1111,24 +1106,26 @@ fn user.fixtures.testset_vibes_nested.ClassifySentiment2@spec(text: string) -> a
     let _0: ai.FunctionSpec<string> // _0 // return
     let _1: string // text // param [captured]
     let _2: map<string, unknown>
-    let _3: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _4: ai.tools.Toolbox
-    let _5: ai.tools.Tool[]
-    let _6: ai.Client
+    let _3: string
+    let _4: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _5: ai.tools.Toolbox
+    let _6: ai.tools.Tool[]
+    let _7: ai.Client
 
     bb0: {
-        _2 = { const "text": copy _1 }: map<string, unknown>;
-        _3 = make_closure lambda[0](copy _1);
-        _5 = []: ai.tools.Tool[];
-        _4 = call const fn ai.tools.Toolbox.new(copy _5) -> [bb1];
+        _3 = copy _1;
+        _2 = { const "text": copy _3 }: map<string, unknown>;
+        _4 = make_closure lambda[0](copy _1);
+        _6 = []: ai.tools.Tool[];
+        _5 = call const fn ai.tools.Toolbox.new(copy _6) -> [bb1];
     }
 
     bb1: {
-        _6 = call const fn ai.clients.resolve(const item user.fixtures.testset_vibes_nested.GPT4o) -> [bb2];
+        _7 = call const fn ai.clients.resolve(const item user.fixtures.testset_vibes_nested.GPT4o) -> [bb2];
     }
 
     bb2: {
-        _0 = ai.FunctionSpec<string> { const "ClassifySentiment2", copy _2, copy _3, copy _4, copy _6 };
+        _0 = ai.FunctionSpec<string> { const "ClassifySentiment2", copy _2, copy _4, copy _5, copy _7 };
         goto -> bb3;
     }
 
@@ -1143,71 +1140,68 @@ fn .<lambda(ClassifySentiment2@spec, 0)>( __spec_output_format: ai.OutputFormat)
     let _0: ai.Prompt // _0 // return
     let _1: ai.OutputFormat //  __spec_output_format // param
     let _2: unknown //  __prompt_render_err
-    let _3: ai.internal.SpecCtx // ctx
-    let _4: baml.TaggedString //  __spec_tagged_prompt
-    let _5: string[] //  __tt_parts
-    let _6: unknown[] //  __tt_values
-    let _7: string //  __tt_cur
-    let _8: string
-    let _9: int
-    let _10: string[]
-    let _11: string
-    let _12: reflect.Type
-    let _13: int
-    let _14: unknown[]
-    let _15: string
-    let _16: reflect.Type
-    let _17: int
-    let _18: string[]
-    let _19: ""
-    let _20: reflect.Type
-    let _21: string[]
-    let _22: unknown[]
-    let _23: string[]
-    let _24: baml.TaggedString
-    let _25: unknown[]
-    let _26: baml.TaggedString
-    let _27: ai.errors.PromptRenderError
-    let _28: never
+    let _3: baml.TaggedString //  __spec_tagged_prompt
+    let _4: string[] //  __tt_parts
+    let _5: unknown[] //  __tt_values
+    let _6: string //  __tt_cur
+    let _7: string
+    let _8: int
+    let _9: string[]
+    let _10: string
+    let _11: reflect.Type
+    let _12: int
+    let _13: unknown[]
+    let _14: string
+    let _15: reflect.Type
+    let _16: int
+    let _17: string[]
+    let _18: ""
+    let _19: reflect.Type
+    let _20: string[]
+    let _21: unknown[]
+    let _22: string[]
+    let _23: baml.TaggedString
+    let _24: unknown[]
+    let _25: baml.TaggedString
+    let _26: ai.errors.PromptRenderError
+    let _27: never
 
     bb0: {
-        _3 = ai.internal.SpecCtx { copy _1 };
-        drop(_3);
-        _5 = []: string[];
-        _6 = []: unknown[];
-        _7 = const "";
-        _8 = copy _7;
-        _7 = copy _8 + const "classify ";
-        _10 = copy _5;
-        _11 = copy _7;
-        _12 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _12>(copy _10, copy _11) -> [bb1, unwind: bb5];
+        _4 = []: string[];
+        _5 = []: unknown[];
+        _6 = const "";
+        _7 = copy _6;
+        _6 = copy _7 + const "classify ";
+        _9 = copy _4;
+        _10 = copy _6;
+        _11 = load_type(string);
+        _8 = call const fn baml.Array.push<copy _11>(copy _9, copy _10) -> [bb1, unwind: bb5];
     }
 
     bb1: {
-        _7 = const "";
-        _14 = copy _6;
-        _15 = copy capture[0];
-        _16 = load_type(unknown);
-        _13 = call const fn baml.Array.push<copy _16>(copy _14, copy _15) -> [bb2, unwind: bb5];
+        _6 = const "";
+        _13 = copy _5;
+        _14 = copy capture[0];
+        _15 = load_type(unknown);
+        _12 = call const fn baml.Array.push<copy _15>(copy _13, copy _14) -> [bb2, unwind: bb5];
     }
 
     bb2: {
-        _18 = copy _5;
-        _19 = copy _7;
-        _20 = load_type(string);
-        _17 = call const fn baml.Array.push<copy _20>(copy _18, copy _19) -> [bb3, unwind: bb5];
+        _17 = copy _4;
+        _18 = copy _6;
+        _19 = load_type(string);
+        _16 = call const fn baml.Array.push<copy _19>(copy _17, copy _18) -> [bb3, unwind: bb5];
     }
 
     bb3: {
+        _20 = copy _4;
         _21 = copy _5;
-        _22 = copy _6;
-        _4 = baml.TaggedString { copy _21, copy _22 };
-        _24 = copy _4;
-        _23 = copy _24.0;
-        _26 = copy _4;
-        _25 = copy _26.1;
-        _0 = call const fn ai.internal.assemble_llm_prompt(copy _23, copy _25) -> [bb4, unwind: bb5];
+        _3 = baml.TaggedString { copy _20, copy _21 };
+        _23 = copy _3;
+        _22 = copy _23.0;
+        _25 = copy _3;
+        _24 = copy _25.1;
+        _0 = call const fn ai.internal.assemble_llm_prompt(copy _22, copy _24) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -1219,9 +1213,9 @@ fn .<lambda(ClassifySentiment2@spec, 0)>( __spec_output_format: ai.OutputFormat)
     }
 
     bb6: {
-        _28 = copy _2;
-        _27 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _28 };
-        throw copy _27;
+        _27 = copy _2;
+        _26 = ai.errors.PromptRenderError { const "prompt template rendering threw", copy _27 };
+        throw copy _26;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/bytecode.snap
@@ -10,18 +10,11 @@ function fixtures.type_annotation.test_let_binding(function_name: string) -> str
 }
 
 function fixtures.type_annotation.test_list(function_name: string) -> string {
-    load_type reflect.Type
-    alloc_array 0
-    pop 1
     load_const "ok"
     return
 }
 
 function fixtures.type_annotation.test_map(function_name: string) -> string {
-    load_type string
-    load_type reflect.Type
-    alloc_map 0
-    pop 1
     load_const "ok"
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/bytecode.snap
@@ -10,11 +10,18 @@ function fixtures.type_annotation.test_let_binding(function_name: string) -> str
 }
 
 function fixtures.type_annotation.test_list(function_name: string) -> string {
+    load_type reflect.Type
+    alloc_array 0
+    pop 1
     load_const "ok"
     return
 }
 
 function fixtures.type_annotation.test_map(function_name: string) -> string {
+    load_type string
+    load_type reflect.Type
+    alloc_map 0
+    pop 1
     load_const "ok"
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/mir.snap
@@ -90,11 +90,8 @@ fn user.fixtures.type_annotation.test_list(function_name: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // function_name // param
-    let _2: reflect.Type[] // ts
 
     bb0: {
-        _2 = []: reflect.Type[];
-        drop(_2);
         _0 = const "ok";
         goto -> bb1;
     }
@@ -123,11 +120,8 @@ fn user.fixtures.type_annotation.test_map(function_name: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // function_name // param
-    let _2: map<string, reflect.Type> // m
 
     bb0: {
-        _2 = {  }: map<string, reflect.Type>;
-        drop(_2);
         _0 = const "ok";
         goto -> bb1;
     }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_annotation/mir.snap
@@ -90,8 +90,11 @@ fn user.fixtures.type_annotation.test_list(function_name: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // function_name // param
+    let _2: reflect.Type[] // ts
 
     bb0: {
+        _2 = []: reflect.Type[];
+        drop(_2);
         _0 = const "ok";
         goto -> bb1;
     }
@@ -120,8 +123,11 @@ fn user.fixtures.type_annotation.test_map(function_name: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // function_name // param
+    let _2: map<string, reflect.Type> // m
 
     bb0: {
+        _2 = {  }: map<string, reflect.Type>;
+        drop(_2);
         _0 = const "ok";
         goto -> bb1;
     }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_kinds/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_kinds/bytecode.snap
@@ -55,70 +55,48 @@ function fixtures.type_kinds.exercise_all_kinds() -> bool {
     call user.fixtures.type_kinds.classify
     load_const "class"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type fixtures.type_kinds.Color
     call user.fixtures.type_kinds.classify
     load_const "enum"
     cmp_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_type int | string
     call user.fixtures.type_kinds.classify
     load_const "union"
     cmp_op ==
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_type "fixed"
     call user.fixtures.type_kinds.classify
     load_const "literal"
     cmp_op ==
-
-  L2:
-    jump_if_false L3
-    pop 1
+    jump_if_false_or_pop L0
     load_type fixtures.type_kinds.Foo[]
     call user.fixtures.type_kinds.classify
     load_const "array"
     cmp_op ==
-
-  L3:
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L0
     load_type map<string, fixtures.type_kinds.Foo>
     call user.fixtures.type_kinds.classify
     load_const "map"
     cmp_op ==
-
-  L4:
-    jump_if_false L5
-    pop 1
+    jump_if_false_or_pop L0
     load_type fixtures.type_kinds.Marker
     call user.fixtures.type_kinds.classify
     load_const "interface"
     cmp_op ==
-
-  L5:
-    jump_if_false L6
-    pop 1
+    jump_if_false_or_pop L0
     load_type int
     call user.fixtures.type_kinds.classify
     load_const "primitive"
     cmp_op ==
-
-  L6:
-    jump_if_false L7
-    pop 1
+    jump_if_false_or_pop L0
     load_type (int) -> bool throws never
     call user.fixtures.type_kinds.classify
     load_const "function"
     cmp_op ==
 
-  L7:
+  L0:
     return
 }
 
@@ -127,7 +105,5 @@ function fixtures.type_kinds.read_class(view: reflect.class.Type) -> reflect.Typ
     load_type reflect.TypeView
     load_const "as_type"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_kinds/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_type_kinds/mir.snap
@@ -97,14 +97,14 @@ fn user.fixtures.type_kinds.exercise_all_kinds() -> bool {
     let _6: bool
     let _7: bool
     let _8: bool
-    let _9: string
-    let _10: reflect.Type
-    let _11: string
-    let _12: reflect.Type
-    let _13: string
-    let _14: reflect.Type
-    let _15: string
-    let _16: reflect.Type
+    let _9: bool
+    let _10: bool
+    let _11: bool
+    let _12: bool
+    let _13: bool
+    let _14: bool
+    let _15: bool
+    let _16: bool
     let _17: string
     let _18: reflect.Type
     let _19: string
@@ -115,162 +115,182 @@ fn user.fixtures.type_kinds.exercise_all_kinds() -> bool {
     let _24: reflect.Type
     let _25: string
     let _26: reflect.Type
+    let _27: string
+    let _28: reflect.Type
+    let _29: string
+    let _30: reflect.Type
+    let _31: string
+    let _32: reflect.Type
+    let _33: string
+    let _34: reflect.Type
 
     bb0: {
-        _10 = load_type(fixtures.type_kinds.Foo);
+        _18 = load_type(fixtures.type_kinds.Foo);
         goto -> bb1;
     }
 
     bb1: {
-        _9 = call const fn user.fixtures.type_kinds.classify(copy _10) -> [bb2];
+        _17 = call const fn user.fixtures.type_kinds.classify(copy _18) -> [bb2];
     }
 
     bb2: {
-        _8 = copy _9 == const "class";
-        _7 = short_circuit(&&) copy _8 -> [eval: bb3, join: bb6];
+        _16 = copy _17 == const "class";
+        _15 = short_circuit(&&) copy _16 -> [eval: bb3, join: bb6];
     }
 
     bb3: {
-        _12 = load_type(fixtures.type_kinds.Color);
+        _20 = load_type(fixtures.type_kinds.Color);
         goto -> bb4;
     }
 
     bb4: {
-        _11 = call const fn user.fixtures.type_kinds.classify(copy _12) -> [bb5];
+        _19 = call const fn user.fixtures.type_kinds.classify(copy _20) -> [bb5];
     }
 
     bb5: {
-        _7 = copy _11 == const "enum";
+        _15 = copy _19 == const "enum";
         goto -> bb6;
     }
 
     bb6: {
-        _6 = short_circuit(&&) copy _7 -> [eval: bb7, join: bb10];
+        _14 = copy _15;
+        _13 = short_circuit(&&) copy _14 -> [eval: bb7, join: bb10];
     }
 
     bb7: {
-        _14 = load_type(int | string);
+        _22 = load_type(int | string);
         goto -> bb8;
     }
 
     bb8: {
-        _13 = call const fn user.fixtures.type_kinds.classify(copy _14) -> [bb9];
+        _21 = call const fn user.fixtures.type_kinds.classify(copy _22) -> [bb9];
     }
 
     bb9: {
-        _6 = copy _13 == const "union";
+        _13 = copy _21 == const "union";
         goto -> bb10;
     }
 
     bb10: {
-        _5 = short_circuit(&&) copy _6 -> [eval: bb11, join: bb14];
+        _12 = copy _13;
+        _11 = short_circuit(&&) copy _12 -> [eval: bb11, join: bb14];
     }
 
     bb11: {
-        _16 = load_type("fixed");
+        _24 = load_type("fixed");
         goto -> bb12;
     }
 
     bb12: {
-        _15 = call const fn user.fixtures.type_kinds.classify(copy _16) -> [bb13];
+        _23 = call const fn user.fixtures.type_kinds.classify(copy _24) -> [bb13];
     }
 
     bb13: {
-        _5 = copy _15 == const "literal";
+        _11 = copy _23 == const "literal";
         goto -> bb14;
     }
 
     bb14: {
-        _4 = short_circuit(&&) copy _5 -> [eval: bb15, join: bb18];
+        _10 = copy _11;
+        _9 = short_circuit(&&) copy _10 -> [eval: bb15, join: bb18];
     }
 
     bb15: {
-        _18 = load_type(fixtures.type_kinds.Foo[]);
+        _26 = load_type(fixtures.type_kinds.Foo[]);
         goto -> bb16;
     }
 
     bb16: {
-        _17 = call const fn user.fixtures.type_kinds.classify(copy _18) -> [bb17];
+        _25 = call const fn user.fixtures.type_kinds.classify(copy _26) -> [bb17];
     }
 
     bb17: {
-        _4 = copy _17 == const "array";
+        _9 = copy _25 == const "array";
         goto -> bb18;
     }
 
     bb18: {
-        _3 = short_circuit(&&) copy _4 -> [eval: bb19, join: bb22];
+        _8 = copy _9;
+        _7 = short_circuit(&&) copy _8 -> [eval: bb19, join: bb22];
     }
 
     bb19: {
-        _20 = load_type(map<string, fixtures.type_kinds.Foo>);
+        _28 = load_type(map<string, fixtures.type_kinds.Foo>);
         goto -> bb20;
     }
 
     bb20: {
-        _19 = call const fn user.fixtures.type_kinds.classify(copy _20) -> [bb21];
+        _27 = call const fn user.fixtures.type_kinds.classify(copy _28) -> [bb21];
     }
 
     bb21: {
-        _3 = copy _19 == const "map";
+        _7 = copy _27 == const "map";
         goto -> bb22;
     }
 
     bb22: {
-        _2 = short_circuit(&&) copy _3 -> [eval: bb23, join: bb26];
+        _6 = copy _7;
+        _5 = short_circuit(&&) copy _6 -> [eval: bb23, join: bb26];
     }
 
     bb23: {
-        _22 = load_type(fixtures.type_kinds.Marker);
+        _30 = load_type(fixtures.type_kinds.Marker);
         goto -> bb24;
     }
 
     bb24: {
-        _21 = call const fn user.fixtures.type_kinds.classify(copy _22) -> [bb25];
+        _29 = call const fn user.fixtures.type_kinds.classify(copy _30) -> [bb25];
     }
 
     bb25: {
-        _2 = copy _21 == const "interface";
+        _5 = copy _29 == const "interface";
         goto -> bb26;
     }
 
     bb26: {
-        _1 = short_circuit(&&) copy _2 -> [eval: bb27, join: bb30];
+        _4 = copy _5;
+        _3 = short_circuit(&&) copy _4 -> [eval: bb27, join: bb30];
     }
 
     bb27: {
-        _24 = load_type(int);
+        _32 = load_type(int);
         goto -> bb28;
     }
 
     bb28: {
-        _23 = call const fn user.fixtures.type_kinds.classify(copy _24) -> [bb29];
+        _31 = call const fn user.fixtures.type_kinds.classify(copy _32) -> [bb29];
     }
 
     bb29: {
-        _1 = copy _23 == const "primitive";
+        _3 = copy _31 == const "primitive";
         goto -> bb30;
     }
 
     bb30: {
-        _0 = short_circuit(&&) copy _1 -> [eval: bb31, join: bb34];
+        _2 = copy _3;
+        _1 = short_circuit(&&) copy _2 -> [eval: bb31, join: bb34];
     }
 
     bb31: {
-        _26 = load_type((int) -> bool throws never);
+        _34 = load_type((int) -> bool throws never);
         goto -> bb32;
     }
 
     bb32: {
-        _25 = call const fn user.fixtures.type_kinds.classify(copy _26) -> [bb33];
+        _33 = call const fn user.fixtures.type_kinds.classify(copy _34) -> [bb33];
     }
 
     bb33: {
-        _0 = copy _25 == const "function";
+        _1 = copy _33 == const "function";
         goto -> bb34;
     }
 
     bb34: {
+        _0 = copy _1;
+        goto -> bb35;
+    }
+
+    bb35: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_floats/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_floats/bytecode.snap
@@ -1482,15 +1482,11 @@ function floats.<(user.floats.FixedFloatRng as baml.random.Rng)>.random_int(self
 }
 
 function floats.float_max_via_local() -> float {
-    call baml.Float.nan
-    store_var _2
     load_const 3.0
-    load_var _2
+    call baml.Float.nan
     load_type baml.ops.Compare
     load_const "max"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1506,34 +1502,31 @@ function floats.float_random_distinct_values() -> bool {
     load_var i
     load_const 100
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 1
     sub_float
     load_const 0.5
     cmp_float_op >
     return
 
-  L2:
+  L1:
     load_const <omitted>
     call baml.Float.random
     store_var r
     load_var2 4 1
     cmp_float_op <
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var r
     store_var min_seen
 
-  L3:
+  L2:
     load_var2 4 2
     cmp_float_op >
-    pop_jump_if_false L4
+    pop_jump_if_false L3
     load_var r
     store_var max_seen
 
-  L4:
+  L3:
     load_var i
     load_const 1
     add_int
@@ -1555,69 +1548,55 @@ function floats.float_random_in_unit_interval_and_covers_both_halves() -> bool {
     load_var i
     load_const 1000
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var ok
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L1
     load_var below
     load_const 350
     cmp_int_op >=
-
-  L2:
-    jump_if_false L3
-    pop 1
+    jump_if_false_or_pop L1
     load_var above
     load_const 350
     cmp_int_op >=
 
-  L3:
+  L1:
     return
 
-  L4:
+  L2:
     load_const <omitted>
     call baml.Float.random
     store_var r
     load_var r
     load_const 0.0
     cmp_float_op <
-    jump_if_false L5
-    jump L6
-
-  L5:
-    pop 1
+    pop_jump_if_true L3
     load_var r
     load_const 1.0
     cmp_float_op >=
+    pop_jump_if_false L4
 
-  L6:
-    pop_jump_if_false L7
+  L3:
     load_const false
     store_var ok
 
-  L7:
+  L4:
     load_var r
     load_const 0.5
     cmp_float_op <
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    pop_jump_if_true L5
     load_var above
     load_const 1
     add_int
     store_var above
-    jump L10
+    jump L6
 
-  L9:
+  L5:
     load_var below
     load_const 1
     add_int
     store_var below
 
-  L10:
+  L6:
     load_var i
     load_const 1
     add_int
@@ -1632,8 +1611,7 @@ function floats.float_random_returns_a_float() -> bool {
     load_var r
     load_const 0.0
     cmp_float_op >=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var r
     load_const 1.0
     cmp_float_op <

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_for_loops/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_for_loops/bytecode.snap
@@ -128,14 +128,11 @@ function for_loops.for_loops_c_for_sum_to_ten() -> int {
     load_var i
     load_const 10
     cmp_int_op <=
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var s
     return
 
-  L2:
+  L1:
     load_var2 1 2
     add_int
     store_var s
@@ -163,10 +160,7 @@ function for_loops.for_loops_count_bounded(c: #0) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var y
     load_var n
@@ -175,7 +169,7 @@ function for_loops.for_loops_count_bounded(c: #0) -> int {
     store_var n
     jump L0
 
-  L2:
+  L1:
     load_var n
     return
 }
@@ -195,10 +189,7 @@ function for_loops.for_loops_first_even(xs: int[]) -> int {
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
     store_var_load_var x
     load_const 2
@@ -207,12 +198,12 @@ function for_loops.for_loops_first_even(xs: int[]) -> int {
     cmp_int_op ==
     pop_jump_if_false L0
     load_var x
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const -1
 
-  L3:
+  L2:
     return
 }
 
@@ -233,24 +224,18 @@ function for_loops.for_loops_for_with_break(xs: int[]) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var_load_var x
     load_const 10
     cmp_int_op >
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 2 5
     add_int
     store_var result
     jump L0
 
-  L3:
+  L1:
     load_var result
     return
 }
@@ -272,24 +257,18 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var_load_var x
     load_const 10
     cmp_int_op >
-    pop_jump_if_false L2
-    jump L0
-
-  L2:
+    pop_jump_if_true L0
     load_var2 2 5
     add_int
     store_var result
     jump L0
 
-  L3:
+  L1:
     load_var result
     return
 }
@@ -309,17 +288,14 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _3
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
-  L2:
+  L1:
     load_var _8
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -327,39 +303,33 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L0
-
-  L3:
+    pop_jump_if_true L0
     load_var _9
     load_const ""
     cmp_op ==
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_const true
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const false
 
-  L5:
+  L3:
     return
 }
 
 function for_loops.for_loops_joined_both_map_arms(xs: int[], b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type int
     load_type int
     load_type never
     load_var xs
     make_closure .<lambda(for_loops_joined_both_map_arms, 1)>, 0
     call baml.Array.map
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_type int
     load_type int
     load_type never
@@ -367,7 +337,7 @@ function for_loops.for_loops_joined_both_map_arms(xs: int[], b: bool) -> int {
     make_closure .<lambda(for_loops_joined_both_map_arms, 0)>, 0
     call baml.Array.map
 
-  L2:
+  L1:
     load_const 0
     store_var n
     load_type baml.iter.Iterable<Error = never, Item = int>
@@ -375,7 +345,7 @@ function for_loops.for_loops_joined_both_map_arms(xs: int[], b: bool) -> int {
     virtual_call nargs=1 ntypeargs=0
     store_var _14
 
-  L3:
+  L2:
     load_var _14
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
@@ -383,40 +353,34 @@ function for_loops.for_loops_joined_both_map_arms(xs: int[], b: bool) -> int {
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var2 3 5
     add_int
     store_var n
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var n
     return
 }
 
 function for_loops.for_loops_joined_map_arm(xs: int[], b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type int
     load_type int
     load_type never
     load_var xs
     make_closure .<lambda(for_loops_joined_map_arm, 0)>, 0
     call baml.Array.map
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 0
     load_type int
     alloc_array 1
 
-  L2:
+  L1:
     load_const 0
     store_var n
     load_type baml.iter.Iterable<Error = never, Item = int>
@@ -424,7 +388,7 @@ function for_loops.for_loops_joined_map_arm(xs: int[], b: bool) -> int {
     virtual_call nargs=1 ntypeargs=0
     store_var _10
 
-  L3:
+  L2:
     load_var _10
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
@@ -432,32 +396,26 @@ function for_loops.for_loops_joined_map_arm(xs: int[], b: bool) -> int {
     store_var _11
     load_var _11
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var2 3 5
     add_int
     store_var n
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var n
     return
 }
 
 function for_loops.for_loops_joined_map_arm_first(xs: int[], b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0
     load_type int
     alloc_array 1
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_type int
     load_type int
     load_type never
@@ -465,7 +423,7 @@ function for_loops.for_loops_joined_map_arm_first(xs: int[], b: bool) -> int {
     make_closure .<lambda(for_loops_joined_map_arm_first, 0)>, 0
     call baml.Array.map
 
-  L2:
+  L1:
     load_const 0
     store_var n
     load_type baml.iter.Iterable<Error = never, Item = int>
@@ -473,7 +431,7 @@ function for_loops.for_loops_joined_map_arm_first(xs: int[], b: bool) -> int {
     virtual_call nargs=1 ntypeargs=0
     store_var _10
 
-  L3:
+  L2:
     load_var _10
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
@@ -481,16 +439,13 @@ function for_loops.for_loops_joined_map_arm_first(xs: int[], b: bool) -> int {
     store_var _11
     load_var _11
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var2 3 5
     add_int
     store_var n
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var n
     return
 }
@@ -512,17 +467,14 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var arr_b
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
 
-  L2:
+  L1:
     load_var _9
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
@@ -530,18 +482,15 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     store_var _10
     load_var _10
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L0
-
-  L3:
+    pop_jump_if_true L0
     load_var2 3 5
     load_var _10
     mul_int
     add_int
     store_var result
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_var result
     return
 }
@@ -563,31 +512,25 @@ function for_loops.for_loops_render(xs: string[]) -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _4
     store_var_load_var x
     load_const ""
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 2 5
     bin_op +
     store_var result
     jump L0
 
-  L3:
+  L1:
     load_var result
     load_const "."
     bin_op +
     store_var result
     jump L0
 
-  L4:
+  L2:
     load_var result
     return
 }
@@ -609,16 +552,13 @@ function for_loops.for_loops_sum(xs: int[]) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 4
     add_int
     store_var result
     jump L0
 
-  L2:
+  L1:
     load_var result
     return
 }
@@ -644,16 +584,13 @@ function for_loops.for_loops_sum_let_var() -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     add_int
     store_var sum
     jump L0
 
-  L2:
+  L1:
     load_var sum
     return
 }
@@ -679,16 +616,13 @@ function for_loops.for_loops_sum_let_var_no_parens() -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     add_int
     store_var sum
     jump L0
 
-  L2:
+  L1:
     load_var sum
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fs/bytecode.snap
@@ -437,24 +437,21 @@ function fs.fs_chmod_missing_path_errors_fn() -> bool {
     load_const 420
     sys_op baml.fs.chmod
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -503,24 +500,21 @@ function fs.fs_chmod_rejects_mode(path: string, mode: int) -> bool {
     load_var2 1 2
     sys_op baml.fs.chmod
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -588,26 +582,23 @@ function fs.fs_file_close_invalidates_handle_fn() -> bool {
     load_const "text"
     virtual_call nargs=1 ntypeargs=0
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var _0
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var _0
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -668,18 +659,11 @@ function fs.fs_file_read_advances_cursor_fn() -> uint8array {
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _9
-    load_var _9
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const b""
     call baml.deep_copy
-    store_var _8
 
   L0:
-    load_var _8
     store_var result
     load_var path
     sys_op baml.fs.remove
@@ -703,26 +687,19 @@ function fs.fs_file_read_bytes_n_fn() -> bool {
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _8
-    load_var _8
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const b""
     call baml.deep_copy
-    store_var _7
 
   L0:
-    load_var _7
     store_var data
     load_var path
     sys_op baml.fs.remove
     pop 1
     load_var data
     container_len
-    store_var _12
-    load_var _12
+    store_var _11
+    load_var _11
     load_const 3
     cmp_int_op ==
     return
@@ -743,18 +720,11 @@ function fs.fs_file_read_n_bytes_fn() -> uint8array {
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _8
-    load_var _8
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const b""
     call baml.deep_copy
-    store_var _7
 
   L0:
-    load_var _7
     store_var result
     load_var path
     sys_op baml.fs.remove
@@ -809,18 +779,11 @@ function fs.fs_file_read_truncates_at_eof_fn() -> uint8array {
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _8
-    load_var _8
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const b""
     call baml.deep_copy
-    store_var _7
 
   L0:
-    load_var _7
     store_var result
     load_var path
     sys_op baml.fs.remove
@@ -992,26 +955,23 @@ function fs.fs_file_seek_negative_errors_fn() -> bool {
     load_const -1
     sys_op baml.fs.File.seek_from
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -1035,27 +995,24 @@ function fs.fs_file_write_on_readonly_errors_fn() -> bool {
     load_const "write"
     virtual_call nargs=2 ntypeargs=0
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .message
     store_var msg
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no error thrown"
     store_var msg
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -1093,26 +1050,23 @@ function fs.fs_mkdir_non_recursive_errors_when_dir_exists_fn() -> bool {
     init_instance baml.fs.MkdirOptions .recursive
     sys_op baml.fs.mkdir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var dir
     sys_op baml.fs.remove_dir
     pop 1
@@ -1131,24 +1085,21 @@ function fs.fs_mkdir_non_recursive_errors_when_parent_missing_fn() -> bool {
     init_instance baml.fs.MkdirOptions .recursive
     sys_op baml.fs.mkdir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -1180,26 +1131,23 @@ function fs.fs_mkdir_recursive_errors_when_leaf_is_file_fn() -> bool {
     init_instance baml.fs.MkdirOptions .recursive
     sys_op baml.fs.mkdir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -1300,8 +1248,7 @@ function fs.fs_open_append_creates_and_appends_fn() -> bool {
     load_var n
     load_const 5
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "start!more!"
     cmp_op ==
@@ -1339,8 +1286,7 @@ function fs.fs_open_append_creates_missing_file_fn() -> bool {
     load_var n
     load_const 2
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "hi"
     cmp_op ==
@@ -1395,24 +1341,21 @@ function fs.fs_open_nonexistent_file_fn() -> bool {
     load_const "text"
     virtual_call nargs=1 ntypeargs=0
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -1437,8 +1380,7 @@ function fs.fs_open_w_creates_missing_file_fn() -> bool {
     load_var n
     load_const 2
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "hi"
     cmp_op ==
@@ -1469,8 +1411,7 @@ function fs.fs_open_w_creates_parent_dirs_fn() -> bool {
     load_var n
     load_const 6
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "nested"
     cmp_op ==
@@ -1539,8 +1480,7 @@ function fs.fs_open_w_truncates_existing_fn() -> bool {
     load_var n
     load_const 3
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "new"
     cmp_op ==
@@ -1575,24 +1515,21 @@ function fs.fs_read_dir_nonexistent_errors_fn() -> bool {
     bin_op +
     sys_op baml.fs.read_dir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -1607,26 +1544,23 @@ function fs.fs_read_dir_on_file_errors_fn() -> bool {
     load_var path
     sys_op baml.fs.read_dir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -1699,21 +1633,14 @@ function fs.fs_read_dir_returns_entries_fn() -> bool {
     load_var _24
     load_const 3
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var has_a
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var has_b
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_var has_sub
 
-  L2:
+  L0:
     return
 }
 
@@ -1760,8 +1687,7 @@ function fs.fs_read_dir_type_flags_fn() -> bool {
     call baml.Array.some
     store_var dir_ok
     load_var file_ok
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var dir_ok
 
   L0:
@@ -1775,24 +1701,21 @@ function fs.fs_read_nonexistent_errors_fn() -> bool {
     bin_op +
     sys_op baml.fs.read
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -1855,26 +1778,23 @@ function fs.fs_remove_dir_all_on_file_errors_fn() -> bool {
     load_var path
     sys_op baml.fs.remove_dir_all
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.exists
     store_var survived
@@ -1882,11 +1802,10 @@ function fs.fs_remove_dir_all_on_file_errors_fn() -> bool {
     sys_op baml.fs.remove
     pop 1
     load_var threw
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L3
     load_var survived
 
-  L4:
+  L3:
     return
 }
 
@@ -1933,26 +1852,23 @@ function fs.fs_remove_dir_on_file_errors_fn() -> bool {
     load_var path
     sys_op baml.fs.remove_dir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var path
     sys_op baml.fs.exists
     store_var survived
@@ -1960,11 +1876,10 @@ function fs.fs_remove_dir_on_file_errors_fn() -> bool {
     sys_op baml.fs.remove
     pop 1
     load_var threw
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L3
     load_var survived
 
-  L4:
+  L3:
     return
 }
 
@@ -1973,24 +1888,21 @@ function fs.fs_remove_dir_on_missing_errors_fn() -> bool {
     call user.fs.fs_tmp
     sys_op baml.fs.remove_dir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -2012,26 +1924,23 @@ function fs.fs_remove_dir_on_nonempty_errors_fn() -> bool {
     load_var dir
     sys_op baml.fs.remove_dir
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var dir
     load_const "/file.txt"
     bin_op +
@@ -2041,11 +1950,10 @@ function fs.fs_remove_dir_on_nonempty_errors_fn() -> bool {
     sys_op baml.fs.remove_dir_all
     pop 1
     load_var threw
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L3
     load_var survived
 
-  L4:
+  L3:
     return
 }
 
@@ -2074,24 +1982,21 @@ function fs.fs_remove_nonexistent_errors_fn() -> bool {
     bin_op +
     sys_op baml.fs.remove
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -2107,27 +2012,24 @@ function fs.fs_remove_on_directory_points_at_remove_dir_fn() -> bool {
     load_var dir
     sys_op baml.fs.remove
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
     load_field .message
     store_var msg
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const "no error thrown"
     store_var msg
 
-  L3:
+  L2:
     load_var dir
     sys_op baml.fs.exists
     store_var still_there
@@ -2137,18 +2039,14 @@ function fs.fs_remove_on_directory_points_at_remove_dir_fn() -> bool {
     load_var msg
     load_const "it is a directory"
     call baml.String.includes
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L3
     load_var msg
     load_const "baml.fs.remove_dir or baml.fs.remove_dir_all"
     call baml.String.includes
-
-  L4:
-    jump_if_false L5
-    pop 1
+    jump_if_false_or_pop L3
     load_var still_there
 
-  L5:
+  L3:
     return
 }
 
@@ -2196,24 +2094,21 @@ function fs.fs_symlink_is_refused_at(path: string) -> bool {
     load_var2 1 1
     sys_op baml.fs.symlink
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -2235,8 +2130,7 @@ function fs.fs_symlink_onto_existing_path_errors_fn() -> bool {
     sys_op baml.fs.remove
     pop 1
     load_var threw
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var _7
     load_const "keep me"
     cmp_op ==
@@ -2317,12 +2211,11 @@ function fs.fs_write_bytes_fn() -> bool {
     load_var n
     load_const 11
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     container_len
-    store_var _20
-    load_var _20
+    store_var _21
+    load_var _21
     load_const 11
     cmp_int_op ==
 
@@ -2348,8 +2241,7 @@ function fs.fs_write_creates_parent_dirs_fn() -> bool {
     load_var n
     load_const 14
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "nested content"
     cmp_op ==
@@ -2379,8 +2271,7 @@ function fs.fs_write_overwrites_existing_fn() -> bool {
     load_var n
     load_const 11
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "new content"
     cmp_op ==
@@ -2406,8 +2297,7 @@ function fs.fs_write_string_fn() -> bool {
     load_var n
     load_const 13
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var readback
     load_const "Hello, world!"
     cmp_op ==
@@ -2429,36 +2319,32 @@ function fs.fs_write_wrapper_closes_on_error_fn() -> bool {
     load_const "oops"
     sys_op baml.fs.write
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_var dir
     sys_op baml.fs.remove_dir
     pop 1
     load_var threw
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L3
     load_var dir
     sys_op baml.fs.exists
     unary_op !
 
-  L4:
+  L3:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_functions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_functions/bytecode.snap
@@ -100,11 +100,9 @@ function functions.call_twice(f: (int, int) -> int throws never, x: int, y: int)
     load_var2 2 3
     load_var f
     call_indirect
-    store_var _4
     load_var2 2 3
     load_var f
     call_indirect
-    load_var _4
     add_int
     return
 }
@@ -120,61 +118,21 @@ function functions.early_return(x: int) -> int {
     load_var x
     load_const 42
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     load_const 5
     add_int
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function functions.early_return_nested() -> int {
-    load_const 1
     load_const 0
-    cmp_int_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
-    load_const 1
-    load_const 1
-    cmp_int_op !=
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
-    load_const 3
-    load_const 2
-    cmp_int_op !=
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_const 7
-    jump L6
-
-  L3:
-    load_const true
-    pop_jump_if_false L1
-    load_const 0
-    jump L6
-
-  L4:
-    load_const 0
-    jump L6
-
-  L5:
-    load_const 0
-
-  L6:
     return
 }
 
@@ -182,27 +140,22 @@ function functions.fib(n: int) -> int {
     load_var n
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var n
     load_const 1
     sub_int
     call user.functions.fib
-    store_var _3
     load_var n
     load_const 2
     sub_int
     call user.functions.fib
-    load_var _3
     add_int
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var n
 
-  L2:
+  L1:
     return
 }
 
@@ -242,11 +195,7 @@ function functions.literal_string() -> string {
 }
 
 function functions.mutable_variables_fn() -> int {
-    load_const 3
-    store_var y
     load_const 5
-    store_var y
-    load_var y
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_future_methods/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_future_methods/bytecode.snap
@@ -97,17 +97,14 @@ function future_methods.methods_on_errored_future() -> baml.future.State {
     store_var_load_var f
     await
     pop 1
-    jump L1
+    jump L0
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var f
     call baml.future.Future.state
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_future_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_future_types/bytecode.snap
@@ -119,25 +119,12 @@ function future_types.captured_local_future_is_int_future_fn() -> bool {
     spawn
     store_var _4
     load_var _4
-    store_var_load_var f
-    is_type baml.future.Future<int, never>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var f
     load_var f
     await
     pop 1
-    load_var observed
+    load_var f
+    is_type baml.future.Future<int, never>
     return
 }
 
@@ -146,17 +133,14 @@ function future_types.classify_future(f: baml.future.Future<int, never> | baml.f
     store_var _2
     load_var _2
     narrow_bind baml.future.Future<int, never>, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "string"
     jump L1
 
   L0:
-    load_const "string"
-    jump L2
-
-  L1:
     load_const "int"
 
-  L2:
+  L1:
     return
 }
 
@@ -201,47 +185,35 @@ function future_types.classify_string_future_fn() -> string {
 function future_types.classify_tagged(v: baml.future.Future<int, never> | baml.future.Future<string, never> | int | string | bool) -> string {
     load_var v
     is_type baml.future.Future<int, never>
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var v
     is_type baml.future.Future<string, never>
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var v
     is_type int
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var v
     is_type string
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const "bool"
+    jump L4
+
+  L0:
+    load_const "string"
+    jump L4
+
+  L1:
+    load_const "int"
+    jump L4
+
+  L2:
+    load_const "string-future"
     jump L4
 
   L3:
-    load_const "bool"
-    jump L8
-
-  L4:
-    load_const "string"
-    jump L8
-
-  L5:
-    load_const "int"
-    jump L8
-
-  L6:
-    load_const "string-future"
-    jump L8
-
-  L7:
     load_const "int-future"
 
-  L8:
+  L4:
     return
 }
 
@@ -262,27 +234,14 @@ function future_types.future_array_matches_fn() -> bool {
     load_var _4
     load_type baml.future.Future<int, never>
     alloc_array 1
-    store_var_load_var fs
-    is_type baml.future.Future<int, never>[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var fs
     load_var fs
     load_const 0
     load_array_element
     await
     pop 1
-    load_var observed
+    load_var fs
+    is_type baml.future.Future<int, never>[]
     return
 }
 
@@ -323,25 +282,12 @@ function future_types.int_future_is_int_future_fn() -> bool {
     spawn
     store_var _3
     load_var _3
-    store_var_load_var f
-    is_type baml.future.Future<int, never>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var f
     load_var f
     await
     pop 1
-    load_var observed
+    load_var f
+    is_type baml.future.Future<int, never>
     return
 }
 
@@ -354,25 +300,12 @@ function future_types.int_future_is_string_future_fn() -> bool {
     spawn
     store_var _3
     load_var _3
-    store_var_load_var f
-    is_type baml.future.Future<string, never>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var f
     load_var f
     await
     pop 1
-    load_var observed
+    load_var f
+    is_type baml.future.Future<string, never>
     return
 }
 
@@ -390,25 +323,12 @@ function future_types.spawn_is_int_future(v: #0) -> bool {
     spawn
     store_var _4
     load_var _4
-    store_var_load_var f
-    is_type baml.future.Future<int, never>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var f
     load_var f
     await
     pop 1
-    load_var observed
+    load_var f
+    is_type baml.future.Future<int, never>
     return
 }
 
@@ -459,36 +379,20 @@ function future_types.throwing_future_is_non_throwing_future_fn() -> bool {
     spawn
     store_var _3
     load_var _3
-    store_var_load_var f
-    is_type baml.future.Future<int, never>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var f
     load_var f
     await
     pop 1
-    jump L4
+    jump L0
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L4:
-    load_var observed
+  L0:
+    load_var f
+    is_type baml.future.Future<int, never>
     return
 }
 
@@ -503,26 +407,13 @@ function future_types.wrong_future_array_fn() -> bool {
     load_var _4
     load_type baml.future.Future<string, never>
     alloc_array 1
-    store_var_load_var fs
-    is_type baml.future.Future<int, never>[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var observed
-    jump L2
-
-  L1:
-    load_const true
-    store_var observed
-
-  L2:
+    store_var fs
     load_var fs
     load_const 0
     load_array_element
     await
     pop 1
-    load_var observed
+    load_var fs
+    is_type baml.future.Future<int, never>[]
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_gc/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_gc/bytecode.snap
@@ -94,6 +94,15 @@ function gc.gc_map_survives_pressure() -> int {
     return
 
   L2:
+    load_var2 2 2
+    load_const 1
+    add_int
+    load_var i
+    load_const 2
+    add_int
+    load_type int
+    alloc_array 3
+    pop 1
     load_var i
     load_const 1
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_gc/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_gc/bytecode.snap
@@ -47,14 +47,11 @@ function gc.gc_heavy_allocation_loop() -> int {
     load_var i
     load_const 1000
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var sum
     return
 
-  L2:
+  L1:
     load_var2 1 2
     load_var i
     load_const 2
@@ -85,24 +82,12 @@ function gc.gc_map_survives_pressure() -> int {
     load_var i
     load_const 500
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var m
     container_len
     return
 
-  L2:
-    load_var2 2 2
-    load_const 1
-    add_int
-    load_var i
-    load_const 2
-    add_int
-    load_type int
-    alloc_array 3
-    pop 1
+  L1:
     load_var i
     load_const 1
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_rigid/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_rigid/bytecode.snap
@@ -189,17 +189,6 @@ function generic_match_rigid.<(user.generic_match_rigid.RigidTagged as user.gene
 function generic_match_rigid.RigidBox.is_own(self: generic_match_rigid.RigidBox<#0>, other: generic_match_rigid.RigidBox<int> | int) -> bool {
     load_var other
     is_type generic_match_rigid.RigidBox<...>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -208,17 +197,14 @@ function generic_match_rigid.RigidBox.match_own(self: generic_match_rigid.RigidB
     store_var _3
     load_var _3
     narrow_bind generic_match_rigid.RigidBox<...>, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "box"
 
-  L2:
+  L1:
     return
 }
 
@@ -294,17 +280,6 @@ function generic_match_rigid.fn_generic_is_value_miss_fn() -> bool {
 function generic_match_rigid.is_rigid_box(x: generic_match_rigid.RigidBox<int> | int) -> bool {
     load_var x
     is_type generic_match_rigid.RigidBox<...>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -313,17 +288,14 @@ function generic_match_rigid.pick_bounded(x: generic_match_rigid.RigidTagged | s
     store_var _2
     load_var _2
     narrow_bind #0, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "bounded"
 
-  L2:
+  L1:
     return
 }
 
@@ -347,19 +319,16 @@ function generic_match_rigid.pick_concrete(x: #0) -> string {
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_var _2
     load_const "!"
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -382,41 +351,32 @@ function generic_match_rigid.pick_mixed_union(x: #0 | bool) -> string {
     store_var _2
     load_var _2
     narrow_bind #0, slot=2
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L1
     load_var x
     store_var _3
     load_var _3
     narrow_bind string, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     is_type true
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var x
     is_type false
-    pop_jump_if_false L6
+    pop_jump_if_false L3
     load_const "f"
-    jump L5
+    jump L2
 
-  L3:
+  L0:
     load_const "t"
-    jump L5
+    jump L2
 
-  L4:
+  L1:
     load_const "p"
 
-  L5:
+  L2:
     return
 
-  L6:
+  L3:
     unreachable
 }
 
@@ -439,17 +399,14 @@ function generic_match_rigid.pick_rigid(x: int | string) -> string {
     store_var _2
     load_var _2
     narrow_bind #0, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "fallthrough"
     jump L1
 
   L0:
-    load_const "fallthrough"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
@@ -479,25 +436,19 @@ function generic_match_rigid.pick_written_union(x: #0 | int) -> string {
     store_var _2
     load_var _2
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     store_var _3
     load_var _3
     narrow_bind string, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "other"
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const "int-or-string"
 
-  L3:
+  L1:
     return
 }
 
@@ -556,26 +507,16 @@ function generic_match_rigid.rigid_cell_split(c: generic_match_rigid.RigidCell<i
     load_var c
     load_field .v
     is_type 1
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var c
     is_type generic_match_rigid.RigidCell<...>
     pop_jump_if_false L3
-    load_var c
-    load_field .v
-    pop 1
-    load_var c
-    load_field .v
-    pop 1
     load_const "concrete"
     jump L2
 
   L1:
-    load_var c
-    load_field .v
-    pop 1
     load_const "rigid-one"
 
   L2:
@@ -631,26 +572,13 @@ function generic_match_rigid.rigid_row_split(r: generic_match_rigid.RigidRow) ->
     load_var r
     load_field .n
     is_type 1
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
-    load_var r
-    load_field .xs
-    pop 1
-    load_var r
-    load_field .n
-    pop 1
     load_const "slice"
     jump L2
 
   L1:
-    load_var r
-    load_field .xs
-    pop 1
-    load_var r
-    load_field .n
-    pop 1
     load_const "rigid-one"
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_rigid/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_rigid/bytecode.snap
@@ -563,10 +563,19 @@ function generic_match_rigid.rigid_cell_split(c: generic_match_rigid.RigidCell<i
     load_var c
     is_type generic_match_rigid.RigidCell<...>
     pop_jump_if_false L3
+    load_var c
+    load_field .v
+    pop 1
+    load_var c
+    load_field .v
+    pop 1
     load_const "concrete"
     jump L2
 
   L1:
+    load_var c
+    load_field .v
+    pop 1
     load_const "rigid-one"
 
   L2:
@@ -626,10 +635,22 @@ function generic_match_rigid.rigid_row_split(r: generic_match_rigid.RigidRow) ->
     jump L1
 
   L0:
+    load_var r
+    load_field .xs
+    pop 1
+    load_var r
+    load_field .n
+    pop 1
     load_const "slice"
     jump L2
 
   L1:
+    load_var r
+    load_field .xs
+    pop 1
+    load_var r
+    load_field .n
+    pop 1
     load_const "rigid-one"
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_subtype/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_subtype/bytecode.snap
@@ -118,8 +118,6 @@ function generic_match_subtype.generic_match_falls_through_on_non_fn() -> int {
     load_type generic_match_subtype.Shape
     load_const "area"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -137,8 +135,6 @@ function generic_match_subtype.generic_match_subtype_narrow_default_fn() -> int 
     load_type generic_match_subtype.Shape
     load_const "area"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -156,8 +152,6 @@ function generic_match_subtype.generic_match_widened_default_fn() -> int {
     load_type generic_match_subtype.Shape
     load_const "area"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -173,17 +167,14 @@ function generic_match_subtype.pick_concrete(x: generic_match_subtype.Foo<int> |
     store_var _2
     load_var _2
     narrow_bind generic_match_subtype.Foo<...>, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "string"
     jump L1
 
   L0:
-    load_const "string"
-    jump L2
-
-  L1:
     load_const "int"
 
-  L2:
+  L1:
     return
 }
 
@@ -192,53 +183,41 @@ function generic_match_subtype.pick_concrete_switch(x: generic_match_subtype.Foo
     store_var _2
     load_var _2
     narrow_bind generic_match_subtype.Foo<...>, slot=2
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var x
     store_var _3
     load_var _3
     narrow_bind generic_match_subtype.Foo<...>, slot=3
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var x
     store_var _4
     load_var _4
     narrow_bind int, slot=4
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var x
     store_var _5
     load_var _5
     narrow_bind string, slot=5
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const "prim bool"
+    jump L4
+
+  L0:
+    load_const "prim string"
+    jump L4
+
+  L1:
+    load_const "prim int"
+    jump L4
+
+  L2:
+    load_const "string"
     jump L4
 
   L3:
-    load_const "prim bool"
-    jump L8
-
-  L4:
-    load_const "prim string"
-    jump L8
-
-  L5:
-    load_const "prim int"
-    jump L8
-
-  L6:
-    load_const "string"
-    jump L8
-
-  L7:
     load_const "int"
 
-  L8:
+  L4:
     return
 }
 
@@ -247,17 +226,14 @@ function generic_match_subtype.unwrap_or(o: generic_match_subtype.Opt<#0> | gene
     store_var _3
     load_var _3
     narrow_bind generic_match_subtype.Opt<...>, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var default
     jump L1
 
   L0:
-    load_var default
-    jump L2
-
-  L1:
     load_var _3
     load_field .value
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_typevar/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_match_typevar/bytecode.snap
@@ -79,17 +79,6 @@ function generic_match_typevar.$init_test_ns_generic_match_typevar_generic_match
 function generic_match_typevar.is_t(x: #0 | string) -> bool {
     load_var x
     is_type #0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -112,25 +101,22 @@ function generic_match_typevar.pick(x: #0 | string) -> string {
     store_var _2
     load_var _2
     narrow_bind #0, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     store_var _3
     load_var _3
     narrow_bind string, slot=3
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_const "string"
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "T"
 
-  L2:
+  L1:
     return
 
-  L3:
+  L2:
     unreachable
 }
 
@@ -153,25 +139,22 @@ function generic_match_typevar.pick_list(x: #0[] | string[]) -> string {
     store_var _2
     load_var _2
     narrow_bind #0[], slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     store_var _3
     load_var _3
     narrow_bind string[], slot=3
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_const "string[]"
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "T[]"
 
-  L2:
+  L1:
     return
 
-  L3:
+  L2:
     unreachable
 }
 
@@ -210,25 +193,22 @@ function generic_match_typevar.pick_map(x: map<string, #0> | map<string, string>
     store_var _2
     load_var _2
     narrow_bind map<string, #0>, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     store_var _3
     load_var _3
     narrow_bind map<string, string>, slot=3
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_const "map<string>"
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "map<T>"
 
-  L2:
+  L1:
     return
 
-  L3:
+  L2:
     unreachable
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_union_returns/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_union_returns/bytecode.snap
@@ -11,18 +11,12 @@ function generic_union_returns.model_step_flattens_union_type_arg() -> bool {
     store_var _4
     load_var _4
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _3
     store_var _7
     load_var _7
     narrow_bind generic_union_returns.FinalValue, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _3
     load_field .calls
     container_len
@@ -30,21 +24,21 @@ function generic_union_returns.model_step_flattens_union_type_arg() -> bool {
     load_var _11
     load_const 99
     cmp_int_op ==
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_var _7
     load_field .value
     load_const "never"
     cmp_op ==
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _4
     load_const "done"
     cmp_op ==
 
-  L4:
+  L2:
     return
 }
 
@@ -77,132 +71,97 @@ function generic_union_returns.sap_nullable_container_types_are_preserved() -> b
     load_var empty_json
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var empty_json
+    container_len
     jump L1
 
   L0:
-    load_var empty_json
-    container_len
-    jump L2
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    load_const -1
 
   L2:
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    load_const -1
-    store_var _9
-
-  L3:
-    load_var _9
     load_const 0
     cmp_int_op ==
     store_var empty_ok
     load_var metadata
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var metadata
     container_len
-    jump L6
+    jump L4
+
+  L3:
+    load_const null
+
+  L4:
+    jump_if_not_null_or_pop L5
+    load_const 0
 
   L5:
-    load_const null
-
-  L6:
-    store_var_load_var _17
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
-    load_const 0
-    store_var _17
-
-  L7:
-    load_var _17
     load_const 1
     cmp_int_op ==
     store_var map_ok
     load_var children
     load_const null
     cmp_op ==
-    pop_jump_if_false L8
-    jump L11
-
-  L8:
+    pop_jump_if_true L6
     load_type generic_union_returns.ParsedChild
     load_var children
     load_const 0
     call baml.Array.at
     load_const null
     cmp_op ==
-    pop_jump_if_false L9
-    jump L11
-
-  L9:
+    pop_jump_if_true L6
     load_var children
     load_const null
     cmp_op ==
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L6
     load_type generic_union_returns.ParsedChild
     load_var children
     load_const 0
     call baml.Array.at
     load_field .0
-    jump L12
+    jump L7
 
-  L11:
+  L6:
     load_const null
 
-  L12:
+  L7:
     load_const "first"
     call baml.ops.equals_equals
     store_var children_ok
     load_var statuses
     load_const null
     cmp_op ==
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
+    pop_jump_if_true L8
     load_type generic_union_returns.ParsedStatus
     load_var statuses
     load_const 0
     call baml.Array.at
-    jump L15
+    jump L9
 
-  L14:
+  L8:
     load_const null
 
-  L15:
+  L9:
     load_const user.generic_union_returns.ParsedStatus.Ready
     alloc_variant user.generic_union_returns.ParsedStatus
     call baml.ops.equals_equals
     store_var statuses_ok
     load_var empty_ok
-    jump_if_false L16
-    pop 1
+    jump_if_false_or_pop L10
     load_var map_ok
-
-  L16:
-    jump_if_false L17
-    pop 1
+    jump_if_false_or_pop L10
     load_var children_ok
-
-  L17:
-    jump_if_false L18
-    pop 1
+    jump_if_false_or_pop L10
     load_var statuses_ok
 
-  L18:
+  L10:
     return
 }
 
@@ -214,20 +173,17 @@ function generic_union_returns.sap_parses_optional_json_null() -> bool {
     load_var parsed
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var parsed
     call baml.json.stringify
     load_const "never"
     cmp_op ==
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const true
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_glob/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_glob/bytecode.snap
@@ -796,40 +796,34 @@ function glob.scan_propagates_permission_errors_fn() -> bool {
     load_const null
     sys_op baml.sys.shell
     call baml.sys.ShellOutput.ok
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_const "**/*.txt"
     sys_op baml.glob.new
     load_var root
     sys_op baml.glob.Glob.scan
     pop 1
-    jump L3
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
+
+  L0:
+    load_const true
+    store_var threw
+    jump L3
+
+  L1:
+    load_const false
+    store_var threw
+    jump L3
 
   L2:
     load_const true
     store_var threw
-    jump L5
 
   L3:
-    load_const false
-    store_var threw
-    jump L5
-
-  L4:
-    load_const true
-    store_var threw
-
-  L5:
     load_const "chmod 755 "
     load_var locked
     bin_op +
@@ -970,26 +964,23 @@ function glob.scan_throws_on_broken_symlink_when_opted_in_fn() -> bool {
     init_instance baml.glob.ScanOptions .cwd, .dot, .absolute, .follow_symlinks, .throw_error_on_broken_symlink, .only_files
     sys_op baml.glob.Glob.scan
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
     store_var threw
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
     store_var threw
 
-  L3:
+  L2:
     load_const "rm -rf "
     load_var root
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_http_server/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_http_server/bytecode.snap
@@ -115,8 +115,7 @@ function http_server.server_bind_resolves_ephemeral_port() -> bool {
     load_field .addr
     load_const ""
     cmp_op !=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var server
     load_field .addr
     load_const "127.0.0.1:0"
@@ -248,8 +247,7 @@ function http_server.server_isolates_handler_panic() -> bool {
     load_field .status_code
     load_const 500
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var good
     load_field .status_code
     load_const 200
@@ -515,14 +513,11 @@ function http_server.tls_config_handshake_timeout_arg() -> bool {
 function http_server.tls_config_handshake_timeout_bad_pem() -> bool {
     load_const "not a cert"
     call baml.String.to_utf8
-    store_var _2
     load_const "not a key"
     call baml.String.to_utf8
-    store_var _3
     load_const 3n
     call baml.time.Duration.from_seconds
     store_var _4
-    load_var2 1 2
     load_const <omitted>
     load_var _4
     call baml.http.TlsConfig.new
@@ -534,11 +529,8 @@ function http_server.tls_config_handshake_timeout_bad_pem() -> bool {
 function http_server.tls_config_new_bad_pem() -> bool {
     load_const "not a cert"
     call baml.String.to_utf8
-    store_var _2
     load_const "not a key"
     call baml.String.to_utf8
-    store_var _3
-    load_var2 1 2
     load_const <omitted>
     load_const <omitted>
     call baml.http.TlsConfig.new

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_if_else/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_if_else/bytecode.snap
@@ -236,199 +236,120 @@ function if_else.block_expression_fn() -> int {
 }
 
 function if_else.consecutive_if_without_else_fn() -> int {
-    load_const 0
-    store_var x
-    load_const true
-    pop_jump_if_false L0
     load_const 1
-    store_var x
-
-  L0:
-    load_const false
-    pop_jump_if_false L1
-    load_const 2
-    store_var x
-
-  L1:
-    load_var x
     return
 }
 
 function if_else.else_if_assignment_fn(a: bool, b: bool) -> int {
     load_var a
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L1
+    load_var b
+    pop_jump_if_true L0
+    load_const 3
+    jump L2
 
   L0:
-    load_var b
-    pop_jump_if_false L1
+    load_const 2
     jump L2
 
   L1:
-    load_const 3
-    jump L4
-
-  L2:
-    load_const 2
-    jump L4
-
-  L3:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function if_else.else_if_assignment_with_locals_fn(a: bool, b: bool) -> int {
     load_var a
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L1
+    load_var b
+    pop_jump_if_true L0
+    load_const 3
+    jump L2
 
   L0:
-    load_var b
-    pop_jump_if_false L1
+    load_const 2
     jump L2
 
   L1:
-    load_const 3
-    jump L4
-
-  L2:
-    load_const 2
-    jump L4
-
-  L3:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function if_else.else_if_return_locals(a: bool, b: bool) -> int {
     load_var a
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L1
+    load_var b
+    pop_jump_if_true L0
+    load_const 3
+    jump L2
 
   L0:
-    load_var b
-    pop_jump_if_false L1
+    load_const 2
     jump L2
 
   L1:
-    load_const 3
-    jump L4
-
-  L2:
-    load_const 2
-    jump L4
-
-  L3:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function if_else.else_if_with_comparisons_fn() -> int {
-    load_const 5
-    load_const 0
-    cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
-    load_const 5
-    load_const 10
-    cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const 2
-    jump L4
-
-  L2:
     load_const 1
-    jump L4
-
-  L3:
-    load_const 0
-
-  L4:
     return
 }
 
 function if_else.else_if_with_param(a: bool, b: bool) -> int {
     load_var a
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L1
+    load_var b
+    pop_jump_if_true L0
+    load_const 3
+    jump L2
 
   L0:
-    load_var b
-    pop_jump_if_false L1
+    load_const 2
     jump L2
 
   L1:
-    load_const 3
-    jump L4
-
-  L2:
-    load_const 2
-    jump L4
-
-  L3:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function if_else.if_else_assigned_then_passed_fn() -> int {
-    load_const false
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
     load_const 20
-    jump L2
-
-  L1:
-    load_const 10
-
-  L2:
     call user.if_else.if_else_identity
     return
 }
 
 function if_else.if_else_assignment_with_locals_fn(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function if_else.if_else_assignment_with_param(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -439,85 +360,60 @@ function if_else.if_else_identity(x: int) -> int {
 
 function if_else.if_else_return_locals(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function if_else.if_else_statement_fn(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 4
     call user.if_else.if_else_identity
     pop 1
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 1
     call user.if_else.if_else_identity
     pop 1
 
-  L2:
+  L1:
     load_const 1
     return
 }
 
 function if_else.if_else_with_param_true(b: bool) -> int {
     load_var b
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
 function if_else.if_without_else_fn() -> int {
-    load_const 0
-    store_var x
-    load_const true
-    pop_jump_if_false L0
     load_const 5
-    store_var x
-
-  L0:
-    load_var x
     return
 }
 
 function if_else.if_without_else_with_local_fn() -> int {
-    load_const true
-    pop_jump_if_false L0
-
-  L0:
     load_const 0
     return
 }
 
 function if_else.nested_block_with_if_fn() -> int {
-    load_const 1
-    store_var a
-    load_const 2
-    load_const 3
-    add_int
+    load_const 5
     store_var_load_var a
     load_const 5
     cmp_int_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_inferred_generic_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_inferred_generic_type_args/bytecode.snap
@@ -109,10 +109,7 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.ArrIter<#0
     load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     copy 0
     load_field .idx
@@ -120,12 +117,12 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.ArrIter<#0
     bin_op +
     store_field .idx
     load_var _2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     alloc_instance user.inferred_generic_type_args.IterDone
 
-  L2:
+  L1:
     return
 }
 
@@ -182,21 +179,18 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.IntCounter
 function inferred_generic_type_args.<(user.inferred_generic_type_args.LoneIter<#0> as user.inferred_generic_type_args.NextIter<#0, never>)>.next2(self: inferred_generic_type_args.LoneIter<#0>) -> #0 | inferred_generic_type_args.IterDone {
     load_var self
     load_field .used
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_const true
     store_field .used
     load_var self
     load_field .v
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     alloc_instance user.inferred_generic_type_args.IterDone
 
-  L2:
+  L1:
     return
 }
 
@@ -222,8 +216,6 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.ProbeA as 
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -256,8 +248,6 @@ function inferred_generic_type_args.<(user.inferred_generic_type_args.TypedBox<#
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -290,8 +280,6 @@ function inferred_generic_type_args.Counter.element_type(self: inferred_generic_
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -300,8 +288,6 @@ function inferred_generic_type_args.Cursor.take_one(self: inferred_generic_type_
     load_type inferred_generic_type_args.Cursor<#1>
     load_const "head"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_type #1
     init_instance<1> user.inferred_generic_type_args.SingleCursor .value
     return
@@ -319,8 +305,6 @@ function inferred_generic_type_args.Named.tname(self: inferred_generic_type_args
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -330,8 +314,6 @@ function inferred_generic_type_args.NextIter.collect2(self: inferred_generic_typ
     store_var out
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type inferred_generic_type_args.NextIter<#1, #2>
     load_const "next2"
@@ -339,17 +321,14 @@ function inferred_generic_type_args.NextIter.collect2(self: inferred_generic_typ
     store_var _3
     load_var _3
     is_type inferred_generic_type_args.IterDone
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type #1
     load_var2 2 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -387,8 +366,6 @@ function inferred_generic_type_args.class_method_builds_generic() -> int {
     load_type inferred_generic_type_args.Wrap<int>
     load_const "first"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -399,8 +376,6 @@ function inferred_generic_type_args.default_forward_reads_type_var() -> string {
     load_type inferred_generic_type_args.Counter<int>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -416,8 +391,6 @@ function inferred_generic_type_args.default_method_typevar_name() -> string {
     load_type inferred_generic_type_args.Named<int>
     load_const "tname"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -426,8 +399,6 @@ function inferred_generic_type_args.echo_type(a: #0) -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -447,8 +418,6 @@ function inferred_generic_type_args.free_fn_tname(a: #0[]) -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -459,8 +428,6 @@ function inferred_generic_type_args.generic_behind_nongeneric_iface() -> string 
     load_type inferred_generic_type_args.Describable
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -475,8 +442,6 @@ function inferred_generic_type_args.inferred_ctor_collect_count() -> int {
     load_type inferred_generic_type_args.NextIter<int, never>
     load_const "collect2"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
     container_len
     return
 }
@@ -494,29 +459,23 @@ function inferred_generic_type_args.inferred_ctor_instance_is_typed() -> int {
     store_var _4
     load_var _4
     narrow_bind inferred_generic_type_args.ArrBag<...>, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var s
     store_var _5
     load_var _5
     narrow_bind inferred_generic_type_args.OneBag<...>, slot=3
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const 9
+    jump L2
+
+  L0:
+    load_const 2
     jump L2
 
   L1:
-    load_const 9
-    jump L4
-
-  L2:
-    load_const 2
-    jump L4
-
-  L3:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
@@ -531,8 +490,6 @@ function inferred_generic_type_args.inferred_static_ctor_first() -> int {
     load_type inferred_generic_type_args.Bag<int>
     load_const "first"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -543,8 +500,6 @@ function inferred_generic_type_args.inferred_static_ctor_speak() -> string {
     load_type inferred_generic_type_args.Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -555,8 +510,6 @@ function inferred_generic_type_args.interface_dispatch_inferred_method_type_arg(
     load_type inferred_generic_type_args.TypeProbe
     load_const "seen"
     virtual_call nargs=2 ntypeargs=1
-    store_var _0
-    load_var _0
     return
 }
 
@@ -566,8 +519,6 @@ function inferred_generic_type_args.nested_self_inferred_binding() -> string {
     load_type inferred_generic_type_args.SelfEcho
     load_const "nested_self_type"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -582,12 +533,8 @@ function inferred_generic_type_args.take_one_then_head() -> int {
     load_type inferred_generic_type_args.Cursor<int>
     load_const "take_one"
     virtual_call nargs=1 ntypeargs=0
-    store_var single
-    load_var single
     load_type inferred_generic_type_args.Cursor<int>
     load_const "head"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/bytecode.snap
@@ -111,8 +111,6 @@ function instantiation_expr.describe() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/ns_qualified/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_instantiation_expr/ns_qualified/bytecode.snap
@@ -6,8 +6,6 @@ function instantiation_expr.qualified.q_describe() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
@@ -2602,6 +2602,14 @@ function interfaces.bgfb_same(x: #0) -> bool {
 }
 
 function interfaces.birr_main() -> bool {
+    load_const 1
+    load_type int
+    init_instance<1> user.interfaces.BirrContainer .value
+    pop 1
+    load_const "two"
+    load_type string
+    init_instance<1> user.interfaces.BirrContainer .value
+    pop 1
     load_type interfaces.BirrContainer<int>
     load_type interfaces.BirrPrintable<int>
     call reflect.Type.implements
@@ -3924,7 +3932,8 @@ function interfaces.gbr_first_name(items: #0[]) -> string {
 function interfaces.gbr_main() -> string {
     load_const "Rex"
     init_instance user.interfaces.GbrDog .name
-    store_var mydog
+    load_field .name
+    pop 1
     load_type interfaces.GbrDog
     load_const "Rex"
     init_instance user.interfaces.GbrDog .name
@@ -4377,11 +4386,20 @@ function interfaces.mdci_describe(a: interfaces.MdciAnimal) -> string {
   L2:
     load_var a
     load_field .0
+    pop 1
+    load_var a
+    load_field .0
     load_const " the cat"
     bin_op +
     jump L4
 
   L3:
+    load_var a
+    load_field .0
+    pop 1
+    load_var a
+    load_field .1
+    pop 1
     load_var a
     load_field .0
     load_const " the "
@@ -4461,10 +4479,18 @@ function interfaces.midr_describe(s: interfaces.MidrSwitch) -> string {
     jump L1
 
   L0:
+    load_var s
+    load_type interfaces.MidrSwitch
+    virtual_load_field .active
+    pop 1
     load_const "off"
     jump L2
 
   L1:
+    load_var s
+    load_type interfaces.MidrSwitch
+    virtual_load_field .active
+    pop 1
     load_const "on"
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
@@ -1696,16 +1696,13 @@ function interfaces.<(user.interfaces.Fz38MyFetcher as user.interfaces.Fz38DataF
     load_var key
     load_const "net"
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "data:"
     load_var key
     bin_op +
     return
 
-  L1:
+  L0:
     load_const "connection refused"
     init_instance user.interfaces.Fz38NetworkError .msg
     throw
@@ -1805,13 +1802,11 @@ function interfaces.<(user.interfaces.GoopBox<#0> as user.interfaces.GoopDescrib
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
     load_type #1
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
-    load_var _4
     load_const ":"
     bin_op +
     load_var _6
@@ -1978,8 +1973,6 @@ function interfaces.<(user.interfaces.SapcPolite as user.interfaces.SapcFarewell
     load_type interfaces.SapcGreeter
     load_const "greet"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_const " — and goodbye!"
     bin_op +
     return
@@ -2217,8 +2210,6 @@ function interfaces.CridEquals.neq(self: interfaces.CridEquals, other: #0) -> bo
     load_type interfaces.CridEquals
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     unary_op !
     return
 }
@@ -2364,8 +2355,6 @@ function interfaces.Fz16Container.get_or(self: interfaces.Fz16Container<#1>, fal
     load_type interfaces.Fz16Container<#1>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2407,8 +2396,6 @@ function interfaces.IdmcEquatable.neq(self: interfaces.IdmcEquatable, other: #0)
     load_type interfaces.IdmcEquatable
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     unary_op !
     return
 }
@@ -2460,8 +2447,6 @@ function interfaces.W301Sub.sub_get(self: interfaces.W301Sub<#1>) -> #1 {
     load_type interfaces.W301Base<#1>
     load_const "base_get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2480,8 +2465,6 @@ function interfaces.apss_main() -> string {
     load_type interfaces.ApssSerializer
     load_const "encode"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2490,8 +2473,6 @@ function interfaces.apwu_main() -> string {
     load_type interfaces.ApwuAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2504,8 +2485,7 @@ function interfaces.ausi_main() -> bool {
     virtual_load_field .name
     load_const "widget"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var i
     load_type interfaces.AusiLabeled
     virtual_load_field .name
@@ -2520,29 +2500,21 @@ function interfaces.b1180_optional_get(value: interfaces.B1180Getter<int> | null
     load_var value
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var value
     load_type interfaces.B1180Getter<int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
+
+  L0:
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    load_const -1
 
   L2:
-    store_var_load_var _2
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    load_const -1
-    store_var _2
-
-  L3:
-    load_var _2
     return
 }
 
@@ -2550,29 +2522,21 @@ function interfaces.b1180_optional_name(value: interfaces.B1180Named | null) -> 
     load_var value
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var value
     load_type interfaces.B1180Named
     load_const "name"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
+
+  L0:
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    load_const "nobody"
 
   L2:
-    store_var_load_var _2
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    load_const "nobody"
-    store_var _2
-
-  L3:
-    load_var _2
     return
 }
 
@@ -2596,60 +2560,37 @@ function interfaces.bgfb_same(x: #0) -> bool {
     load_type interfaces.BgfbEquatable
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function interfaces.birr_main() -> bool {
-    load_const 1
-    load_type int
-    init_instance<1> user.interfaces.BirrContainer .value
-    pop 1
-    load_const "two"
-    load_type string
-    init_instance<1> user.interfaces.BirrContainer .value
-    pop 1
     load_type interfaces.BirrContainer<int>
     load_type interfaces.BirrPrintable<int>
     call reflect.Type.implements
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type interfaces.BirrContainer<string>
     load_type interfaces.BirrPrintable<string>
     call reflect.Type.implements
+    jump_if_false_or_pop L0
+    load_type interfaces.BirrPrintable<int>
+    load_type interfaces.BirrContainer<int>
+    call reflect.Type.implemented_by
+    jump_if_false_or_pop L0
+    load_type interfaces.BirrPrintable<string>
+    load_type interfaces.BirrContainer<string>
+    call reflect.Type.implemented_by
+    jump_if_false_or_pop L0
+    load_type interfaces.BirrPrintable<int>
+    load_type interfaces.BirrContainer<string>
+    call reflect.Type.implemented_by
+    unary_op !
+    jump_if_false_or_pop L0
+    load_type interfaces.BirrPrintable<string>
+    load_type interfaces.BirrContainer<int>
+    call reflect.Type.implemented_by
+    unary_op !
 
   L0:
-    jump_if_false L1
-    pop 1
-    load_type interfaces.BirrPrintable<int>
-    load_type interfaces.BirrContainer<int>
-    call reflect.Type.implemented_by
-
-  L1:
-    jump_if_false L2
-    pop 1
-    load_type interfaces.BirrPrintable<string>
-    load_type interfaces.BirrContainer<string>
-    call reflect.Type.implemented_by
-
-  L2:
-    jump_if_false L3
-    pop 1
-    load_type interfaces.BirrPrintable<int>
-    load_type interfaces.BirrContainer<string>
-    call reflect.Type.implemented_by
-    unary_op !
-
-  L3:
-    jump_if_false L4
-    pop 1
-    load_type interfaces.BirrPrintable<string>
-    load_type interfaces.BirrContainer<int>
-    call reflect.Type.implemented_by
-    unary_op !
-
-  L4:
     return
 }
 
@@ -2677,8 +2618,6 @@ function interfaces.btvi_f(x: #0) -> string {
     load_type interfaces.BtviPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2695,8 +2634,6 @@ function interfaces.btvs_f(x: #0) -> string {
     load_type interfaces.BtvsPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2714,8 +2651,6 @@ function interfaces.cimd_main() -> string {
     load_type interfaces.CimdGreeter
     load_const "greet"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2727,8 +2662,7 @@ function interfaces.cofs_main() -> bool {
     load_field .host
     load_const 0
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var s
     load_type interfaces.CofsConfig
     virtual_load_field .host
@@ -2745,8 +2679,6 @@ function interfaces.comc_main() -> string {
     load_type interfaces.ComcConfigurable
     load_const "configure"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2758,8 +2690,6 @@ function interfaces.crid_main() -> bool {
     load_type interfaces.CridEquals
     load_const "neq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2777,13 +2707,11 @@ function interfaces.dapc_main() -> string {
     load_type interfaces.DapcLeft
     load_const "foo"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     load_var d
     load_type interfaces.DapcRight
     load_const "foo"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
-    load_var _3
     load_const ":"
     bin_op +
     load_var _5
@@ -2798,8 +2726,6 @@ function interfaces.dcfo_main() -> string {
     load_type interfaces.DcfoLogger
     load_const "log"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2812,8 +2738,6 @@ function interfaces.dcgo_main() -> string {
     load_type interfaces.DcgoLogger
     load_const "log"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2822,23 +2746,15 @@ function interfaces.dcmr_main() -> string {
     load_type interfaces.DcmrAnimal
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
-    load_var _5
     load_type interfaces.DcmrAnimal
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
     load_type interfaces.DcmrAnimal
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     load_type interfaces.DcmrAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2849,8 +2765,6 @@ function interfaces.dcob_main() -> string {
     load_type interfaces.DcobLogger
     load_const "log"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2866,8 +2780,6 @@ function interfaces.dctf_main() -> string {
     load_type interfaces.DctfAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2902,8 +2814,6 @@ function interfaces.dctio_main() -> string {
     load_type interfaces.DctioLogger
     load_const "log"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2914,8 +2824,6 @@ function interfaces.dcwc_main() -> string {
     load_type interfaces.DcwcWrapper
     load_const "decorate"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2926,7 +2834,6 @@ function interfaces.ddti_main() -> string {
     load_type interfaces.DdtiLeft
     load_const "left_tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
     load_var h
     load_type interfaces.DdtiRight
     load_const "right_tag"
@@ -2942,7 +2849,7 @@ function interfaces.ddti_main() -> string {
     load_const "y_note"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
-    load_var2 2 3
+    load_var _5
     bin_op +
     load_var _6
     bin_op +
@@ -2974,10 +2881,7 @@ function interfaces.dflo_main() -> string {
     store_var _10
     load_var _10
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var acc
     store_var _15
     load_var _10
@@ -2992,7 +2896,7 @@ function interfaces.dflo_main() -> string {
     store_var acc
     jump L0
 
-  L2:
+  L1:
     load_var acc
     return
 }
@@ -3003,8 +2907,6 @@ function interfaces.dksl_main() -> string {
     load_type interfaces.DkslLogger
     load_const "log"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3014,8 +2916,6 @@ function interfaces.dmdt_main() -> string {
     load_type interfaces.DmdtAnimal
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3024,8 +2924,6 @@ function interfaces.drtc_main() -> string {
     load_type interfaces.DrtcA
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3108,17 +3006,14 @@ function interfaces.dtba_main() -> string {
 
 function interfaces.dtba_pick(use_dog: bool) -> interfaces.DtbaAnimal {
     load_var use_dog
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    alloc_instance user.interfaces.DtbaCat
     jump L1
 
   L0:
-    alloc_instance user.interfaces.DtbaCat
-    jump L2
-
-  L1:
     alloc_instance user.interfaces.DtbaDog
 
-  L2:
+  L1:
     return
 }
 
@@ -3129,8 +3024,6 @@ function interfaces.dtfa_main() -> string {
     load_type interfaces.DtfaAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3144,8 +3037,6 @@ function interfaces.dtfc_main() -> string {
     load_type interfaces.DtfcAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3164,8 +3055,6 @@ function interfaces.dtfl_main() -> string {
     load_type interfaces.DtflAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3181,8 +3070,6 @@ function interfaces.dtfo_main() -> string {
     load_type interfaces.DtfoAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3197,8 +3084,6 @@ function interfaces.dtmv_main() -> string {
     load_type interfaces.DtmvAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3221,7 +3106,6 @@ function interfaces.dtna_main() -> string {
     load_type interfaces.DtnaAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _9
     load_var pack
     load_const 1
     load_array_element
@@ -3231,7 +3115,6 @@ function interfaces.dtna_main() -> string {
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
-    load_var _9
     load_const ":"
     bin_op +
     load_var _15
@@ -3275,8 +3158,6 @@ function interfaces.f1bg_main() -> string {
     load_type interfaces.F1bgPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3287,8 +3168,6 @@ function interfaces.f1d_main() -> string {
     load_type interfaces.F1dPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3322,8 +3201,6 @@ function interfaces.f1g_main() -> int {
     load_type interfaces.F1gContainer<int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3336,8 +3213,6 @@ function interfaces.f1sa_main() -> string {
     load_type interfaces.F1saDescribable
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3368,8 +3243,6 @@ function interfaces.f2d_main() -> string {
     load_type interfaces.F2dPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3386,8 +3259,7 @@ function interfaces.f2rs_main() -> bool {
     load_var printable
     load_type interfaces.F2rsPerson
     call reflect.Type.implemented_by
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var printable
     load_type interfaces.F2rsTeam
     call reflect.Type.implemented_by
@@ -3402,8 +3274,6 @@ function interfaces.f2sa_main() -> string {
     load_type interfaces.F2saLabeled
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3412,20 +3282,17 @@ function interfaces.fz03_accepts_optional(a: interfaces.Fz03Animal | null) -> st
     load_const null
     call baml.ops.equals_equals
     unary_op !
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "none"
     jump L1
 
   L0:
-    load_const "none"
-    jump L2
-
-  L1:
     load_var a
     load_type interfaces.Fz03Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -3436,23 +3303,10 @@ function interfaces.fz03_main() -> string {
 }
 
 function interfaces.fz04_main() -> string {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    alloc_instance user.interfaces.Fz04Cat
-    jump L2
-
-  L1:
     alloc_instance user.interfaces.Fz04Dog
-
-  L2:
     load_type interfaces.Fz04Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3461,8 +3315,6 @@ function interfaces.fz05_main() -> string {
     load_type interfaces.Fz05A
     load_const "foo"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3472,8 +3324,6 @@ function interfaces.fz07_main() -> int {
     load_type interfaces.Fz07Echo<int>
     load_const "echo"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3490,8 +3340,6 @@ function interfaces.fz10_read(b: interfaces.Fz10Box<#0>) -> #0 {
     load_type interfaces.Fz10Box<#0>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3505,8 +3353,6 @@ function interfaces.fz15_main() -> string {
     load_type interfaces.Fz15Container<int>
     load_const "describe_with_self_call"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3520,8 +3366,6 @@ function interfaces.fz17_main() -> string {
     load_type interfaces.Fz17Greetable
     load_const "greet"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3569,11 +3413,9 @@ function interfaces.fz21_main() -> string {
     init_instance user.interfaces.Fz21D .a_label, .b_label
     store_var_load_var d
     call user.interfaces.fz21_get_from_a
-    store_var _3
     load_var d
     call user.interfaces.fz21_get_from_b
     store_var _5
-    load_var _3
     load_const "|"
     bin_op +
     load_var _5
@@ -3586,8 +3428,6 @@ function interfaces.fz23_main() -> string {
     load_type interfaces.Fz23Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3601,8 +3441,6 @@ function interfaces.fz24_main() -> int {
     load_type interfaces.Fz24Container<int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3611,18 +3449,15 @@ function interfaces.fz29_describe(a: interfaces.Fz29Animal) -> string {
     store_var _2
     load_var _2
     narrow_bind interfaces.Fz29Dog, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_var _2
     load_field .breed
 
-  L2:
+  L1:
     return
 }
 
@@ -3636,22 +3471,17 @@ function interfaces.fz29_main() -> string {
 function interfaces.fz31_main() -> string {
     load_const true
     is_type true
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    alloc_instance user.interfaces.Fz31Cat
     jump L1
 
   L0:
-    alloc_instance user.interfaces.Fz31Cat
-    jump L2
-
-  L1:
     alloc_instance user.interfaces.Fz31Dog
 
-  L2:
+  L1:
     load_type interfaces.Fz31Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3675,8 +3505,7 @@ function interfaces.fz33_main() -> bool {
     load_const null
     call baml.ops.equals_equals
     unary_op !
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var n
     load_const null
     call baml.ops.equals_equals
@@ -3687,18 +3516,15 @@ function interfaces.fz33_main() -> bool {
 
 function interfaces.fz33_maybe_dog(want_dog: bool) -> interfaces.Fz33Animal | null {
     load_var want_dog
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_const "Lab"
     init_instance user.interfaces.Fz33Dog .breed
 
-  L2:
+  L1:
     return
 }
 
@@ -3723,31 +3549,26 @@ function interfaces.fz38_main() -> bool {
 
 function interfaces.fz39_main() -> string {
     call user.interfaces.fz39_risky
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind interfaces.Fz39IError, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const "wildcard-caught"
-    jump L2
+    jump L1
 
-  L1:
+  L0:
+    load_const "interface-caught: "
     load_var _2
     load_type interfaces.Fz39IError
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_const "interface-caught: "
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -3779,20 +3600,17 @@ function interfaces.fz41_maybe_speak(a: interfaces.Fz41Animal | null) -> string 
     store_var _2
     load_var _2
     narrow_bind interfaces.Fz41Animal, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "silent"
     jump L1
 
   L0:
-    load_const "silent"
-    jump L2
-
-  L1:
     load_var _2
     load_type interfaces.Fz41Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -3801,8 +3619,6 @@ function interfaces.fz42_main() -> string {
     load_type interfaces.Fz42Printable
     load_const "print"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3811,8 +3627,6 @@ function interfaces.fz43_get_value(p: interfaces.Fz43Producer<#0>) -> #0 {
     load_type interfaces.Fz43Producer<#0>
     load_const "produce"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3830,8 +3644,6 @@ function interfaces.fz44_main() -> int {
     load_type interfaces.Fz44Wrapper<int>
     load_const "wrap"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3840,20 +3652,17 @@ function interfaces.fz45_describe(x: interfaces.Fz45Animal | string) -> string {
     store_var _2
     load_var _2
     narrow_bind interfaces.Fz45Animal, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var x
     jump L1
 
   L0:
-    load_var x
-    jump L2
-
-  L1:
     load_var _2
     load_type interfaces.Fz45Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -3876,8 +3685,6 @@ function interfaces.gbap_read_int(m: #0) -> int {
     load_type interfaces.GbapConverter<int>
     load_const "convert"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3894,8 +3701,6 @@ function interfaces.gbdm_read_int(m: #0) -> int {
     load_type interfaces.GbdmConverter<int>
     load_const "convert"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -3930,10 +3735,6 @@ function interfaces.gbr_first_name(items: #0[]) -> string {
 }
 
 function interfaces.gbr_main() -> string {
-    load_const "Rex"
-    init_instance user.interfaces.GbrDog .name
-    load_field .name
-    pop 1
     load_type interfaces.GbrDog
     load_const "Rex"
     init_instance user.interfaces.GbrDog .name
@@ -3960,8 +3761,6 @@ function interfaces.gbsp_same(x: #0, y: #0) -> bool {
     load_type interfaces.GbspEquatable
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4010,8 +3809,6 @@ function interfaces.gict_main() -> int {
     load_type interfaces.GictContainer<int>
     load_const "size"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4023,8 +3820,7 @@ function interfaces.gif_main() -> bool {
     call user.interfaces.gif_read
     load_const "one"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const "x"
     load_const "ex"
     load_type string
@@ -4051,8 +3847,6 @@ function interfaces.gimp_main() -> string {
     load_type interfaces.GimpEcho<int>
     load_const "echo"
     virtual_call nargs=2 ntypeargs=1
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4065,8 +3859,6 @@ function interfaces.goop_main() -> string {
     load_type interfaces.GoopDescriber<int>
     load_const "describe"
     virtual_call nargs=2 ntypeargs=1
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4079,8 +3871,6 @@ function interfaces.grlr_main() -> string {
     load_type interfaces.GrlrLabel
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4093,8 +3883,6 @@ function interfaces.grmr_main() -> string {
     load_type interfaces.GrmrLabel
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4103,8 +3891,6 @@ function interfaces.grpa_main() -> string {
     load_type interfaces.GrpaParent<int>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4129,8 +3915,6 @@ function interfaces.grpt_main() -> string {
     load_type interfaces.GrptParent<int>
     load_const "describeGrpt"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4145,7 +3929,6 @@ function interfaces.hiad_main() -> string {
     load_type interfaces.HiadAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
     load_var animals
     load_const 1
     load_array_element
@@ -4153,7 +3936,7 @@ function interfaces.hiad_main() -> string {
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
-    load_var2 2 3
+    load_var _8
     bin_op +
     return
 }
@@ -4163,8 +3946,6 @@ function interfaces.idmc_differ(x: #0, y: #0) -> bool {
     load_type interfaces.IdmcEquatable
     load_const "neq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4200,31 +3981,24 @@ function interfaces.ifcc_main() -> bool {
     virtual_load_field .host
     load_const "localhost"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var c
     load_type interfaces.IfccConfig
     virtual_load_field .port
     load_const 8080
     cmp_int_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var s
     load_field .host
     load_const "localhost"
     cmp_op ==
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_var s
     load_field .max_connections
     load_const 50
     cmp_int_op ==
 
-  L2:
+  L0:
     return
 }
 
@@ -4283,8 +4057,7 @@ function interfaces.ifw_main() -> bool {
     load_type interfaces.IfwCounter
     virtual_store_field .count
     load_var after_assign
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var b
     load_field .count
     load_const 15
@@ -4316,18 +4089,13 @@ function interfaces.itamp_main() -> bool {
     load_type interfaces.ItampConv<int, string>
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
-    load_var _5
     load_const "int->string"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var p
     load_type interfaces.ItampConv<string, int>
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _6
-    load_var _6
     load_const "string->int"
     cmp_op ==
 
@@ -4340,20 +4108,17 @@ function interfaces.itic_main() -> string {
     store_var _3
     load_var _3
     narrow_bind interfaces.IticDog, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "not a swimmer"
     jump L1
 
   L0:
-    load_const "not a swimmer"
-    jump L2
-
-  L1:
     load_var _3
     load_type interfaces.IticSwimmer
     load_const "swim"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -4362,44 +4127,27 @@ function interfaces.itvd_main() -> string {
     load_type interfaces.ItvdAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function interfaces.mdci_describe(a: interfaces.MdciAnimal) -> string {
     load_var a
     is_type interfaces.MdciDog
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var a
     is_type interfaces.MdciCat
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "other"
     jump L2
 
-  L1:
-    load_const "other"
-    jump L4
-
-  L2:
-    load_var a
-    load_field .0
-    pop 1
+  L0:
     load_var a
     load_field .0
     load_const " the cat"
     bin_op +
-    jump L4
+    jump L2
 
-  L3:
-    load_var a
-    load_field .0
-    pop 1
-    load_var a
-    load_field .1
-    pop 1
+  L1:
     load_var a
     load_field .0
     load_const " the "
@@ -4408,7 +4156,7 @@ function interfaces.mdci_describe(a: interfaces.MdciAnimal) -> string {
     load_field .1
     bin_op +
 
-  L4:
+  L2:
     return
 }
 
@@ -4452,18 +4200,15 @@ function interfaces.mdif_main() -> string {
     store_var _2
     load_var _2
     narrow_bind interfaces.MdifDog, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_var _2
     load_field .name
 
-  L2:
+  L1:
     return
 }
 
@@ -4475,22 +4220,13 @@ function interfaces.midr_describe(s: interfaces.MidrSwitch) -> string {
     load_type interfaces.MidrSwitch
     virtual_load_field .active
     is_type true
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
-    load_var s
-    load_type interfaces.MidrSwitch
-    virtual_load_field .active
-    pop 1
     load_const "off"
     jump L2
 
   L1:
-    load_var s
-    load_type interfaces.MidrSwitch
-    virtual_load_field .active
-    pop 1
     load_const "on"
 
   L2:
@@ -4510,18 +4246,15 @@ function interfaces.mntc_main() -> string {
     store_var _2
     load_var _2
     narrow_bind interfaces.MntcDog, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_var _2
     load_field .breed
 
-  L2:
+  L1:
     return
 }
 
@@ -4530,17 +4263,14 @@ function interfaces.moiw_main() -> string {
     store_var _2
     load_var _2
     narrow_bind interfaces.MoiwDog, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "dog"
 
-  L2:
+  L1:
     return
 }
 
@@ -4552,8 +4282,6 @@ function interfaces.msma_main() -> bool {
     load_type interfaces.MsmaEquatable
     load_const "same"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4563,8 +4291,6 @@ function interfaces.odnd_main() -> string {
     load_type interfaces.OdndAnimal
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4573,16 +4299,14 @@ function interfaces.oobp_main() -> string {
     load_type interfaces.OobpDebuggable
     load_const "debugOobp"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
     load_const 1
     load_type interfaces.OobpDebuggable
     load_const "debugOobp"
     virtual_call nargs=1 ntypeargs=0
-    store_var _6
-    load_var _4
+    store_var _3
     load_const ":"
     bin_op +
-    load_var _6
+    load_var _3
     bin_op +
     return
 }
@@ -4591,8 +4315,7 @@ function interfaces.oobv_main() -> bool {
     load_type interfaces.OobvDog
     load_type interfaces.OobvAnimal
     call reflect.Type.implements
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type interfaces.OobvAnimal
     load_type interfaces.OobvDog
     call reflect.Type.implemented_by
@@ -4609,8 +4332,6 @@ function interfaces.ptu_main() -> string {
     load_type interfaces.PtuPipe<interfaces.PtuErrA | interfaces.PtuErrB>
     load_const "run"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4628,8 +4349,6 @@ function interfaces.rcfl_main() -> string {
     load_type interfaces.RcflA
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4640,8 +4359,6 @@ function interfaces.rcpf_main() -> string {
     load_type interfaces.RcpfPerson
     load_const "introduce"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4651,18 +4368,13 @@ function interfaces.rcpm_main() -> bool {
     load_type interfaces.RcpmParent<int>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     load_const "int"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var both
     load_type interfaces.RcpmParent<string>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
-    load_var _5
     load_const "string"
     cmp_op ==
 
@@ -4708,8 +4420,7 @@ function interfaces.riig_is_animal() -> bool {
 function interfaces.riig_main() -> bool {
     load_type interfaces.RiigDog
     call user.interfaces.riig_is_animal
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type int
     call user.interfaces.riig_is_animal
     load_const false
@@ -4738,8 +4449,6 @@ function interfaces.rtit_main() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4749,8 +4458,6 @@ function interfaces.sapc_main() -> string {
     load_type interfaces.SapcFarewell
     load_const "bye"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4763,8 +4470,7 @@ function interfaces.sfnd_main() -> bool {
     virtual_load_field .id
     load_const "abc"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var t
     load_type interfaces.SfndHasNumId
     virtual_load_field .id
@@ -4784,8 +4490,7 @@ function interfaces.sgid_main() -> bool {
     call user.interfaces.sgid_read_int
     load_const 42
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type interfaces.SgidMultiFormat
     load_var m
     call user.interfaces.sgid_read_float
@@ -4801,8 +4506,6 @@ function interfaces.sgid_read_float(m: #0) -> float {
     load_type interfaces.SgidConverter<float>
     load_const "convert"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4811,8 +4514,6 @@ function interfaces.sgid_read_int(m: #0) -> int {
     load_type interfaces.SgidConverter<int>
     load_const "convert"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4825,8 +4526,7 @@ function interfaces.sgif_main() -> bool {
     virtual_load_field .value
     load_const 7
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var p
     load_type interfaces.SgifSlot<string>
     virtual_load_field .value
@@ -4854,8 +4554,7 @@ function interfaces.sgif_symbolic_main() -> bool {
     call user.interfaces.sgif_read
     load_const 7
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type string
     load_var p
     call user.interfaces.sgif_read
@@ -4871,8 +4570,6 @@ function interfaces.spma_combine(x: #0, ys: #0[]) -> int {
     load_type interfaces.SpmaAdder
     load_const "addAll"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4907,8 +4604,6 @@ function interfaces.srtc_main() -> int {
     load_type interfaces.SrtcCloneable
     load_const "clone"
     virtual_call nargs=1 ntypeargs=0
-    store_var c
-    load_var c
     load_field .value
     return
 }
@@ -4918,23 +4613,20 @@ function interfaces.tidu_main() -> string {
     load_type interfaces.TiduFallible
     load_const "run"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     store_var _3
     load_var _3
     narrow_bind interfaces.TiduBoom, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _3
     load_field .message
 
-  L2:
+  L1:
     return
 }
 
@@ -4947,8 +4639,7 @@ function interfaces.tisf_main() -> bool {
     virtual_load_field .name
     load_const "widget"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var i
     load_type interfaces.TisfLabeled
     virtual_load_field .name
@@ -4978,21 +4669,18 @@ function interfaces.uf02_addOne(x: interfaces.Uf02Slot<int> | interfaces.Uf02Slo
     store_var _2
     load_var _2
     narrow_bind interfaces.Uf02Slot<int>, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_var _2
     load_type interfaces.Uf02Slot<int>
     virtual_load_field .value
     load_const 1
     add_int
 
-  L2:
+  L1:
     return
 }
 
@@ -5008,17 +4696,14 @@ function interfaces.uf05_go(x: interfaces.Uf05Slot<int> | interfaces.Uf05Slot<st
     store_var _2
     load_var _2
     narrow_bind interfaces.Uf05Slot<int>, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "int"
 
-  L2:
+  L1:
     return
 }
 
@@ -5100,13 +4785,11 @@ function interfaces.uf08_main() -> string {
     store_var d
     load_var d
     call user.interfaces.Uf08Dog.fetch
-    store_var _5
     load_var d
     load_type interfaces.Uf08Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
-    load_var _5
     load_const "/"
     bin_op +
     load_var _6
@@ -5119,20 +4802,17 @@ function interfaces.uf09_main() -> string {
     store_var _2
     load_var _2
     narrow_bind interfaces.Uf09Animal, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "none"
     jump L1
 
   L0:
-    load_const "none"
-    jump L2
-
-  L1:
     load_var _2
     load_type interfaces.Uf09Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -5141,8 +4821,6 @@ function interfaces.uf10_main() -> string {
     load_type interfaces.Uf10Debuggable
     load_const "debugUf10"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5151,8 +4829,6 @@ function interfaces.ufp1_describe(x: interfaces.Ufp1Dog | interfaces.Ufp1Cat) ->
     load_type interfaces.Ufp1Greeter
     load_const "greet"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5230,19 +4906,16 @@ function interfaces.ufp4_readName(x: interfaces.Ufp4Dog | interfaces.Ufp4Named |
     load_var x
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var x
     load_type interfaces.Ufp4Named
     virtual_load_field .name
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -5293,8 +4966,6 @@ function interfaces.urdm_main() -> string {
     load_type interfaces.UrdmPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5303,8 +4974,6 @@ function interfaces.uric_f(x: #0) -> string {
     load_type interfaces.UricPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5322,8 +4991,6 @@ function interfaces.urii_f(x: #0) -> string {
     load_type interfaces.UriiPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5341,8 +5008,6 @@ function interfaces.uris_f(x: #0) -> string {
     load_type interfaces.UrisPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5366,8 +5031,6 @@ function interfaces.urni_main() -> int {
     load_type interfaces.UrniContainer<int[]>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     container_len
     return
 }
@@ -5385,8 +5048,6 @@ function interfaces.urrc_take(child: interfaces.UrrcChild<int>) -> int {
     load_type interfaces.UrrcParent<int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5394,8 +5055,7 @@ function interfaces.urrs_main() -> bool {
     load_type interfaces.UrrsBox<int>
     load_type interfaces.UrrsPrintable
     call reflect.Type.implements
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type interfaces.UrrsBox<string>
     load_type interfaces.UrrsPrintable
     call reflect.Type.implements
@@ -5413,8 +5073,6 @@ function interfaces.urrt_main() -> string {
     load_type interfaces.UrrtSame
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5424,12 +5082,10 @@ function interfaces.vdc_dispatch_distinguishes_instantiations() -> string {
     load_type interfaces.VdcAnimal
     load_var value
     call user.interfaces.vdc_read_tag
-    store_var _3
     load_type interfaces.VdcAnimal | interfaces.VdcDog
     load_var value
     call user.interfaces.vdc_read_tag
     store_var _6
-    load_var _3
     load_const "|"
     bin_op +
     load_var _6
@@ -5442,8 +5098,6 @@ function interfaces.vdc_read_tag(value: interfaces.VdcTagged<#0>) -> string {
     load_type interfaces.VdcTagged<#0>
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5453,8 +5107,6 @@ function interfaces.w301_main() -> int {
     load_type interfaces.W301Sub<int>
     load_const "sub_get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5464,8 +5116,6 @@ function interfaces.w302_main() -> string {
     load_type interfaces.W302Loud
     load_const "shout"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5475,8 +5125,6 @@ function interfaces.w304_main() -> string {
     load_type interfaces.W304Named
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5524,28 +5172,21 @@ function interfaces.w307_box_impls_stringbox() -> bool {
 function interfaces.w307_main() -> bool {
     load_type int
     call user.interfaces.w307_box_impls_intbox
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type string
     call user.interfaces.w307_box_impls_intbox
     load_const false
     cmp_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_type string
     call user.interfaces.w307_box_impls_stringbox
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_type int
     call user.interfaces.w307_box_impls_stringbox
     load_const false
     cmp_op ==
 
-  L2:
+  L0:
     return
 }
 
@@ -5554,8 +5195,6 @@ function interfaces.w311_main() -> string {
     load_type interfaces.W311Base
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5570,8 +5209,6 @@ function interfaces.w312_main() -> string {
     load_type interfaces.W312Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5585,22 +5222,18 @@ function interfaces.w315_main() -> int {
     call reflect.Type.implemented_by
     store_var b
     load_var a
-    jump_if_false L0
-    pop 1
+    pop_jump_if_false L0
     load_var b
+    pop_jump_if_true L1
 
   L0:
-    pop_jump_if_false L1
+    load_const 0
     jump L2
 
   L1:
-    load_const 0
-    jump L3
-
-  L2:
     load_const 1001
 
-  L3:
+  L2:
     return
 }
 
@@ -5610,8 +5243,7 @@ function interfaces.w3bg_main() -> bool {
     load_var int_box
     load_type interfaces.W3bgIntBox
     call reflect.Type.implemented_by
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var int_box
     load_type interfaces.W3bgStringBox
     call reflect.Type.implemented_by
@@ -5628,8 +5260,6 @@ function interfaces.w3bm_main() -> string {
     load_type interfaces.W3bmPrintable
     load_const "display"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5646,8 +5276,6 @@ function interfaces.w3oo_main() -> string {
     load_type interfaces.W3ooDebuggable
     load_const "debugW3oo"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5657,8 +5285,6 @@ function interfaces.w3sp_main() -> string {
     load_type interfaces.W3spNamed
     load_const "greet"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5667,8 +5293,6 @@ function interfaces.w3um_describe(x: interfaces.W3umDog | interfaces.W3umCat) ->
     load_type interfaces.W3umAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
@@ -2838,7 +2838,6 @@ function interfaces.ddti_main() -> string {
     load_type interfaces.DdtiRight
     load_const "right_tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_var h
     load_type interfaces.DdtiX
     load_const "x_note"
@@ -2849,7 +2848,6 @@ function interfaces.ddti_main() -> string {
     load_const "y_note"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
-    load_var _5
     bin_op +
     load_var _6
     bin_op +
@@ -3935,8 +3933,6 @@ function interfaces.hiad_main() -> string {
     load_type interfaces.HiadAnimal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _8
-    load_var _8
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
@@ -324,8 +324,6 @@ function interfaces_associated_types.ApdSomeInterface.same_label(self: interface
     load_type interfaces_associated_types.ApdSomeInterface
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
     cmp_op ==
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
@@ -207,8 +207,6 @@ function interfaces_associated_types.<(user.interfaces_associated_types.BcpWrapp
     load_type interfaces_associated_types.BcpSource<Item = string>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -224,8 +222,6 @@ function interfaces_associated_types.<(user.interfaces_associated_types.BspWrapp
     load_type interfaces_associated_types.BspSource<Item = string>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -324,13 +320,12 @@ function interfaces_associated_types.ApdSomeInterface.same_label(self: interface
     load_type interfaces_associated_types.ApdSomeInterface
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     load_var other
     load_type interfaces_associated_types.ApdSomeInterface
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
-    load_var2 3 4
+    load_var _4
     cmp_op ==
     return
 }
@@ -340,8 +335,6 @@ function interfaces_associated_types.CaeTask.drive(self: interfaces_associated_t
     load_type interfaces_associated_types.CaeDriver<interfaces_associated_types.CaeTask<#0>, Error = #2, Output = #1>
     load_const "drive"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -350,8 +343,6 @@ function interfaces_associated_types.Describable.describe(self: interfaces_assoc
     load_type interfaces_associated_types.Describable
     load_const "value"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -360,8 +351,6 @@ function interfaces_associated_types.Fallible.value_plus_one(self: interfaces_as
     load_type interfaces_associated_types.Fallible
     load_const "value"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_const 1
     add_int
     return
@@ -372,8 +361,6 @@ function interfaces_associated_types.OgbTallier.tally(self: interfaces_associate
     load_type interfaces_associated_types.OgbTagged
     load_const "tag_of"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -391,13 +378,9 @@ function interfaces_associated_types.adb_summarize(holder: #0) -> string {
     load_type interfaces_associated_types.AdbHolder<interfaces_associated_types.AdbUser>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_type interfaces_associated_types.AdbSummarizable
     load_const "summary"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -407,12 +390,10 @@ function interfaces_associated_types.apd_holder_matches_itself(holder: #0) -> bo
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
     store_var item
-    load_var2 3 3
+    load_var2 2 2
     load_type interfaces_associated_types.ApdSomeInterface
     load_const "same_label"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -421,13 +402,9 @@ function interfaces_associated_types.apd_label_from_holder(holder: #0) -> string
     load_type interfaces_associated_types.ApdHolder
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var item
-    load_var item
     load_type interfaces_associated_types.ApdSomeInterface
     load_const "label"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -439,19 +416,16 @@ function interfaces_associated_types.apd_main() -> string {
     load_type interfaces_associated_types.ApdWidgetHolder
     load_var holder
     call user.interfaces_associated_types.apd_holder_matches_itself
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "false"
+    store_var same
     jump L1
 
   L0:
-    load_const "false"
-    store_var same
-    jump L2
-
-  L1:
     load_const "true"
     store_var same
 
-  L2:
+  L1:
     load_type interfaces_associated_types.ApdWidgetHolder
     load_var holder
     call user.interfaces_associated_types.apd_label_from_holder
@@ -468,55 +442,47 @@ function interfaces_associated_types.atp_throws_main() -> string {
     load_const "value_plus_one"
     virtual_call nargs=1 ntypeargs=0
     store_var default_result
-    jump L2
+    jump L1
     load_var e
     is_type interfaces_associated_types.Boom
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "default:"
     load_var e
     load_field .message
     bin_op +
     store_var default_result
 
-  L2:
+  L1:
     load_type interfaces_associated_types.AlwaysFails
     alloc_instance user.interfaces_associated_types.AlwaysFails
     call user.interfaces_associated_types.call_value
     store_var generic_result
-    jump L5
+    jump L3
     load_var e
     is_type interfaces_associated_types.Boom
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var e
     rethrow
 
-  L4:
+  L2:
     load_const "generic:"
     load_var e
     load_field .message
     bin_op +
     store_var generic_result
 
-  L5:
+  L3:
     load_type int | string
     load_var default_result
     call baml.String.from
-    store_var _13
     load_type int | string
     load_var generic_result
     call baml.String.from
     store_var _15
-    load_var _13
     load_const "|"
     bin_op +
     load_var _15
@@ -532,8 +498,6 @@ function interfaces_associated_types.bcp_main() -> string {
     load_type interfaces_associated_types.BcpWrapperView<Output = string>
     load_const "output"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -566,8 +530,6 @@ function interfaces_associated_types.bsp_take_source(source: #0) -> (#0 as inter
     load_type interfaces_associated_types.BspSource<Item = string>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -581,23 +543,20 @@ function interfaces_associated_types.cae_main() -> int {
     init_instance<1> user.interfaces_associated_types.CaeTask .value
     alloc_instance user.interfaces_associated_types.CaeIntDriver
     call user.interfaces_associated_types.CaeTask.drive
-    jump L2
+    jump L1
     load_var e
     store_var _8
     load_var _8
     narrow_bind interfaces_associated_types.CaeKaboom, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _8
     load_field .data
 
-  L2:
+  L1:
     return
 }
 
@@ -606,8 +565,6 @@ function interfaces_associated_types.call_value(value: #0) -> int {
     load_type interfaces_associated_types.Fallible
     load_const "value"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -617,8 +574,6 @@ function interfaces_associated_types.dms_main() -> string {
     load_type interfaces_associated_types.Describable<Output = string>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -639,8 +594,6 @@ function interfaces_associated_types.ing_stringify_next(iter: interfaces_associa
     load_type interfaces_associated_types.IngIterator<Item = int | null>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     call baml.json.to_string
     return
 }
@@ -653,8 +606,6 @@ function interfaces_associated_types.ogb_main(s: interfaces_associated_types.Ogb
     load_type interfaces_associated_types.OgbTallier<Marker = int>
     load_const "tally"
     virtual_call nargs=3 ntypeargs=2
-    store_var _0
-    load_var _0
     return
 }
 
@@ -674,23 +625,16 @@ function interfaces_associated_types.rdf_main() -> int {
 function interfaces_associated_types.rdf_score(source: interfaces_associated_types.RdfSource<Item = int> | interfaces_associated_types.RdfSource<Item = string>) -> int {
     load_var source
     is_type interfaces_associated_types.RdfSource<Item = int>
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
+    load_var source
+    load_type interfaces_associated_types.RdfSource<Item = int>
+    virtual_load_field .value
 
   L1:
-    load_var source
-    load_type interfaces_associated_types.RdfSource<Item = int>
-    virtual_load_field .value
-    pop 1
-    load_var source
-    load_type interfaces_associated_types.RdfSource<Item = int>
-    virtual_load_field .value
-
-  L2:
     return
 }
 
@@ -709,13 +653,9 @@ function interfaces_associated_types.rdn_unwrap(outer: interfaces_associated_typ
     load_type interfaces_associated_types.RdnOuter<Inner = interfaces_associated_types.RdnSource<Item = int>>
     load_const "inner"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_type interfaces_associated_types.RdnSource<Item = int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -732,8 +672,6 @@ function interfaces_associated_types.rds_unwrap(c: interfaces_associated_types.R
     load_type interfaces_associated_types.RdsContainer<Item = int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -922,20 +860,17 @@ function interfaces_associated_types.rmf_score(source: interfaces_associated_typ
     store_var _2
     load_var _2
     narrow_bind interfaces_associated_types.RmfSource<Item = int>, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_var _2
     load_type interfaces_associated_types.RmfSource<Item = int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -972,8 +907,6 @@ function interfaces_associated_types.srab_main() -> string {
     load_type interfaces_associated_types.SrabNode<Peer = interfaces_associated_types.SrabLeaf>
     load_const "srab_tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -994,12 +927,10 @@ function interfaces_associated_types.upc_main() -> string {
     load_type interfaces_associated_types.UpcSummarizes<Key = string>
     load_const "summary"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_type interfaces_associated_types.UpcUser
     load_var user
     call user.interfaces_associated_types.upc_entity_key
     store_var _6
-    load_var _5
     load_const "|"
     bin_op +
     load_var _6

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
@@ -685,6 +685,10 @@ function interfaces_associated_types.rdf_score(source: interfaces_associated_typ
     load_var source
     load_type interfaces_associated_types.RdfSource<Item = int>
     virtual_load_field .value
+    pop 1
+    load_var source
+    load_type interfaces_associated_types.RdfSource<Item = int>
+    virtual_load_field .value
 
   L2:
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_class_generics/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_class_generics/bytecode.snap
@@ -39,8 +39,6 @@ function interfaces_class_generics.<(user.interfaces_class_generics.AemEchoer as
     load_type interfaces_class_generics.AemEq<#0>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -55,17 +53,14 @@ function interfaces_class_generics.<(user.interfaces_class_generics.McapIntDrive
     load_field .value
     load_const 42
     cmp_int_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "wrong"
     jump L1
 
   L0:
-    load_const "wrong"
-    jump L2
-
-  L1:
     load_const "ok"
 
-  L2:
+  L1:
     return
 }
 
@@ -82,8 +77,6 @@ function interfaces_class_generics.McapTask.drive(self: interfaces_class_generic
     load_type interfaces_class_generics.McapDriver<interfaces_class_generics.McapTask<#0>>
     load_const "drive"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -97,8 +90,6 @@ function interfaces_class_generics.aem_accept_echo(value: interfaces_class_gener
     load_type interfaces_class_generics.AemEcho<int>
     load_const "echo"
     virtual_call nargs=2 ntypeargs=2
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_intersection_bounds/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_intersection_bounds/bytecode.snap
@@ -146,7 +146,6 @@ function intersection_bounds.ib_label(item: #0) -> string {
     load_type intersection_bounds.IbTagged<Label = string>
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     load_var item
     load_type intersection_bounds.IbSized
     load_const "size"
@@ -156,7 +155,6 @@ function intersection_bounds.ib_label(item: #0) -> string {
     load_var _5
     call baml.String.from
     store_var _4
-    load_var _3
     load_const "/"
     bin_op +
     load_var _4

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_ints/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_ints/bytecode.snap
@@ -841,29 +841,24 @@ function ints.<(user.ints.RejectionThenAcceptedRng as baml.random.Rng)>.random_i
     load_field .calls
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     call baml.Int.min_value
     load_const 4
     add_int
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     call baml.Int.max_value
 
-  L2:
+  L1:
     return
 }
 
 function ints.count_zeros_plus_ones(n: int) -> int {
     load_var n
     call baml.Int.count_zeros
-    store_var _2
     load_var n
     call baml.Int.count_ones
-    load_var _2
     add_int
     return
 }
@@ -892,17 +887,14 @@ function ints.int_random_distinct_values_in_wide_range() -> bool {
     load_var i
     load_const 100
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 1
     sub_int
     load_const 500
     cmp_int_op >=
     return
 
-  L2:
+  L1:
     load_const 0
     load_const 1000
     load_const <omitted>
@@ -910,18 +902,18 @@ function ints.int_random_distinct_values_in_wide_range() -> bool {
     store_var r
     load_var2 4 1
     cmp_int_op <
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var r
     store_var min_seen
 
-  L3:
+  L2:
     load_var2 4 2
     cmp_int_op >
-    pop_jump_if_false L4
+    pop_jump_if_false L3
     load_var r
     store_var max_seen
 
-  L4:
+  L3:
     load_var i
     load_const 1
     add_int
@@ -943,24 +935,17 @@ function ints.int_random_in_range_and_covers_endpoints() -> bool {
     load_var i
     load_const 1000
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var ok
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L1
     load_var saw_lo
-
-  L2:
-    jump_if_false L3
-    pop 1
+    jump_if_false_or_pop L1
     load_var saw_hi
 
-  L3:
+  L1:
     return
 
-  L4:
+  L2:
     load_const 0
     load_const 10
     load_const <omitted>
@@ -969,37 +954,33 @@ function ints.int_random_in_range_and_covers_endpoints() -> bool {
     load_var r
     load_const 0
     cmp_int_op <
-    jump_if_false L5
-    jump L6
-
-  L5:
-    pop 1
+    pop_jump_if_true L3
     load_var r
     load_const 10
     cmp_int_op >=
+    pop_jump_if_false L4
 
-  L6:
-    pop_jump_if_false L7
+  L3:
     load_const false
     store_var ok
 
-  L7:
+  L4:
     load_var r
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L8
+    pop_jump_if_false L5
     load_const true
     store_var saw_lo
 
-  L8:
+  L5:
     load_var r
     load_const 9
     cmp_int_op ==
-    pop_jump_if_false L9
+    pop_jump_if_false L6
     load_const true
     store_var saw_hi
 
-  L9:
+  L6:
     load_var i
     load_const 1
     add_int
@@ -1017,14 +998,11 @@ function ints.int_random_negative_range() -> bool {
     load_var i
     load_const 200
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var ok
     return
 
-  L2:
+  L1:
     load_const -5
     load_const 5
     load_const <omitted>
@@ -1033,21 +1011,17 @@ function ints.int_random_negative_range() -> bool {
     load_var r
     load_const -5
     cmp_int_op <
-    jump_if_false L3
-    jump L4
-
-  L3:
-    pop 1
+    pop_jump_if_true L2
     load_var r
     load_const 5
     cmp_int_op >=
+    pop_jump_if_false L3
 
-  L4:
-    pop_jump_if_false L5
+  L2:
     load_const false
     store_var ok
 
-  L5:
+  L3:
     load_var i
     load_const 1
     add_int
@@ -1065,25 +1039,22 @@ function ints.int_random_single_element_range() -> bool {
     load_var i
     load_const 50
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var ok
     return
 
-  L2:
+  L1:
     load_const 0
     load_const 1
     load_const <omitted>
     call baml.Int.random
     load_const 0
     cmp_int_op !=
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_const false
     store_var ok
 
-  L3:
+  L2:
     load_var i
     load_const 1
     add_int
@@ -1093,22 +1064,18 @@ function ints.int_random_single_element_range() -> bool {
 
 function ints.int_random_widest_range_returns_some_int() -> bool {
     call baml.Int.min_value
-    store_var _2
     call baml.Int.max_value
-    store_var _3
-    load_var2 2 3
     load_const <omitted>
     call baml.Int.random
     store_var r
     call baml.Int.min_value
-    store_var _6
-    load_var2 1 4
+    store_var _7
+    load_var2 1 2
     cmp_int_op >=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     call baml.Int.max_value
-    store_var _8
-    load_var2 1 5
+    store_var _9
+    load_var2 1 3
     cmp_int_op <
 
   L0:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_invoke_error_normalization/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_invoke_error_normalization/bytecode.snap
@@ -106,12 +106,10 @@ function invoke_error_normalization.TimeoutSpec(client: ai.Client | null, on_eve
     call user.invoke_error_normalization.TimeoutSpec@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -260,57 +258,44 @@ function invoke_error_normalization.normalized_kind(error: ai.errors.Failure | b
     store_var _3
     load_var _3
     narrow_bind baml.errors.Timeout, slot=3
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L2
+    load_var _2
+    store_var _15
+    load_var _15
+    narrow_bind ai.errors.NetworkFailure, slot=8
+    pop_jump_if_true L1
+    load_var _2
+    store_var _20
+    load_var _20
+    narrow_bind baml.errors.UnknownError, slot=9
+    pop_jump_if_true L0
+    load_const "other"
+    jump L6
 
   L0:
-    load_var _2
-    store_var _16
-    load_var _16
-    narrow_bind ai.errors.NetworkFailure, slot=8
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
-    load_var _2
-    store_var _21
-    load_var _21
-    narrow_bind baml.errors.UnknownError, slot=10
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_const "other"
-    jump L7
-
-  L3:
     load_type string
-    load_var _21
+    load_var _20
     load_field .message
     load_const "|"
     call baml.Array.join
-    store_var _24
-    load_type string
-    load_var _24
-    call baml.String.from
     store_var _23
     load_const "UnknownError:"
-    load_var _23
-    bin_op +
-    jump L7
-
-  L4:
     load_type string
-    load_var _16
+    load_var _23
+    call baml.String.from
+    bin_op +
+    jump L6
+
+  L1:
+    load_const "NetworkFailure:"
+    load_type string
+    load_var _15
     load_field .detail
     call baml.String.from
-    store_var _18
-    load_const "NetworkFailure:"
-    load_var _18
     bin_op +
-    jump L7
+    jump L6
 
-  L5:
+  L2:
     load_var _3
     store_var timeout
     load_type string
@@ -320,14 +305,18 @@ function invoke_error_normalization.normalized_kind(error: ai.errors.Failure | b
     store_var _7
     load_var timeout
     load_field .duration_ms
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
+    jump_if_not_null_or_pop L3
+    jump L4
+
+  L3:
+    store_var _12
+    jump L5
+
+  L4:
     load_const -1
     store_var _12
 
-  L6:
+  L5:
     load_type int
     load_var _12
     call baml.String.from
@@ -340,7 +329,7 @@ function invoke_error_normalization.normalized_kind(error: ai.errors.Failure | b
     load_var _10
     bin_op +
 
-  L7:
+  L6:
     return
 }
 
@@ -349,24 +338,19 @@ function invoke_error_normalization.timeout_detail(error: unknown) -> string {
     store_var _2
     load_var _2
     narrow_bind baml.errors.Timeout, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type unknown
     load_var error
     call baml.String.from
-    store_var _15
-    load_type string
-    load_var _15
-    call baml.String.from
     store_var _14
     load_const "unexpected:"
+    load_type string
     load_var _14
+    call baml.String.from
     bin_op +
-    jump L3
+    jump L4
 
-  L1:
+  L0:
     load_var _2
     store_var timeout
     load_type string
@@ -376,14 +360,18 @@ function invoke_error_normalization.timeout_detail(error: unknown) -> string {
     store_var _5
     load_var timeout
     load_field .duration_ms
-    store_var_load_var _10
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _10
+    jump L3
+
+  L2:
     load_const -1
     store_var _10
 
-  L2:
+  L3:
     load_type int
     load_var _10
     call baml.String.from
@@ -394,7 +382,7 @@ function invoke_error_normalization.timeout_detail(error: unknown) -> string {
     load_var _8
     bin_op +
 
-  L3:
+  L4:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_io/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_io/bytecode.snap
@@ -65,27 +65,21 @@ function io.<(user.io.ChunkReader as baml.io.Read)>.read(self: io.ChunkReader, l
     store_var _5
     load_var2 3 4
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L4
     load_var2 2 1
     load_field .chunk_size
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var self
     load_field .chunk_size
     store_var count
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var limit
     store_var count
 
-  L3:
+  L1:
     load_var self
     load_field .cursor
     load_var count
@@ -97,24 +91,21 @@ function io.<(user.io.ChunkReader as baml.io.Read)>.read(self: io.ChunkReader, l
     store_var _15
     load_var2 7 8
     cmp_int_op <
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var self
     load_field .data
     container_len
     store_var end
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_var self
     load_field .cursor
     load_var count
     add_int
     store_var end
 
-  L6:
+  L3:
     load_var self
     load_field .data
     load_var self
@@ -123,12 +114,12 @@ function io.<(user.io.ChunkReader as baml.io.Read)>.read(self: io.ChunkReader, l
     call baml.Uint8Array.slice
     load_var2 1 6
     store_field .cursor
-    jump L8
+    jump L5
 
-  L7:
+  L4:
     load_const null
 
-  L8:
+  L5:
     return
 }
 
@@ -144,21 +135,18 @@ function io.<(user.io.ChunkWriter as baml.io.Write)>.write_some(self: io.ChunkWr
     load_var2 4 1
     load_field .chunk_size
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .chunk_size
     store_var count
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var data
     container_len
     store_var count
 
-  L2:
+  L1:
     load_var self
     load_field .data
     store_var _7

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_is_operator/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_is_operator/bytecode.snap
@@ -436,108 +436,52 @@ function is_operator.$init_test_ns_is_operator_is_operator(registry: testing.Tes
 function is_operator.describe_int_string_bool(v: int | string | bool) -> string {
     load_var v
     is_type int
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
+    load_var v
+    is_type bool
+    pop_jump_if_true L0
+    load_const "got string"
+    jump L2
 
   L0:
-    load_const false
+    load_const "got bool"
     jump L2
 
   L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L9
-
-  L3:
-    load_var v
-    is_type bool
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
-    load_const false
-    jump L6
-
-  L5:
-    load_const true
-
-  L6:
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
-    load_const "got string"
-    jump L10
-
-  L8:
-    load_const "got bool"
-    jump L10
-
-  L9:
     load_const "got int"
 
-  L10:
+  L2:
     return
 }
 
 function is_operator.describe_success_failure(v: is_operator.Success | is_operator.Failure) -> string {
     load_var v
     is_type is_operator.Success
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var v
+    load_field .0
     jump L1
 
   L0:
-    load_const false
-    jump L2
+    load_var v
+    load_field .0
 
   L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_var v
-    load_field .0
-    jump L5
-
-  L4:
-    load_var v
-    load_field .0
-
-  L5:
     return
 }
 
 function is_operator.describe_success_or_failed(v: is_operator.Success | is_operator.Failure) -> string {
     load_var v
     is_type is_operator.Success
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "failed"
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const "failed"
-    jump L5
-
-  L4:
     load_var v
     load_field .0
 
-  L5:
+  L1:
     return
 }
 
@@ -553,34 +497,12 @@ function is_operator.is_array_type_pattern_fn() -> bool {
     load_type int
     alloc_array 3
     is_type int[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_array_type_pattern_mismatch_fn() -> bool {
     load_const 1
     is_type int[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -598,224 +520,67 @@ function is_operator.is_bare_binding_pattern_matches_fn() -> bool {
 function is_operator.is_bool_literal_pattern_false_fn() -> bool {
     load_const true
     is_type false
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_bool_literal_pattern_true_fn() -> bool {
     load_const true
     is_type true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_chained_negation_and_or_fn() -> bool {
     load_const "x"
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     unary_op !
-    jump_if_false L3
-    jump L6
-
-  L3:
-    pop 1
+    jump_if_true_or_pop L0
     load_const 2
     is_type int
-    pop_jump_if_false L4
-    jump L5
 
-  L4:
-    load_const false
-    jump L6
-
-  L5:
-    load_const true
-
-  L6:
+  L0:
     return
 }
 
 function is_operator.is_chained_on_itself_fn() -> bool {
     load_const 1
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     is_type bool
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
     return
 }
 
 function is_operator.is_chained_on_itself_without_parens_is_left_associative_fn() -> bool {
     load_const 1
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     is_type bool
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
     return
 }
 
 function is_operator.is_chained_on_itself_without_parens_negative_outer_fn() -> bool {
     load_const 1
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     is_type bool
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
     return
 }
 
 function is_operator.is_chained_with_and_fn() -> bool {
     load_const 1
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    jump_if_false L5
-    pop 1
+    jump_if_false_or_pop L0
     load_const 2
     is_type int
-    pop_jump_if_false L3
-    jump L4
 
-  L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
+  L0:
     return
 }
 
 function is_operator.is_chained_with_or_fn() -> bool {
     load_const "x"
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    jump_if_false L3
-    jump L6
-
-  L3:
-    pop 1
+    jump_if_true_or_pop L0
     load_const 2
     is_type int
-    pop_jump_if_false L4
-    jump L5
 
-  L4:
-    load_const false
-    jump L6
-
-  L5:
-    load_const true
-
-  L6:
+  L0:
     return
 }
 
@@ -823,42 +588,13 @@ function is_operator.is_class_destructure_pattern_match_fn() -> bool {
     load_const "Ada"
     load_const 36
     init_instance user.is_operator.User .name, .age
-    store_var_load_var u
     is_type is_operator.User
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_var u
-    load_field .name
-    pop 1
-    load_var u
-    load_field .age
-    pop 1
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_compared_with_eq_binds_tighter_fn() -> bool {
     load_const 1
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     load_const true
     cmp_op ==
     return
@@ -867,36 +603,23 @@ function is_operator.is_compared_with_eq_binds_tighter_fn() -> bool {
 function is_operator.is_else_narrows_nested_optional_member_fn() -> int {
     load_const 7
     is_type string
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_const 7
     is_type null
-    pop_jump_if_false L1
-    jump L2
+    jump L1
+
+  L0:
+    load_const true
 
   L1:
-    load_const false
+    pop_jump_if_true L2
+    load_const 8
     jump L3
 
   L2:
-    load_const true
-
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
-    load_const 7
-    load_const 1
-    add_int
-    jump L6
-
-  L5:
     load_const -1
 
-  L6:
+  L3:
     return
 }
 
@@ -906,17 +629,6 @@ function is_operator.is_enum_variant_pattern_match_fn() -> bool {
     load_const user.is_operator.Status.Active
     alloc_variant user.is_operator.Status
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -926,17 +638,6 @@ function is_operator.is_enum_variant_pattern_mismatch_fn() -> bool {
     load_const user.is_operator.Status.Active
     alloc_variant user.is_operator.Status
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -952,21 +653,12 @@ function is_operator.is_evaluates_scrutinee_exactly_once_fn() -> int {
     store_var _3
     load_var _3
     is_type int
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var _3
     is_type string
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L0
 
-  L1:
-    load_var _3
-    is_type bool
-    pop_jump_if_false L2
-
-  L2:
+  L0:
     load_deref ?1
     return
 }
@@ -974,116 +666,54 @@ function is_operator.is_evaluates_scrutinee_exactly_once_fn() -> int {
 function is_operator.is_in_if_condition_fn() -> string {
     load_const 7
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "text"
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const "text"
-    jump L5
-
-  L4:
     load_const "number"
 
-  L5:
+  L1:
     return
 }
 
 function is_operator.is_in_let_initializer_fn() -> bool {
     load_const 7
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_in_match_guard_fn() -> int {
     load_const 5
-    store_var _2
-    load_var _2
+    store_var _1
+    load_var _1
     narrow_bind int, slot=1
-    pop_jump_if_false L3
-    load_var _2
+    pop_jump_if_false L0
+    load_var _1
     store_var_load_var n
     is_type int
-    pop_jump_if_false L0
-    jump L1
+    store_var _3
+    load_var _3
+    pop_jump_if_true L1
 
   L0:
-    load_const false
+    load_const 0
     jump L2
 
   L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 0
-    jump L5
-
-  L4:
     load_var n
     load_const 1
     add_int
 
-  L5:
+  L2:
     return
 }
 
 function is_operator.is_inside_array_literal_fn() -> bool[] {
     load_const 1
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _2
-    jump L2
-
-  L1:
-    load_const true
-    store_var _2
-
-  L2:
     load_const 1
     is_type string
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _4
-    jump L5
-
-  L4:
-    load_const true
-    store_var _4
-
-  L5:
-    load_var2 1 2
     load_type bool
     alloc_array 2
     return
@@ -1105,32 +735,19 @@ function is_operator.is_inside_while_condition_fn() -> int {
   L0:
     load_var v
     is_type int
+    store_var _3
+    load_var _3
     pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const false
-    jump L3
-
-  L2:
-    load_const true
-
-  L3:
-    jump_if_false L4
-    pop 1
     load_var count
     load_const 3
     cmp_int_op <
+    pop_jump_if_true L2
 
-  L4:
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+  L1:
     load_var count
     return
 
-  L6:
+  L2:
     load_var count
     load_const 1
     add_int
@@ -1146,51 +763,18 @@ function is_operator.is_inside_while_condition_fn() -> int {
 function is_operator.is_int_literal_pattern_mismatch_fn() -> bool {
     load_const 5
     is_type 0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_int_literal_pattern_zero_fn() -> bool {
     load_const 0
     is_type 0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_int_param(v: int | string) -> bool {
     load_var v
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -1198,279 +782,151 @@ function is_operator.is_null_pattern_on_non_null_fn() -> bool {
     load_const 7
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_null_pattern_on_null_fn() -> bool {
-    load_const null
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
     load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_or_pattern_first_alternative_fn() -> bool {
     load_const 7
     is_type int
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_const 7
     is_type bool
-    pop_jump_if_false L1
-    jump L2
+    jump L1
 
-  L1:
-    load_const false
-    jump L3
-
-  L2:
+  L0:
     load_const true
 
-  L3:
+  L1:
     return
 }
 
 function is_operator.is_or_pattern_fn() -> bool {
     load_const true
     is_type int
-    pop_jump_if_false L0
-    jump L2
+    pop_jump_if_true L0
+    load_const true
+    is_type bool
+    jump L1
 
   L0:
     load_const true
-    is_type bool
-    pop_jump_if_false L1
-    jump L2
 
   L1:
-    load_const false
-    jump L3
-
-  L2:
-    load_const true
-
-  L3:
     return
 }
 
 function is_operator.is_or_pattern_none_match_fn() -> bool {
     load_const "x"
     is_type int
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_const "x"
     is_type bool
-    pop_jump_if_false L1
-    jump L2
+    jump L1
 
-  L1:
-    load_const false
-    jump L3
-
-  L2:
+  L0:
     load_const true
 
-  L3:
+  L1:
     return
 }
 
 function is_operator.is_or_pattern_parenthesised_alternatives_fn() -> bool {
     load_const 1
     is_type int
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
     is_type string
-    pop_jump_if_false L1
-    jump L2
+    jump L1
 
-  L1:
-    load_const false
-    jump L3
-
-  L2:
+  L0:
     load_const true
 
-  L3:
+  L1:
     return
 }
 
 function is_operator.is_or_pattern_with_literals_fn() -> bool {
     load_const 2
     is_type 1
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L0
     load_const 2
     is_type 2
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L0
     load_const 2
     is_type 3
-    pop_jump_if_false L2
-    jump L3
+    jump L1
 
-  L2:
-    load_const false
-    jump L4
-
-  L3:
+  L0:
     load_const true
 
-  L4:
+  L1:
     return
 }
 
 function is_operator.is_pattern_disjoint_from_scrutinee_type_returns_false_fn() -> bool {
     load_const 42
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_string_literal_pattern_match_fn() -> bool {
     load_const "hello"
     is_type "hello"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_string_literal_pattern_mismatch_fn() -> bool {
     load_const "world"
     is_type "hello"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_type_match_false_fn() -> bool {
     load_const "hi"
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_type_match_true_fn() -> bool {
     load_const 42
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_typed_binding_pattern_matches_fn() -> bool {
     load_const 7
-    store_var _2
-    load_var _2
+    store_var _1
+    load_var _1
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
 function is_operator.is_typed_binding_pattern_mismatch_fn() -> bool {
     load_const "hi"
-    store_var _2
-    load_var _2
+    store_var _1
+    load_var _1
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -1487,17 +943,6 @@ function is_operator.is_wildcard_pattern_is_always_true_fn() -> bool {
 function is_operator.is_with_call_scrutinee_fn() -> bool {
     call user.is_operator.get_value
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -1506,176 +951,77 @@ function is_operator.is_with_field_access_scrutinee_fn() -> bool {
     init_instance user.is_operator.Wrap .value
     load_field .value
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.is_with_not_fn() -> bool {
     load_const "hi"
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     unary_op !
     return
 }
 
 function is_operator.is_with_optional_chain_scrutinee_fn() -> bool {
-    load_const null
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const null
-    load_field .0
-    jump L2
-
-  L1:
-    load_const null
-
-  L2:
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    jump L5
-
-  L4:
     load_const true
-
-  L5:
     return
 }
 
 function is_operator.is_with_parenthesised_arithmetic_scrutinee_fn() -> bool {
     load_const 3
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function is_operator.narrowing_else_branch_runs_for_non_matching_value_fn() -> string {
     load_const "hi"
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "text"
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const "text"
-    jump L5
-
-  L4:
     load_const "number"
 
-  L5:
+  L1:
     return
 }
 
 function is_operator.narrowing_else_branch_subtracts_matched_type_fn() -> int {
     load_const "hi"
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "hi"
+    call baml.String.length
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const "hi"
-    call baml.String.length
-    jump L5
-
-  L4:
     load_const 0
 
-  L5:
+  L1:
     return
 }
 
 function is_operator.narrowing_else_branch_subtracts_or_pattern_fn() -> int {
     load_const "hello"
     is_type int
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_const "hello"
     is_type bool
-    pop_jump_if_false L1
-    jump L2
+    jump L1
+
+  L0:
+    load_const true
 
   L1:
-    load_const false
+    pop_jump_if_true L2
+    load_const "hello"
+    call baml.String.length
     jump L3
 
   L2:
-    load_const true
-
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
-    load_const "hello"
-    call baml.String.length
-    jump L6
-
-  L5:
     load_const 0
 
-  L6:
+  L3:
     return
 }
 
@@ -1689,94 +1035,43 @@ function is_operator.narrowing_else_branch_with_class_types_fn() -> string {
 function is_operator.narrowing_else_branch_with_literal_pattern_keeps_original_fn() -> int {
     load_const 5
     is_type 0
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 6
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 5
-    load_const 1
-    add_int
-    jump L5
-
-  L4:
     load_const 0
 
-  L5:
+  L1:
     return
 }
 
 function is_operator.narrowing_negation_subtracts_in_then_branch_fn() -> int {
     load_const "abc"
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "abc"
+    call baml.String.length
     jump L1
 
   L0:
-    load_const false
-    jump L2
+    load_const 0
 
   L1:
-    load_const true
-
-  L2:
-    unary_op !
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 0
-    jump L5
-
-  L4:
-    load_const "abc"
-    call baml.String.length
-
-  L5:
     return
 }
 
 function is_operator.narrowing_persists_across_multiple_uses_in_then_fn() -> int {
     load_const 4
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const false
-    jump L2
+    load_const 11
 
   L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 0
-    jump L5
-
-  L4:
-    load_const 4
-    load_const 1
-    add_int
-    load_const 4
-    load_const 2
-    add_int
-    add_int
-
-  L5:
     return
 }
 
@@ -1792,28 +1087,14 @@ function is_operator.narrowing_skipped_for_non_path_scrutinee_fn() -> string {
     init_instance user.is_operator.Wrap .value
     load_field .value
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "text"
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const "text"
-    jump L5
-
-  L4:
     load_const "int"
 
-  L5:
+  L1:
     return
 }
 
@@ -1826,112 +1107,49 @@ function is_operator.narrowing_then_branch_picks_or_pattern_type_fn() -> string 
 function is_operator.narrowing_then_branch_picks_pattern_type_fn() -> int {
     load_const 7
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const false
-    jump L2
+    load_const 8
 
   L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 0
-    jump L5
-
-  L4:
-    load_const 7
-    load_const 1
-    add_int
-
-  L5:
     return
 }
 
 function is_operator.narrowing_through_negation_fn() -> int {
     load_const 5
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const false
-    jump L2
+    load_const 105
 
   L1:
-    load_const true
-
-  L2:
-    unary_op !
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 5
-    load_const 100
-    add_int
-    jump L5
-
-  L4:
-    load_const 0
-
-  L5:
     return
 }
 
 function is_operator.narrowing_with_early_return_fn() -> int {
     load_const 7
     is_type string
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
+    load_const 7
+    is_type int
+    pop_jump_if_true L0
+    load_const -1
+    jump L2
 
   L0:
-    load_const false
+    load_const 14
     jump L2
 
   L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L9
-
-  L3:
-    load_const 7
-    is_type int
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
-    load_const false
-    jump L6
-
-  L5:
-    load_const true
-
-  L6:
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
-    load_const -1
-    jump L10
-
-  L8:
-    load_const 7
-    load_const 2
-    mul_int
-    jump L10
-
-  L9:
     load_const 0
 
-  L10:
+  L2:
     return
 }
 
@@ -1944,29 +1162,15 @@ function is_operator.narrowing_works_on_function_parameter_fn() -> int {
 function is_operator.process(v: int | string) -> int {
     load_var v
     is_type int
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const 0
-    jump L5
-
-  L4:
     load_var v
     load_const 3
     bin_op *
 
-  L5:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_is_operator/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_is_operator/bytecode.snap
@@ -823,6 +823,7 @@ function is_operator.is_class_destructure_pattern_match_fn() -> bool {
     load_const "Ada"
     load_const 36
     init_instance user.is_operator.User .name, .age
+    store_var_load_var u
     is_type is_operator.User
     pop_jump_if_false L0
     jump L1
@@ -832,6 +833,12 @@ function is_operator.is_class_destructure_pattern_match_fn() -> bool {
     jump L2
 
   L1:
+    load_var u
+    load_field .name
+    pop 1
+    load_var u
+    load_field .age
+    pop 1
     load_const true
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_item_projections/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_item_projections/bytecode.snap
@@ -191,12 +191,12 @@ function item_projections.<(user.item_projections.Gadget as user.item_projection
 }
 
 function item_projections.<(user.item_projections.Gadget as user.item_projections.Buildable)>.describe(self: item_projections.Gadget) -> string {
+    load_const "gadget "
     load_type int
     load_var self
     load_field .g
     call baml.String.from
     store_var _2
-    load_const "gadget "
     load_var _2
     bin_op +
     return
@@ -218,12 +218,12 @@ function item_projections.<(user.item_projections.Loud as user.item_projections.
 }
 
 function item_projections.<(user.item_projections.Plate<#0> as user.item_projections.Embosser)>.emboss(u: #1) -> string {
+    load_const "emboss "
     load_type #1
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
-    load_const "emboss "
     load_var _2
     bin_op +
     return
@@ -261,24 +261,24 @@ function item_projections.<(user.item_projections.Poly as user.item_projections.
 }
 
 function item_projections.<(user.item_projections.Press as user.item_projections.Stamper)>.emboss(u: #0) -> string {
+    load_const "emboss "
     load_type #0
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
-    load_const "emboss "
     load_var _2
     bin_op +
     return
 }
 
 function item_projections.<(user.item_projections.Press as user.item_projections.Stamper)>.stamp(self: item_projections.Press, u: #0) -> string {
+    load_const "stamp "
     load_type #0
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
-    load_const "stamp "
     load_var _3
     bin_op +
     return
@@ -296,17 +296,14 @@ function item_projections.<(user.item_projections.Sized as user.item_projections
     load_var other
     load_field .s
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var other
     jump L1
 
   L0:
-    load_var other
-    jump L2
-
-  L1:
     load_var self
 
-  L2:
+  L1:
     return
 }
 
@@ -329,12 +326,12 @@ function item_projections.<(user.item_projections.Widget as user.item_projection
 }
 
 function item_projections.<(user.item_projections.Widget as user.item_projections.Buildable)>.describe(self: item_projections.Widget) -> string {
+    load_const "widget "
     load_type int
     load_var self
     load_field .w
     call baml.String.from
     store_var _2
-    load_const "widget "
     load_var _2
     bin_op +
     return
@@ -355,8 +352,6 @@ function item_projections.Sizer.grow(self: item_projections.Sizer) -> #0 {
     load_type item_projections.Sizer
     load_const "pick"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -375,7 +370,5 @@ function item_projections.marked_via(t: #1) -> #0 {
     load_type item_projections.Marked<#0>
     load_const "mark"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_item_projections/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_item_projections/bytecode.snap
@@ -196,8 +196,6 @@ function item_projections.<(user.item_projections.Gadget as user.item_projection
     load_var self
     load_field .g
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -223,8 +221,6 @@ function item_projections.<(user.item_projections.Plate<#0> as user.item_project
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -266,8 +262,6 @@ function item_projections.<(user.item_projections.Press as user.item_projections
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -278,8 +272,6 @@ function item_projections.<(user.item_projections.Press as user.item_projections
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     bin_op +
     return
 }
@@ -331,8 +323,6 @@ function item_projections.<(user.item_projections.Widget as user.item_projection
     load_var self
     load_field .w
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter/bytecode.snap
@@ -458,10 +458,7 @@ function iter.<(user.iter.FlakyIterator as baml.iter.Iterator)>.next(self: iter.
     load_var self
     load_field .fail_at
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_var self
     load_field .pos
     store_var _7
@@ -471,10 +468,7 @@ function iter.<(user.iter.FlakyIterator as baml.iter.Iterator)>.next(self: iter.
     store_var _8
     load_var2 2 3
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var self
     load_field .values
     load_var self
@@ -488,15 +482,15 @@ function iter.<(user.iter.FlakyIterator as baml.iter.Iterator)>.next(self: iter.
     bin_op +
     store_field .pos
     load_var item
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     alloc_instance baml.iter.Done
 
-  L3:
+  L1:
     return
 
-  L4:
+  L2:
     load_var self
     load_const -1
     store_field .fail_at
@@ -516,10 +510,7 @@ function iter.<(user.iter.ResumableIterator as baml.iter.Iterator)>.next(self: i
     load_var self
     load_field .done_at
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .pos
     store_var _6
@@ -529,10 +520,7 @@ function iter.<(user.iter.ResumableIterator as baml.iter.Iterator)>.next(self: i
     store_var _7
     load_var2 2 3
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var self
     load_field .values
     load_var self
@@ -546,19 +534,19 @@ function iter.<(user.iter.ResumableIterator as baml.iter.Iterator)>.next(self: i
     bin_op +
     store_field .pos
     load_var item
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     alloc_instance baml.iter.Done
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var self
     load_const -1
     store_field .done_at
     alloc_instance baml.iter.Done
 
-  L4:
+  L2:
     return
 }
 
@@ -598,13 +586,9 @@ function iter.iter_array_as_iterable_param_inner(xs: baml.iter.Iterable<Error = 
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -626,13 +610,9 @@ function iter.iter_array_chain_fluent() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "chain"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -647,32 +627,25 @@ function iter.iter_array_collect_count() -> bool {
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
+    store_var _4
+    load_var _4
     load_const 4
     load_const 5
     load_const 6
     load_type int
     alloc_array 3
     call baml.ops.equals_equals
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var xs
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _7
-    load_var _7
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
-    store_var _6
-    load_var _6
     load_const 3
     cmp_int_op ==
 
@@ -734,13 +707,9 @@ function iter.iter_array_filter_map_fluent() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -762,26 +731,20 @@ function iter.iter_array_filter_step_by() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
-    store_var _2
-    load_var _2
     load_const 2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "step_by"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function iter.iter_array_first_adapter_defaults() -> bool {
-    load_var ?12
+    load_var ?10
     make_cell
-    store_var ?12
+    store_var ?10
     load_type int
     load_const 1
     load_const 2
@@ -805,8 +768,6 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _2
-    load_var _2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
@@ -834,8 +795,6 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
-    store_var _13
-    load_var _13
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
@@ -867,7 +826,7 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     store_var reduced
     load_type int
     alloc_array 0
-    store_deref ?12
+    store_deref ?10
     load_type int
     load_const 1
     load_const 2
@@ -884,7 +843,7 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     virtual_call nargs=2 ntypeargs=1
     store_var _36
     load_type never
-    load_var2 13 12
+    load_var2 11 10
     make_closure .<lambda(iter_array_first_adapter_defaults, 7)>, 1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "for_each"
@@ -896,8 +855,7 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type int
     alloc_array 2
     call baml.ops.equals_equals
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var flattened
     load_const 1
     load_const 11
@@ -906,25 +864,19 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type int
     alloc_array 4
     call baml.ops.equals_equals
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var reduced
     load_const 9
     cmp_int_op ==
-
-  L1:
-    jump_if_false L2
-    pop 1
-    load_deref ?12
+    jump_if_false_or_pop L0
+    load_deref ?10
     load_const 3
     load_const 9
     load_type int
     alloc_array 2
     call baml.ops.equals_equals
 
-  L2:
+  L0:
     return
 }
 
@@ -970,8 +922,7 @@ function iter.iter_array_first_native_methods() -> bool {
     load_type int
     alloc_array 3
     call baml.ops.equals_equals
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var flat_mapped
     load_const 1
     load_const 11
@@ -980,15 +931,12 @@ function iter.iter_array_first_native_methods() -> bool {
     load_type int
     alloc_array 4
     call baml.ops.equals_equals
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var reduced
     load_const 10
     cmp_int_op ==
 
-  L1:
+  L0:
     return
 }
 
@@ -1023,13 +971,9 @@ function iter.iter_array_iter() -> int[] {
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1050,18 +994,16 @@ function iter.iter_array_iter_lazy_over_source_details() -> int[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _4
     load_type never
-    load_var2 4 2
+    load_var2 3 2
     make_closure .<lambda(iter_array_iter_lazy_over_source_details, 0)>, 1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
-    store_var it
     load_type int
     load_var xs
     load_const 3
     call baml.Array.push
     pop 1
-    load_var it
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
@@ -1088,17 +1030,14 @@ function iter.iter_array_iter_lazy_over_source_details() -> int[] {
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type int
-    load_var2 6 9
+    load_var2 5 8
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var details
     return
 }
@@ -1128,13 +1067,9 @@ function iter.iter_array_lazy_filter_map_collect() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1165,10 +1100,7 @@ function iter.iter_array_nullable_elements_details() -> int[] {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _7
     store_var x
     load_var visited
@@ -1178,23 +1110,20 @@ function iter.iter_array_nullable_elements_details() -> int[] {
     load_var x
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 4 7
     add_int
     store_var sum
     jump L0
 
-  L3:
+  L1:
     load_var nulls
     load_const 1
     add_int
     store_var nulls
     jump L0
 
-  L4:
+  L2:
     load_var visited
     store_var _14
     load_var nulls
@@ -1205,8 +1134,6 @@ function iter.iter_array_nullable_elements_details() -> int[] {
     load_type baml.iter.Iterable<Error = never, Item = int | null>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _18
-    load_var _18
     load_type baml.iter.Iterator<Error = never, Item = int | null>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
@@ -1226,8 +1153,6 @@ function iter.iter_array_peekable_fluent() -> int[] {
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "peekable"
     virtual_call nargs=1 ntypeargs=0
@@ -1242,12 +1167,23 @@ function iter.iter_array_peekable_fluent() -> int[] {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_type int
+    load_var2 2 3
+    call baml.Array.push
+    pop 1
 
   L0:
+    load_var p
+    load_type baml.iter.Iterator<Error = never, Item = int>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _14
+    load_var _14
+    is_type baml.iter.Done
+    pop_jump_if_true L1
     load_type int
-    load_var2 3 4
+    load_var2 2 4
     call baml.Array.push
     pop 1
 
@@ -1256,36 +1192,16 @@ function iter.iter_array_peekable_fluent() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _14
-    load_var _14
-    is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_type int
-    load_var2 3 5
-    call baml.Array.push
-    pop 1
-
-  L3:
-    load_var p
-    load_type baml.iter.Iterator<Error = never, Item = int>
-    load_const "next"
-    virtual_call nargs=1 ntypeargs=0
     store_var _20
     load_var _20
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_type int
-    load_var2 3 6
+    load_var2 2 5
     call baml.Array.push
     pop 1
 
-  L5:
+  L2:
     load_var out
     return
 }
@@ -1306,17 +1222,13 @@ function iter.iter_chain() -> int[] {
     call baml.iter.ArrayIterator.new
     store_var b
     load_type never
-    load_var2 2 3
+    load_var2 1 2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "chain"
     virtual_call nargs=2 ntypeargs=1
-    store_var _7
-    load_var _7
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1331,8 +1243,6 @@ function iter.iter_collect() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1347,8 +1257,6 @@ function iter.iter_count() -> int {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1371,8 +1279,6 @@ function iter.iter_explicit_map_coerces_to_iterator() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1392,13 +1298,9 @@ function iter.iter_filter() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
-    store_var _4
-    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1418,13 +1320,9 @@ function iter.iter_filter_implicit_source() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1445,13 +1343,9 @@ function iter.iter_filter_map() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _4
-    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1472,13 +1366,9 @@ function iter.iter_filter_map_implicit_source() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1498,13 +1388,9 @@ function iter.iter_flat_map() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
-    store_var _4
-    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1524,13 +1410,9 @@ function iter.iter_flat_map_implicit_source() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1550,7 +1432,7 @@ function iter.iter_flatten() -> int[] {
     call baml.iter.ArrayIterator.new
     store_var _5
     load_type baml.iter.ArrayIterator<int>
-    load_var2 2 3
+    load_var2 1 2
     load_type baml.iter.ArrayIterator<int>
     alloc_array 2
     call baml.iter.ArrayIterator.new
@@ -1564,8 +1446,6 @@ function iter.iter_flatten() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1593,17 +1473,14 @@ function iter.iter_for_in_array_iterator() -> int[] {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type int
     load_var2 1 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1629,17 +1506,14 @@ function iter.iter_for_in_array_literal() -> int[] {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type int
     load_var2 1 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1666,17 +1540,14 @@ function iter.iter_for_in_array_of_classes() -> int {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     load_field .value
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -1702,20 +1573,14 @@ function iter.iter_for_in_array_of_unions() -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _5
     store_var x
     load_var x
     store_var _9
     load_var _9
     narrow_bind int, slot=5
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var x
     load_const "two"
     cmp_op ==
@@ -1726,13 +1591,13 @@ function iter.iter_for_in_array_of_unions() -> int {
     store_var total
     jump L0
 
-  L3:
+  L1:
     load_var2 1 5
     add_int
     store_var total
     jump L0
 
-  L4:
+  L2:
     load_var total
     return
 }
@@ -1758,17 +1623,14 @@ function iter.iter_for_in_range() -> int[] {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type int
     load_var2 1 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1794,17 +1656,14 @@ function iter.iter_for_in_repeat() -> int[] {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type int
     load_var2 1 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1834,10 +1693,7 @@ function iter.iter_for_loop_pop_during_iteration() -> int[] {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type int
     load_var2 2 4
     call baml.Array.push
@@ -1848,7 +1704,7 @@ function iter.iter_for_loop_pop_during_iteration() -> int[] {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var visited
     return
 }
@@ -1876,10 +1732,7 @@ function iter.iter_for_loop_sees_push_during_iteration() -> int[] {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var x
     load_type int
@@ -1897,7 +1750,7 @@ function iter.iter_for_loop_sees_push_during_iteration() -> int[] {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var visited
     return
 }
@@ -1918,13 +1771,9 @@ function iter.iter_map() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _4
-    load_var _4
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1944,13 +1793,9 @@ function iter.iter_map_implicit_source() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1975,12 +1820,23 @@ function iter.iter_peekable() -> int[] {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type int
     load_var2 2 3
+    call baml.Array.push
+    pop 1
+
+  L0:
+    load_var p
+    load_type baml.iter.Iterator<Error = never, Item = int>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _15
+    load_var _15
+    is_type baml.iter.Done
+    pop_jump_if_true L1
+    load_type int
+    load_var2 2 4
     call baml.Array.push
     pop 1
 
@@ -1989,36 +1845,16 @@ function iter.iter_peekable() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _15
-    load_var _15
-    is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_type int
-    load_var2 2 4
-    call baml.Array.push
-    pop 1
-
-  L3:
-    load_var p
-    load_type baml.iter.Iterator<Error = never, Item = int>
-    load_const "next"
-    virtual_call nargs=1 ntypeargs=0
     store_var _21
     load_var _21
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_type int
     load_var2 2 5
     call baml.Array.push
     pop 1
 
-  L5:
+  L2:
     load_type int
     load_type never
     load_var p
@@ -2026,24 +1862,21 @@ function iter.iter_peekable() -> int[] {
     store_var _27
     load_var _27
     is_type baml.iter.Done
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L3
     load_type int
     load_var2 2 6
     call baml.Array.push
     pop 1
-    jump L8
+    jump L4
 
-  L7:
+  L3:
     load_type int
     load_var out
     load_const 99
     call baml.Array.push
     pop 1
 
-  L8:
+  L4:
     load_var out
     return
 }
@@ -2056,8 +1889,6 @@ function iter.iter_range() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2079,8 +1910,6 @@ function iter.iter_reduce() -> int {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "reduce"
     virtual_call nargs=3 ntypeargs=2
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2092,8 +1921,6 @@ function iter.iter_repeat() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2118,17 +1945,14 @@ function iter.iter_shadowed_param_for_in(source: baml.iter.Iterable<Error = neve
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type string
     load_var2 2 4
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -2148,13 +1972,9 @@ function iter.iter_skip() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2193,10 +2013,7 @@ function iter.iter_skip_does_not_respend_quota_after_done() -> int[] {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _7
     store_var i
     load_var s
@@ -2206,17 +2023,14 @@ function iter.iter_skip_does_not_respend_quota_after_done() -> int[] {
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type int
     load_var2 2 6
     call baml.Array.push
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_type int
     load_var out
     load_const -1
@@ -2224,7 +2038,7 @@ function iter.iter_skip_does_not_respend_quota_after_done() -> int[] {
     pop 1
     jump L0
 
-  L4:
+  L2:
     load_var out
     return
 }
@@ -2240,13 +2054,9 @@ function iter.iter_skip_past_end() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2273,19 +2083,14 @@ function iter.iter_skip_quota_survives_source_error() -> int[] {
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     pop 1
-    jump L1
+    jump L0
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
-    load_const true
-    pop_jump_if_false L3
+  L0:
     load_var s
     load_type baml.iter.Iterator<Error = baml.errors.InvalidArgument, Item = int>
     load_const "next"
@@ -2293,17 +2098,14 @@ function iter.iter_skip_quota_survives_source_error() -> int[] {
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type int
     load_var2 2 4
     call baml.Array.push
     pop 1
-    jump L1
+    jump L0
 
-  L3:
+  L1:
     load_var out
     return
 }
@@ -2317,19 +2119,13 @@ function iter.iter_skip_then_take() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip"
     virtual_call nargs=2 ntypeargs=0
-    store_var _2
-    load_var _2
     load_const 4
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2350,13 +2146,9 @@ function iter.iter_skip_while() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2374,13 +2166,9 @@ function iter.iter_skip_while_all_match() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2399,13 +2187,9 @@ function iter.iter_skip_while_none_match() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2418,13 +2202,9 @@ function iter.iter_skip_zero() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "skip"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2476,18 +2256,14 @@ function iter.iter_some_every_find() -> bool {
     virtual_call nargs=2 ntypeargs=1
     store_var found
     load_var some_large
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var every_small
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var found
     load_const 2
     call baml.ops.equals_equals
 
-  L1:
+  L0:
     return
 }
 
@@ -2500,13 +2276,9 @@ function iter.iter_step_by() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "step_by"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2519,13 +2291,9 @@ function iter.iter_take_bounds_infinite_repeat() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2540,13 +2308,9 @@ function iter.iter_take_more_than_available() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2575,34 +2339,26 @@ function iter.iter_take_quota_survives_source_error() -> int[] {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type int
     load_var2 2 3
     call baml.Array.push
     pop 1
 
-  L1:
+  L0:
     load_var t
     load_type baml.iter.Iterator<Error = baml.errors.InvalidArgument, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     pop 1
-    jump L3
+    jump L1
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L3:
-    load_const true
-    pop_jump_if_false L5
+  L1:
     load_var t
     load_type baml.iter.Iterator<Error = baml.errors.InvalidArgument, Item = int>
     load_const "next"
@@ -2610,17 +2366,14 @@ function iter.iter_take_quota_survives_source_error() -> int[] {
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_type int
     load_var2 2 5
     call baml.Array.push
     pop 1
-    jump L3
+    jump L1
 
-  L5:
+  L2:
     load_var out
     return
 }
@@ -2660,10 +2413,7 @@ function iter.iter_take_stays_done_after_source_done() -> int[] {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _7
     store_var i
     load_var t
@@ -2673,17 +2423,14 @@ function iter.iter_take_stays_done_after_source_done() -> int[] {
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type int
     load_var2 2 6
     call baml.Array.push
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_type int
     load_var out
     load_const -1
@@ -2691,7 +2438,7 @@ function iter.iter_take_stays_done_after_source_done() -> int[] {
     pop 1
     jump L0
 
-  L4:
+  L2:
     load_var out
     return
 }
@@ -2705,13 +2452,9 @@ function iter.iter_take_stops_early() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2732,13 +2475,9 @@ function iter.iter_take_while() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2754,13 +2493,9 @@ function iter.iter_take_while_bounds_infinite() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2778,13 +2513,9 @@ function iter.iter_take_while_none_match() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2805,13 +2536,9 @@ function iter.iter_take_while_stops_not_filters() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take_while"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2824,12 +2551,8 @@ function iter.iter_take_zero() -> int[] {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "take"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_closure_elements/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_closure_elements/bytecode.snap
@@ -51,10 +51,7 @@ function iter_closure_elements.closure_loop_sum() -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const null
     make_cell
     store_var i
@@ -68,14 +65,14 @@ function iter_closure_elements.closure_loop_sum() -> int {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var total
     load_type baml.iter.Iterable<Error = never, Item = () -> void throws never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
-  L3:
+  L2:
     load_var _13
     load_type baml.iter.Iterator<Error = never, Item = () -> void throws never>
     load_const "next"
@@ -83,16 +80,13 @@ function iter_closure_elements.closure_loop_sum() -> int {
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var _14
     call_indirect
     pop 1
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_deref ?1
     return
 }
@@ -118,31 +112,25 @@ function iter_closure_elements.nullable_elements_sum() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _4
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var count
     load_const 1
     add_int
     store_var count
     jump L0
 
-  L3:
+  L1:
     load_var count
     load_const 10
     add_int
     store_var count
     jump L0
 
-  L4:
+  L2:
     load_var count
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_impl_generics_only/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_impl_generics_only/bytecode.snap
@@ -164,8 +164,6 @@ function iter_impl_generics_only.iter_array_iter() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -184,17 +182,13 @@ function iter_impl_generics_only.iter_chain() -> int[] {
     alloc_array 2
     call user.iter_impl_generics_only.core.ArrayIterator.new
     store_var b
-    load_var2 2 3
+    load_var2 1 2
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "chain"
     virtual_call nargs=2 ntypeargs=0
-    store_var _7
-    load_var _7
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -209,8 +203,6 @@ function iter_impl_generics_only.iter_collect() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -225,8 +217,6 @@ function iter_impl_generics_only.iter_count() -> int {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -249,8 +239,6 @@ function iter_impl_generics_only.iter_explicit_map_coerces_to_iterator() -> int[
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -270,13 +258,9 @@ function iter_impl_generics_only.iter_filter() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
-    store_var _4
-    load_var _4
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -296,13 +280,9 @@ function iter_impl_generics_only.iter_filter_implicit_source() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
-    store_var _1
-    load_var _1
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -323,13 +303,9 @@ function iter_impl_generics_only.iter_filter_map() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _4
-    load_var _4
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -350,13 +326,9 @@ function iter_impl_generics_only.iter_filter_map_implicit_source() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _1
-    load_var _1
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -376,13 +348,9 @@ function iter_impl_generics_only.iter_flat_map() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
-    store_var _4
-    load_var _4
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -402,13 +370,9 @@ function iter_impl_generics_only.iter_flat_map_implicit_source() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
-    store_var _1
-    load_var _1
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -428,7 +392,7 @@ function iter_impl_generics_only.iter_flatten() -> int[] {
     call user.iter_impl_generics_only.core.ArrayIterator.new
     store_var _5
     load_type iter_impl_generics_only.core.Iterable<int, never>
-    load_var2 2 3
+    load_var2 1 2
     load_type iter_impl_generics_only.core.Iterable<int, never>
     alloc_array 2
     call user.iter_impl_generics_only.core.ArrayIterator.new
@@ -441,8 +405,6 @@ function iter_impl_generics_only.iter_flatten() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -462,13 +424,9 @@ function iter_impl_generics_only.iter_map() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _4
-    load_var _4
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -488,13 +446,9 @@ function iter_impl_generics_only.iter_map_implicit_source() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
-    store_var _1
-    load_var _1
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -519,12 +473,23 @@ function iter_impl_generics_only.iter_peekable() -> int[] {
     store_var _7
     load_var _7
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type int
     load_var2 2 3
+    call baml.Array.push
+    pop 1
+
+  L0:
+    load_var p
+    load_type iter_impl_generics_only.core.Iterator<int, never>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _15
+    load_var _15
+    is_type iter_impl_generics_only.core.Done
+    pop_jump_if_true L1
+    load_type int
+    load_var2 2 4
     call baml.Array.push
     pop 1
 
@@ -533,36 +498,16 @@ function iter_impl_generics_only.iter_peekable() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _15
-    load_var _15
-    is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_type int
-    load_var2 2 4
-    call baml.Array.push
-    pop 1
-
-  L3:
-    load_var p
-    load_type iter_impl_generics_only.core.Iterator<int, never>
-    load_const "next"
-    virtual_call nargs=1 ntypeargs=0
     store_var _21
     load_var _21
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_type int
     load_var2 2 5
     call baml.Array.push
     pop 1
 
-  L5:
+  L2:
     load_type int
     load_type never
     load_var p
@@ -570,24 +515,21 @@ function iter_impl_generics_only.iter_peekable() -> int[] {
     store_var _27
     load_var _27
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L3
     load_type int
     load_var2 2 6
     call baml.Array.push
     pop 1
-    jump L8
+    jump L4
 
-  L7:
+  L3:
     load_type int
     load_var out
     load_const 99
     call baml.Array.push
     pop 1
 
-  L8:
+  L4:
     load_var out
     return
 }
@@ -600,8 +542,6 @@ function iter_impl_generics_only.iter_range() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -623,8 +563,6 @@ function iter_impl_generics_only.iter_reduce() -> int {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "reduce"
     virtual_call nargs=3 ntypeargs=2
-    store_var _0
-    load_var _0
     return
 }
 
@@ -636,8 +574,6 @@ function iter_impl_generics_only.iter_repeat() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -689,18 +625,14 @@ function iter_impl_generics_only.iter_some_every_find() -> bool {
     virtual_call nargs=2 ntypeargs=1
     store_var found
     load_var some_large
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var every_small
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var found
     load_const 2
     call baml.ops.equals_equals
 
-  L1:
+  L0:
     return
 }
 
@@ -713,13 +645,9 @@ function iter_impl_generics_only.iter_step_by() -> int[] {
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "step_by"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
     load_type iter_impl_generics_only.core.Iterator<int, never>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -730,7 +658,5 @@ function iter_impl_generics_only.out_of_body_inferred_ctor_dispatch() -> int {
     load_type iter_impl_generics_only.core.OutOfBodyValue<int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_impl_generics_only/ns_core/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_impl_generics_only/ns_core/bytecode.snap
@@ -17,10 +17,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.ArrayI
     load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     copy 0
     load_field .idx
@@ -28,12 +25,12 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.ArrayI
     bin_op +
     store_field .idx
     load_var _2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     alloc_instance user.iter_impl_generics_only.core.Done
 
-  L2:
+  L1:
     return
 }
 
@@ -45,36 +42,32 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Chain<
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Chain<#0, #1> as user.iter_impl_generics_only.core.Iterator<#0, #1>)>.next(self: iter_impl_generics_only.core.Chain<#0, #1>) -> #0 | iter_impl_generics_only.core.Done {
     load_var self
     load_field .first_done
-    unary_op !
-    pop_jump_if_false L2
+    pop_jump_if_true L1
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_var _3
+    jump L2
 
   L0:
-    load_var _4
-    jump L3
-
-  L1:
     load_var self
     load_const true
     store_field .first_done
 
-  L2:
+  L1:
     load_var self
     load_field .other
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
 
-  L3:
+  L2:
     return
 }
 
@@ -85,15 +78,6 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter
 
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter<#0, #1, #2> as user.iter_impl_generics_only.core.Iterator<#0, #1 | #2>)>.next(self: iter_impl_generics_only.core.Filter<#0, #1, #2>) -> #0 | iter_impl_generics_only.core.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance user.iter_impl_generics_only.core.Done
-    jump L5
-
-  L2:
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
@@ -102,10 +86,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter
     store_var _2
     load_var _2
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var _2
     store_var_load_var x
     load_var self
@@ -113,12 +94,12 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter
     call_indirect
     pop_jump_if_false L0
     load_var x
-    jump L5
+    jump L2
 
-  L4:
+  L1:
     alloc_instance user.iter_impl_generics_only.core.Done
 
-  L5:
+  L2:
     return
 }
 
@@ -129,15 +110,6 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter
 
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FilterMap<#0, #1, #2, #3> as user.iter_impl_generics_only.core.Iterator<#1, #2 | #3>)>.next(self: iter_impl_generics_only.core.FilterMap<#0, #1, #2, #3>) -> #1 | iter_impl_generics_only.core.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance user.iter_impl_generics_only.core.Done
-    jump L6
-
-  L2:
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #2>
@@ -146,10 +118,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter
     store_var _2
     load_var _2
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L3
-    jump L5
-
-  L3:
+    pop_jump_if_true L1
     load_var2 2 1
     load_field .func
     call_indirect
@@ -157,17 +126,14 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Filter
     load_var _6
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L0
-
-  L4:
+    pop_jump_if_true L0
     load_var _6
-    jump L6
+    jump L2
 
-  L5:
+  L1:
     alloc_instance user.iter_impl_generics_only.core.Done
 
-  L6:
+  L2:
     return
 }
 
@@ -178,15 +144,6 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FlatMa
 
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FlatMap<#0, #1, #2, #3, #4> as user.iter_impl_generics_only.core.Iterator<#1, #2 | #3 | #4>)>.next(self: iter_impl_generics_only.core.FlatMap<#0, #1, #2, #3, #4>) -> #1 | iter_impl_generics_only.core.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance user.iter_impl_generics_only.core.Done
-    jump L8
-
-  L2:
     load_var self
     load_field .inner
     store_var _2
@@ -194,13 +151,10 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FlatMa
     store_var _3
     load_var _3
     narrow_bind iter_impl_generics_only.core.Iterator<#1, #4>, slot=3
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L2
     load_var _2
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L10
+    pop_jump_if_false L5
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #2>
@@ -209,10 +163,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FlatMa
     store_var _9
     load_var _9
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_var2 5 1
     load_field .func
     call_indirect
@@ -224,11 +175,11 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FlatMa
     store_field .inner
     jump L0
 
-  L5:
+  L1:
     alloc_instance user.iter_impl_generics_only.core.Done
-    jump L8
+    jump L3
 
-  L6:
+  L2:
     load_var _3
     load_type iter_impl_generics_only.core.Iterator<#1, #4>
     load_const "next"
@@ -236,22 +187,19 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.FlatMa
     store_var _5
     load_var _5
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L7
-    jump L9
-
-  L7:
+    pop_jump_if_true L4
     load_var _5
 
-  L8:
+  L3:
     return
 
-  L9:
+  L4:
     load_var self
     alloc_instance user.iter_impl_generics_only.core.Done
     store_field .inner
     jump L0
 
-  L10:
+  L5:
     unreachable
 }
 
@@ -262,15 +210,6 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Flatte
 
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Flatten<#0, #1, #2> as user.iter_impl_generics_only.core.Iterator<#0, #1 | #2>)>.next(self: iter_impl_generics_only.core.Flatten<#0, #1, #2>) -> #0 | iter_impl_generics_only.core.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance user.iter_impl_generics_only.core.Done
-    jump L8
-
-  L2:
     load_var self
     load_field .inner
     store_var _2
@@ -278,13 +217,10 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Flatte
     store_var _3
     load_var _3
     narrow_bind iter_impl_generics_only.core.Iterator<#0, #2>, slot=3
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L2
     load_var _2
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L10
+    pop_jump_if_false L5
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<iter_impl_generics_only.core.Iterable<#0, #2>, #1>
@@ -293,10 +229,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Flatte
     store_var _9
     load_var _9
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_var _9
     load_type iter_impl_generics_only.core.Iterable<#0, #2>
     load_const "iter"
@@ -306,11 +239,11 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Flatte
     store_field .inner
     jump L0
 
-  L5:
+  L1:
     alloc_instance user.iter_impl_generics_only.core.Done
-    jump L8
+    jump L3
 
-  L6:
+  L2:
     load_var _3
     load_type iter_impl_generics_only.core.Iterator<#0, #2>
     load_const "next"
@@ -318,22 +251,19 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Flatte
     store_var _5
     load_var _5
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L7
-    jump L9
-
-  L7:
+    pop_jump_if_true L4
     load_var _5
 
-  L8:
+  L3:
     return
 
-  L9:
+  L4:
     load_var self
     alloc_instance user.iter_impl_generics_only.core.Done
     store_field .inner
     jump L0
 
-  L10:
+  L5:
     unreachable
 }
 
@@ -351,19 +281,16 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Map<#0
     store_var _2
     load_var _2
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var2 2 1
     load_field .func
     call_indirect
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     alloc_instance user.iter_impl_generics_only.core.Done
 
-  L2:
+  L1:
     return
 }
 
@@ -381,18 +308,15 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Peekab
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Peekable<#0, #1> as user.iter_impl_generics_only.core.Iterator<#0, #1>)>.next(self: iter_impl_generics_only.core.Peekable<#0, #1>) -> #0 | iter_impl_generics_only.core.Done {
     load_var self
     load_field .has_buffer
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var self
     load_field .buffer
     store_var v
@@ -404,7 +328,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Peekab
     store_field .has_buffer
     load_var v
 
-  L2:
+  L1:
     return
 }
 
@@ -419,14 +343,11 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Range 
     load_var self
     load_field .max
     cmp_int_op <
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    alloc_instance user.iter_impl_generics_only.core.Done
     jump L1
 
   L0:
-    alloc_instance user.iter_impl_generics_only.core.Done
-    jump L2
-
-  L1:
     load_var self
     load_field .i
     store_var cur
@@ -439,7 +360,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Range 
     store_field .i
     load_var cur
 
-  L2:
+  L1:
     return
 }
 
@@ -453,22 +374,16 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Repeat
     load_field .count
     load_const 0
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    alloc_instance user.iter_impl_generics_only.core.Done
     jump L2
 
-  L1:
-    alloc_instance user.iter_impl_generics_only.core.Done
-    jump L4
-
-  L2:
+  L0:
     load_var self
     copy 0
     load_field .count
@@ -477,13 +392,13 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.Repeat
     store_field .count
     load_var self
     load_field .value
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var self
     load_field .value
 
-  L4:
+  L2:
     return
 }
 
@@ -495,54 +410,43 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.StepBy
 function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.StepBy<#0, #1> as user.iter_impl_generics_only.core.Iterator<#0, #1>)>.next(self: iter_impl_generics_only.core.StepBy<#0, #1>) -> #0 | iter_impl_generics_only.core.Done {
     load_var self
     load_field .first
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_const 0
     store_var i
 
-  L1:
+  L0:
     load_var2 2 1
     load_field .n
     load_const 1
     sub_int
     cmp_int_op <
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    jump L7
+    jump L4
 
-  L3:
+  L1:
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _9
-    load_var _9
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L1
+    jump L0
 
-  L5:
+  L2:
     alloc_instance user.iter_impl_generics_only.core.Done
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_var self
     load_const false
     store_field .first
@@ -552,7 +456,7 @@ function iter_impl_generics_only.core.<(user.iter_impl_generics_only.core.StepBy
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
 
-  L7:
+  L4:
     return
 }
 
@@ -586,8 +490,6 @@ function iter_impl_generics_only.core.Iterator.collect(self: iter_impl_generics_
     store_var r
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type iter_impl_generics_only.core.Iterator<#1, #2>
     load_const "next"
@@ -595,17 +497,14 @@ function iter_impl_generics_only.core.Iterator.collect(self: iter_impl_generics_
     store_var _4
     load_var _4
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type #1
     load_var2 2 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var r
     return
 }
@@ -615,34 +514,25 @@ function iter_impl_generics_only.core.Iterator.count(self: iter_impl_generics_on
     store_var n
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type iter_impl_generics_only.core.Iterator<#1, #2>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var n
     load_const 1
     add_int
     store_var n
     jump L0
 
-  L2:
+  L1:
     load_var n
     return
 }
 
 function iter_impl_generics_only.core.Iterator.every(self: iter_impl_generics_only.core.Iterator<#1, #2>, predicate: (#1) -> bool throws #3) -> bool {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type iter_impl_generics_only.core.Iterator<#1, #2>
     load_const "next"
@@ -650,21 +540,17 @@ function iter_impl_generics_only.core.Iterator.every(self: iter_impl_generics_on
     store_var _3
     load_var _3
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_var2 3 2
+    call_indirect
+    pop_jump_if_true L0
+    load_const false
     jump L2
 
   L1:
-    load_var2 3 2
-    call_indirect
-    unary_op !
-    pop_jump_if_false L0
-    load_const false
-    jump L3
-
-  L2:
     load_const true
 
-  L3:
+  L2:
     return
 }
 
@@ -689,8 +575,6 @@ function iter_impl_generics_only.core.Iterator.filter_map(self: iter_impl_generi
 
 function iter_impl_generics_only.core.Iterator.find(self: iter_impl_generics_only.core.Iterator<#1, #2>, predicate: (#1) -> bool throws #3) -> #1 | null {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type iter_impl_generics_only.core.Iterator<#1, #2>
     load_const "next"
@@ -698,22 +582,19 @@ function iter_impl_generics_only.core.Iterator.find(self: iter_impl_generics_onl
     store_var _3
     load_var _3
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
     store_var_load_var x
     load_var predicate
     call_indirect
     pop_jump_if_false L0
     load_var x
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const null
 
-  L3:
+  L2:
     return
 }
 
@@ -754,8 +635,6 @@ function iter_impl_generics_only.core.Iterator.reduce(self: iter_impl_generics_o
     store_var acc
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type iter_impl_generics_only.core.Iterator<#1, #2>
     load_const "next"
@@ -763,25 +642,20 @@ function iter_impl_generics_only.core.Iterator.reduce(self: iter_impl_generics_o
     store_var _5
     load_var _5
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 4 5
     load_var fn
     call_indirect
     store_var acc
     jump L0
 
-  L2:
+  L1:
     load_var acc
     return
 }
 
 function iter_impl_generics_only.core.Iterator.some(self: iter_impl_generics_only.core.Iterator<#1, #2>, predicate: (#1) -> bool throws #3) -> bool {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type iter_impl_generics_only.core.Iterator<#1, #2>
     load_const "next"
@@ -789,20 +663,17 @@ function iter_impl_generics_only.core.Iterator.some(self: iter_impl_generics_onl
     store_var _3
     load_var _3
     is_type iter_impl_generics_only.core.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 3 2
     call_indirect
     pop_jump_if_false L0
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -825,10 +696,7 @@ function iter_impl_generics_only.core.OutOfBodyBox.new(value: #0) -> iter_impl_g
 function iter_impl_generics_only.core.Peekable.peek(self: iter_impl_generics_only.core.Peekable<#0, #1>) -> #0 | iter_impl_generics_only.core.Done {
     load_var self
     load_field .has_buffer
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .iter
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
@@ -841,13 +709,13 @@ function iter_impl_generics_only.core.Peekable.peek(self: iter_impl_generics_onl
     load_const true
     store_field .has_buffer
     load_var v
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var self
     load_field .buffer
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_alias/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_alias/bytecode.snap
@@ -83,18 +83,15 @@ function json_alias.json_array_len() -> int {
     store_var _2
     load_var _2
     narrow_bind baml.json.json[], slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _2
     container_len
 
-  L2:
+  L1:
     return
 }
 
@@ -107,14 +104,11 @@ function json_alias.json_map_has_key() -> bool {
     store_var _2
     load_var _2
     narrow_bind map<string, baml.json.json>, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_var _2
     container_len
     store_var _4
@@ -122,7 +116,7 @@ function json_alias.json_map_has_key() -> bool {
     load_const 1
     cmp_int_op ==
 
-  L2:
+  L1:
     return
 }
 
@@ -133,8 +127,6 @@ function json_alias.json_wrap_tag() -> string {
     load_type json_alias.JsonTagged
     load_const "tag"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -142,76 +134,58 @@ function json_alias.match_json(j: baml.json.json) -> string {
     load_var j
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L11
-
-  L0:
+    pop_jump_if_true L5
     load_var j
     store_var _3
     load_var _3
     narrow_bind bool, slot=2
-    pop_jump_if_false L1
-    jump L10
-
-  L1:
+    pop_jump_if_true L4
     load_var j
     store_var _4
     load_var _4
     narrow_bind int, slot=3
-    pop_jump_if_false L2
-    jump L9
-
-  L2:
+    pop_jump_if_true L3
     load_var j
     store_var _5
     load_var _5
     narrow_bind float, slot=4
-    pop_jump_if_false L3
-    jump L8
-
-  L3:
+    pop_jump_if_true L2
     load_var j
     store_var _6
     load_var _6
     narrow_bind string, slot=5
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L1
     load_var j
     store_var _7
     load_var _7
     narrow_bind baml.json.json[], slot=6
-    pop_jump_if_false L5
+    pop_jump_if_true L0
+    load_const "map"
+    jump L6
+
+  L0:
+    load_const "array"
+    jump L6
+
+  L1:
+    load_const "string"
+    jump L6
+
+  L2:
+    load_const "float"
+    jump L6
+
+  L3:
+    load_const "int"
+    jump L6
+
+  L4:
+    load_const "bool"
     jump L6
 
   L5:
-    load_const "map"
-    jump L12
-
-  L6:
-    load_const "array"
-    jump L12
-
-  L7:
-    load_const "string"
-    jump L12
-
-  L8:
-    load_const "float"
-    jump L12
-
-  L9:
-    load_const "int"
-    jump L12
-
-  L10:
-    load_const "bool"
-    jump L12
-
-  L11:
     load_const "null"
 
-  L12:
+  L6:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_auto_derive/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_auto_derive/bytecode.snap
@@ -431,17 +431,14 @@ function json_auto_derive.alias_chain_dispatch_to_json_val() -> int {
     store_var _3
     load_var _3
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _3
 
-  L2:
+  L1:
     return
 }
 
@@ -533,17 +530,14 @@ function json_auto_derive.from_json_wrapper_body_fallback_val() -> int {
     store_var _6
     load_var _6
     narrow_bind int, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _6
 
-  L2:
+  L1:
     return
 }
 
@@ -839,18 +833,15 @@ function json_auto_derive.optional_class_override_non_null_val() -> int {
     store_var_load_var _5
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var _5
+    load_field .y
     jump L1
 
   L0:
-    load_var _5
-    load_field .y
-    jump L2
-
-  L1:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -865,18 +856,15 @@ function json_auto_derive.optional_class_override_null_val() -> int {
     store_var_load_var _5
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var _5
+    load_field .y
     jump L1
 
   L0:
-    load_var _5
-    load_field .y
-    jump L2
-
-  L1:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -900,37 +888,31 @@ function json_auto_derive.optional_primitive_field_from_json_sum() -> int {
     store_var_load_var _10
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var _10
+    store_var v1
     jump L1
 
   L0:
-    load_var _10
-    store_var v1
-    jump L2
-
-  L1:
     load_const -1
     store_var v1
 
-  L2:
+  L1:
     load_var c2
     load_field .x
     store_var_load_var _14
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _14
     store_var v2
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const -1
     store_var v2
 
-  L5:
+  L3:
     load_var2 5 7
     add_int
     return
@@ -1006,8 +988,6 @@ function json_auto_derive.round_trip_with_overrides_both_directions_val() -> str
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var json_val
-    load_var json_val
     call baml.json.stringify
     call baml.json.parse
     store_var parsed_json
@@ -1062,7 +1042,5 @@ function json_auto_derive.user_to_json_override_result() -> baml.json.json {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_parse_stringify/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_parse_stringify/bytecode.snap
@@ -68,18 +68,15 @@ function json_parse_stringify.parse_array_len() -> int {
     store_var _2
     load_var _2
     narrow_bind baml.json.json[], slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _2
     container_len
 
-  L2:
+  L1:
     return
 }
 
@@ -89,17 +86,14 @@ function json_parse_stringify.parse_is_float() -> bool {
     store_var _2
     load_var _2
     narrow_bind float, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -109,17 +103,14 @@ function json_parse_stringify.parse_is_int() -> bool {
     store_var _2
     load_var _2
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -129,18 +120,15 @@ function json_parse_stringify.parse_then_match_array_len() -> int {
     store_var _2
     load_var _2
     narrow_bind baml.json.json[], slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _2
     container_len
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_to_from_string/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_json_to_from_string/bytecode.snap
@@ -222,31 +222,28 @@ function json_to_from_string.check_decode_error_path_contains_field() -> bool {
     load_const "{\"inner\":{}}"
     call baml.json.from_string
     store_var u
-    jump L2
+    jump L1
     load_var e
     store_var _4
     load_var _4
     narrow_bind baml.json.DecodeError, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _4
     load_field .path
     load_const ".inner.value"
     call assert.contains
     pop 1
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -334,17 +331,14 @@ function json_to_from_string.from_string_json_passthrough_int_match() -> bool {
     store_var _3
     load_var _3
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -355,18 +349,15 @@ function json_to_from_string.from_string_json_passthrough_object_len() -> int {
     store_var _3
     load_var _3
     narrow_bind map<string, baml.json.json>, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var _3
     container_len
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_lambdas/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_lambdas/bytecode.snap
@@ -275,30 +275,24 @@ function lambdas.lambda_contextual_call(cb: (int) -> int throws int | string) ->
 function lambdas.lambda_contextual_main() -> int {
     make_closure .<lambda(lambda_contextual_main, 0)>, 0
     call user.lambdas.lambda_contextual_call
-    jump L4
+    jump L2
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const 2
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
@@ -330,20 +324,17 @@ function lambdas.lambda_effect_main() -> int {
     load_type string
     load_const user.lambdas.lambda_effect_fail
     call user.lambdas.lambda_effect_forward
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -375,8 +366,6 @@ function lambdas.lambdas_callback_return_name(callback: (bool) -> #0 throws neve
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -432,16 +421,13 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 4 2
     call_indirect
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_deref ?1
     return
 }
@@ -508,22 +494,19 @@ function lambdas.lambdas_explicit_throwing_lambda_catches_error() -> int {
     load_const -1
     make_closure .<lambda(lambdas_explicit_throwing_lambda_catches_error, 0)>, 0
     call_indirect
-    jump L2
+    jump L1
     load_var e
     is_type "negative"
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const -2
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -582,8 +565,6 @@ function lambdas.lambdas_inferred_returns_join_with_tail() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -596,14 +577,12 @@ function lambdas.lambdas_inferred_signature() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_var sig
     load_field .errors
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
-    load_var _5
     load_const "/"
     bin_op +
     load_var _7
@@ -620,14 +599,12 @@ function lambdas.lambdas_inferred_throwing_signature() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_var sig
     load_field .errors
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
-    load_var _5
     load_const "/"
     bin_op +
     load_var _7

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_lexical_scoping/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_lexical_scoping/bytecode.snap
@@ -169,26 +169,23 @@ function lexical_scoping.capture_catch_arm_binding() -> string {
     make_cell
     store_var ?3
     call user.lexical_scoping.throw_string
-    jump L2
+    jump L1
     load_var e
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _2
     store_deref ?3
     load_var s
     make_closure .<lambda(capture_catch_arm_binding, 0)>, 1
     call_indirect
 
-  L2:
+  L1:
     return
 }
 
@@ -197,26 +194,23 @@ function lexical_scoping.capture_catch_clause_binding() -> string {
     make_cell
     store_var ?2
     call user.lexical_scoping.throw_string
-    jump L2
+    jump L1
     load_var _1
     store_deref ?2
     load_var _1
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _1
     rethrow
 
-  L1:
+  L0:
     load_var _1
     store_deref ?2
     load_var e
     make_closure .<lambda(capture_catch_clause_binding, 0)>, 1
     call_indirect
 
-  L2:
+  L1:
     return
 }
 
@@ -236,32 +230,26 @@ function lexical_scoping.catch_base_uses_outer_lambda() -> int {
     make_closure .<lambda(catch_base_uses_outer_lambda, 0)>, 0
     call_indirect
     call user.lexical_scoping.throw_string_arg
-    jump L2
+    jump L1
     load_var e
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var e
 
-  L2:
+  L1:
     is_type "base"
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_const 0
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const 3
 
-  L5:
+  L3:
     return
 }
 
@@ -291,16 +279,13 @@ function lexical_scoping.closure_parameter_in_for_iterable() -> int {
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     add_int
     store_var sum
     jump L0
 
-  L2:
+  L1:
     load_var sum
     return
 }
@@ -313,14 +298,11 @@ function lexical_scoping.closure_parameter_in_while_condition() -> int {
     load_var i
     make_closure .<lambda(closure_parameter_in_while_condition, 0)>, 0
     call_indirect
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var i
     return
 
-  L2:
+  L1:
     load_var i
     load_const 1
     add_int
@@ -346,44 +328,37 @@ function lexical_scoping.for_loop_restores_outer() -> int {
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
+    store_var _2
 
   L0:
-    load_var _3
+    load_var _2
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var _4
+    pop_jump_if_true L1
+    load_var _3
     store_var x
     jump L0
 
-  L2:
+  L1:
     load_const 1
     return
 }
 
 function lexical_scoping.initializer_uses_previous() -> int {
-    load_const 1
-    load_const 1
-    add_int
+    load_const 2
     return
 }
 
 function lexical_scoping.lambdas_capture_main() -> string {
     call user.lexical_scoping.capture_match_arm
-    store_var _4
     call user.lexical_scoping.capture_catch_clause_binding
     store_var _5
     call user.lexical_scoping.capture_catch_arm_binding
     store_var _6
-    load_var _4
     load_const ":"
     bin_op +
     load_var _5
@@ -397,17 +372,16 @@ function lexical_scoping.lambdas_capture_main() -> string {
 
 function lexical_scoping.match_and_catch_main() -> int {
     call user.lexical_scoping.match_post_match_restores_outer
-    store_var _2
     call user.lexical_scoping.match_later_arm_uses_outer
     store_var _4
-    load_var2 2 3
+    load_var _4
     load_const 100
     mul_int
     add_int
     store_var _1
     call user.lexical_scoping.catch_base_uses_outer_lambda
     store_var _6
-    load_var2 1 4
+    load_var2 1 3
     load_const 10000
     mul_int
     add_int
@@ -416,64 +390,49 @@ function lexical_scoping.match_and_catch_main() -> int {
 
 function lexical_scoping.match_later_arm_uses_outer() -> int {
     load_const "value"
-    store_var _3
-    load_var _3
+    store_var _1
+    load_var _1
     narrow_bind "specific", slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 20
     jump L1
 
   L0:
-    load_const 20
-    jump L2
-
-  L1:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 
 function lexical_scoping.match_post_match_restores_outer() -> int {
-    load_const 1
-    store_var x
     load_const 10
     return
 }
 
 function lexical_scoping.multi_clause_catch_main() -> int {
     call user.lexical_scoping.fail
-    jump L4
+    jump L2
     load_var _1
     is_type string
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _1
     is_type int
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _1
     rethrow
 
-  L2:
+  L0:
     load_var _1
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function lexical_scoping.nested_outer_restored() -> int {
-    load_const 2
-    store_var x
-    load_const 3
-    store_var x
     load_const 1
     return
 }
@@ -487,14 +446,11 @@ function lexical_scoping.rule1_while_no_leakage() -> int {
     load_const true
 
   L0:
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 1
     return
 
-  L2:
+  L1:
     load_const false
     jump L0
 }
@@ -507,16 +463,13 @@ function lexical_scoping.rule1_while_observed_inner_shadow() -> int {
 
   L0:
     load_var once
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 1
     load_var observed
     add_int
     return
 
-  L2:
+  L1:
     load_var observed
     load_const 99
     add_int
@@ -527,11 +480,7 @@ function lexical_scoping.rule1_while_observed_inner_shadow() -> int {
 }
 
 function lexical_scoping.rule2_block_outer_mutation_escapes() -> int {
-    load_const 1
-    store_var x
     load_const 2
-    store_var x
-    load_var x
     return
 }
 
@@ -551,28 +500,19 @@ function lexical_scoping.rule2_for_outer_mutation_escapes() -> int {
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 2
     store_var x
     jump L0
 
-  L2:
+  L1:
     load_var x
     return
 }
 
 function lexical_scoping.rule2_pre_shadow_mutation_escapes_post_shadow_does_not() -> int {
-    load_const 1
-    store_var x
     load_const 2
-    store_var x
-    load_var x
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_literal_pattern_membership/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_literal_pattern_membership/bytecode.snap
@@ -163,148 +163,63 @@ function literal_pattern_membership.$init_test_ns_literal_pattern_membership_lit
 function literal_pattern_membership.bigint_pattern(x: int | bigint) -> bool {
     load_var x
     is_type 1n
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function literal_pattern_membership.bool_pattern(x: int | bool) -> bool {
     load_var x
     is_type true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function literal_pattern_membership.int_pattern_over_bigint(x: int | bigint) -> bool {
     load_var x
     is_type 1
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function literal_pattern_membership.int_pattern_over_bool(x: int | bool) -> bool {
     load_var x
     is_type 1
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function literal_pattern_membership.string_pattern(x: string) -> int {
     load_var x
     is_type "go"
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var x
     is_type "stop"
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const 0
+    jump L2
+
+  L0:
+    load_const 2
     jump L2
 
   L1:
-    load_const 0
-    jump L4
-
-  L2:
-    load_const 2
-    jump L4
-
-  L3:
     load_const 1
 
-  L4:
+  L2:
     return
 }
 
 function literal_pattern_membership.via_alias(x: int) -> bool {
     load_var x
     is_type 1
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function literal_pattern_membership.via_guarded_match(x: int | float) -> bool {
     load_var x
     is_type 1
-    pop_jump_if_false L0
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function literal_pattern_membership.via_is(x: int | float) -> bool {
     load_var x
     is_type 1
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_maps/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_maps/bytecode.snap
@@ -320,15 +320,10 @@ function maps.map_clear_then_reuse_main() -> int {
     load_var m
     load_const "b"
     call baml.Map.get
-    store_var_load_var _11
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const -1
-    store_var _11
 
   L0:
-    load_var _11
     return
 }
 
@@ -399,15 +394,10 @@ function maps.map_delete_does_not_affect_other_keys_main() -> int {
     load_var m
     load_const "b"
     call baml.Map.get
-    store_var_load_var _11
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const -1
-    store_var _11
 
   L0:
-    load_var _11
     return
 }
 
@@ -485,15 +475,10 @@ function maps.map_get_or_insert_does_not_overwrite_main() -> int {
     load_var m
     load_const "k"
     call baml.Map.get
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const -1
-    store_var _8
 
   L0:
-    load_var _8
     return
 }
 
@@ -550,15 +535,10 @@ function maps.map_get_or_insert_persists_main() -> int {
     load_var m
     load_const "k"
     call baml.Map.get
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const -1
-    store_var _5
 
   L0:
-    load_var _5
     return
 }
 
@@ -760,15 +740,10 @@ function maps.map_set_then_get_main() -> int {
     load_var m
     load_const "a"
     call baml.Map.get
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const -1
-    store_var _8
 
   L0:
-    load_var _8
     return
 }
 
@@ -784,19 +759,16 @@ function maps.use_map_contains_helper() -> string {
     load_var map
     load_const "hello"
     call baml.Map.has
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "hi"
     jump L1
 
   L0:
-    load_const "hi"
-    jump L2
-
-  L1:
     load_var map
     load_const "hello"
     load_map_element
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_arm_break_continue/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_arm_break_continue/bytecode.snap
@@ -34,8 +34,6 @@ function match_arm_break_continue.countdown_sum(start: int) -> int {
     store_var i
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var i
     load_const 0
     cmp_int_op ==
@@ -69,14 +67,11 @@ function match_arm_break_continue.sum_1_to_5_skip_3() -> int {
     load_var i
     load_const 5
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var total
     return
 
-  L2:
+  L1:
     load_var i
     load_const 1
     add_int
@@ -84,10 +79,10 @@ function match_arm_break_continue.sum_1_to_5_skip_3() -> int {
     load_var i
     load_const 3
     cmp_int_op ==
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     jump L0
 
-  L3:
+  L2:
     load_var i
     store_var add
     load_var2 1 3
@@ -103,8 +98,6 @@ function match_arm_break_continue.sum_skip_three_break_at_six() -> int {
     store_var i
 
   L0:
-    load_const true
-    pop_jump_if_false L3
     load_var i
     load_const 1
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_basics/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_basics/bytecode.snap
@@ -322,9 +322,7 @@ function match_basics.catch_all_binding_with_int_patterns() -> int {
     jump_table [L4, L3, L2, L1], default L0
 
   L0:
-    load_const 99
-    load_const 10
-    mul_int
+    load_const 990
     jump L5
 
   L1: 3
@@ -347,26 +345,21 @@ function match_basics.catch_all_binding_with_int_patterns() -> int {
 }
 
 function match_basics.catch_all_with_variable() -> int {
-    load_const 42
-    load_const 1
-    add_int
+    load_const 43
     return
 }
 
 function match_basics.check_bool(flag: bool) -> string {
     load_var flag
     is_type true
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no"
     jump L1
 
   L0:
-    load_const "no"
-    jump L2
-
-  L1:
     load_const "yes"
 
-  L2:
+  L1:
     return
 }
 
@@ -423,148 +416,112 @@ function match_basics.classify_dense(n: int) -> int {
 function match_basics.classify_string(s: string) -> int {
     load_var s
     is_type "hello"
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var s
     is_type "world"
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const 0
+    jump L2
+
+  L0:
+    load_const 200
     jump L2
 
   L1:
-    load_const 0
-    jump L4
-
-  L2:
-    load_const 200
-    jump L4
-
-  L3:
     load_const 100
 
-  L4:
+  L2:
     return
 }
 
 function match_basics.classify_string_four_arms(s: string) -> int {
     load_var s
     is_type "a"
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var s
     is_type "b"
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var s
     is_type "c"
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var s
     is_type "d"
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const 0
+    jump L4
+
+  L0:
+    load_const 4
+    jump L4
+
+  L1:
+    load_const 3
+    jump L4
+
+  L2:
+    load_const 2
     jump L4
 
   L3:
-    load_const 0
-    jump L8
-
-  L4:
-    load_const 4
-    jump L8
-
-  L5:
-    load_const 3
-    jump L8
-
-  L6:
-    load_const 2
-    jump L8
-
-  L7:
     load_const 1
 
-  L8:
+  L4:
     return
 }
 
 function match_basics.classify_string_many(s: string) -> int {
     load_var s
     is_type "alpha"
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var s
     is_type "beta"
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var s
     is_type "gamma"
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var s
     is_type "delta"
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const 0
+    jump L4
+
+  L0:
+    load_const 4
+    jump L4
+
+  L1:
+    load_const 3
+    jump L4
+
+  L2:
+    load_const 2
     jump L4
 
   L3:
-    load_const 0
-    jump L8
-
-  L4:
-    load_const 4
-    jump L8
-
-  L5:
-    load_const 3
-    jump L8
-
-  L6:
-    load_const 2
-    jump L8
-
-  L7:
     load_const 1
 
-  L8:
+  L4:
     return
 }
 
 function match_basics.classify_string_typed_fallback(s: string) -> int {
     load_var s
     is_type "ok"
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var s
     is_type "error"
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const 0
+    jump L2
+
+  L0:
+    load_const 500
     jump L2
 
   L1:
-    load_const 0
-    jump L4
-
-  L2:
-    load_const 500
-    jump L4
-
-  L3:
     load_const 200
 
-  L4:
+  L2:
     return
 }
 
@@ -652,34 +609,28 @@ function match_basics.helper_42() -> int {
 function match_basics.literal_bool_false() -> string {
     load_const false
     is_type true
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no"
     jump L1
 
   L0:
-    load_const "no"
-    jump L2
-
-  L1:
     load_const "yes"
 
-  L2:
+  L1:
     return
 }
 
 function match_basics.literal_bool_true() -> string {
     load_const true
     is_type true
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "no"
     jump L1
 
   L0:
-    load_const "no"
-    jump L2
-
-  L1:
     load_const "yes"
 
-  L2:
+  L1:
     return
 }
 
@@ -785,44 +736,41 @@ function match_basics.match_in_loop_helper() -> int {
     load_var i
     load_const 5
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var sum
     return
 
-  L2:
+  L1:
     load_var sum
     store_var _5
     load_var i
-    jump_table [L7, L6, L5, L4], default L3
+    jump_table [L6, L5, L4, L3], default L2
 
-  L3:
+  L2:
     load_const 50
     store_var _6
-    jump L8
+    jump L7
 
-  L4: 3
+  L3: 3
     load_const 40
     store_var _6
-    jump L8
+    jump L7
 
-  L5: 2
+  L4: 2
     load_const 30
     store_var _6
-    jump L8
+    jump L7
 
-  L6: 1
+  L5: 1
     load_const 20
     store_var _6
-    jump L8
+    jump L7
 
-  L7: 0
+  L6: 0
     load_const 10
     store_var _6
 
-  L8:
+  L7:
     load_var2 3 4
     bin_op +
     store_var sum
@@ -964,17 +912,14 @@ function match_basics.process_optional(x: int | null) -> string {
     load_var x
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "some"
     jump L1
 
   L0:
-    load_const "some"
-    jump L2
-
-  L1:
     load_const "none"
 
-  L2:
+  L1:
     return
 }
 
@@ -982,27 +927,21 @@ function match_basics.process_optional_with_zero(x: int | null) -> string {
     load_var x
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var x
     is_type 0
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "other"
+    jump L2
+
+  L0:
+    load_const "zero"
     jump L2
 
   L1:
-    load_const "other"
-    jump L4
-
-  L2:
-    load_const "zero"
-    jump L4
-
-  L3:
     load_const "none"
 
-  L4:
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_container_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_container_types/bytecode.snap
@@ -157,8 +157,7 @@ function match_container_types.classify_list(x: int[] | string[]) -> string {
     store_var_load_var _4
     load_const 0
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const "strings"
@@ -176,17 +175,14 @@ function match_container_types.classify_map(x: map<string, int> | map<string, st
     store_var _2
     load_var _2
     narrow_bind map<string, int>, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "string values"
     jump L1
 
   L0:
-    load_const "string values"
-    jump L2
-
-  L1:
     load_const "int values"
 
-  L2:
+  L1:
     return
 }
 
@@ -214,53 +210,41 @@ function match_container_types.classify_switch(x: int[] | string[] | int | strin
     store_var _2
     load_var _2
     narrow_bind int[], slot=2
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var x
     store_var _3
     load_var _3
     narrow_bind string[], slot=3
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var x
     store_var _4
     load_var _4
     narrow_bind int, slot=4
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var x
     store_var _5
     load_var _5
     narrow_bind string, slot=5
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const "bool"
+    jump L4
+
+  L0:
+    load_const "string"
+    jump L4
+
+  L1:
+    load_const "int"
+    jump L4
+
+  L2:
+    load_const "strings"
     jump L4
 
   L3:
-    load_const "bool"
-    jump L8
-
-  L4:
-    load_const "string"
-    jump L8
-
-  L5:
-    load_const "int"
-    jump L8
-
-  L6:
-    load_const "strings"
-    jump L8
-
-  L7:
     load_const "ints"
 
-  L8:
+  L4:
     return
 }
 
@@ -294,17 +278,14 @@ function match_container_types.classify_union_element(u: (int | string)[] | int[
     store_var _2
     load_var _2
     narrow_bind int[], slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "mixed"
     jump L1
 
   L0:
-    load_const "mixed"
-    jump L2
-
-  L1:
     load_const "ints"
 
-  L2:
+  L1:
     return
 }
 
@@ -313,17 +294,14 @@ function match_container_types.classify_union_element_mixed_first(u: (int | stri
     store_var _2
     load_var _2
     narrow_bind (int | string)[], slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "ints"
     jump L1
 
   L0:
-    load_const "ints"
-    jump L2
-
-  L1:
     load_const "mixed"
 
-  L2:
+  L1:
     return
 }
 
@@ -332,17 +310,14 @@ function match_container_types.classify_unknown_vs_int(u: unknown[] | int[]) -> 
     store_var _2
     load_var _2
     narrow_bind unknown[], slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "ints"
     jump L1
 
   L0:
-    load_const "ints"
-    jump L2
-
-  L1:
     load_const "unknowns"
 
-  L2:
+  L1:
     return
 }
 
@@ -353,17 +328,6 @@ function match_container_types.int_list_is_int_array_fn() -> bool {
     load_type int
     alloc_array 3
     is_type int[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -373,17 +337,6 @@ function match_container_types.int_list_is_not_unknown_list_fn() -> bool {
     load_type int
     alloc_array 2
     is_type unknown[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -420,17 +373,6 @@ function match_container_types.string_list_is_int_array_fn() -> bool {
     load_type string
     alloc_array 2
     is_type int[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -467,16 +409,5 @@ function match_container_types.unknown_list_is_unknown_list_fn() -> bool {
     load_type unknown
     alloc_array 2
     is_type unknown[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_enum_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_enum_types/bytecode.snap
@@ -53,17 +53,14 @@ function match_enum_types.classify(x: match_enum_types.Color | match_enum_types.
     store_var _2
     load_var _2
     narrow_bind match_enum_types.Color, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "status"
     jump L1
 
   L0:
-    load_const "status"
-    jump L2
-
-  L1:
     load_const "color"
 
-  L2:
+  L1:
     return
 }
 
@@ -79,41 +76,32 @@ function match_enum_types.classify_one_enum(x: match_enum_types.Color | int | st
     store_var _2
     load_var _2
     narrow_bind match_enum_types.Color, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var x
     store_var _3
     load_var _3
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     store_var _4
     load_var _4
     narrow_bind string, slot=4
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "bool"
+    jump L3
+
+  L0:
+    load_const "string"
+    jump L3
+
+  L1:
+    load_const "int"
     jump L3
 
   L2:
-    load_const "bool"
-    jump L6
-
-  L3:
-    load_const "string"
-    jump L6
-
-  L4:
-    load_const "int"
-    jump L6
-
-  L5:
     load_const "color"
 
-  L6:
+  L3:
     return
 }
 
@@ -136,53 +124,41 @@ function match_enum_types.classify_switch(x: match_enum_types.Color | match_enum
     store_var _2
     load_var _2
     narrow_bind match_enum_types.Color, slot=2
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var x
     store_var _3
     load_var _3
     narrow_bind match_enum_types.Status, slot=3
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var x
     store_var _4
     load_var _4
     narrow_bind int, slot=4
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var x
     store_var _5
     load_var _5
     narrow_bind string, slot=5
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const "bool"
+    jump L4
+
+  L0:
+    load_const "string"
+    jump L4
+
+  L1:
+    load_const "int"
+    jump L4
+
+  L2:
+    load_const "status"
     jump L4
 
   L3:
-    load_const "bool"
-    jump L8
-
-  L4:
-    load_const "string"
-    jump L8
-
-  L5:
-    load_const "int"
-    jump L8
-
-  L6:
-    load_const "status"
-    jump L8
-
-  L7:
     load_const "color"
 
-  L8:
+  L4:
     return
 }
 
@@ -203,16 +179,5 @@ function match_enum_types.status_is_color_fn() -> bool {
     load_const user.match_enum_types.Status.Active
     alloc_variant user.match_enum_types.Status
     is_type match_enum_types.Color
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_self_workaround/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_self_workaround/bytecode.snap
@@ -72,17 +72,6 @@ function match_self_workaround.$init_test_ns_match_self_workaround_match_self_wo
 function match_self_workaround.BoxG.is_own_instantiation(self: match_self_workaround.BoxG<#0>, other: unknown) -> bool {
     load_var other
     is_type match_self_workaround.BoxG<...>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -91,34 +80,20 @@ function match_self_workaround.BoxG.same_box(self: match_self_workaround.BoxG<#0
     store_var _3
     load_var _3
     narrow_bind match_self_workaround.BoxG<...>, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "box"
 
-  L2:
+  L1:
     return
 }
 
 function match_self_workaround.Shape.is_shape(self: match_self_workaround.Shape, other: match_self_workaround.Shape | int) -> bool {
     load_var other
     is_type match_self_workaround.Shape
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -127,17 +102,14 @@ function match_self_workaround.Shape.same_kind(self: match_self_workaround.Shape
     store_var _3
     load_var _3
     narrow_bind match_self_workaround.Shape, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "shape"
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_types/bytecode.snap
@@ -242,24 +242,21 @@ function match_types.classify_all_guarded(x: int, flag: bool) -> string {
     is_type 0
     pop_jump_if_false L0
     load_var flag
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L5
 
   L0:
     load_var x
     is_type 1
     pop_jump_if_false L1
     load_var flag
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L4
 
   L1:
     load_var x
     is_type 2
     pop_jump_if_false L2
     load_var flag
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L3
 
   L2:
     load_const "fallback"
@@ -285,38 +282,32 @@ function match_types.classify_animal(animal: match_types.Cat | match_types.Dog |
     store_var _2
     load_var _2
     narrow_bind match_types.Cat, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var animal
     store_var _5
     load_var _5
     narrow_bind match_types.Dog, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const "bird: "
     load_var animal
     load_field .name
     bin_op +
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_const "dog: "
     load_var _5
     load_field .name
     bin_op +
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "cat: "
     load_var _2
     load_field .name
     bin_op +
 
-  L4:
+  L2:
     return
 }
 
@@ -325,35 +316,29 @@ function match_types.classify_animal_wildcard(animal: match_types.Cat | match_ty
     store_var _2
     load_var _2
     narrow_bind match_types.Cat, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var animal
     store_var _5
     load_var _5
     narrow_bind match_types.Dog, slot=3
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "other"
     jump L2
 
-  L1:
-    load_const "other"
-    jump L4
-
-  L2:
+  L0:
     load_const "dog: "
     load_var _5
     load_field .name
     bin_op +
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "cat: "
     load_var _2
     load_field .name
     bin_op +
 
-  L4:
+  L2:
     return
 }
 
@@ -367,29 +352,25 @@ function match_types.classify_guard_on_typed_field(result: match_types.Success |
     load_field .data
     load_const ""
     cmp_op !=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L2
 
   L0:
     load_var result
     store_var _6
     load_var _6
     narrow_bind match_types.Success, slot=3
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+    load_const "failure"
+    jump L3
 
   L1:
-    load_const "failure"
-    jump L4
+    load_const "empty success"
+    jump L3
 
   L2:
-    load_const "empty success"
-    jump L4
-
-  L3:
     load_const "success with data"
 
-  L4:
+  L3:
     return
 }
 
@@ -398,37 +379,30 @@ function match_types.classify_guarded_int(x: int, flag: bool) -> string {
     is_type 1
     pop_jump_if_false L0
     load_var flag
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L3
 
   L0:
     load_var x
     is_type 1
-    pop_jump_if_false L1
+    pop_jump_if_true L2
+    load_var x
+    is_type 2
+    pop_jump_if_true L1
+    load_const "other"
     jump L4
 
   L1:
-    load_var x
-    is_type 2
-    pop_jump_if_false L2
-    jump L3
+    load_const "two"
+    jump L4
 
   L2:
-    load_const "other"
-    jump L6
+    load_const "one without flag"
+    jump L4
 
   L3:
-    load_const "two"
-    jump L6
-
-  L4:
-    load_const "one without flag"
-    jump L6
-
-  L5:
     load_const "one with flag"
 
-  L6:
+  L4:
     return
 }
 
@@ -437,70 +411,57 @@ function match_types.classify_mixed_class_primitive(x: match_types.MyClass | int
     store_var _2
     load_var _2
     narrow_bind match_types.MyClass, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var x
     store_var _3
     load_var _3
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     store_var _4
     load_var _4
     narrow_bind string, slot=4
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "bool"
+    jump L3
+
+  L0:
+    load_const "string"
+    jump L3
+
+  L1:
+    load_const "int"
     jump L3
 
   L2:
-    load_const "bool"
-    jump L6
-
-  L3:
-    load_const "string"
-    jump L6
-
-  L4:
-    load_const "int"
-    jump L6
-
-  L5:
     load_const "class"
 
-  L6:
+  L3:
     return
 }
 
 function match_types.classify_mixed_lit_typed_guard(x: int, flag: bool) -> string {
     load_var x
     is_type 0
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L2
     load_var x
     is_type 1
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var flag
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+
+  L0:
+    load_const "other int"
+    jump L3
 
   L1:
-    load_const "other int"
-    jump L4
+    load_const "one with flag"
+    jump L3
 
   L2:
-    load_const "one with flag"
-    jump L4
-
-  L3:
     load_const "zero"
 
-  L4:
+  L3:
     return
 }
 
@@ -509,29 +470,23 @@ function match_types.classify_null_with_class(x: match_types.Cat | match_types.D
     store_var _2
     load_var _2
     narrow_bind match_types.Cat, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var x
     store_var _3
     load_var _3
     narrow_bind match_types.Dog, slot=3
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const "nothing"
+    jump L2
+
+  L0:
+    load_const "dog"
     jump L2
 
   L1:
-    load_const "nothing"
-    jump L4
-
-  L2:
-    load_const "dog"
-    jump L4
-
-  L3:
     load_const "cat"
 
-  L4:
+  L2:
     return
 }
 
@@ -540,17 +495,14 @@ function match_types.classify_nullable_status(s: match_types.Status | null) -> s
     load_const user.match_types.Status.Active
     alloc_variant user.match_types.Status
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "active"
 
-  L2:
+  L1:
     return
 }
 
@@ -591,8 +543,7 @@ function match_types.classify_result_guarded(result: match_types.SuccessCode | m
     load_field .code
     load_const 200
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L4
 
   L0:
     load_var result
@@ -601,33 +552,29 @@ function match_types.classify_result_guarded(result: match_types.SuccessCode | m
     narrow_bind match_types.SuccessCode, slot=4
     pop_jump_if_false L1
     load_var strict
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L3
 
   L1:
     load_var result
     store_var _8
     load_var _8
     narrow_bind match_types.SuccessCode, slot=5
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L2
+    load_const "failure"
+    jump L5
 
   L2:
-    load_const "failure"
-    jump L6
+    load_const "success"
+    jump L5
 
   L3:
-    load_const "success"
-    jump L6
+    load_const "strict success"
+    jump L5
 
   L4:
-    load_const "strict success"
-    jump L6
-
-  L5:
     load_const "redirect"
 
-  L6:
+  L5:
     return
 }
 
@@ -752,41 +699,32 @@ function match_types.describe_animal(animal: match_types.Cat | match_types.Dog |
     store_var _2
     load_var _2
     narrow_bind match_types.Cat, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var animal
     store_var _3
     load_var _3
     narrow_bind match_types.Dog, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var animal
     store_var _4
     load_var _4
     narrow_bind match_types.Bird, slot=4
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "fish"
+    jump L3
+
+  L0:
+    load_const "bird"
+    jump L3
+
+  L1:
+    load_const "dog"
     jump L3
 
   L2:
-    load_const "fish"
-    jump L6
-
-  L3:
-    load_const "bird"
-    jump L6
-
-  L4:
-    load_const "dog"
-    jump L6
-
-  L5:
     load_const "cat"
 
-  L6:
+  L3:
     return
 }
 
@@ -795,41 +733,32 @@ function match_types.describe_sparse(animal: match_types.Cat | match_types.Dog |
     store_var _2
     load_var _2
     narrow_bind match_types.Cat, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var animal
     store_var _3
     load_var _3
     narrow_bind match_types.Dog, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var animal
     store_var _4
     load_var _4
     narrow_bind match_types.Bird, slot=4
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "fish"
+    jump L3
+
+  L0:
+    load_const "bird"
+    jump L3
+
+  L1:
+    load_const "dog"
     jump L3
 
   L2:
-    load_const "fish"
-    jump L6
-
-  L3:
-    load_const "bird"
-    jump L6
-
-  L4:
-    load_const "dog"
-    jump L6
-
-  L5:
     load_const "cat"
 
-  L6:
+  L3:
     return
 }
 
@@ -838,17 +767,14 @@ function match_types.describe_two(animal: match_types.Cat | match_types.Dog) -> 
     store_var _2
     load_var _2
     narrow_bind match_types.Cat, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "dog"
     jump L1
 
   L0:
-    load_const "dog"
-    jump L2
-
-  L1:
     load_const "cat"
 
-  L2:
+  L1:
     return
 }
 
@@ -865,8 +791,7 @@ function match_types.guard_all_fail() -> string {
     load_field .value
     load_const 90
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var s
@@ -878,8 +803,7 @@ function match_types.guard_all_fail() -> string {
     load_field .value
     load_const 70
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const "needs work"
@@ -909,8 +833,7 @@ function match_types.guard_fallthrough() -> string {
     load_field .value
     load_const 90
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var s
@@ -922,8 +845,7 @@ function match_types.guard_fallthrough() -> string {
     load_field .value
     load_const 70
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const "needs work"
@@ -953,8 +875,7 @@ function match_types.guard_true() -> string {
     load_field .value
     load_const 90
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var s
@@ -966,8 +887,7 @@ function match_types.guard_true() -> string {
     load_field .value
     load_const 70
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const "needs work"
@@ -1003,41 +923,32 @@ function match_types.identify(x: int | string | bool | float) -> string {
     store_var _2
     load_var _2
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var x
     store_var _3
     load_var _3
     narrow_bind string, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     store_var _4
     load_var _4
     narrow_bind bool, slot=4
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "decimal"
+    jump L3
+
+  L0:
+    load_const "boolean"
+    jump L3
+
+  L1:
+    load_const "text"
     jump L3
 
   L2:
-    load_const "decimal"
-    jump L6
-
-  L3:
-    load_const "boolean"
-    jump L6
-
-  L4:
-    load_const "text"
-    jump L6
-
-  L5:
     load_const "integer"
 
-  L6:
+  L3:
     return
 }
 
@@ -1050,15 +961,12 @@ function match_types.match_typed_pattern_with_field_access() -> int {
     store_var _2
     load_var _2
     narrow_bind match_types.MtpPoint, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var shape
+    load_field .radius
     jump L1
 
   L0:
-    load_var shape
-    load_field .radius
-    jump L2
-
-  L1:
     load_var _2
     store_var_load_var p
     load_field .x
@@ -1066,7 +974,7 @@ function match_types.match_typed_pattern_with_field_access() -> int {
     load_field .y
     add_int
 
-  L2:
+  L1:
     return
 }
 
@@ -1078,22 +986,19 @@ function match_types.typed_pattern_second_arm() -> string {
     store_var _2
     load_var _2
     narrow_bind match_types.Success, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "failure: "
     load_var result
     load_field .reason
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "success: "
     load_var _2
     load_field .data
     bin_op +
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_media_json_union/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_media_json_union/bytecode.snap
@@ -44,37 +44,28 @@ function media_json_union.$init_test_ns_media_json_union_media_json_union(regist
 function media_json_union.classify_media_json_union(value: image | audio | video | pdf) -> string {
     load_var value
     is_type image
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var value
     is_type audio
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var value
     is_type video
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "pdf"
+    jump L3
+
+  L0:
+    load_const "video"
+    jump L3
+
+  L1:
+    load_const "audio"
     jump L3
 
   L2:
-    load_const "pdf"
-    jump L6
-
-  L3:
-    load_const "video"
-    jump L6
-
-  L4:
-    load_const "audio"
-    jump L6
-
-  L5:
     load_const "image"
 
-  L6:
+  L3:
     return
 }
 
@@ -88,17 +79,14 @@ function media_json_union.media_json_union_respects_reversed_order() -> string {
     load_var json
     call baml.json.from_json
     is_type audio
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "image"
     jump L1
 
   L0:
-    load_const "image"
-    jump L2
-
-  L1:
     load_const "audio"
 
-  L2:
+  L1:
     return
 }
 
@@ -141,7 +129,6 @@ function media_json_union.media_json_union_roundtrips_every_kind() -> string {
     store_var pdf_value
     load_var image_value
     call user.media_json_union.classify_media_json_union
-    store_var _26
     load_var audio_value
     call user.media_json_union.classify_media_json_union
     store_var _28
@@ -151,7 +138,6 @@ function media_json_union.media_json_union_roundtrips_every_kind() -> string {
     load_var pdf_value
     call user.media_json_union.classify_media_json_union
     store_var _32
-    load_var _26
     load_const ","
     bin_op +
     load_var _28
@@ -172,23 +158,20 @@ function media_json_union.rejects_media_json(json: string) -> bool {
     load_var json
     call baml.json.from_string
     pop 1
-    jump L2
+    jump L1
     load_var e
     is_type baml.json.DecodeError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_media_union_narrowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_media_union_narrowing/bytecode.snap
@@ -156,83 +156,25 @@ function media_union_narrowing.an_image() -> image {
 function media_union_narrowing.audio_is_audio() -> string {
     call user.media_union_narrowing.an_audio
     store_var v
+    load_type bool
     load_var v
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _8
-    jump L2
-
-  L1:
-    load_const true
-    store_var _8
-
-  L2:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
+    load_type bool
     load_var v
     is_type audio
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _12
-    jump L5
-
-  L4:
-    load_const true
-    store_var _12
-
-  L5:
-    load_type bool
-    load_var _12
     call baml.String.from
     store_var _11
+    load_type bool
     load_var v
     is_type video
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _16
-    jump L8
-
-  L7:
-    load_const true
-    store_var _16
-
-  L8:
-    load_type bool
-    load_var _16
     call baml.String.from
     store_var _15
+    load_type bool
     load_var v
     is_type pdf
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_const false
-    store_var _20
-    jump L11
-
-  L10:
-    load_const true
-    store_var _20
-
-  L11:
-    load_type bool
-    load_var _20
     call baml.String.from
     store_var _19
-    load_var _7
     load_const "|"
     bin_op +
     load_var _11
@@ -253,35 +195,28 @@ function media_union_narrowing.audio_or_image_match(v: image | audio) -> string 
     store_var _2
     load_var _2
     narrow_bind audio, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     call baml.media.Image.base64
     store_var _9
+    load_const "image:"
     load_type string
     load_var _9
     call baml.String.from
-    store_var _8
-    load_const "image:"
-    load_var _8
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _2
     call baml.media.Audio.base64
     store_var _5
+    load_const "audio:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "audio:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -290,124 +225,57 @@ function media_union_narrowing.four_kind_match(v: image | audio | video | pdf) -
     store_var _2
     load_var _2
     narrow_bind pdf, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var v
     store_var _3
     load_var _3
     narrow_bind video, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var v
     store_var _4
     load_var _4
     narrow_bind audio, slot=4
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "image"
+    jump L3
+
+  L0:
+    load_const "audio"
+    jump L3
+
+  L1:
+    load_const "video"
     jump L3
 
   L2:
-    load_const "image"
-    jump L6
-
-  L3:
-    load_const "audio"
-    jump L6
-
-  L4:
-    load_const "video"
-    jump L6
-
-  L5:
     load_const "pdf"
 
-  L6:
+  L3:
     return
 }
 
 function media_union_narrowing.image_is_image() -> string {
     call user.media_union_narrowing.an_image
     store_var v
+    load_type bool
     load_var v
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _8
-    jump L2
-
-  L1:
-    load_const true
-    store_var _8
-
-  L2:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
+    load_type bool
     load_var v
     is_type audio
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _12
-    jump L5
-
-  L4:
-    load_const true
-    store_var _12
-
-  L5:
-    load_type bool
-    load_var _12
     call baml.String.from
     store_var _11
+    load_type bool
     load_var v
     is_type video
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _16
-    jump L8
-
-  L7:
-    load_const true
-    store_var _16
-
-  L8:
-    load_type bool
-    load_var _16
     call baml.String.from
     store_var _15
+    load_type bool
     load_var v
     is_type pdf
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_const false
-    store_var _20
-    jump L11
-
-  L10:
-    load_const true
-    store_var _20
-
-  L11:
-    load_type bool
-    load_var _20
     call baml.String.from
     store_var _19
-    load_var _7
     load_const "|"
     bin_op +
     load_var _11
@@ -428,35 +296,28 @@ function media_union_narrowing.image_or_audio_match(v: image | audio) -> string 
     store_var _2
     load_var _2
     narrow_bind image, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     call baml.media.Audio.base64
     store_var _9
+    load_const "audio:"
     load_type string
     load_var _9
     call baml.String.from
-    store_var _8
-    load_const "audio:"
-    load_var _8
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _2
     call baml.media.Image.base64
     store_var _5
+    load_const "image:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "image:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -487,10 +348,7 @@ function media_union_narrowing.iterate_string_or_image() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _7
     call user.media_union_narrowing.string_or_image_match
     store_var _12
@@ -500,7 +358,7 @@ function media_union_narrowing.iterate_string_or_image() -> string {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_type string
     load_var out
     load_const ","
@@ -515,83 +373,27 @@ function media_union_narrowing.media_array_is_tests() -> string {
     store_var imgs
     call user.media_union_narrowing.an_image
     store_var _4
+    load_type bool
     load_var imgs
     is_type image[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _11
-    jump L2
-
-  L1:
-    load_const true
-    store_var _11
-
-  L2:
-    load_type bool
-    load_var _11
     call baml.String.from
     store_var _10
+    load_type bool
     load_var imgs
     is_type audio[]
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _15
-    jump L5
-
-  L4:
-    load_const true
-    store_var _15
-
-  L5:
-    load_type bool
-    load_var _15
     call baml.String.from
     store_var _14
+    load_type bool
     load_var imgs
     is_type string[]
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _19
-    jump L8
-
-  L7:
-    load_const true
-    store_var _19
-
-  L8:
-    load_type bool
-    load_var _19
     call baml.String.from
     store_var _18
+    load_type bool
     load_const "a"
     load_var _4
     load_type string | image
     alloc_array 2
     is_type (string | image)[]
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_const false
-    store_var _23
-    jump L11
-
-  L10:
-    load_const true
-    store_var _23
-
-  L11:
-    load_type bool
-    load_var _23
     call baml.String.from
     store_var _22
     load_var _10
@@ -613,94 +415,36 @@ function media_union_narrowing.media_array_is_tests() -> string {
 function media_union_narrowing.media_vs_non_media() -> string {
     call user.media_union_narrowing.an_image
     store_var img
+    load_type bool
     load_var img
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _9
-    jump L2
-
-  L1:
-    load_const true
-    store_var _9
-
-  L2:
-    load_type bool
-    load_var _9
     call baml.String.from
-    store_var _8
+    load_type bool
     load_var img
     is_type int
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _13
-    jump L5
-
-  L4:
-    load_const true
-    store_var _13
-
-  L5:
-    load_type bool
-    load_var _13
     call baml.String.from
-    store_var _12
+    store_var _11
+    load_type bool
     load_const "aGVsbG8="
     is_type image
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _17
-    jump L8
-
-  L7:
-    load_const true
-    store_var _17
-
-  L8:
-    load_type bool
-    load_var _17
     call baml.String.from
-    store_var _16
+    store_var _15
+    load_type bool
     load_const 42
     is_type image
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_const false
-    store_var _21
-    jump L11
-
-  L10:
-    load_const true
-    store_var _21
-
-  L11:
-    load_type bool
-    load_var _21
     call baml.String.from
-    store_var _20
-    load_var _8
+    store_var _19
     load_const "|"
     bin_op +
-    load_var _12
-    bin_op +
-    load_const "|"
-    bin_op +
-    load_var _16
+    load_var _11
     bin_op +
     load_const "|"
     bin_op +
-    load_var _20
+    load_var _15
+    bin_op +
+    load_const "|"
+    bin_op +
+    load_var _19
     bin_op +
     return
 }
@@ -710,51 +454,39 @@ function media_union_narrowing.mixed_union_match(v: media_union_narrowing.Note |
     store_var _2
     load_var _2
     narrow_bind media_union_narrowing.Note, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var v
     store_var _7
     load_var _7
-    narrow_bind image, slot=4
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    narrow_bind image, slot=3
+    pop_jump_if_true L0
+    load_const "int:"
     load_type int
     load_var v
     call baml.String.from
-    store_var _13
-    load_const "int:"
-    load_var _13
     bin_op +
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_var _7
     call baml.media.Image.base64
     store_var _10
+    load_const "image:"
     load_type string
     load_var _10
     call baml.String.from
-    store_var _9
-    load_const "image:"
-    load_var _9
     bin_op +
-    jump L4
+    jump L2
 
-  L3:
+  L1:
+    load_const "note:"
     load_type string
     load_var _2
     load_field .text
     call baml.String.from
-    store_var _4
-    load_const "note:"
-    load_var _4
     bin_op +
 
-  L4:
+  L2:
     return
 }
 
@@ -762,109 +494,46 @@ function media_union_narrowing.optional_image_match(v: image | null) -> string {
     load_var v
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     call baml.media.Image.base64
     store_var _5
+    load_const "image:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "image:"
-    load_var _4
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "none"
 
-  L2:
+  L1:
     return
 }
 
 function media_union_narrowing.pdf_is_pdf() -> string {
     call user.media_union_narrowing.a_pdf
     store_var v
+    load_type bool
     load_var v
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _8
-    jump L2
-
-  L1:
-    load_const true
-    store_var _8
-
-  L2:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
+    load_type bool
     load_var v
     is_type audio
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _12
-    jump L5
-
-  L4:
-    load_const true
-    store_var _12
-
-  L5:
-    load_type bool
-    load_var _12
     call baml.String.from
     store_var _11
+    load_type bool
     load_var v
     is_type video
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _16
-    jump L8
-
-  L7:
-    load_const true
-    store_var _16
-
-  L8:
-    load_type bool
-    load_var _16
     call baml.String.from
     store_var _15
+    load_type bool
     load_var v
     is_type pdf
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_const false
-    store_var _20
-    jump L11
-
-  L10:
-    load_const true
-    store_var _20
-
-  L11:
-    load_type bool
-    load_var _20
     call baml.String.from
     store_var _19
-    load_var _7
     load_const "|"
     bin_op +
     load_var _11
@@ -883,45 +552,15 @@ function media_union_narrowing.pdf_is_pdf() -> string {
 function media_union_narrowing.string_or_image_holding_image_is() -> string {
     call user.media_union_narrowing.an_image
     store_var v
+    load_type bool
     load_var v
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _4
-    jump L2
-
-  L1:
-    load_const true
-    store_var _4
-
-  L2:
-    load_type bool
-    load_var _4
     call baml.String.from
-    store_var _3
+    load_type bool
     load_var v
     is_type string
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _8
-    jump L5
-
-  L4:
-    load_const true
-    store_var _8
-
-  L5:
-    load_type bool
-    load_var _8
     call baml.String.from
     store_var _7
-    load_var _3
     load_const "|"
     bin_op +
     load_var _7
@@ -930,48 +569,18 @@ function media_union_narrowing.string_or_image_holding_image_is() -> string {
 }
 
 function media_union_narrowing.string_or_image_holding_string_is() -> string {
+    load_type bool
     load_const "hello"
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _4
-    jump L2
-
-  L1:
-    load_const true
-    store_var _4
-
-  L2:
-    load_type bool
-    load_var _4
     call baml.String.from
-    store_var _3
+    load_type bool
     load_const "hello"
     is_type string
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _8
-    jump L5
-
-  L4:
-    load_const true
-    store_var _8
-
-  L5:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
-    load_var _3
+    store_var _6
     load_const "|"
     bin_op +
-    load_var _7
+    load_var _6
     bin_op +
     return
 }
@@ -981,32 +590,25 @@ function media_union_narrowing.string_or_image_if_let(v: string | image) -> stri
     store_var _2
     load_var _2
     narrow_bind image, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
+    load_const "text:"
     load_type string
     load_var v
     call baml.String.from
-    store_var _7
-    load_const "text:"
-    load_var _7
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _2
     call baml.media.Image.base64
     store_var _5
+    load_const "image:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "image:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -1015,32 +617,25 @@ function media_union_narrowing.string_or_image_match(v: string | image) -> strin
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     call baml.media.Image.base64
     store_var _9
+    load_const "image:"
     load_type string
     load_var _9
     call baml.String.from
-    store_var _8
-    load_const "image:"
-    load_var _8
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
+    load_const "text:"
     load_type string
     load_var _2
     call baml.String.from
-    store_var _4
-    load_const "text:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -1049,115 +644,50 @@ function media_union_narrowing.string_or_image_match_reversed(v: string | image)
     store_var _2
     load_var _2
     narrow_bind image, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
+    load_const "text:"
     load_type string
     load_var v
     call baml.String.from
-    store_var _8
-    load_const "text:"
-    load_var _8
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _2
     call baml.media.Image.base64
     store_var _5
+    load_const "image:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "image:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
 function media_union_narrowing.video_is_video() -> string {
     call user.media_union_narrowing.a_video
     store_var v
+    load_type bool
     load_var v
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _8
-    jump L2
-
-  L1:
-    load_const true
-    store_var _8
-
-  L2:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
+    load_type bool
     load_var v
     is_type audio
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _12
-    jump L5
-
-  L4:
-    load_const true
-    store_var _12
-
-  L5:
-    load_type bool
-    load_var _12
     call baml.String.from
     store_var _11
+    load_type bool
     load_var v
     is_type video
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _16
-    jump L8
-
-  L7:
-    load_const true
-    store_var _16
-
-  L8:
-    load_type bool
-    load_var _16
     call baml.String.from
     store_var _15
+    load_type bool
     load_var v
     is_type pdf
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_const false
-    store_var _20
-    jump L11
-
-  L10:
-    load_const true
-    store_var _20
-
-  L11:
-    load_type bool
-    load_var _20
     call baml.String.from
     store_var _19
-    load_var _7
     load_const "|"
     bin_op +
     load_var _11

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_middleware/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_middleware/bytecode.snap
@@ -103,11 +103,10 @@ function middleware.chained_transformers_apply_left_to_right() -> int {
     init_instance baml.spawn.Params .body, .name, .group, .cancel, .detach
     load_var _4
     call_indirect
-    store_var _6
     load_type never
     call user.middleware.withAddOne
     store_var _7
-    load_var2 3 4
+    load_var _7
     call_indirect
     store_var _9
     load_var _2
@@ -136,24 +135,24 @@ function middleware.custom_with_retry() -> int {
     load_type string
     load_const 5
     call user.middleware.withRetry
-    store_var _6
+    store_var _5
     load_var _3
     load_const "retry-test"
     load_const null
     load_const null
     load_const false
     init_instance baml.spawn.Params .body, .name, .group, .cancel, .detach
-    load_var _6
+    load_var _5
     call_indirect
-    store_var _9
+    store_var _8
     load_var _3
     load_const "retry-test"
-    load_var _9
+    load_var _8
     load_type int
     load_type string
     spawn
-    store_var _10
-    load_var _10
+    store_var _9
+    load_var _9
     await
     return
 }
@@ -162,14 +161,11 @@ function middleware.flaky(n: int) -> int {
     load_var n
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var n
     return
 
-  L1:
+  L0:
     load_const "boom"
     throw
 }
@@ -186,14 +182,11 @@ function middleware.flaky_then_42(calls: int[]) -> int {
     load_var _5
     load_const 3
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 42
     return
 
-  L1:
+  L0:
     load_const "flaky"
     throw
 }
@@ -242,24 +235,24 @@ function middleware.options_as_transformer() -> int {
     load_const <omitted>
     load_const false
     call baml.spawn.options
-    store_var _5
+    store_var _4
     load_var _2
     load_const "opted"
     load_const null
     load_const null
     load_const false
     init_instance baml.spawn.Params .body, .name, .group, .cancel, .detach
-    load_var _5
+    load_var _4
     call_indirect
-    store_var _8
+    store_var _7
     load_var _2
     load_const "opted"
-    load_var _8
+    load_var _7
     load_type int
     load_type never
     spawn
-    store_var _9
-    load_var _9
+    store_var _8
+    load_var _8
     await
     return
 }
@@ -280,23 +273,20 @@ function middleware.throwing_transformer_throws_at_spawn_site() -> string {
     load_var _5
     call_indirect
     store_var _8
-    jump L2
+    jump L1
     load_var e
     store_var _10
     load_var _10
     narrow_bind string, slot=6
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _10
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_var _3
     load_const null
     load_var _8
@@ -306,21 +296,18 @@ function middleware.throwing_transformer_throws_at_spawn_site() -> string {
     store_var _9
     load_var _9
 
-  L3:
+  L2:
     store_var _12
     load_var _12
     narrow_bind string, slot=7
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_const "wrong"
-    jump L6
+    jump L4
 
-  L5:
+  L3:
     load_var _12
 
-  L6:
+  L4:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_net/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_net/bytecode.snap
@@ -47,8 +47,6 @@ function net.net_tcp_listener_accept_after_close_errors_fn() -> uint8array | nul
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -67,19 +65,14 @@ function net.net_tcp_read_after_close_errors_fn() -> uint8array | null {
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function net.net_udp_recv_timeout_fires_fn() -> uint8array {
     load_const "127.0.0.1:0"
     sys_op baml.net.UdpSocket.bind
-    store_var sock
     load_const 50n
     call baml.time.Duration.from_milliseconds
-    store_var _3
-    load_var2 1 2
     call baml.net.UdpSocket.recv_from
     load_field .data
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_null_coalesce_assign/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_null_coalesce_assign/bytecode.snap
@@ -67,15 +67,19 @@ function null_coalesce_assign.nca_cross_field(a: int | null, b: int | null) -> i
     init_instance user.null_coalesce_assign.NcaBox .a, .b
     store_var_load_var s
     load_field .a
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _4
+    jump L2
+
+  L1:
     load_var s
     load_field .b
     store_var _4
 
-  L0:
+  L2:
     load_var2 3 4
     store_field .a
     load_var s
@@ -89,15 +93,19 @@ function null_coalesce_assign.nca_field_self(seed: int | null, incoming: int | n
     init_instance user.null_coalesce_assign.NcaBox .a, .b
     store_var s
     load_var incoming
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _4
+    jump L2
+
+  L1:
     load_var s
     load_field .a
     store_var _4
 
-  L0:
+  L2:
     load_var2 3 4
     store_field .a
     load_var s
@@ -109,15 +117,10 @@ function null_coalesce_assign.nca_local_int(seed: int | null, incoming: int | nu
     load_var seed
     store_var a
     load_var incoming
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var a
-    store_var _4
 
   L0:
-    load_var _4
     store_var a
     load_var a
     return
@@ -127,15 +130,10 @@ function null_coalesce_assign.nca_local_string(seed: string | null, incoming: st
     load_var seed
     store_var a
     load_var incoming
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var a
-    store_var _4
 
   L0:
-    load_var _4
     store_var a
     load_var a
     return
@@ -148,15 +146,10 @@ function null_coalesce_assign.nca_method_lhs(seed: int | null, xs: int[]) -> int
     load_var xs
     load_const 0
     call baml.Array.at
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var a
-    store_var _4
 
   L0:
-    load_var _4
     store_var a
     load_var a
     return
@@ -166,24 +159,12 @@ function null_coalesce_assign.nca_nested(seed: int | null, outer: int | null, in
     load_var seed
     store_var a
     load_var outer
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
     load_var inner
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var a
-    store_var _7
 
   L0:
-    load_var _7
-    store_var _5
-
-  L1:
-    load_var _5
     store_var a
     load_var a
     return
@@ -191,61 +172,42 @@ function null_coalesce_assign.nca_nested(seed: int | null, outer: int | null, in
 
 function null_coalesce_assign.nca_plain(n: int | null, fallback: int) -> int {
     load_var n
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var fallback
-    store_var _3
 
   L0:
-    load_var _3
     return
 }
 
 function null_coalesce_assign.nca_plain_chain(x: int | null, y: int | null, z: int) -> int {
     load_var x
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var y
-    store_var _6
+    jump_if_not_null_or_pop L0
+    load_var z
 
   L0:
-    load_var _6
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
-    load_var z
-    store_var _4
-
-  L1:
-    load_var _4
     return
 }
 
 function null_coalesce_assign.nca_rhs_not_evaluated(seed: int | null, incoming: int | null) -> int {
     load_const 0
     store_var calls
-    load_var seed
-    store_var a
     load_var incoming
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    pop 1
+    jump L2
+
+  L1:
     load_var calls
     load_const 1
     add_int
     store_var calls
-    load_var a
-    store_var _5
 
-  L0:
-    load_var _5
-    store_var a
+  L2:
     load_var calls
     return
 }
@@ -254,15 +216,10 @@ function null_coalesce_assign.nca_via_temp(seed: int | null, incoming: int | nul
     load_var seed
     store_var a
     load_var incoming
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var a
-    store_var _5
 
   L0:
-    load_var _5
     store_var a
     load_var a
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_null_handling/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_null_handling/bytecode.snap
@@ -101,30 +101,28 @@ function null_handling.nh_combined_lhs_null(node: null_handling.NhNode | null, i
     load_var node
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L5
     load_var items
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var items
     load_const 0
     load_array_element
+    jump L1
+
+  L0:
+    load_const null
+
+  L1:
+    jump_if_not_null_or_pop L2
     jump L3
 
   L2:
-    load_const null
+    store_var _6
+    jump L4
 
   L3:
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
     load_const 1
     store_var _6
 
@@ -140,18 +138,15 @@ function null_handling.nh_combined_lhs_null(node: null_handling.NhNode | null, i
     load_var node
     load_const null
     cmp_op ==
-    pop_jump_if_false L6
+    pop_jump_if_true L6
+    load_var node
+    load_field .0
     jump L7
 
   L6:
-    load_var node
-    load_field .0
-    jump L8
-
-  L7:
     load_const null
 
-  L8:
+  L7:
     return
 }
 
@@ -159,30 +154,28 @@ function null_handling.nh_combined_rhs_null(node: null_handling.NhNode | null, i
     load_var node
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L5
     load_var items
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var items
     load_const 0
     load_array_element
+    jump L1
+
+  L0:
+    load_const null
+
+  L1:
+    jump_if_not_null_or_pop L2
     jump L3
 
   L2:
-    load_const null
+    store_var _6
+    jump L4
 
   L3:
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
     load_const 1
     store_var _6
 
@@ -198,18 +191,15 @@ function null_handling.nh_combined_rhs_null(node: null_handling.NhNode | null, i
     load_var node
     load_const null
     cmp_op ==
-    pop_jump_if_false L6
+    pop_jump_if_true L6
+    load_var node
+    load_field .0
     jump L7
 
   L6:
-    load_var node
-    load_field .0
-    jump L8
-
-  L7:
     load_const null
 
-  L8:
+  L7:
     return
 }
 
@@ -217,10 +207,7 @@ function null_handling.nh_compound_assign_non_null(user: null_handling.NhUser | 
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var user
     copy 0
     load_field .0
@@ -228,22 +215,19 @@ function null_handling.nh_compound_assign_non_null(user: null_handling.NhUser | 
     bin_op +
     store_field .0
 
-  L1:
+  L0:
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var user
     load_field .0
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const null
 
-  L4:
+  L2:
     return
 }
 
@@ -251,10 +235,7 @@ function null_handling.nh_compound_assign_null(user: null_handling.NhUser | null
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var user
     copy 0
     load_field .0
@@ -262,22 +243,19 @@ function null_handling.nh_compound_assign_null(user: null_handling.NhUser | null
     bin_op +
     store_field .0
 
-  L1:
+  L0:
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var user
     load_field .0
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const null
 
-  L4:
+  L2:
     return
 }
 
@@ -285,19 +263,16 @@ function null_handling.nh_multi_union_optional_access(animal: null_handling.NhCa
     load_var animal
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var animal
     load_type null_handling.NhHasSound
     virtual_load_field .sound
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -308,17 +283,12 @@ function null_handling.nh_null_coalesce_lazy_non_null(value: int | null) -> int 
     load_const 0
     store_deref ?2
     load_var value
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var counter
     make_closure .<lambda(nh_null_coalesce_lazy_non_null, 0)>, 1
     call_indirect
-    store_var _5
 
   L0:
-    load_var _5
     load_const 10
     mul_int
     load_deref ?2
@@ -333,17 +303,12 @@ function null_handling.nh_null_coalesce_null_lhs(value: int | null) -> int {
     load_const 0
     store_deref ?2
     load_var value
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var counter
     make_closure .<lambda(nh_null_coalesce_null_lhs, 0)>, 1
     call_indirect
-    store_var _5
 
   L0:
-    load_var _5
     load_const 10
     mul_int
     load_deref ?2
@@ -359,15 +324,19 @@ function null_handling.nh_null_coalesce_self_field(input: int | null) -> int {
     init_instance user.null_handling.NhNode .value, .next, .children, .labels
     store_var node
     load_var input
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _3
+    jump L2
+
+  L1:
     load_var node
     load_field .value
     store_var _3
 
-  L0:
+  L2:
     load_var2 2 3
     store_field .value
     load_var node
@@ -379,15 +348,10 @@ function null_handling.nh_null_coalesce_self_local(input: int | null) -> int {
     load_const 7
     store_var value
     load_var input
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var value
-    store_var _3
 
   L0:
-    load_var _3
     store_var value
     load_var value
     return
@@ -484,32 +448,26 @@ function null_handling.nh_safe_assign_index_non_null(items: int[] | null) -> int
     load_var items
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var items
     load_const 0
     load_const 42
     store_array_element
 
-  L1:
+  L0:
     load_var items
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var items
     load_const 0
     load_array_element
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const null
 
-  L4:
+  L2:
     return
 }
 
@@ -517,32 +475,26 @@ function null_handling.nh_safe_assign_index_null(items: int[] | null) -> int | n
     load_var items
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var items
     load_const 0
     load_const 42
     store_array_element
 
-  L1:
+  L0:
     load_var items
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var items
     load_const 0
     load_array_element
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const null
 
-  L4:
+  L2:
     return
 }
 
@@ -550,55 +502,40 @@ function null_handling.nh_safe_assign_non_null(user: null_handling.NhUser | null
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var user
     load_field .1
     store_var_load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _2
     load_const "updated"
     store_field .0
 
-  L2:
+  L0:
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L1
     load_var user
     load_field .1
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L1
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L1
     load_var user
     load_field .1
     load_field .0
-    jump L7
+    jump L2
 
-  L6:
+  L1:
     load_const null
 
-  L7:
+  L2:
     return
 }
 
@@ -606,54 +543,39 @@ function null_handling.nh_safe_assign_null(user: null_handling.NhUser | null) ->
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var user
     load_field .1
     store_var_load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _2
     load_const "updated"
     store_field .0
 
-  L2:
+  L0:
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L1
     load_var user
     load_field .1
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L1
     load_var user
     load_const null
     cmp_op ==
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L1
     load_var user
     load_field .1
     load_field .0
-    jump L7
+    jump L2
 
-  L6:
+  L1:
     load_const null
 
-  L7:
+  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_operators/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_operators/bytecode.snap
@@ -471,8 +471,6 @@ function operators.<(user.operators.Boom as baml.ops.Compare)>.cmp(self: operato
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -527,8 +525,6 @@ function operators.<(user.operators.OddOrder as baml.ops.Compare)>.cmp(self: ope
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -572,8 +568,6 @@ function operators.<(user.operators.Ranked as baml.ops.Compare)>.cmp(self: opera
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -634,8 +628,6 @@ function operators.<(user.operators.Tier as baml.ops.Compare)>.cmp(self: operato
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -682,8 +674,6 @@ function operators.<(user.operators.Wrapped<#0> as baml.ops.Compare)>.cmp(self: 
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -701,8 +691,6 @@ function operators.Ordered.precedes(self: operators.Ordered, other: #0) -> bool 
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -743,20 +731,17 @@ function operators.drv_catch_add_overflow() -> int {
     call baml.Int.max_value
     load_const 1
     call user.operators.drv_int_add
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -764,20 +749,17 @@ function operators.drv_catch_bigint_div_zero() -> bigint {
     load_const 1n
     load_const 0n
     call user.operators.drv_bigint_div
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1n
 
-  L2:
+  L1:
     return
 }
 
@@ -785,20 +767,17 @@ function operators.drv_catch_div_min_by_minus_one() -> int {
     call baml.Int.min_value
     load_const -1
     call user.operators.drv_int_div
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -806,20 +785,17 @@ function operators.drv_catch_int_div_zero() -> int {
     load_const 1
     load_const 0
     call user.operators.drv_int_div
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -827,20 +803,17 @@ function operators.drv_catch_int_rem_zero() -> int {
     load_const 1
     load_const 0
     call user.operators.drv_int_rem
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -848,40 +821,34 @@ function operators.drv_catch_mul_overflow() -> int {
     call baml.Int.max_value
     load_const 2
     call user.operators.drv_int_mul
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
 function operators.drv_catch_neg_overflow() -> int {
     call baml.Int.min_value
     call user.operators.drv_int_neg
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const -1
 
-  L2:
+  L1:
     return
 }
 
@@ -923,30 +890,23 @@ function operators.drv_float_div_zero_is_infinite() -> bool {
     load_const 0.0
     call user.operators.drv_float_div
     call baml.Float.is_infinite
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const 1.0
     load_const 0.0
     div_float
     call baml.Float.is_infinite
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_const 1
     load_const 0.0
     bin_op /
     call baml.Float.is_infinite
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_const 1.0
     load_const 0
     bin_op /
     call baml.Float.is_infinite
 
-  L2:
+  L0:
     return
 }
 
@@ -1065,8 +1025,6 @@ function operators.ops_counter_add(c: operators.Counter, n: int) -> int {
 
 function operators.ops_double_neg_var() -> int {
     load_const -10
-    unary_op -
-    unary_op -
     return
 }
 
@@ -1094,17 +1052,14 @@ function operators.ops_pick_int_or_float(n: int) -> int | float {
     load_var n
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2.5
     jump L1
 
   L0:
-    load_const 2.5
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -1169,19 +1124,14 @@ function operators.ord_as_if_cond() -> int {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 20
     jump L1
 
   L0:
-    load_const 20
-    jump L2
-
-  L1:
     load_const 10
 
-  L2:
+  L1:
     return
 }
 
@@ -1195,16 +1145,11 @@ function operators.ord_as_while_cond() -> int {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var n
     return
 
-  L2:
+  L1:
     load_var n
     load_const 1
     add_int
@@ -1225,8 +1170,6 @@ function operators.ord_bool_ge(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1235,8 +1178,6 @@ function operators.ord_bool_gt(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1245,8 +1186,6 @@ function operators.ord_bool_le(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1255,8 +1194,6 @@ function operators.ord_bool_lt(a: bool, b: bool) -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1268,20 +1205,17 @@ function operators.ord_catch_ge() -> bool {
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -1293,20 +1227,17 @@ function operators.ord_catch_gt() -> bool {
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -1318,20 +1249,17 @@ function operators.ord_catch_le() -> bool {
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -1343,20 +1271,17 @@ function operators.ord_catch_lt() -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const true
 
-  L2:
+  L1:
     return
 }
 
@@ -1366,8 +1291,6 @@ function operators.ord_clamp(v: #0, lo: #0, hi: #0) -> #0 {
     load_type baml.ops.Compare
     load_const "clamp"
     virtual_call nargs=3 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1390,8 +1313,6 @@ function operators.ord_ge(a: #0, b: #0) -> bool {
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1400,8 +1321,6 @@ function operators.ord_generic_int(a: operators.Wrapped<int>, b: operators.Wrapp
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1410,8 +1329,6 @@ function operators.ord_generic_string(a: operators.Wrapped<string>, b: operators
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1420,8 +1337,6 @@ function operators.ord_gt(a: #0, b: #0) -> bool {
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1433,10 +1348,7 @@ function operators.ord_in_short_circuit() -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _1
-    load_var _1
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const true
     load_const false
     load_type baml.ops.Compare
@@ -1559,8 +1471,6 @@ function operators.ord_le(a: #0, b: #0) -> bool {
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1569,8 +1479,6 @@ function operators.ord_lt(a: #0, b: #0) -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1579,8 +1487,6 @@ function operators.ord_max(a: #0, b: #0) -> #0 {
     load_type baml.ops.Compare
     load_const "max"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1589,8 +1495,6 @@ function operators.ord_min(a: #0, b: #0) -> #0 {
     load_type baml.ops.Compare
     load_const "min"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1599,8 +1503,6 @@ function operators.ord_odd_gt(a: operators.OddOrder, b: operators.OddOrder) -> b
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1609,8 +1511,6 @@ function operators.ord_odd_le(a: operators.OddOrder, b: operators.OddOrder) -> b
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1627,8 +1527,6 @@ function operators.ord_rank_ge(a: operators.Ranked, b: operators.Ranked) -> bool
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1644,8 +1542,6 @@ function operators.ord_rank_gt(a: operators.Ranked, b: operators.Ranked) -> bool
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1654,8 +1550,6 @@ function operators.ord_rank_le(a: operators.Ranked, b: operators.Ranked) -> bool
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1664,8 +1558,6 @@ function operators.ord_rank_lt(a: operators.Ranked, b: operators.Ranked) -> bool
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1681,8 +1573,6 @@ function operators.ord_self_in_default(a: operators.Tier, b: operators.Tier) -> 
     load_type operators.Ordered
     load_const "precedes"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_ops_bitwise/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_ops_bitwise/bytecode.snap
@@ -39,33 +39,11 @@ function ops_bitwise.band(x: #0, y: int) -> (#0 as baml.ops.BitAnd<int>).Output 
     load_type baml.ops.BitAnd<int>
     load_const "bit_and"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function ops_bitwise.bigint_ops() -> bool {
     load_const true
-    jump_if_false L0
-    pop 1
-    load_const true
-
-  L0:
-    jump_if_false L1
-    pop 1
-    load_const true
-
-  L1:
-    jump_if_false L2
-    pop 1
-    load_const true
-
-  L2:
-    jump_if_false L3
-    pop 1
-    load_const true
-
-  L3:
     return
 }
 
@@ -74,33 +52,11 @@ function ops_bitwise.bshl(x: #0, y: int) -> (#0 as baml.ops.ShiftLeft<int>).Outp
     load_type baml.ops.ShiftLeft<int>
     load_const "shl"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function ops_bitwise.int_ops() -> bool {
     load_const true
-    jump_if_false L0
-    pop 1
-    load_const true
-
-  L0:
-    jump_if_false L1
-    pop 1
-    load_const true
-
-  L1:
-    jump_if_false L2
-    pop 1
-    load_const true
-
-  L2:
-    jump_if_false L3
-    pop 1
-    load_const true
-
-  L3:
     return
 }
 
@@ -110,8 +66,7 @@ function ops_bitwise.mixed_widens() -> bool {
     bit_and_bigint
     load_const 2n
     cmp_bigint_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const 6n
     load_const 3
     bit_and_bigint

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_ops_index/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_ops_index/bytecode.snap
@@ -66,8 +66,7 @@ function ops_index.direct_ops() -> bool {
     load_array_element
     load_const 20
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const 1
     load_const "a"
     load_type string
@@ -77,10 +76,7 @@ function ops_index.direct_ops() -> bool {
     load_map_element
     load_const 1
     cmp_int_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_const b"\x41\x42"
     call baml.deep_copy
     load_const 0
@@ -88,7 +84,7 @@ function ops_index.direct_ops() -> bool {
     load_const 65
     cmp_int_op ==
 
-  L1:
+  L0:
     return
 }
 
@@ -97,7 +93,5 @@ function ops_index.nth(c: #0, i: int) -> (#0 as baml.ops.Index<int>).Output {
     load_type baml.ops.Index<int>
     load_const "index"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optimizer_effects/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optimizer_effects/bytecode.snap
@@ -76,17 +76,14 @@ function optimizer_effects.and_inline(a: bool, box: optimizer_effects.Box) -> in
 
 function optimizer_effects.or_inline(a: bool, box: optimizer_effects.Box) -> int {
     load_var a
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var2 2 2
     load_field .value
     load_const 1
     bin_op +
     store_field .value
 
-  L1:
+  L0:
     load_var box
     load_field .value
     return
@@ -103,14 +100,11 @@ function optimizer_effects.unused_division(x: int) -> int {
     return
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L2:
+  L1:
     load_const 7
     jump L0
 }
@@ -125,14 +119,11 @@ function optimizer_effects.unused_index(values: int[], index: int) -> int {
     return
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L2:
+  L1:
     load_const 7
     jump L0
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optimizer_effects/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optimizer_effects/bytecode.snap
@@ -1,0 +1,138 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+function optimizer_effects.$init_test_ns_optimizer_effects_optimizer_effects(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.optimizer_effects"
+    load_const "discarded logical expressions preserve conditional effects"
+    make_closure .<lambda($init_test_ns_optimizer_effects_optimizer_effects, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.optimizer_effects"
+    load_const "unused evaluations preserve catchable panics"
+    make_closure .<lambda($init_test_ns_optimizer_effects_optimizer_effects, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function optimizer_effects.and_capture(a: bool) -> int {
+    load_var ?2
+    make_cell
+    store_var ?2
+    load_const 0
+    store_deref ?2
+    load_var value
+    make_closure .<lambda(and_capture, 0)>, 1
+    store_var read
+    load_var a
+    pop_jump_if_false L0
+    load_const 1
+    store_deref ?2
+
+  L0:
+    load_var read
+    call_indirect
+    return
+}
+
+function optimizer_effects.and_index(a: bool, values: int[]) -> int {
+    load_var a
+    pop_jump_if_false L0
+    load_var values
+    load_const 0
+    load_var values
+    load_const 0
+    load_array_element
+    load_const 1
+    bin_op +
+    store_array_element
+
+  L0:
+    load_var values
+    load_const 0
+    load_array_element
+    return
+}
+
+function optimizer_effects.and_inline(a: bool, box: optimizer_effects.Box) -> int {
+    load_var a
+    pop_jump_if_false L0
+    load_var2 2 2
+    load_field .value
+    load_const 1
+    bin_op +
+    store_field .value
+
+  L0:
+    load_var box
+    load_field .value
+    return
+}
+
+function optimizer_effects.or_inline(a: bool, box: optimizer_effects.Box) -> int {
+    load_var a
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var2 2 2
+    load_field .value
+    load_const 1
+    bin_op +
+    store_field .value
+
+  L1:
+    load_var box
+    load_field .value
+    return
+}
+
+function optimizer_effects.unused_division(x: int) -> int {
+    load_const 1
+    load_var x
+    div_int
+    pop 1
+    load_const 42
+
+  L0:
+    return
+    load_var e
+    is_type baml.panics.DivisionByZero
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_var e
+    rethrow
+
+  L2:
+    load_const 7
+    jump L0
+}
+
+function optimizer_effects.unused_index(values: int[], index: int) -> int {
+    load_var2 1 2
+    load_array_element
+    pop 1
+    load_const 42
+
+  L0:
+    return
+    load_var e
+    is_type baml.panics.IndexOutOfBounds
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_var e
+    rethrow
+
+  L2:
+    load_const 7
+    jump L0
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optimizer_stack/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optimizer_stack/bytecode.snap
@@ -1,0 +1,839 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+function optimizer_stack.$init_test_ns_optimizer_stack_optimizer_stack(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.optimizer_stack"
+    load_const "optimized value and predicate paths preserve behavior"
+    make_closure .<lambda($init_test_ns_optimizer_stack_optimizer_stack, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function optimizer_stack.<(user.optimizer_stack.Sequence as user.optimizer_stack.Source)>.next(self: optimizer_stack.Sequence) -> int {
+    load_var self
+    load_field .counter
+    call user.optimizer_stack.tick
+    return
+}
+
+function optimizer_stack.and_value(a: bool, b: bool, c: bool) -> bool {
+    load_var a
+    jump_if_false_or_pop L0
+    load_var b
+    jump_if_false_or_pop L0
+    load_var c
+
+  L0:
+    return
+}
+
+function optimizer_stack.array_effects() -> int[] {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var_load_var counter
+    call user.optimizer_stack.tick
+    load_const 42
+    load_var counter
+    call user.optimizer_stack.tick
+    load_var counter
+    load_field .value
+    load_type int
+    alloc_array 4
+    return
+}
+
+function optimizer_stack.array_mixed() -> int[] {
+    load_const 1
+    call user.optimizer_stack.number
+    load_const 2
+    load_const 3
+    call user.optimizer_stack.number
+    load_type int
+    alloc_array 3
+    return
+}
+
+function optimizer_stack.binary_effects() -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var_load_var counter
+    call user.optimizer_stack.tick
+    load_var counter
+    call user.optimizer_stack.tick
+    sub_int
+    return
+}
+
+function optimizer_stack.call_effects() -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var_load_var counter
+    call user.optimizer_stack.tick
+    load_var counter
+    call user.optimizer_stack.tick
+    call user.optimizer_stack.combine
+    return
+}
+
+function optimizer_stack.coalesce(value: int | null) -> int {
+    load_var value
+    jump_if_not_null_or_pop L0
+    load_const 42
+
+  L0:
+    return
+}
+
+function optimizer_stack.coalesce_effect(value: int | null) -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var counter
+    load_var value
+    jump_if_not_null_or_pop L0
+    load_var counter
+    call user.optimizer_stack.tick
+
+  L0:
+    load_const 10
+    mul_int
+    load_var counter
+    load_field .value
+    add_int
+    return
+}
+
+function optimizer_stack.coalesce_mutable(value: int | null) -> int {
+    load_var value
+    jump_if_not_null_or_pop L0
+    load_const 42
+
+  L0:
+    return
+}
+
+function optimizer_stack.combine(a: int, b: int) -> int {
+    load_var a
+    load_const 10
+    mul_int
+    load_var b
+    add_int
+    return
+}
+
+function optimizer_stack.condition_effects(a: bool, b: bool) -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var counter
+    load_var a
+    pop_jump_if_false L0
+    load_var counter
+    call user.optimizer_stack.tick
+    pop 1
+    load_var b
+    pop_jump_if_false L0
+    load_var counter
+    call user.optimizer_stack.tick
+    pop 1
+    load_var counter
+    call user.optimizer_stack.tick
+    pop 1
+
+  L0:
+    load_var counter
+    load_field .value
+    return
+}
+
+function optimizer_stack.constant_overflow() -> int {
+    load_const 4611686018427387903
+    load_const 1
+    add_int
+
+  L0:
+    return
+    load_var e
+    is_type baml.panics.IntegerOverflow
+    pop_jump_if_true L1
+    load_var e
+    rethrow
+
+  L1:
+    load_const 7
+    jump L0
+}
+
+function optimizer_stack.constants() -> int {
+    load_const 13
+    return
+}
+
+function optimizer_stack.failing_operand(counter: optimizer_stack.Counter, divisor: int) -> int {
+    load_var counter
+    call user.optimizer_stack.tick
+    pop 1
+    load_const 1
+    load_var divisor
+    div_int
+    return
+}
+
+function optimizer_stack.generic_effects() -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var_load_var counter
+    call user.optimizer_stack.tick
+    store_var _3
+    load_type int
+    load_var _3
+    call user.optimizer_stack.identity
+    load_var counter
+    call user.optimizer_stack.tick
+    store_var _7
+    load_type int
+    load_var _7
+    call user.optimizer_stack.identity
+    call user.optimizer_stack.combine
+    return
+}
+
+function optimizer_stack.handler_observes_store(divisor: int) -> int {
+    load_const 1
+    store_var result
+    load_const 2
+    store_var result
+    load_const 1
+    load_var divisor
+    div_int
+    pop 1
+    load_const 3
+    store_var result
+    load_var result
+
+  L0:
+    return
+    load_var e
+    is_type baml.panics.DivisionByZero
+    pop_jump_if_true L1
+    load_var e
+    rethrow
+
+  L1:
+    load_var result
+    jump L0
+}
+
+function optimizer_stack.identity(value: #0) -> #0 {
+    load_var value
+    return
+}
+
+function optimizer_stack.indirect_effects() -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var_load_var counter
+    call user.optimizer_stack.tick
+    load_var counter
+    call user.optimizer_stack.tick
+    make_closure .<lambda(indirect_effects, 0)>, 0
+    call_indirect
+    return
+}
+
+function optimizer_stack.iterator_sum(values: int[]) -> int {
+    load_const 0
+    store_var sum
+    load_var values
+    load_type baml.iter.Iterable<Error = never, Item = int>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+
+  L0:
+    load_var _3
+    load_type baml.iter.Iterator<Error = never, Item = int>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_true L1
+    load_var2 2 4
+    add_int
+    store_var sum
+    jump L0
+
+  L1:
+    load_var sum
+    return
+}
+
+function optimizer_stack.loop_values(count: int) -> int {
+    load_const 0
+    store_var index
+    load_const 0
+    store_var total
+
+  L0:
+    load_var2 2 1
+    cmp_int_op <
+    pop_jump_if_false L1
+    load_var total
+    load_const 20000
+    cmp_int_op <
+    pop_jump_if_true L2
+
+  L1:
+    load_var total
+    return
+
+  L2:
+    load_var index
+    load_const 500
+    cmp_int_op <
+    jump_if_false_or_pop L3
+    load_var index
+    load_const 250
+    cmp_int_op <
+
+  L3:
+    jump_if_true_or_pop L4
+    load_var index
+    load_const 750
+    cmp_int_op >=
+
+  L4:
+    pop_jump_if_false L5
+    load_var total
+    load_const 1
+    add_int
+    store_var total
+
+  L5:
+    load_var index
+    load_const 1
+    add_int
+    store_var index
+    jump L0
+}
+
+function optimizer_stack.mixed_value(a: bool, b: bool, c: bool) -> bool {
+    load_var a
+    jump_if_false_or_pop L0
+    load_var b
+
+  L0:
+    jump_if_true_or_pop L1
+    load_var c
+
+  L1:
+    return
+}
+
+function optimizer_stack.mutable_value(a: bool, b: bool, c: bool) -> bool {
+    load_const false
+    store_var value
+    load_var c
+    pop_jump_if_false L1
+    load_var a
+    jump_if_false_or_pop L0
+    load_var b
+
+  L0:
+    store_var value
+
+  L1:
+    load_var value
+    return
+}
+
+function optimizer_stack.negated_truthiness(value: string | null) -> int {
+    load_var value
+    unary_op truthy
+    pop_jump_if_true L0
+    load_const 1
+    jump L1
+
+  L0:
+    load_const 2
+
+  L1:
+    return
+}
+
+function optimizer_stack.number(value: int) -> int {
+    load_var value
+    return
+}
+
+function optimizer_stack.or_value(a: bool, b: bool, c: bool) -> bool {
+    load_var a
+    jump_if_true_or_pop L0
+    load_var b
+    jump_if_true_or_pop L0
+    load_var c
+
+  L0:
+    return
+}
+
+function optimizer_stack.overwritten(a: bool) -> int {
+    load_var a
+    pop_jump_if_true L0
+    load_const 2
+    jump L1
+
+  L0:
+    load_const 1
+
+  L1:
+    return
+}
+
+function optimizer_stack.overwritten_panic(divisor: int) -> int {
+    load_const 1
+    load_var divisor
+    div_int
+    store_var result
+    load_const 42
+    store_var result
+    load_var result
+
+  L0:
+    return
+    load_var e
+    is_type baml.panics.DivisionByZero
+    pop_jump_if_true L1
+    load_var e
+    rethrow
+
+  L1:
+    load_const 7
+    jump L0
+}
+
+function optimizer_stack.parameter_copy(value: int) -> int {
+    load_var value
+    store_var before
+    load_const 8
+    store_var value
+    load_var before
+    return
+}
+
+function optimizer_stack.predicate(a: bool, b: bool, c: bool) -> bool {
+    load_var a
+    pop_jump_if_false L0
+    load_var b
+    pop_jump_if_true L1
+
+  L0:
+    load_const true
+    jump L2
+
+  L1:
+    load_var c
+
+  L2:
+    return
+}
+
+function optimizer_stack.prefix_unwind(divisor: int) -> int {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    store_var_load_var counter
+    call user.optimizer_stack.tick
+    load_const 42
+    load_var2 2 1
+    call user.optimizer_stack.failing_operand
+    jump L1
+    load_var e
+    is_type baml.panics.DivisionByZero
+    pop_jump_if_true L0
+    load_var e
+    rethrow
+
+  L0:
+    load_var counter
+    load_field .value
+    jump L2
+
+  L1:
+    load_type int
+    alloc_array 3
+    store_var_load_var values
+    load_const 0
+    load_array_element
+    load_var values
+    load_const 1
+    load_array_element
+    add_int
+    load_var values
+    load_const 2
+    load_array_element
+    add_int
+
+  L2:
+    return
+}
+
+function optimizer_stack.tick(counter: optimizer_stack.Counter) -> int {
+    load_var2 1 1
+    load_field .value
+    load_const 1
+    bin_op +
+    store_field .value
+    load_var counter
+    load_field .value
+    return
+}
+
+function optimizer_stack.truth_tables() -> bool {
+    load_const 0
+    store_var bits
+
+  L0:
+    load_var bits
+    load_const 8
+    cmp_int_op <
+    pop_jump_if_true L1
+    load_const true
+    jump L13
+
+  L1:
+    load_var bits
+    load_const 1
+    bin_op &
+    load_const 0
+    cmp_int_op !=
+    store_var a
+    load_var bits
+    load_const 2
+    bin_op &
+    load_const 0
+    cmp_int_op !=
+    store_var b
+    load_var bits
+    load_const 4
+    bin_op &
+    load_const 0
+    cmp_int_op !=
+    store_var c
+    load_var2 2 3
+    load_var c
+    call user.optimizer_stack.and_value
+    load_var bits
+    load_const 7
+    cmp_int_op ==
+    cmp_op !=
+    pop_jump_if_true L12
+    load_var2 2 3
+    load_var c
+    call user.optimizer_stack.or_value
+    load_var bits
+    load_const 0
+    cmp_int_op !=
+    cmp_op !=
+    pop_jump_if_true L11
+    load_var2 2 3
+    load_var c
+    call user.optimizer_stack.mixed_value
+    store_var _28
+    load_var bits
+    load_const 3
+    bin_op &
+    load_const 3
+    cmp_int_op ==
+    jump_if_true_or_pop L2
+    jump L3
+
+  L2:
+    store_var _33
+    jump L4
+
+  L3:
+    load_var c
+    store_var _33
+
+  L4:
+    load_var2 5 6
+    cmp_op !=
+    pop_jump_if_true L10
+    load_var2 2 3
+    load_var c
+    call user.optimizer_stack.predicate
+    store_var _38
+    load_var bits
+    load_const 3
+    bin_op &
+    load_const 3
+    cmp_int_op !=
+    jump_if_true_or_pop L5
+    jump L6
+
+  L5:
+    store_var _43
+    jump L7
+
+  L6:
+    load_var c
+    store_var _43
+
+  L7:
+    load_var2 7 8
+    cmp_op !=
+    pop_jump_if_true L9
+    load_var2 2 3
+    load_var c
+    call user.optimizer_stack.mutable_value
+    load_var bits
+    load_const 7
+    cmp_int_op ==
+    cmp_op !=
+    pop_jump_if_true L8
+    load_var bits
+    load_const 1
+    add_int
+    store_var bits
+    jump L0
+
+  L8:
+    load_const false
+    jump L13
+
+  L9:
+    load_const false
+    jump L13
+
+  L10:
+    load_const false
+    jump L13
+
+  L11:
+    load_const false
+    jump L13
+
+  L12:
+    load_const false
+
+  L13:
+    return
+}
+
+function optimizer_stack.verify_all() -> bool {
+    call user.optimizer_stack.truth_tables
+    jump_if_false_or_pop L0
+    load_const "hi"
+    call user.optimizer_stack.negated_truthiness
+    load_const 2
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const ""
+    call user.optimizer_stack.negated_truthiness
+    load_const 1
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const null
+    call user.optimizer_stack.negated_truthiness
+    load_const 1
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const false
+    load_const true
+    call user.optimizer_stack.condition_effects
+    load_const 0
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const true
+    load_const false
+    call user.optimizer_stack.condition_effects
+    load_const 1
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const true
+    load_const true
+    call user.optimizer_stack.condition_effects
+    load_const 3
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const null
+    call user.optimizer_stack.coalesce
+    load_const 42
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 0
+    call user.optimizer_stack.coalesce
+    load_const 0
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const null
+    call user.optimizer_stack.coalesce_effect
+    load_const 11
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 0
+    call user.optimizer_stack.coalesce_effect
+    load_const 0
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const null
+    call user.optimizer_stack.coalesce_mutable
+    load_const 42
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 9
+    call user.optimizer_stack.coalesce_mutable
+    load_const 9
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.array_mixed
+    store_var _79
+    load_var _79
+    load_const 1
+    load_const 2
+    load_const 3
+    load_type int
+    alloc_array 3
+    call baml.ops.equals_equals
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.array_effects
+    store_var _81
+    load_var _81
+    load_const 1
+    load_const 42
+    load_const 2
+    load_const 2
+    load_type int
+    alloc_array 4
+    call baml.ops.equals_equals
+    jump_if_false_or_pop L0
+    load_const 0
+    call user.optimizer_stack.prefix_unwind
+    load_const 2
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 1
+    call user.optimizer_stack.prefix_unwind
+    load_const 44
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.call_effects
+    load_const 12
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.indirect_effects
+    load_const 12
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.binary_effects
+    load_const -1
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.virtual_effects
+    store_var _88
+    load_var _88
+    load_const 1
+    load_const 42
+    load_const 2
+    load_type int
+    alloc_array 3
+    call baml.ops.equals_equals
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.generic_effects
+    load_const 12
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.constants
+    load_const 13
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const true
+    call user.optimizer_stack.overwritten
+    load_const 1
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const false
+    call user.optimizer_stack.overwritten
+    load_const 2
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 0
+    call user.optimizer_stack.overwritten_panic
+    load_const 7
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 1
+    call user.optimizer_stack.overwritten_panic
+    load_const 42
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 0
+    call user.optimizer_stack.handler_observes_store
+    load_const 2
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 1
+    call user.optimizer_stack.handler_observes_store
+    load_const 3
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    call user.optimizer_stack.constant_overflow
+    load_const 7
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 3
+    call user.optimizer_stack.parameter_copy
+    load_const 3
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 1000
+    call user.optimizer_stack.loop_values
+    load_const 500
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_const 1
+    load_const 2
+    load_const 3
+    load_const 4
+    load_type int
+    alloc_array 4
+    call user.optimizer_stack.iterator_sum
+    load_const 10
+    cmp_int_op ==
+    jump_if_false_or_pop L0
+    load_type int
+    alloc_array 0
+    call user.optimizer_stack.iterator_sum
+    load_const 0
+    cmp_int_op ==
+
+  L0:
+    return
+}
+
+function optimizer_stack.virtual_effects() -> int[] {
+    load_const 0
+    init_instance user.optimizer_stack.Counter .value
+    init_instance user.optimizer_stack.Sequence .counter
+    store_var_load_var source
+    call user.optimizer_stack.virtual_result
+    load_const 42
+    load_var source
+    load_type optimizer_stack.Source
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    load_type int
+    alloc_array 3
+    return
+}
+
+function optimizer_stack.virtual_result(source: optimizer_stack.Source) -> int {
+    load_var source
+    load_type optimizer_stack.Source
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
@@ -1019,6 +1019,9 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
     rethrow
 
   L4:
+    load_var e
+    load_field .0
+    pop 1
     load_const "type-mismatch"
     jump L8
 
@@ -1026,15 +1029,15 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
     load_const null
 
   L6:
-    store_var_load_var _12
+    store_var_load_var _13
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_const "null"
-    store_var _12
+    store_var _13
 
   L7:
-    load_var _12
+    load_var _13
 
   L8:
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
@@ -105,12 +105,12 @@ function optional_chain_type_args.$init_test_ns_optional_chain_type_args_optiona
 }
 
 function optional_chain_type_args.<(user.optional_chain_type_args.Cat as user.optional_chain_type_args.Speaker)>.speak(self: optional_chain_type_args.Cat) -> string {
+    load_const "cat:"
     load_type #0
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
-    load_const "cat:"
     load_var _2
     bin_op +
     return
@@ -121,8 +121,6 @@ function optional_chain_type_args.<(user.optional_chain_type_args.Dog as user.op
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -131,13 +129,11 @@ function optional_chain_type_args.<(user.optional_chain_type_args.Pair<#0> as us
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     load_type #1
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
-    load_var _3
     load_const "/"
     bin_op +
     load_var _5
@@ -150,13 +146,11 @@ function optional_chain_type_args.Boxed.both(self: optional_chain_type_args.Boxe
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     load_type #1
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
-    load_var _3
     load_const "/"
     bin_op +
     load_var _5
@@ -169,17 +163,15 @@ function optional_chain_type_args.Boxed.describe(self: optional_chain_type_args.
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function optional_chain_type_args.Callables.method(self: optional_chain_type_args.Callables, v: int) -> string {
+    load_const "method:"
     load_type int
     load_var v
     call baml.String.from
     store_var _3
-    load_const "method:"
     load_var _3
     bin_op +
     return
@@ -190,8 +182,6 @@ function optional_chain_type_args.Holder.ident(self: optional_chain_type_args.Ho
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -218,8 +208,6 @@ function optional_chain_type_args.Holder.value(self: optional_chain_type_args.Ho
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -227,48 +215,39 @@ function optional_chain_type_args.animal(which: int) -> optional_chain_type_args
     load_var which
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var which
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const null
+    jump L2
+
+  L0:
+    load_const "tom"
+    init_instance user.optional_chain_type_args.Cat .name
     jump L2
 
   L1:
-    load_const null
-    jump L4
-
-  L2:
-    load_const "tom"
-    init_instance user.optional_chain_type_args.Cat .name
-    jump L4
-
-  L3:
     load_const "rex"
     init_instance user.optional_chain_type_args.Dog .name
 
-  L4:
+  L2:
     return
 }
 
 function optional_chain_type_args.boxed(present: bool) -> optional_chain_type_args.Boxed<int> | null {
     load_var present
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_const 1
     load_type int
     init_instance<1> user.optional_chain_type_args.Boxed .v
 
-  L2:
+  L1:
     return
 }
 
@@ -279,10 +258,7 @@ function optional_chain_type_args.callable_field_eval_count_fn() -> string {
     call user.optional_chain_type_args.counted
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var c
     call user.optional_chain_type_args.counted
     store_var _7
@@ -290,33 +266,35 @@ function optional_chain_type_args.callable_field_eval_count_fn() -> string {
     load_var _7
     load_field .0
     call_indirect
-    jump L2
+    jump L1
+
+  L0:
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    jump L3
 
   L2:
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    store_var _12
+    jump L4
+
+  L3:
     load_const "null"
     store_var _12
 
-  L3:
+  L4:
     load_type string
     load_var _12
     call baml.String.from
-    store_var _10
     load_type int
     load_var c
     load_field .n
     call baml.String.from
-    store_var _16
-    load_var _10
+    store_var _15
     load_const "/"
     bin_op +
-    load_var _16
+    load_var _15
     bin_op +
     return
 }
@@ -328,10 +306,7 @@ function optional_chain_type_args.callable_field_null_after_two_fn() -> string {
     call user.optional_chain_type_args.counted_null_after_two
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var c
     call user.optional_chain_type_args.counted_null_after_two
     store_var _7
@@ -339,33 +314,35 @@ function optional_chain_type_args.callable_field_null_after_two_fn() -> string {
     load_var _7
     load_field .0
     call_indirect
-    jump L2
+    jump L1
+
+  L0:
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    jump L3
 
   L2:
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    store_var _12
+    jump L4
+
+  L3:
     load_const "null"
     store_var _12
 
-  L3:
+  L4:
     load_type string
     load_var _12
     call baml.String.from
-    store_var _10
     load_type int
     load_var c
     load_field .n
     call baml.String.from
-    store_var _16
-    load_var _10
+    store_var _15
     load_const "/"
     bin_op +
-    load_var _16
+    load_var _15
     bin_op +
     return
 }
@@ -375,27 +352,18 @@ function optional_chain_type_args.chained_fn() -> string | null {
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.inner
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.inner
@@ -403,12 +371,12 @@ function optional_chain_type_args.chained_fn() -> string | null {
     load_type int
     load_var _6
     call user.optional_chain_type_args.Holder.value
-    jump L4
+    jump L1
 
-  L3:
+  L0:
     load_const null
 
-  L4:
+  L1:
     return
 }
 
@@ -417,27 +385,18 @@ function optional_chain_type_args.chained_null_fn() -> string | null {
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L0
     load_const false
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.inner
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L0
     load_const false
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const false
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.inner
@@ -445,12 +404,12 @@ function optional_chain_type_args.chained_null_fn() -> string | null {
     load_type int
     load_var _6
     call user.optional_chain_type_args.Holder.value
-    jump L4
+    jump L1
 
-  L3:
+  L0:
     load_const null
 
-  L4:
+  L1:
     return
 }
 
@@ -459,27 +418,18 @@ function optional_chain_type_args.chained_null_second_stage_fn() -> string | nul
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.inner_missing
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.inner_missing
@@ -487,12 +437,12 @@ function optional_chain_type_args.chained_null_second_stage_fn() -> string | nul
     load_type int
     load_var _6
     call user.optional_chain_type_args.Holder.value
-    jump L4
+    jump L1
 
-  L3:
+  L0:
     load_const null
 
-  L4:
+  L1:
     return
 }
 
@@ -501,10 +451,7 @@ function optional_chain_type_args.class_and_method_type_args_fn() -> string | nu
     call user.optional_chain_type_args.boxed
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.boxed
     store_var _3
@@ -512,12 +459,12 @@ function optional_chain_type_args.class_and_method_type_args_fn() -> string | nu
     load_type string
     load_var _3
     call user.optional_chain_type_args.Boxed.both
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -526,22 +473,19 @@ function optional_chain_type_args.class_type_arg_fn() -> string | null {
     call user.optional_chain_type_args.boxed
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.boxed
     store_var _3
     load_type int
     load_var _3
     call user.optional_chain_type_args.Boxed.describe
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -550,10 +494,7 @@ function optional_chain_type_args.concrete_receiver_interface_method_fn() -> str
     call user.optional_chain_type_args.dog
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.dog
     store_var _3
@@ -562,12 +503,12 @@ function optional_chain_type_args.concrete_receiver_interface_method_fn() -> str
     load_type optional_chain_type_args.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=1
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -592,35 +533,29 @@ function optional_chain_type_args.counted_null_after_two(c: optional_chain_type_
     load_field .n
     load_const 2
     cmp_int_op <=
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     make_closure .<lambda(counted_null_after_two, 0)>, 0
     init_instance user.optional_chain_type_args.Callables .describe
 
-  L2:
+  L1:
     return
 }
 
 function optional_chain_type_args.dog(present: bool) -> optional_chain_type_args.Dog | null {
     load_var present
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_const "rex"
     init_instance user.optional_chain_type_args.Dog .name
 
-  L2:
+  L1:
     return
 }
 
@@ -629,22 +564,19 @@ function optional_chain_type_args.explicit_type_arg_fn() -> string | null {
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     store_var _3
     load_type int
     load_var _3
     call user.optional_chain_type_args.Holder.value
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -654,19 +586,16 @@ function optional_chain_type_args.explicit_type_arg_let_else_fn() -> string {
     store_var _2
     load_var _2
     narrow_bind optional_chain_type_args.Holder, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "none"
     jump L1
 
   L0:
-    load_const "none"
-    jump L2
-
-  L1:
     load_type int
     load_var _2
     call user.optional_chain_type_args.Holder.value
 
-  L2:
+  L1:
     return
 }
 
@@ -675,39 +604,33 @@ function optional_chain_type_args.explicit_type_arg_null_receiver_fn() -> string
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const false
     call user.optional_chain_type_args.holder
     store_var _3
     load_type int
     load_var _3
     call user.optional_chain_type_args.Holder.value
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
 function optional_chain_type_args.holder(present: bool) -> optional_chain_type_args.Holder | null {
     load_var present
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_const "seven"
     init_instance user.optional_chain_type_args.Holder .raw
 
-  L2:
+  L1:
     return
 }
 
@@ -716,10 +639,7 @@ function optional_chain_type_args.inferred_type_arg_fn() -> string | null {
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     store_var _3
@@ -727,12 +647,12 @@ function optional_chain_type_args.inferred_type_arg_fn() -> string | null {
     load_var _3
     load_const "hi"
     call user.optional_chain_type_args.Holder.ident
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -741,10 +661,7 @@ function optional_chain_type_args.interface_receiver_fn() -> string | null {
     call user.optional_chain_type_args.speaker
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.speaker
     store_var _3
@@ -753,12 +670,12 @@ function optional_chain_type_args.interface_receiver_fn() -> string | null {
     load_type optional_chain_type_args.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=1
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -769,41 +686,40 @@ function optional_chain_type_args.method_eval_count_fn() -> string {
     call user.optional_chain_type_args.counted
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var c
     call user.optional_chain_type_args.counted
     load_const 1
     call user.optional_chain_type_args.Callables.method
-    jump L2
+    jump L1
+
+  L0:
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    jump L3
 
   L2:
-    store_var_load_var _11
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    store_var _11
+    jump L4
+
+  L3:
     load_const "null"
     store_var _11
 
-  L3:
+  L4:
     load_type string
     load_var _11
     call baml.String.from
-    store_var _9
     load_type int
     load_var c
     load_field .n
     call baml.String.from
-    store_var _15
-    load_var _9
+    store_var _14
     load_const "/"
     bin_op +
-    load_var _15
+    load_var _14
     bin_op +
     return
 }
@@ -813,19 +729,16 @@ function optional_chain_type_args.non_generic_call_fn() -> string | null {
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const true
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.plain
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -834,19 +747,16 @@ function optional_chain_type_args.non_generic_call_null_fn() -> string | null {
     call user.optional_chain_type_args.holder
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const false
     call user.optional_chain_type_args.holder
     call user.optional_chain_type_args.Holder.plain
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -892,32 +802,26 @@ function optional_chain_type_args.pair(which: int) -> optional_chain_type_args.P
     load_var which
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var which
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const null
     jump L2
 
-  L1:
-    load_const null
-    jump L4
-
-  L2:
+  L0:
     load_const "a"
     load_type string
     init_instance<1> user.optional_chain_type_args.Pair .v
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const 1
     load_type int
     init_instance<1> user.optional_chain_type_args.Pair .v
 
-  L4:
+  L2:
     return
 }
 
@@ -928,14 +832,11 @@ function optional_chain_type_args.reflected_field_read_fn() -> int | null {
     store_var _2
     load_var _2
     narrow_bind reflect.AnyClass, slot=1
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const null
+    jump L2
 
   L0:
-    load_const null
-    jump L4
-
-  L1:
     load_var _2
     store_var value
     load_var value
@@ -943,14 +844,9 @@ function optional_chain_type_args.reflected_field_read_fn() -> int | null {
     load_type reflect.AnyClass
     load_const "get_field"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var value
     load_const "x"
     load_type reflect.AnyClass
@@ -960,12 +856,12 @@ function optional_chain_type_args.reflected_field_read_fn() -> int | null {
     load_type int
     load_var _6
     call reflect.class.Field.value
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const null
 
-  L4:
+  L2:
     return
 }
 
@@ -976,14 +872,11 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
     store_var _2
     load_var _2
     narrow_bind reflect.AnyClass, slot=1
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const "no-class"
+    jump L4
 
   L0:
-    load_const "no-class"
-    jump L8
-
-  L1:
     load_var _2
     store_var value
     load_var value
@@ -991,14 +884,9 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
     load_type reflect.AnyClass
     load_const "get_field"
     virtual_call nargs=2 ntypeargs=0
-    store_var _6
-    load_var _6
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L2
     load_var value
     load_const "x"
     load_type reflect.AnyClass
@@ -1008,38 +896,25 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
     load_type string
     load_var _8
     call reflect.class.Field.value
-    jump L6
+    jump L3
     load_var e
     is_type reflect.errors.TypeMismatch
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L4:
-    load_var e
-    load_field .0
-    pop 1
+  L1:
     load_const "type-mismatch"
-    jump L8
+    jump L4
 
-  L5:
+  L2:
     load_const null
 
-  L6:
-    store_var_load_var _13
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
+  L3:
+    jump_if_not_null_or_pop L4
     load_const "null"
-    store_var _13
 
-  L7:
-    load_var _13
-
-  L8:
+  L4:
     return
 }
 
@@ -1050,14 +925,11 @@ function optional_chain_type_args.reflected_missing_field_fn() -> int | null {
     store_var _2
     load_var _2
     narrow_bind reflect.AnyClass, slot=1
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const null
+    jump L2
 
   L0:
-    load_const null
-    jump L4
-
-  L1:
     load_var _2
     store_var value
     load_var value
@@ -1065,14 +937,9 @@ function optional_chain_type_args.reflected_missing_field_fn() -> int | null {
     load_type reflect.AnyClass
     load_const "get_field"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var value
     load_const "absent"
     load_type reflect.AnyClass
@@ -1082,29 +949,26 @@ function optional_chain_type_args.reflected_missing_field_fn() -> int | null {
     load_type int
     load_var _6
     call reflect.class.Field.value
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const null
 
-  L4:
+  L2:
     return
 }
 
 function optional_chain_type_args.speaker(present: bool) -> optional_chain_type_args.Speaker | null {
     load_var present
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_const "rex"
     init_instance user.optional_chain_type_args.Dog .name
 
-  L2:
+  L1:
     return
 }
 
@@ -1120,36 +984,28 @@ function optional_chain_type_args.sys_op_optional_receiver_fn() -> string {
     call user.optional_chain_type_args.optional_file
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var path
     call user.optional_chain_type_args.optional_file
     load_type baml.io.Read
     load_const "text"
     virtual_call nargs=1 ntypeargs=0
     store_var text
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
     store_var text
 
-  L2:
+  L1:
     load_var path
     sys_op baml.fs.remove
     pop 1
     load_var text
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L2
     load_const "null"
-    store_var _12
 
-  L3:
-    load_var _12
+  L2:
     return
 }
 
@@ -1180,10 +1036,7 @@ function optional_chain_type_args.union_class_type_args_fn(which: int) -> string
     call user.optional_chain_type_args.pair
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var which
     call user.optional_chain_type_args.pair
     store_var _4
@@ -1192,12 +1045,12 @@ function optional_chain_type_args.union_class_type_args_fn(which: int) -> string
     load_type optional_chain_type_args.Tagged
     load_const "tag"
     virtual_call nargs=1 ntypeargs=1
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -1206,10 +1059,7 @@ function optional_chain_type_args.union_receiver_fn(which: int) -> string | null
     call user.optional_chain_type_args.animal
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var which
     call user.optional_chain_type_args.animal
     store_var _4
@@ -1218,11 +1068,11 @@ function optional_chain_type_args.union_receiver_fn(which: int) -> string | null
     load_type optional_chain_type_args.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=1
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
@@ -110,8 +110,6 @@ function optional_chain_type_args.<(user.optional_chain_type_args.Cat as user.op
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     bin_op +
     return
 }
@@ -171,8 +169,6 @@ function optional_chain_type_args.Callables.method(self: optional_chain_type_arg
     load_type int
     load_var v
     call baml.String.from
-    store_var _3
-    load_var _3
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_function_parameters/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_function_parameters/bytecode.snap
@@ -60,17 +60,14 @@ function optional_function_parameters.classify(value: int | null) -> int {
     load_var value
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_var value
     jump L2
 
   L1:
-    load_var value
-    jump L3
-
-  L2:
     load_const 1
 
-  L3:
+  L2:
     return
 }
 
@@ -227,19 +224,16 @@ function optional_function_parameters.score(query: string, max_results: int, fil
     load_var filter
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L3
+    pop_jump_if_true L3
+    load_const 100
+    store_var filter_bonus
     jump L4
 
   L3:
-    load_const 100
-    store_var filter_bonus
-    jump L5
-
-  L4:
     load_const 0
     store_var filter_bonus
 
-  L5:
+  L4:
     load_var2 2 4
     add_int
     load_var filter_bonus

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_output_format_options/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_output_format_options/bytecode.snap
@@ -55,12 +55,10 @@ function output_format_options.OfAllLegacyOptions(client: ai.Client | null, on_e
     call user.output_format_options.OfAllLegacyOptions@spec
     store_var _8
     load_type output_format_options.OfOptionResult
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_panic_channel/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_panic_channel/bytecode.snap
@@ -43,15 +43,12 @@ function panic_channel.$init_test_ns_panic_channel_panic_channel(registry: testi
 
 function panic_channel.throws_a_mixture(fail: bool) -> int {
     load_var fail
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "thrown"
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L1:
+  L0:
     load_const "raised"
     init_instance baml.panics.AssertionFailed .message
     throw

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_parse_companions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_parse_companions/bytecode.snap
@@ -48,12 +48,10 @@ function parse_companions.ParseCompanionsParseAliasPayload(client: ai.Client | n
     call user.parse_companions.ParseCompanionsParseAliasPayload@spec
     store_var _8
     load_type parse_companions.ParseCompanionsAliasPayload
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -165,12 +163,10 @@ function parse_companions.ParseCompanionsParseOptPayload(client: ai.Client | nul
     call user.parse_companions.ParseCompanionsParseOptPayload@spec
     store_var _8
     load_type parse_companions.ParseCompanionsOptPayload
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_patterns_new_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_patterns_new_runtime/bytecode.snap
@@ -798,6 +798,9 @@ function patterns_new_runtime.classify_box_union_by_field(box: patterns_new_runt
     jump L2
 
   L1:
+    load_var box
+    load_field .0
+    pop 1
     load_var _4
 
   L2:
@@ -924,21 +927,49 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     pop_jump_if_false L2
     load_var xs
     container_len
-    store_var_load_var _11
+    store_var_load_var _13
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L2
     jump L3
 
   L2:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_const 3
     jump L6
 
   L3:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 1
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 1
+    load_array_element
+    pop 1
     load_const 2
     jump L6
 
   L4:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_const 1
     jump L6
 
@@ -998,6 +1029,9 @@ function patterns_new_runtime.from_optional_box(box: patterns_new_runtime.BoxT<i
     jump L2
 
   L1:
+    load_var box
+    load_field .0
+    pop 1
     load_var _4
 
   L2:
@@ -1021,6 +1055,9 @@ function patterns_new_runtime.from_union_box(box: patterns_new_runtime.BoxT<int>
     jump L2
 
   L1:
+    load_var box
+    load_field .0
+    pop 1
     load_var _4
 
   L2:
@@ -1048,10 +1085,16 @@ function patterns_new_runtime.match_box_union(b: patterns_new_runtime.BoxUnion) 
     jump L1
 
   L0:
+    load_var b
+    load_field .value
+    pop 1
     load_const 2
     jump L2
 
   L1:
+    load_var b
+    load_field .value
+    pop 1
     load_const 1
 
   L2:
@@ -1097,6 +1140,12 @@ function patterns_new_runtime.match_coord_user() -> int {
     jump L2
 
   L1:
+    load_var _1
+    load_field .profile
+    load_field .address
+    load_field .coordinate
+    load_field .zip
+    pop 1
     load_const 1
 
   L2:
@@ -1119,6 +1168,9 @@ function patterns_new_runtime.match_person_as(p: patterns_new_runtime.PersonAS) 
     jump L2
 
   L1:
+    load_var p
+    load_field .age
+    pop 1
     load_const 70
 
   L2:
@@ -1162,21 +1214,21 @@ function patterns_new_runtime.or_deep_class() -> int {
     pop_jump_if_false L1
     load_var _1
     load_field .address
-    store_var_load_var _17
+    store_var_load_var _19
     is_type patterns_new_runtime.Address3
     pop_jump_if_false L1
-    load_var _17
+    load_var _19
     load_field .coordinate
-    store_var_load_var _19
+    store_var_load_var _21
     is_type patterns_new_runtime.Coordinate3
     pop_jump_if_false L1
-    load_var _19
+    load_var _21
     load_field .zip
-    store_var _22
-    load_var _22
-    narrow_bind int, slot=7
+    store_var _24
+    load_var _24
+    narrow_bind int, slot=9
     pop_jump_if_false L1
-    load_var _19
+    load_var _21
     load_field .plus4
     is_type 2
     pop_jump_if_false L1
@@ -1187,11 +1239,33 @@ function patterns_new_runtime.or_deep_class() -> int {
     jump L4
 
   L2:
-    load_var _22
+    load_var _1
+    load_field .address
+    load_field .coordinate
+    store_var_load_var _28
+    load_field .zip
+    pop 1
+    load_var _24
+    store_var zip
+    load_var _28
+    load_field .plus4
+    pop 1
+    load_var zip
     jump L4
 
   L3:
+    load_var _1
+    load_field .address
+    load_field .coordinate
+    store_var_load_var _14
+    load_field .zip
+    pop 1
     load_var _10
+    store_var zip
+    load_var _14
+    load_field .plus4
+    pop 1
+    load_var zip
 
   L4:
     return
@@ -1213,19 +1287,23 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     cmp_int_op >=
     pop_jump_if_false L0
     load_var _3
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _3
     load_const 1
     load_array_element
-    store_var_load_var _9
+    store_var_load_var _10
     is_type patterns_new_runtime.Cell1
     pop_jump_if_false L0
-    load_var _9
+    load_var _10
     load_field .row
-    store_var_load_var _11
+    store_var_load_var _12
     is_type int[]
     pop_jump_if_false L0
-    load_var _11
+    load_var _12
     container_len
-    store_var_load_var _13
+    store_var_load_var _14
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
@@ -1237,33 +1315,33 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     pop_jump_if_false L1
     load_var g
     load_field .cells
-    store_var_load_var _27
+    store_var_load_var _32
     is_type patterns_new_runtime.Cell1[]
     pop_jump_if_false L1
-    load_var _27
+    load_var _32
     container_len
-    store_var_load_var _29
+    store_var_load_var _34
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _27
+    load_var _32
     container_len
-    store_var _31
-    load_var2 7 9
+    store_var _36
+    load_var2 9 11
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _33
+    store_var_load_var _38
     is_type patterns_new_runtime.Cell1
     pop_jump_if_false L1
-    load_var _33
+    load_var _38
     load_field .row
-    store_var_load_var _35
+    store_var_load_var _40
     is_type int[]
     pop_jump_if_false L1
-    load_var _35
+    load_var _40
     container_len
-    store_var_load_var _37
+    store_var_load_var _42
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
@@ -1274,42 +1352,77 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     jump L4
 
   L2:
-    load_var _35
-    container_len
-    store_var _39
-    load_var _35
-    container_len
-    store_var _41
-    load_var g
-    load_field .cells
-    store_var _43
-    load_var _43
+    load_var _40
     container_len
     store_var _44
-    load_var2 15 16
-    load_const 1
-    sub_int
-    load_array_element
-    load_field .row
-    store_var _47
-    load_var _47
-    container_len
-    store_var _48
-    load_var _47
-    container_len
-    store_var _52
-    load_var2 17 18
+    load_var2 13 15
     load_const 2
     sub_int
     load_array_element
+    pop 1
+    load_var _40
+    container_len
+    store_var _47
+    load_var2 13 16
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var g
+    load_field .cells
+    store_var _50
+    load_var _50
+    container_len
+    store_var _51
+    load_var2 17 18
+    load_const 1
+    sub_int
+    load_array_element
+    load_field .row
+    store_var _54
+    load_var _54
+    container_len
+    store_var _55
+    load_var2 19 20
+    load_const 2
+    sub_int
+    load_array_element
+    store_var x
+    load_var _54
+    container_len
+    store_var _59
+    load_var2 19 22
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var x
     jump L4
 
   L3:
+    load_var _12
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _12
+    load_const 1
+    load_array_element
+    pop 1
     load_var g
     load_field .cells
+    store_var_load_var _20
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _20
     load_const 1
     load_array_element
     load_field .row
+    store_var_load_var _25
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _25
     load_const 1
     load_array_element
 
@@ -1338,10 +1451,14 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     cmp_int_op >=
     pop_jump_if_false L0
     load_var _5
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _5
     load_const 1
     load_array_element
-    store_var _12
-    load_var _12
+    store_var _13
+    load_var _13
     narrow_bind int, slot=5
     pop_jump_if_false L0
     jump L7
@@ -1351,22 +1468,33 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     is_type patterns_new_runtime.Pair1
     pop_jump_if_false L1
     load_var p
+    load_field .0
+    pop 1
+    load_var p
     load_field .1
-    store_var_load_var _19
+    store_var_load_var _25
     is_type int[]
     pop_jump_if_false L1
-    load_var _19
+    load_var _25
     container_len
-    store_var_load_var _21
+    store_var_load_var _27
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _19
+    load_var _25
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _25
+    load_const 1
+    load_array_element
+    pop 1
+    load_var _25
     load_const 2
     load_array_element
-    store_var _27
-    load_var _27
-    narrow_bind int, slot=8
+    store_var _35
+    load_var _35
+    narrow_bind int, slot=10
     pop_jump_if_false L1
     jump L6
 
@@ -1376,25 +1504,25 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     pop_jump_if_false L2
     load_var p
     load_field .0
-    store_var_load_var _34
+    store_var_load_var _46
     is_type int[]
     pop_jump_if_false L2
-    load_var _34
+    load_var _46
     container_len
-    store_var_load_var _36
+    store_var_load_var _48
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L2
-    load_var _34
+    load_var _46
     container_len
-    store_var _38
-    load_var2 9 11
+    store_var _50
+    load_var2 12 14
     load_const 3
     sub_int
     load_array_element
-    store_var _41
-    load_var _41
-    narrow_bind int, slot=12
+    store_var _53
+    load_var _53
+    narrow_bind int, slot=15
     pop_jump_if_false L2
     jump L5
 
@@ -1404,32 +1532,36 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     pop_jump_if_false L3
     load_var p
     container_len
-    store_var_load_var _55
+    store_var_load_var _72
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L3
     load_var p
+    load_const 0
+    load_array_element
+    pop 1
+    load_var p
     load_const 1
     load_array_element
-    store_var_load_var _59
+    store_var_load_var _77
     is_type int[]
     pop_jump_if_false L3
-    load_var _59
+    load_var _77
     container_len
-    store_var_load_var _61
+    store_var_load_var _79
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L3
-    load_var _59
+    load_var _77
     container_len
-    store_var _63
-    load_var2 20 22
+    store_var _81
+    load_var2 24 26
     load_const 1
     sub_int
     load_array_element
-    store_var _66
-    load_var _66
-    narrow_bind int, slot=23
+    store_var _84
+    load_var _84
+    narrow_bind int, slot=27
     pop_jump_if_false L3
     jump L4
 
@@ -1439,41 +1571,115 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
 
   L4:
     load_var p
+    load_const 0
+    load_array_element
+    pop 1
+    load_var p
     load_const 1
     load_array_element
+    store_var _88
+    load_var _88
     container_len
-    store_var _70
-    load_var _66
+    store_var _89
+    load_var2 28 29
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var _84
     jump L8
 
   L5:
-    load_var _34
+    load_var _46
     container_len
-    store_var _42
-    load_var _34
+    store_var _54
+    load_var2 12 16
+    load_const 2
+    sub_int
+    load_array_element
+    pop 1
+    load_var _46
     container_len
-    store_var _44
+    store_var _57
+    load_var2 12 17
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
     load_var p
     load_field .0
-    store_var _46
-    load_var _46
+    store_var _60
+    load_var _60
     container_len
-    store_var _47
-    load_var _46
+    store_var _61
+    load_var2 18 19
+    load_const 3
+    sub_int
+    load_array_element
+    pop 1
+    load_var _53
+    store_var v
+    load_var _60
     container_len
-    store_var _50
-    load_var _46
+    store_var _65
+    load_var2 18 21
+    load_const 2
+    sub_int
+    load_array_element
+    pop 1
+    load_var _60
     container_len
-    store_var _52
-    load_var _41
+    store_var _68
+    load_var2 18 22
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var v
     jump L8
 
   L6:
-    load_var _27
+    load_var p
+    load_field .0
+    pop 1
+    load_var p
+    load_field .1
+    store_var_load_var _37
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _37
+    load_const 1
+    load_array_element
+    pop 1
+    load_var _37
+    load_const 2
+    load_array_element
+    pop 1
+    load_var _35
     jump L8
 
   L7:
-    load_var _12
+    load_var p
+    load_field .1
+    pop 1
+    load_var p
+    load_field .0
+    load_field .inner
+    store_var_load_var _16
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _16
+    load_const 1
+    load_array_element
+    pop 1
+    load_var _13
+    store_var v
+    load_var p
+    load_field .1
+    pop 1
+    load_var v
 
   L8:
     return
@@ -1495,49 +1701,61 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     cmp_int_op >=
     pop_jump_if_false L0
     load_var _3
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _3
     load_const 1
     load_array_element
-    store_var_load_var _9
+    store_var_load_var _10
     is_type patterns_new_runtime.Row1
     pop_jump_if_false L0
-    load_var _9
+    load_var _10
     load_field .slots
-    store_var_load_var _11
+    store_var_load_var _12
     is_type patterns_new_runtime.Slot1[]
     pop_jump_if_false L0
-    load_var _11
+    load_var _12
     container_len
-    store_var_load_var _13
+    store_var_load_var _14
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
-    load_var _11
+    load_var _12
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _12
     load_const 1
     load_array_element
-    store_var_load_var _17
+    store_var_load_var _19
     is_type patterns_new_runtime.Slot1
     pop_jump_if_false L0
-    load_var _17
+    load_var _19
     load_field .atoms
-    store_var_load_var _19
+    store_var_load_var _21
     is_type patterns_new_runtime.Atom1[]
     pop_jump_if_false L0
-    load_var _19
+    load_var _21
     container_len
-    store_var_load_var _21
+    store_var_load_var _23
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
-    load_var _19
+    load_var _21
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _21
     load_const 1
     load_array_element
-    store_var_load_var _25
+    store_var_load_var _28
     is_type patterns_new_runtime.Atom1
     pop_jump_if_false L0
-    load_var _25
-    load_field .value
-    store_var _28
     load_var _28
+    load_field .value
+    store_var _31
+    load_var _31
     narrow_bind int, slot=11
     pop_jump_if_false L0
     jump L3
@@ -1548,72 +1766,72 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     pop_jump_if_false L1
     load_var s
     load_field .rows
-    store_var_load_var _43
+    store_var_load_var _50
     is_type patterns_new_runtime.Row1[]
     pop_jump_if_false L1
-    load_var _43
+    load_var _50
     container_len
-    store_var_load_var _45
+    store_var_load_var _52
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _43
+    load_var _50
     container_len
-    store_var _47
-    load_var2 12 14
+    store_var _54
+    load_var2 15 17
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _49
+    store_var_load_var _56
     is_type patterns_new_runtime.Row1
     pop_jump_if_false L1
-    load_var _49
+    load_var _56
     load_field .slots
-    store_var_load_var _51
+    store_var_load_var _58
     is_type patterns_new_runtime.Slot1[]
     pop_jump_if_false L1
-    load_var _51
+    load_var _58
     container_len
-    store_var_load_var _53
+    store_var_load_var _60
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _51
+    load_var _58
     container_len
-    store_var _55
-    load_var2 16 18
+    store_var _62
+    load_var2 19 21
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _57
+    store_var_load_var _64
     is_type patterns_new_runtime.Slot1
     pop_jump_if_false L1
-    load_var _57
+    load_var _64
     load_field .atoms
-    store_var_load_var _59
+    store_var_load_var _66
     is_type patterns_new_runtime.Atom1[]
     pop_jump_if_false L1
-    load_var _59
+    load_var _66
     container_len
-    store_var_load_var _61
+    store_var_load_var _68
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _59
+    load_var _66
     container_len
-    store_var _63
-    load_var2 20 22
+    store_var _70
+    load_var2 23 25
     load_const 2
     sub_int
     load_array_element
-    store_var_load_var _65
+    store_var_load_var _72
     is_type patterns_new_runtime.Atom1
     pop_jump_if_false L1
-    load_var _65
+    load_var _72
     load_field .value
-    store_var _68
-    load_var _68
-    narrow_bind int, slot=24
+    store_var _75
+    load_var _75
+    narrow_bind int, slot=27
     pop_jump_if_false L1
     jump L2
 
@@ -1622,41 +1840,86 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     jump L4
 
   L2:
-    load_var _59
-    container_len
-    store_var _69
-    load_var s
-    load_field .rows
-    store_var _71
-    load_var _71
-    container_len
-    store_var _72
-    load_var2 26 27
-    load_const 1
-    sub_int
-    load_array_element
-    load_field .slots
-    store_var _75
-    load_var _75
+    load_var _66
     container_len
     store_var _76
-    load_var2 28 29
+    load_var2 23 28
     load_const 1
     sub_int
     load_array_element
-    load_field .atoms
+    pop 1
+    load_var s
+    load_field .rows
     store_var _79
     load_var _79
     container_len
     store_var _80
-    load_var _79
+    load_var2 29 30
+    load_const 1
+    sub_int
+    load_array_element
+    load_field .slots
+    store_var _83
+    load_var _83
     container_len
     store_var _84
-    load_var _68
+    load_var2 31 32
+    load_const 1
+    sub_int
+    load_array_element
+    load_field .atoms
+    store_var _87
+    load_var _87
+    container_len
+    store_var _88
+    load_var2 33 34
+    load_const 2
+    sub_int
+    load_array_element
+    load_field .value
+    pop 1
+    load_var _75
+    store_var x
+    load_var _87
+    container_len
+    store_var _93
+    load_var2 33 36
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var x
     jump L4
 
   L3:
-    load_var _28
+    load_var s
+    load_field .rows
+    store_var_load_var _32
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _32
+    load_const 1
+    load_array_element
+    load_field .slots
+    store_var_load_var _37
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _37
+    load_const 1
+    load_array_element
+    load_field .atoms
+    store_var_load_var _42
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _42
+    load_const 1
+    load_array_element
+    load_field .value
+    pop 1
+    load_var _31
 
   L4:
     return
@@ -1679,6 +1942,14 @@ function patterns_new_runtime.prefix_length(xs: int[]) -> int {
     jump L2
 
   L1:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_const 1
 
   L2:
@@ -1741,11 +2012,17 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
 
   L4:
     load_var v
+    load_field .0
+    pop 1
+    load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
     jump L8
 
   L5:
+    load_var v
+    load_field .0
+    pop 1
     load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
@@ -1753,11 +2030,17 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
 
   L6:
     load_var v
+    load_field .0
+    pop 1
+    load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
     jump L8
 
   L7:
+    load_var v
+    load_field .0
+    pop 1
     load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
@@ -1789,13 +2072,13 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var_load_var _10
+    store_var_load_var _11
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var _12
+    store_var _13
     load_var2 1 4
     load_const 1
     sub_int
@@ -1810,7 +2093,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     pop_jump_if_false L2
     load_var xs
     container_len
-    store_var_load_var _19
+    store_var_load_var _21
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L2
@@ -1827,11 +2110,20 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
   L4:
     load_var xs
     container_len
-    store_var _16
+    store_var _17
+    load_var2 1 5
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
     load_const 2
     jump L6
 
   L5:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_const 1
 
   L6:
@@ -1850,14 +2142,21 @@ function patterns_new_runtime.score_depth(v: patterns_new_runtime.DepthClass | p
     pop_jump_if_false L2
     load_var v
     load_field .0
+    store_var_load_var _7
     is_type patterns_new_runtime.DepthClass3
     pop_jump_if_false L2
+    load_var _7
+    load_field .field
+    pop 1
     load_var v
     load_field .0
     load_field .field
     jump L2
 
   L1:
+    load_var v
+    load_field .0
+    pop 1
     load_var v
     load_field .0
 
@@ -1912,7 +2211,7 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     pop_jump_if_false L1
     load_var _1
     container_len
-    store_var_load_var _10
+    store_var_load_var _11
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L1
@@ -1926,6 +2225,14 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     load_var _1
     load_const 0
     load_array_element
+    pop 1
+    load_var _1
+    load_const 1
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 0
+    load_array_element
     load_const 10
     mul_int
     load_var _1
@@ -1935,6 +2242,10 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     jump L4
 
   L3:
+    load_var _1
+    load_const 0
+    load_array_element
+    pop 1
     load_var _1
     load_const 0
     load_array_element
@@ -1988,18 +2299,42 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     jump L3
 
   L2:
+    load_var f
+    load_field .first
+    pop 1
+    load_var f
+    load_field .second
+    pop 1
     load_const 4
     jump L6
 
   L3:
+    load_var f
+    load_field .first
+    pop 1
+    load_var f
+    load_field .second
+    pop 1
     load_const 3
     jump L6
 
   L4:
+    load_var f
+    load_field .first
+    pop 1
+    load_var f
+    load_field .second
+    pop 1
     load_const 2
     jump L6
 
   L5:
+    load_var f
+    load_field .first
+    pop 1
+    load_var f
+    load_field .second
+    pop 1
     load_const 1
 
   L6:
@@ -2027,14 +2362,23 @@ function patterns_new_runtime.score_foo_union(f: patterns_new_runtime.FooUnion) 
     jump L2
 
   L1:
+    load_var f
+    load_field .value
+    pop 1
     load_const 3
     jump L4
 
   L2:
+    load_var f
+    load_field .value
+    pop 1
     load_const 2
     jump L4
 
   L3:
+    load_var f
+    load_field .value
+    pop 1
     load_const 1
 
   L4:
@@ -2106,6 +2450,10 @@ function patterns_new_runtime.score_int_string_array(v: int[] | string[]) -> int
     load_var v
     load_const 0
     load_array_element
+    pop 1
+    load_var v
+    load_const 0
+    load_array_element
     load_var _7
     add_int
 
@@ -2141,7 +2489,7 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var_load_var _14
+    store_var_load_var _16
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2157,10 +2505,22 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     jump L4
 
   L2:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_const 10
     jump L4
 
   L3:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 1
+    load_array_element
+    pop 1
     load_const 12
 
   L4:
@@ -2179,12 +2539,12 @@ function patterns_new_runtime.score_opat(input: patterns_new_runtime.OPat_A | pa
     pop_jump_if_false L1
     load_var input
     load_field .0
-    store_var_load_var _6
+    store_var_load_var _7
     is_type int[]
     pop_jump_if_false L1
-    load_var _6
+    load_var _7
     container_len
-    store_var_load_var _8
+    store_var_load_var _9
     load_const 2
     cmp_int_op ==
     pop_jump_if_false L1
@@ -2195,13 +2555,29 @@ function patterns_new_runtime.score_opat(input: patterns_new_runtime.OPat_A | pa
     jump L4
 
   L2:
+    load_var _7
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _7
+    load_const 1
+    load_array_element
+    pop 1
     load_var input
     load_field .0
+    store_var_load_var _15
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _15
     load_const 1
     load_array_element
     jump L4
 
   L3:
+    load_var input
+    load_field .0
+    pop 1
     load_var input
     load_field .0
 
@@ -2234,15 +2610,15 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     pop_jump_if_false L1
     load_var v
     container_len
-    store_var_load_var _15
+    store_var_load_var _16
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var v
     load_const 0
     load_array_element
-    store_var _19
-    load_var _19
+    store_var _20
+    load_var _20
     narrow_bind int, slot=5
     pop_jump_if_false L1
     jump L2
@@ -2255,11 +2631,19 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     load_var v
     load_const 0
     load_array_element
-    load_var _19
+    pop 1
+    load_var v
+    load_const 0
+    load_array_element
+    load_var _20
     add_int
     jump L4
 
   L3:
+    load_var v
+    load_const 0
+    load_array_element
+    pop 1
     load_var v
     load_const 0
     load_array_element
@@ -2300,19 +2684,19 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     pop_jump_if_false L1
     load_var rows
     container_len
-    store_var_load_var _17
+    store_var_load_var _18
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var rows
     load_const 0
     load_array_element
-    store_var_load_var _20
+    store_var_load_var _21
     is_type int[]
     pop_jump_if_false L1
-    load_var _20
+    load_var _21
     container_len
-    store_var_load_var _22
+    store_var_load_var _23
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2323,6 +2707,10 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     jump L4
 
   L2:
+    load_var _21
+    load_const 0
+    load_array_element
+    pop 1
     load_var rows
     load_const 0
     load_array_element
@@ -2331,6 +2719,10 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     jump L4
 
   L3:
+    load_var _6
+    load_const 0
+    load_array_element
+    pop 1
     load_var rows
     load_const 0
     load_array_element
@@ -2359,7 +2751,7 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var_load_var _10
+    store_var_load_var _11
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2373,9 +2765,17 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     load_var xs
     load_const 0
     load_array_element
+    pop 1
+    load_var xs
+    load_const 0
+    load_array_element
     jump L4
 
   L3:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_var xs
     load_const 0
     load_array_element
@@ -2407,19 +2807,29 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     load_var xs
     container_len
     store_var _6
+    load_var2 1 3
+    load_const 2
+    sub_int
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _8
+    store_var _9
+    load_var2 1 4
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _10
+    store_var _12
     load_var xs
     container_len
-    store_var _14
+    store_var _16
     load_var xs
     container_len
-    store_var _21
-    load_var _21
+    store_var _23
+    load_var _23
     load_const 2
     sub_int
     load_const 100
@@ -2480,6 +2890,12 @@ function patterns_new_runtime.score_pair_or(p: patterns_new_runtime.PairAB) -> i
     jump L5
 
   L4:
+    load_var p
+    load_field .a
+    pop 1
+    load_var p
+    load_field .b
+    pop 1
     load_const 1
 
   L5:
@@ -2499,6 +2915,9 @@ function patterns_new_runtime.score_person_age(v: patterns_new_runtime.PersonAge
   L1:
     load_var v
     load_field .0
+    pop 1
+    load_var v
+    load_field .0
 
   L2:
     return
@@ -2516,9 +2935,15 @@ function patterns_new_runtime.score_personid(v: patterns_new_runtime.PersonIdA |
     pop_jump_if_false L2
     load_var v
     load_field .0
+    pop 1
+    load_var v
+    load_field .0
     jump L2
 
   L1:
+    load_var v
+    load_field .0
+    pop 1
     load_var v
     load_field .0
 
@@ -2544,17 +2969,31 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
 
   L1:
     load_var xs
-    container_len
-    store_var _6
+    load_const 0
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _8
+    store_var _7
+    load_var2 1 3
+    load_const 2
+    sub_int
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _13
+    store_var _10
+    load_var2 1 4
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _17
+    store_var _16
+    load_var xs
+    container_len
+    store_var _20
     load_var xs
     load_const 0
     load_array_element
@@ -2594,6 +3033,9 @@ function patterns_new_runtime.score_refine_a(v: patterns_new_runtime.RefineA | p
   L1:
     load_var v
     load_field .0
+    pop 1
+    load_var v
+    load_field .0
 
   L2:
     return
@@ -2619,12 +3061,16 @@ function patterns_new_runtime.score_rest_copy(xs: int[]) -> int {
     load_var xs
     load_const 0
     load_array_element
+    pop 1
+    load_var xs
+    load_const 0
+    load_array_element
     load_const 10
     mul_int
-    store_var _9
+    store_var _10
     load_var xs
     container_len
-    store_var _12
+    store_var _13
     load_var2 3 4
     load_const 1
     sub_int
@@ -2657,6 +3103,10 @@ function patterns_new_runtime.score_strings_len(xs: string[]) -> int {
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     container_len
 
   L2:
@@ -2683,13 +3133,18 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
     load_var xs
     container_len
     store_var _5
+    load_var2 1 3
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _7
+    store_var _8
     load_var xs
     container_len
-    store_var _13
-    load_var _13
+    store_var _14
+    load_var _14
     load_const 1
     sub_int
     load_const 10
@@ -2739,24 +3194,24 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     pop_jump_if_false L1
     load_var teams
     container_len
-    store_var_load_var _20
+    store_var_load_var _21
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var teams
     load_const 0
     load_array_element
-    store_var_load_var _23
+    store_var_load_var _24
     is_type patterns_new_runtime.Team2
     pop_jump_if_false L1
-    load_var _23
+    load_var _24
     load_field .scores
-    store_var_load_var _25
+    store_var_load_var _26
     is_type int[]
     pop_jump_if_false L1
-    load_var _25
+    load_var _26
     container_len
-    store_var_load_var _27
+    store_var_load_var _28
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2767,15 +3222,32 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     jump L4
 
   L2:
+    load_var _26
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _26
+    load_const 1
+    load_array_element
+    pop 1
     load_var teams
     load_const 0
     load_array_element
     load_field .scores
+    store_var_load_var _36
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _36
     load_const 1
     load_array_element
     jump L4
 
   L3:
+    load_var _8
+    load_const 0
+    load_array_element
+    pop 1
     load_var teams
     load_const 0
     load_array_element
@@ -2812,6 +3284,9 @@ function patterns_new_runtime.score_team3(team: patterns_new_runtime.Team3) -> i
     jump L2
 
   L1:
+    load_var team
+    load_field .scores
+    pop 1
     load_const 10
 
   L2:
@@ -2840,8 +3315,21 @@ function patterns_new_runtime.score_team4(team: patterns_new_runtime.Team4) -> i
     jump L2
 
   L1:
+    load_var _3
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _3
+    load_const 1
+    load_array_element
+    pop 1
     load_var team
     load_field .scores
+    store_var_load_var _11
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _11
     load_const 1
     load_array_element
 
@@ -2867,11 +3355,24 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
 
   L1:
     load_var xs
-    container_len
-    store_var _7
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 1
+    load_array_element
+    pop 1
     load_var xs
     container_len
-    store_var _15
+    store_var _9
+    load_var2 1 3
+    load_const 1
+    sub_int
+    load_array_element
+    pop 1
+    load_var xs
+    container_len
+    store_var _18
     load_var xs
     load_const 0
     load_array_element
@@ -2947,6 +3448,18 @@ function patterns_new_runtime.score_wildcard_second(xs: int[]) -> int {
 
   L1:
     load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 1
+    load_array_element
+    pop 1
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
+    load_var xs
     load_const 1
     load_array_element
 
@@ -2967,6 +3480,7 @@ function patterns_new_runtime.score_wildcard_user(users: patterns_new_runtime.Us
     load_var users
     load_const 0
     load_array_element
+    store_var_load_var _6
     is_type patterns_new_runtime.UserScore
     pop_jump_if_false L0
     jump L1
@@ -2976,9 +3490,19 @@ function patterns_new_runtime.score_wildcard_user(users: patterns_new_runtime.Us
     jump L2
 
   L1:
+    load_var _6
+    load_field .name
+    pop 1
+    load_var _6
+    load_field .score
+    pop 1
     load_var users
     load_const 0
     load_array_element
+    store_var_load_var _11
+    load_field .name
+    pop 1
+    load_var _11
     load_field .score
 
   L2:
@@ -3015,28 +3539,28 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     pop_jump_if_false L1
     load_var v
     load_field .0
-    store_var_load_var _17
+    store_var_load_var _18
     is_type int[][]
     pop_jump_if_false L1
-    load_var _17
+    load_var _18
     container_len
-    store_var_load_var _19
+    store_var_load_var _20
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _17
+    load_var _18
     container_len
-    store_var _21
+    store_var _22
     load_var2 5 7
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _23
+    store_var_load_var _24
     is_type int[]
     pop_jump_if_false L1
-    load_var _23
+    load_var _24
     container_len
-    store_var_load_var _25
+    store_var_load_var _26
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
@@ -3047,21 +3571,38 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     jump L4
 
   L2:
+    load_var _24
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _24
+    load_const 1
+    load_array_element
+    pop 1
     load_var v
     load_field .0
-    store_var _29
-    load_var _29
+    store_var _32
+    load_var _32
     container_len
-    store_var _30
+    store_var _33
     load_var2 10 11
     load_const 1
     sub_int
     load_array_element
+    store_var_load_var _35
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _35
     load_const 1
     load_array_element
     jump L4
 
   L3:
+    load_var _6
+    load_const 0
+    load_array_element
+    pop 1
     load_var v
     load_const 0
     load_array_element
@@ -3956,10 +4497,22 @@ function patterns_new_runtime.test_generic_backfills_wrapped() -> int {
 
 function patterns_new_runtime.test_let_array_rest_binds() -> int {
     load_const 3
+    load_const 4
+    load_const 5
+    load_type int
+    alloc_array 3
+    pop 1
+    load_const 3
     return
 }
 
 function patterns_new_runtime.test_let_array_rest_irrefutable() -> int {
+    load_const 1
+    load_const 2
+    load_const 3
+    load_type int
+    alloc_array 3
+    pop 1
     load_const 1
     return
 }
@@ -4107,6 +4660,110 @@ function patterns_new_runtime.test_match_alphabet() -> int {
     load_var _1
     load_const 0
     load_array_element
+    pop 1
+    load_var _1
+    load_const 1
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 2
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 3
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 4
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 5
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 6
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 7
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 8
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 9
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 10
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 11
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 12
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 13
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 14
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 15
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 16
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 17
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 18
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 19
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 20
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 21
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 22
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 23
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 24
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 25
+    load_array_element
+    pop 1
+    load_var _1
+    load_const 0
+    load_array_element
     load_var _1
     load_const 1
     load_array_element
@@ -4237,6 +4894,10 @@ function patterns_new_runtime.test_match_array_shadows_outer() -> int {
     load_var _3
     load_const 0
     load_array_element
+    pop 1
+    load_var _3
+    load_const 0
+    load_array_element
     store_var inner
 
   L2:
@@ -4330,6 +4991,16 @@ function patterns_new_runtime.test_match_chain_trailing_binding() -> int {
     load_array_element
     store_var _13
     load_var _3
+    store_var rows
+    load_var _3
+    load_const 0
+    load_array_element
+    pop 1
+    load_var _8
+    load_const 0
+    load_array_element
+    pop 1
+    load_var rows
     load_const 0
     load_array_element
     load_const 0
@@ -4377,6 +5048,11 @@ function patterns_new_runtime.test_match_class_binds_inner_zip() -> int {
     jump L2
 
   L1:
+    load_var _1
+    load_field .address
+    load_field .coordinate
+    load_field .zip
+    pop 1
     load_const 1
 
   L2:
@@ -4460,6 +5136,10 @@ function patterns_new_runtime.test_match_nested_array_projects_inner() -> int {
     jump L2
 
   L1:
+    load_var _7
+    load_const 0
+    load_array_element
+    pop 1
     load_var _1
     load_const 0
     load_array_element

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_patterns_new_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_patterns_new_runtime/bytecode.snap
@@ -752,20 +752,17 @@ function patterns_new_runtime.DispatchCounter.bump(self: patterns_new_runtime.Di
 function patterns_new_runtime.classify_box_either(box: patterns_new_runtime.BoxT<int> | patterns_new_runtime.BoxT<string>) -> int {
     load_var box
     is_type patterns_new_runtime.BoxT<...>
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var box
+    is_type patterns_new_runtime.BoxT<...>
+    pop_jump_if_false L1
+    load_const 7
     jump L1
 
   L0:
-    load_var box
-    is_type patterns_new_runtime.BoxT<...>
-    pop_jump_if_false L2
     load_const 7
-    jump L2
 
   L1:
-    load_const 7
-
-  L2:
     return
 }
 
@@ -788,8 +785,7 @@ function patterns_new_runtime.classify_box_union_by_field(box: patterns_new_runt
     store_var _4
     load_var _4
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var box
@@ -798,9 +794,6 @@ function patterns_new_runtime.classify_box_union_by_field(box: patterns_new_runt
     jump L2
 
   L1:
-    load_var box
-    load_field .0
-    pop 1
     load_var _4
 
   L2:
@@ -810,17 +803,14 @@ function patterns_new_runtime.classify_box_union_by_field(box: patterns_new_runt
 function patterns_new_runtime.classify_box_union_by_type(box: patterns_new_runtime.BoxT<int> | patterns_new_runtime.BoxT<string>) -> int {
     load_var box
     is_type patterns_new_runtime.BoxT<...>
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 2
     jump L1
 
   L0:
-    load_const 2
-    jump L2
-
-  L1:
     load_const 1
 
-  L2:
+  L1:
     return
 }
 
@@ -867,33 +857,26 @@ function patterns_new_runtime.dispatch_cb(cb: ((int) -> int throws never) | ((st
     store_var _2
     load_var _2
     narrow_bind (int) -> int throws never, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
+    load_const "str:"
     load_const "x"
     load_var cb
     call_indirect
-    store_var _9
-    load_const "str:"
-    load_var _9
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const 2
     load_var _2
     call_indirect
     store_var _5
+    load_const "int:"
     load_type int
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "int:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -906,8 +889,7 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     store_var_load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L5
 
   L0:
     load_var xs
@@ -918,8 +900,7 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     store_var_load_var _6
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L4
 
   L1:
     load_var xs
@@ -927,11 +908,10 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     pop_jump_if_false L2
     load_var xs
     container_len
-    store_var_load_var _13
+    store_var_load_var _9
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L3
 
   L2:
     load_var xs
@@ -942,34 +922,10 @@ function patterns_new_runtime.exact_length(xs: int[]) -> int {
     jump L6
 
   L3:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 1
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 1
-    load_array_element
-    pop 1
     load_const 2
     jump L6
 
   L4:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_const 1
     jump L6
 
@@ -997,17 +953,14 @@ function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 4
     load_field .value
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -1021,17 +974,13 @@ function patterns_new_runtime.from_optional_box(box: patterns_new_runtime.BoxT<i
     store_var _4
     load_var _4
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var box
-    load_field .0
-    pop 1
     load_var _4
 
   L2:
@@ -1047,17 +996,13 @@ function patterns_new_runtime.from_union_box(box: patterns_new_runtime.BoxT<int>
     store_var _4
     load_var _4
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var box
-    load_field .0
-    pop 1
     load_var _4
 
   L2:
@@ -1081,20 +1026,13 @@ function patterns_new_runtime.match_box_union(b: patterns_new_runtime.BoxUnion) 
     load_var b
     load_field .value
     is_type int
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
-    load_var b
-    load_field .value
-    pop 1
     load_const 2
     jump L2
 
   L1:
-    load_var b
-    load_field .value
-    pop 1
     load_const 1
 
   L2:
@@ -1128,8 +1066,7 @@ function patterns_new_runtime.match_coord_user() -> int {
     load_var _10
     load_field .zip
     is_type 11111
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var _1
@@ -1140,12 +1077,6 @@ function patterns_new_runtime.match_coord_user() -> int {
     jump L2
 
   L1:
-    load_var _1
-    load_field .profile
-    load_field .address
-    load_field .coordinate
-    load_field .zip
-    pop 1
     load_const 1
 
   L2:
@@ -1159,8 +1090,7 @@ function patterns_new_runtime.match_person_as(p: patterns_new_runtime.PersonAS) 
     load_var p
     load_field .age
     is_type 7
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var p
@@ -1168,9 +1098,6 @@ function patterns_new_runtime.match_person_as(p: patterns_new_runtime.PersonAS) 
     jump L2
 
   L1:
-    load_var p
-    load_field .age
-    pop 1
     load_const 70
 
   L2:
@@ -1205,8 +1132,7 @@ function patterns_new_runtime.or_deep_class() -> int {
     load_var _7
     load_field .plus4
     is_type 1
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var _1
@@ -1214,58 +1140,35 @@ function patterns_new_runtime.or_deep_class() -> int {
     pop_jump_if_false L1
     load_var _1
     load_field .address
-    store_var_load_var _19
+    store_var_load_var _15
     is_type patterns_new_runtime.Address3
     pop_jump_if_false L1
-    load_var _19
+    load_var _15
     load_field .coordinate
-    store_var_load_var _21
+    store_var_load_var _17
     is_type patterns_new_runtime.Coordinate3
     pop_jump_if_false L1
-    load_var _21
+    load_var _17
     load_field .zip
-    store_var _24
-    load_var _24
-    narrow_bind int, slot=9
+    store_var _20
+    load_var _20
+    narrow_bind int, slot=7
     pop_jump_if_false L1
-    load_var _21
+    load_var _17
     load_field .plus4
     is_type 2
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _1
-    load_field .address
-    load_field .coordinate
-    store_var_load_var _28
-    load_field .zip
-    pop 1
-    load_var _24
-    store_var zip
-    load_var _28
-    load_field .plus4
-    pop 1
-    load_var zip
+    load_var _20
     jump L4
 
   L3:
-    load_var _1
-    load_field .address
-    load_field .coordinate
-    store_var_load_var _14
-    load_field .zip
-    pop 1
     load_var _10
-    store_var zip
-    load_var _14
-    load_field .plus4
-    pop 1
-    load_var zip
 
   L4:
     return
@@ -1287,27 +1190,22 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     cmp_int_op >=
     pop_jump_if_false L0
     load_var _3
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _3
     load_const 1
     load_array_element
-    store_var_load_var _10
+    store_var_load_var _8
     is_type patterns_new_runtime.Cell1
     pop_jump_if_false L0
-    load_var _10
+    load_var _8
     load_field .row
-    store_var_load_var _12
+    store_var_load_var _10
     is_type int[]
     pop_jump_if_false L0
-    load_var _12
+    load_var _10
     container_len
-    store_var_load_var _14
+    store_var_load_var _12
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var g
@@ -1315,114 +1213,69 @@ function patterns_new_runtime.pick_grid(g: patterns_new_runtime.Grid1) -> int {
     pop_jump_if_false L1
     load_var g
     load_field .cells
-    store_var_load_var _32
+    store_var_load_var _22
     is_type patterns_new_runtime.Cell1[]
     pop_jump_if_false L1
-    load_var _32
+    load_var _22
     container_len
-    store_var_load_var _34
+    store_var_load_var _24
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _32
+    load_var _22
     container_len
-    store_var _36
-    load_var2 9 11
+    store_var _26
+    load_var2 7 9
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _38
+    store_var_load_var _28
     is_type patterns_new_runtime.Cell1
     pop_jump_if_false L1
-    load_var _38
+    load_var _28
     load_field .row
-    store_var_load_var _40
+    store_var_load_var _30
     is_type int[]
     pop_jump_if_false L1
-    load_var _40
+    load_var _30
     container_len
-    store_var_load_var _42
+    store_var_load_var _32
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _40
-    container_len
-    store_var _44
-    load_var2 13 15
-    load_const 2
-    sub_int
-    load_array_element
-    pop 1
-    load_var _40
-    container_len
-    store_var _47
-    load_var2 13 16
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
     load_var g
     load_field .cells
-    store_var _50
-    load_var _50
+    store_var _34
+    load_var _34
     container_len
-    store_var _51
-    load_var2 17 18
+    store_var _35
+    load_var2 13 14
     load_const 1
     sub_int
     load_array_element
     load_field .row
-    store_var _54
-    load_var _54
+    store_var _38
+    load_var _38
     container_len
-    store_var _55
-    load_var2 19 20
+    store_var _39
+    load_var2 15 16
     load_const 2
     sub_int
     load_array_element
-    store_var x
-    load_var _54
-    container_len
-    store_var _59
-    load_var2 19 22
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var x
     jump L4
 
   L3:
-    load_var _12
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _12
-    load_const 1
-    load_array_element
-    pop 1
     load_var g
     load_field .cells
-    store_var_load_var _20
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _20
     load_const 1
     load_array_element
     load_field .row
-    store_var_load_var _25
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _25
     load_const 1
     load_array_element
 
@@ -1451,52 +1304,35 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     cmp_int_op >=
     pop_jump_if_false L0
     load_var _5
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _5
     load_const 1
     load_array_element
-    store_var _13
-    load_var _13
+    store_var _11
+    load_var _11
     narrow_bind int, slot=5
-    pop_jump_if_false L0
-    jump L7
+    pop_jump_if_true L7
 
   L0:
     load_var p
     is_type patterns_new_runtime.Pair1
     pop_jump_if_false L1
     load_var p
-    load_field .0
-    pop 1
-    load_var p
     load_field .1
-    store_var_load_var _25
+    store_var_load_var _14
     is_type int[]
     pop_jump_if_false L1
-    load_var _25
+    load_var _14
     container_len
-    store_var_load_var _27
+    store_var_load_var _16
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _25
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _25
-    load_const 1
-    load_array_element
-    pop 1
-    load_var _25
+    load_var _14
     load_const 2
     load_array_element
-    store_var _35
-    load_var _35
-    narrow_bind int, slot=10
-    pop_jump_if_false L1
-    jump L6
+    store_var _20
+    load_var _20
+    narrow_bind int, slot=8
+    pop_jump_if_true L6
 
   L1:
     load_var p
@@ -1504,27 +1340,26 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     pop_jump_if_false L2
     load_var p
     load_field .0
-    store_var_load_var _46
+    store_var_load_var _23
     is_type int[]
     pop_jump_if_false L2
-    load_var _46
+    load_var _23
     container_len
-    store_var_load_var _48
+    store_var_load_var _25
     load_const 3
     cmp_int_op >=
     pop_jump_if_false L2
-    load_var _46
+    load_var _23
     container_len
-    store_var _50
-    load_var2 12 14
+    store_var _27
+    load_var2 9 11
     load_const 3
     sub_int
     load_array_element
-    store_var _53
-    load_var _53
-    narrow_bind int, slot=15
-    pop_jump_if_false L2
-    jump L5
+    store_var _30
+    load_var _30
+    narrow_bind int, slot=12
+    pop_jump_if_true L5
 
   L2:
     load_var p
@@ -1532,154 +1367,52 @@ function patterns_new_runtime.pick_pair(p: patterns_new_runtime.Pair1 | patterns
     pop_jump_if_false L3
     load_var p
     container_len
-    store_var_load_var _72
+    store_var_load_var _33
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L3
     load_var p
-    load_const 0
-    load_array_element
-    pop 1
-    load_var p
     load_const 1
     load_array_element
-    store_var_load_var _77
+    store_var_load_var _36
     is_type int[]
     pop_jump_if_false L3
-    load_var _77
+    load_var _36
     container_len
-    store_var_load_var _79
+    store_var_load_var _38
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L3
-    load_var _77
+    load_var _36
     container_len
-    store_var _81
-    load_var2 24 26
+    store_var _40
+    load_var2 14 16
     load_const 1
     sub_int
     load_array_element
-    store_var _84
-    load_var _84
-    narrow_bind int, slot=27
-    pop_jump_if_false L3
-    jump L4
+    store_var _43
+    load_var _43
+    narrow_bind int, slot=17
+    pop_jump_if_true L4
 
   L3:
     load_const 0
     jump L8
 
   L4:
-    load_var p
-    load_const 0
-    load_array_element
-    pop 1
-    load_var p
-    load_const 1
-    load_array_element
-    store_var _88
-    load_var _88
-    container_len
-    store_var _89
-    load_var2 28 29
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var _84
+    load_var _43
     jump L8
 
   L5:
-    load_var _46
-    container_len
-    store_var _54
-    load_var2 12 16
-    load_const 2
-    sub_int
-    load_array_element
-    pop 1
-    load_var _46
-    container_len
-    store_var _57
-    load_var2 12 17
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var p
-    load_field .0
-    store_var _60
-    load_var _60
-    container_len
-    store_var _61
-    load_var2 18 19
-    load_const 3
-    sub_int
-    load_array_element
-    pop 1
-    load_var _53
-    store_var v
-    load_var _60
-    container_len
-    store_var _65
-    load_var2 18 21
-    load_const 2
-    sub_int
-    load_array_element
-    pop 1
-    load_var _60
-    container_len
-    store_var _68
-    load_var2 18 22
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var v
+    load_var _30
     jump L8
 
   L6:
-    load_var p
-    load_field .0
-    pop 1
-    load_var p
-    load_field .1
-    store_var_load_var _37
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _37
-    load_const 1
-    load_array_element
-    pop 1
-    load_var _37
-    load_const 2
-    load_array_element
-    pop 1
-    load_var _35
+    load_var _20
     jump L8
 
   L7:
-    load_var p
-    load_field .1
-    pop 1
-    load_var p
-    load_field .0
-    load_field .inner
-    store_var_load_var _16
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _16
-    load_const 1
-    load_array_element
-    pop 1
-    load_var _13
-    store_var v
-    load_var p
-    load_field .1
-    pop 1
-    load_var v
+    load_var _11
 
   L8:
     return
@@ -1701,64 +1434,51 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     cmp_int_op >=
     pop_jump_if_false L0
     load_var _3
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _3
     load_const 1
     load_array_element
-    store_var_load_var _10
+    store_var_load_var _8
     is_type patterns_new_runtime.Row1
     pop_jump_if_false L0
-    load_var _10
+    load_var _8
     load_field .slots
-    store_var_load_var _12
+    store_var_load_var _10
     is_type patterns_new_runtime.Slot1[]
     pop_jump_if_false L0
-    load_var _12
+    load_var _10
     container_len
-    store_var_load_var _14
+    store_var_load_var _12
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
-    load_var _12
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _12
+    load_var _10
     load_const 1
     load_array_element
-    store_var_load_var _19
+    store_var_load_var _15
     is_type patterns_new_runtime.Slot1
     pop_jump_if_false L0
-    load_var _19
+    load_var _15
     load_field .atoms
-    store_var_load_var _21
+    store_var_load_var _17
     is_type patterns_new_runtime.Atom1[]
     pop_jump_if_false L0
-    load_var _21
+    load_var _17
     container_len
-    store_var_load_var _23
+    store_var_load_var _19
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L0
-    load_var _21
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _21
+    load_var _17
     load_const 1
     load_array_element
-    store_var_load_var _28
+    store_var_load_var _22
     is_type patterns_new_runtime.Atom1
     pop_jump_if_false L0
-    load_var _28
+    load_var _22
     load_field .value
-    store_var _31
-    load_var _31
+    store_var _25
+    load_var _25
     narrow_bind int, slot=11
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var s
@@ -1766,160 +1486,84 @@ function patterns_new_runtime.pick_sheet(s: patterns_new_runtime.Sheet1) -> int 
     pop_jump_if_false L1
     load_var s
     load_field .rows
-    store_var_load_var _50
+    store_var_load_var _28
     is_type patterns_new_runtime.Row1[]
     pop_jump_if_false L1
-    load_var _50
+    load_var _28
     container_len
-    store_var_load_var _52
+    store_var_load_var _30
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _50
+    load_var _28
     container_len
-    store_var _54
-    load_var2 15 17
+    store_var _32
+    load_var2 12 14
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _56
+    store_var_load_var _34
     is_type patterns_new_runtime.Row1
     pop_jump_if_false L1
-    load_var _56
+    load_var _34
     load_field .slots
-    store_var_load_var _58
+    store_var_load_var _36
     is_type patterns_new_runtime.Slot1[]
     pop_jump_if_false L1
-    load_var _58
+    load_var _36
     container_len
-    store_var_load_var _60
+    store_var_load_var _38
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _58
+    load_var _36
     container_len
-    store_var _62
-    load_var2 19 21
+    store_var _40
+    load_var2 16 18
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _64
+    store_var_load_var _42
     is_type patterns_new_runtime.Slot1
     pop_jump_if_false L1
-    load_var _64
+    load_var _42
     load_field .atoms
-    store_var_load_var _66
+    store_var_load_var _44
     is_type patterns_new_runtime.Atom1[]
     pop_jump_if_false L1
-    load_var _66
+    load_var _44
     container_len
-    store_var_load_var _68
+    store_var_load_var _46
     load_const 2
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _66
+    load_var _44
     container_len
-    store_var _70
-    load_var2 23 25
+    store_var _48
+    load_var2 20 22
     load_const 2
     sub_int
     load_array_element
-    store_var_load_var _72
+    store_var_load_var _50
     is_type patterns_new_runtime.Atom1
     pop_jump_if_false L1
-    load_var _72
+    load_var _50
     load_field .value
-    store_var _75
-    load_var _75
-    narrow_bind int, slot=27
-    pop_jump_if_false L1
-    jump L2
+    store_var _53
+    load_var _53
+    narrow_bind int, slot=24
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _66
-    container_len
-    store_var _76
-    load_var2 23 28
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var s
-    load_field .rows
-    store_var _79
-    load_var _79
-    container_len
-    store_var _80
-    load_var2 29 30
-    load_const 1
-    sub_int
-    load_array_element
-    load_field .slots
-    store_var _83
-    load_var _83
-    container_len
-    store_var _84
-    load_var2 31 32
-    load_const 1
-    sub_int
-    load_array_element
-    load_field .atoms
-    store_var _87
-    load_var _87
-    container_len
-    store_var _88
-    load_var2 33 34
-    load_const 2
-    sub_int
-    load_array_element
-    load_field .value
-    pop 1
-    load_var _75
-    store_var x
-    load_var _87
-    container_len
-    store_var _93
-    load_var2 33 36
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var x
+    load_var _53
     jump L4
 
   L3:
-    load_var s
-    load_field .rows
-    store_var_load_var _32
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _32
-    load_const 1
-    load_array_element
-    load_field .slots
-    store_var_load_var _37
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _37
-    load_const 1
-    load_array_element
-    load_field .atoms
-    store_var_load_var _42
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _42
-    load_const 1
-    load_array_element
-    load_field .value
-    pop 1
-    load_var _31
+    load_var _25
 
   L4:
     return
@@ -1934,22 +1578,13 @@ function patterns_new_runtime.prefix_length(xs: int[]) -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_const 1
 
   L2:
@@ -1973,8 +1608,7 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
     load_var v
     load_field .0
     is_type int
-    pop_jump_if_false L0
-    jump L7
+    pop_jump_if_true L7
 
   L0:
     load_var v
@@ -1983,8 +1617,7 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
     load_var v
     load_field .0
     is_type int
-    pop_jump_if_false L1
-    jump L6
+    pop_jump_if_true L6
 
   L1:
     load_var v
@@ -1993,8 +1626,7 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
     load_var v
     load_field .0
     is_type int
-    pop_jump_if_false L2
-    jump L5
+    pop_jump_if_true L5
 
   L2:
     load_var v
@@ -2003,8 +1635,7 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
     load_var v
     load_field .0
     is_type int
-    pop_jump_if_false L3
-    jump L4
+    pop_jump_if_true L4
 
   L3:
     load_const 0
@@ -2012,17 +1643,11 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
 
   L4:
     load_var v
-    load_field .0
-    pop 1
-    load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
     jump L8
 
   L5:
-    load_var v
-    load_field .0
-    pop 1
     load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
@@ -2030,17 +1655,11 @@ function patterns_new_runtime.score_abcde(v: patterns_new_runtime.ABCDE_A | patt
 
   L6:
     load_var v
-    load_field .0
-    pop 1
-    load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
     jump L8
 
   L7:
-    load_var v
-    load_field .0
-    pop 1
     load_var v
     load_type patterns_new_runtime.HasIntField
     virtual_load_field .field
@@ -2063,8 +1682,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     load_const 0
     load_array_element
     is_type true
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L5
 
   L0:
     load_var xs
@@ -2072,20 +1690,19 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var_load_var _11
+    store_var_load_var _9
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var _13
+    store_var _11
     load_var2 1 4
     load_const 1
     sub_int
     load_array_element
     is_type false
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L4
 
   L1:
     load_var xs
@@ -2093,11 +1710,10 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     pop_jump_if_false L2
     load_var xs
     container_len
-    store_var_load_var _21
+    store_var_load_var _16
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L3
 
   L2:
     load_const 4
@@ -2108,22 +1724,10 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     jump L6
 
   L4:
-    load_var xs
-    container_len
-    store_var _17
-    load_var2 1 5
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
     load_const 2
     jump L6
 
   L5:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_const 1
 
   L6:
@@ -2133,34 +1737,24 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
 function patterns_new_runtime.score_depth(v: patterns_new_runtime.DepthClass | patterns_new_runtime.DepthClass2) -> int {
     load_var v
     is_type patterns_new_runtime.DepthClass
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var v
+    is_type patterns_new_runtime.DepthClass2
+    pop_jump_if_false L1
+    load_var v
+    load_field .0
+    is_type patterns_new_runtime.DepthClass3
+    pop_jump_if_false L1
+    load_var v
+    load_field .0
+    load_field .field
     jump L1
 
   L0:
     load_var v
-    is_type patterns_new_runtime.DepthClass2
-    pop_jump_if_false L2
-    load_var v
     load_field .0
-    store_var_load_var _7
-    is_type patterns_new_runtime.DepthClass3
-    pop_jump_if_false L2
-    load_var _7
-    load_field .field
-    pop 1
-    load_var v
-    load_field .0
-    load_field .field
-    jump L2
 
   L1:
-    load_var v
-    load_field .0
-    pop 1
-    load_var v
-    load_field .0
-
-  L2:
     return
 }
 
@@ -2173,8 +1767,7 @@ function patterns_new_runtime.score_empty_prefix_rest(xs: int[]) -> int {
     store_var_load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var xs
@@ -2202,8 +1795,7 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var _1
@@ -2211,25 +1803,16 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     pop_jump_if_false L1
     load_var _1
     container_len
-    store_var_load_var _11
+    store_var_load_var _9
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 1
-    load_array_element
-    pop 1
     load_var _1
     load_const 0
     load_array_element
@@ -2242,10 +1825,6 @@ function patterns_new_runtime.score_exact_length_45() -> int {
     jump L4
 
   L3:
-    load_var _1
-    load_const 0
-    load_array_element
-    pop 1
     load_var _1
     load_const 0
     load_array_element
@@ -2266,8 +1845,7 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     load_field .second
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L5
+    pop_jump_if_true L5
 
   L0:
     load_var f
@@ -2280,8 +1858,7 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     load_var f
     load_field .second
     is_type int[]
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L4
 
   L1:
     load_var f
@@ -2295,46 +1872,21 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     load_field .second
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L3
 
   L2:
-    load_var f
-    load_field .first
-    pop 1
-    load_var f
-    load_field .second
-    pop 1
     load_const 4
     jump L6
 
   L3:
-    load_var f
-    load_field .first
-    pop 1
-    load_var f
-    load_field .second
-    pop 1
     load_const 3
     jump L6
 
   L4:
-    load_var f
-    load_field .first
-    pop 1
-    load_var f
-    load_field .second
-    pop 1
     load_const 2
     jump L6
 
   L5:
-    load_var f
-    load_field .first
-    pop 1
-    load_var f
-    load_field .second
-    pop 1
     load_const 1
 
   L6:
@@ -2348,8 +1900,7 @@ function patterns_new_runtime.score_foo_union(f: patterns_new_runtime.FooUnion) 
     load_var f
     load_field .value
     is_type int
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var f
@@ -2358,27 +1909,17 @@ function patterns_new_runtime.score_foo_union(f: patterns_new_runtime.FooUnion) 
     load_var f
     load_field .value
     is_type float
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
-    load_var f
-    load_field .value
-    pop 1
     load_const 3
     jump L4
 
   L2:
-    load_var f
-    load_field .value
-    pop 1
     load_const 2
     jump L4
 
   L3:
-    load_var f
-    load_field .value
-    pop 1
     load_const 1
 
   L4:
@@ -2389,37 +1930,28 @@ function patterns_new_runtime.score_int_optional(x: int | null) -> int {
     load_var x
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var x
     is_type 0
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var x
     is_type 1
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const 0
+    jump L3
+
+  L0:
+    load_const 1
+    jump L3
+
+  L1:
+    load_const 1
     jump L3
 
   L2:
-    load_const 0
-    jump L6
+    load_const 1
 
   L3:
-    load_const 1
-    jump L6
-
-  L4:
-    load_const 1
-    jump L6
-
-  L5:
-    load_const 1
-
-  L6:
     return
 }
 
@@ -2439,18 +1971,13 @@ function patterns_new_runtime.score_int_string_array(v: int[] | string[]) -> int
     store_var _7
     load_var _7
     narrow_bind int, slot=3
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var v
-    load_const 0
-    load_array_element
-    pop 1
     load_var v
     load_const 0
     load_array_element
@@ -2480,8 +2007,7 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     load_const 1
     load_array_element
     is_type 2
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var xs
@@ -2489,7 +2015,7 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var_load_var _16
+    store_var_load_var _12
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
@@ -2497,30 +2023,17 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     load_const 0
     load_array_element
     is_type 1
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_const 10
     jump L4
 
   L3:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 1
-    load_array_element
-    pop 1
     load_const 12
 
   L4:
@@ -2530,58 +2043,38 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
 function patterns_new_runtime.score_opat(input: patterns_new_runtime.OPat_A | patterns_new_runtime.OPat_B) -> int {
     load_var input
     is_type patterns_new_runtime.OPat_A
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L2
     load_var input
     is_type patterns_new_runtime.OPat_B
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var input
     load_field .0
-    store_var_load_var _7
+    store_var_load_var _6
     is_type int[]
-    pop_jump_if_false L1
-    load_var _7
+    pop_jump_if_false L0
+    load_var _6
     container_len
-    store_var_load_var _9
+    store_var_load_var _8
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+
+  L0:
+    load_const 0
+    jump L3
 
   L1:
-    load_const 0
-    jump L4
+    load_var input
+    load_field .0
+    load_const 1
+    load_array_element
+    jump L3
 
   L2:
-    load_var _7
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _7
-    load_const 1
-    load_array_element
-    pop 1
     load_var input
     load_field .0
-    store_var_load_var _15
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _15
-    load_const 1
-    load_array_element
-    jump L4
 
   L3:
-    load_var input
-    load_field .0
-    pop 1
-    load_var input
-    load_field .0
-
-  L4:
     return
 }
 
@@ -2601,8 +2094,7 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     store_var _7
     load_var _7
     narrow_bind int, slot=3
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var v
@@ -2610,18 +2102,17 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     pop_jump_if_false L1
     load_var v
     container_len
-    store_var_load_var _16
+    store_var_load_var _14
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var v
     load_const 0
     load_array_element
-    store_var _20
-    load_var _20
+    store_var _18
+    load_var _18
     narrow_bind int, slot=5
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
@@ -2631,19 +2122,11 @@ function patterns_new_runtime.score_or_array_refine(v: int[] | string[]) -> int 
     load_var v
     load_const 0
     load_array_element
-    pop 1
-    load_var v
-    load_const 0
-    load_array_element
-    load_var _20
+    load_var _18
     add_int
     jump L4
 
   L3:
-    load_var v
-    load_const 0
-    load_array_element
-    pop 1
     load_var v
     load_const 0
     load_array_element
@@ -2675,8 +2158,7 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     store_var_load_var _8
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var rows
@@ -2684,33 +2166,28 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     pop_jump_if_false L1
     load_var rows
     container_len
-    store_var_load_var _18
+    store_var_load_var _16
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var rows
     load_const 0
     load_array_element
-    store_var_load_var _21
+    store_var_load_var _19
     is_type int[]
     pop_jump_if_false L1
-    load_var _21
+    load_var _19
     container_len
-    store_var_load_var _23
+    store_var_load_var _21
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _21
-    load_const 0
-    load_array_element
-    pop 1
     load_var rows
     load_const 0
     load_array_element
@@ -2719,10 +2196,6 @@ function patterns_new_runtime.score_or_nested_2d(rows: int[][]) -> int {
     jump L4
 
   L3:
-    load_var _6
-    load_const 0
-    load_array_element
-    pop 1
     load_var rows
     load_const 0
     load_array_element
@@ -2742,8 +2215,7 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var xs
@@ -2751,11 +2223,10 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     pop_jump_if_false L1
     load_var xs
     container_len
-    store_var_load_var _11
+    store_var_load_var _9
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
@@ -2765,17 +2236,9 @@ function patterns_new_runtime.score_or_share(xs: int[]) -> int {
     load_var xs
     load_const 0
     load_array_element
-    pop 1
-    load_var xs
-    load_const 0
-    load_array_element
     jump L4
 
   L3:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_var xs
     load_const 0
     load_array_element
@@ -2796,8 +2259,7 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     store_var_load_var _4
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -2807,34 +2269,18 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     load_var xs
     container_len
     store_var _6
-    load_var2 1 3
-    load_const 2
-    sub_int
-    load_array_element
-    pop 1
     load_var xs
     container_len
-    store_var _9
-    load_var2 1 4
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
+    store_var _10
     load_var xs
     container_len
-    store_var _12
-    load_var xs
-    container_len
-    store_var _16
-    load_var xs
-    container_len
-    store_var _23
-    load_var _23
+    store_var _17
+    load_var _17
     load_const 2
     sub_int
     load_const 100
     mul_int
-    load_var2 1 5
+    load_var2 1 3
     load_const 2
     sub_int
     load_array_element
@@ -2843,7 +2289,7 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
     load_const 10
     mul_int
     add_int
-    load_var2 1 6
+    load_var2 1 4
     load_const 1
     sub_int
     load_array_element
@@ -2858,96 +2304,68 @@ function patterns_new_runtime.score_outer_chain(xs: int[][]) -> int {
 function patterns_new_runtime.score_pair_or(p: patterns_new_runtime.PairAB) -> int {
     load_var p
     is_type patterns_new_runtime.PairAB
-    pop_jump_if_false L3
+    pop_jump_if_false L1
     load_var p
     load_field .a
     store_var_load_var _3
     is_type 0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _3
     is_type 1
-    pop_jump_if_false L3
+    pop_jump_if_false L1
 
-  L1:
+  L0:
     load_var p
     load_field .b
     store_var_load_var _6
     is_type 2
-    pop_jump_if_false L2
-    jump L4
-
-  L2:
+    pop_jump_if_true L2
     load_var _6
     is_type 3
-    pop_jump_if_false L3
-    jump L4
+    pop_jump_if_true L2
 
-  L3:
+  L1:
     load_const 0
-    jump L5
+    jump L3
 
-  L4:
-    load_var p
-    load_field .a
-    pop 1
-    load_var p
-    load_field .b
-    pop 1
+  L2:
     load_const 1
 
-  L5:
+  L3:
     return
 }
 
 function patterns_new_runtime.score_person_age(v: patterns_new_runtime.PersonAge | int) -> int {
     load_var v
     is_type patterns_new_runtime.PersonAge
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
+    load_var v
+    load_field .0
 
   L1:
-    load_var v
-    load_field .0
-    pop 1
-    load_var v
-    load_field .0
-
-  L2:
     return
 }
 
 function patterns_new_runtime.score_personid(v: patterns_new_runtime.PersonIdA | patterns_new_runtime.PersonIdB) -> int {
     load_var v
     is_type patterns_new_runtime.PersonIdA
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var v
+    is_type patterns_new_runtime.PersonIdB
+    pop_jump_if_false L1
+    load_var v
+    load_field .0
     jump L1
 
   L0:
     load_var v
-    is_type patterns_new_runtime.PersonIdB
-    pop_jump_if_false L2
-    load_var v
     load_field .0
-    pop 1
-    load_var v
-    load_field .0
-    jump L2
 
   L1:
-    load_var v
-    load_field .0
-    pop 1
-    load_var v
-    load_field .0
-
-  L2:
     return
 }
 
@@ -2960,8 +2378,7 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
     store_var_load_var _3
     load_const 3
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -2969,44 +2386,24 @@ function patterns_new_runtime.score_prefix_two_suffix(xs: int[]) -> int {
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
+    container_len
+    store_var _8
     load_var xs
     container_len
-    store_var _7
-    load_var2 1 3
-    load_const 2
-    sub_int
-    load_array_element
-    pop 1
-    load_var xs
-    container_len
-    store_var _10
-    load_var2 1 4
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var xs
-    container_len
-    store_var _16
-    load_var xs
-    container_len
-    store_var _20
+    store_var _12
     load_var xs
     load_const 0
     load_array_element
     load_const 100
     mul_int
-    load_var2 1 5
+    load_var2 1 3
     load_const 2
     sub_int
     load_array_element
     load_const 10
     mul_int
     add_int
-    load_var2 1 6
+    load_var2 1 4
     load_const 1
     sub_int
     load_array_element
@@ -3023,17 +2420,13 @@ function patterns_new_runtime.score_refine_a(v: patterns_new_runtime.RefineA | p
     load_var v
     load_field .0
     is_type int
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var v
-    load_field .0
-    pop 1
     load_var v
     load_field .0
 
@@ -3050,8 +2443,7 @@ function patterns_new_runtime.score_rest_copy(xs: int[]) -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -3061,16 +2453,12 @@ function patterns_new_runtime.score_rest_copy(xs: int[]) -> int {
     load_var xs
     load_const 0
     load_array_element
-    pop 1
-    load_var xs
-    load_const 0
-    load_array_element
     load_const 10
     mul_int
-    store_var _10
+    store_var _8
     load_var xs
     container_len
-    store_var _13
+    store_var _11
     load_var2 3 4
     load_const 1
     sub_int
@@ -3094,18 +2482,13 @@ function patterns_new_runtime.score_strings_len(xs: string[]) -> int {
     load_const 0
     load_array_element
     is_type string
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_var xs
     container_len
 
@@ -3122,8 +2505,7 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
     store_var_load_var _3
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -3133,23 +2515,15 @@ function patterns_new_runtime.score_suffix_rest(xs: int[]) -> int {
     load_var xs
     container_len
     store_var _5
-    load_var2 1 3
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
     load_var xs
     container_len
-    store_var _8
-    load_var xs
-    container_len
-    store_var _14
-    load_var _14
+    store_var _11
+    load_var _11
     load_const 1
     sub_int
     load_const 10
     mul_int
-    load_var2 1 4
+    load_var2 1 3
     load_const 1
     sub_int
     load_array_element
@@ -3185,8 +2559,7 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     store_var_load_var _10
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var teams
@@ -3194,60 +2567,42 @@ function patterns_new_runtime.score_team2(teams: patterns_new_runtime.Team2[]) -
     pop_jump_if_false L1
     load_var teams
     container_len
-    store_var_load_var _21
+    store_var_load_var _19
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
     load_var teams
     load_const 0
     load_array_element
-    store_var_load_var _24
+    store_var_load_var _22
     is_type patterns_new_runtime.Team2
     pop_jump_if_false L1
-    load_var _24
+    load_var _22
     load_field .scores
-    store_var_load_var _26
+    store_var_load_var _24
     is_type int[]
     pop_jump_if_false L1
-    load_var _26
+    load_var _24
     container_len
-    store_var_load_var _28
+    store_var_load_var _26
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _26
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _26
-    load_const 1
-    load_array_element
-    pop 1
     load_var teams
     load_const 0
     load_array_element
     load_field .scores
-    store_var_load_var _36
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _36
     load_const 1
     load_array_element
     jump L4
 
   L3:
-    load_var _8
-    load_const 0
-    load_array_element
-    pop 1
     load_var teams
     load_const 0
     load_array_element
@@ -3273,8 +2628,7 @@ function patterns_new_runtime.score_team3(team: patterns_new_runtime.Team3) -> i
     store_var_load_var _5
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var team
@@ -3284,9 +2638,6 @@ function patterns_new_runtime.score_team3(team: patterns_new_runtime.Team3) -> i
     jump L2
 
   L1:
-    load_var team
-    load_field .scores
-    pop 1
     load_const 10
 
   L2:
@@ -3307,29 +2658,15 @@ function patterns_new_runtime.score_team4(team: patterns_new_runtime.Team4) -> i
     store_var_load_var _5
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var _3
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _3
-    load_const 1
-    load_array_element
-    pop 1
     load_var team
     load_field .scores
-    store_var_load_var _11
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _11
     load_const 1
     load_array_element
 
@@ -3346,8 +2683,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     store_var_load_var _3
     load_const 3
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -3355,24 +2691,8 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
 
   L1:
     load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 1
-    load_array_element
-    pop 1
-    load_var xs
     container_len
-    store_var _9
-    load_var2 1 3
-    load_const 1
-    sub_int
-    load_array_element
-    pop 1
-    load_var xs
-    container_len
-    store_var _18
+    store_var _11
     load_var xs
     load_const 0
     load_array_element
@@ -3384,7 +2704,7 @@ function patterns_new_runtime.score_two_prefix(xs: int[]) -> int {
     load_const 10
     mul_int
     add_int
-    load_var2 1 4
+    load_var2 1 3
     load_const 1
     sub_int
     load_array_element
@@ -3403,8 +2723,7 @@ function patterns_new_runtime.score_user_score(users: patterns_new_runtime.UserS
     store_var_load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var users
@@ -3439,26 +2758,13 @@ function patterns_new_runtime.score_wildcard_second(xs: int[]) -> int {
     store_var_load_var _3
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 1
-    load_array_element
-    pop 1
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_var xs
     load_const 1
     load_array_element
@@ -3480,29 +2786,17 @@ function patterns_new_runtime.score_wildcard_user(users: patterns_new_runtime.Us
     load_var users
     load_const 0
     load_array_element
-    store_var_load_var _6
     is_type patterns_new_runtime.UserScore
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var _6
-    load_field .name
-    pop 1
-    load_var _6
-    load_field .score
-    pop 1
     load_var users
     load_const 0
     load_array_element
-    store_var_load_var _11
-    load_field .name
-    pop 1
-    load_var _11
     load_field .score
 
   L2:
@@ -3530,8 +2824,7 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     store_var_load_var _8
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L3
 
   L0:
     load_var v
@@ -3539,70 +2832,52 @@ function patterns_new_runtime.score_wrap2(v: int[][] | patterns_new_runtime.Wrap
     pop_jump_if_false L1
     load_var v
     load_field .0
-    store_var_load_var _18
+    store_var_load_var _16
     is_type int[][]
     pop_jump_if_false L1
-    load_var _18
+    load_var _16
     container_len
-    store_var_load_var _20
+    store_var_load_var _18
     load_const 1
     cmp_int_op >=
     pop_jump_if_false L1
-    load_var _18
+    load_var _16
     container_len
-    store_var _22
+    store_var _20
     load_var2 5 7
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _24
+    store_var_load_var _22
     is_type int[]
     pop_jump_if_false L1
-    load_var _24
+    load_var _22
     container_len
-    store_var_load_var _26
+    store_var_load_var _24
     load_const 2
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_const 0
     jump L4
 
   L2:
-    load_var _24
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _24
-    load_const 1
-    load_array_element
-    pop 1
     load_var v
     load_field .0
-    store_var _32
-    load_var _32
+    store_var _26
+    load_var _26
     container_len
-    store_var _33
+    store_var _27
     load_var2 10 11
     load_const 1
     sub_int
     load_array_element
-    store_var_load_var _35
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _35
     load_const 1
     load_array_element
     jump L4
 
   L3:
-    load_var _6
-    load_const 0
-    load_array_element
-    pop 1
     load_var v
     load_const 0
     load_array_element
@@ -3733,27 +3008,22 @@ function patterns_new_runtime.test_fn_arm_before_wildcard(cb: ((int) -> int thro
     store_var _2
     load_var _2
     narrow_bind (int) -> int throws never, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const 3
     load_var _2
     call_indirect
     store_var _5
+    load_const "fn:"
     load_type int
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "fn:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -3772,34 +3042,12 @@ function patterns_new_runtime.test_fn_arm_before_wildcard_int() -> string {
 function patterns_new_runtime.test_fn_is_matching() -> bool {
     make_closure .<lambda(test_fn_is_matching, 0)>, 0
     is_type (int) -> int throws unknown
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function patterns_new_runtime.test_fn_is_mismatched() -> bool {
     make_closure .<lambda(test_fn_is_mismatched, 0)>, 0
     is_type (string) -> string throws unknown
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -3833,10 +3081,7 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     load_field .address
     load_field .coordinate
@@ -3845,7 +3090,7 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     store_var product
     jump L0
 
-  L2:
+  L1:
     load_var product
     return
 }
@@ -3884,10 +3129,7 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const null
     make_cell
     store_var zip
@@ -3903,7 +3145,7 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var funcs
     load_const 0
     load_array_element
@@ -3960,10 +3202,7 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     load_field .address
     load_field .coordinate
@@ -3972,7 +3211,7 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4007,10 +3246,7 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     store_var _11
     load_var _11
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _11
     load_field .scores
     container_len
@@ -4020,7 +3256,7 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4050,10 +3286,7 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var _6
     load_var _6
@@ -4070,7 +3303,7 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var funcs
     load_const 0
     load_array_element
@@ -4118,10 +3351,7 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var _6
     load_var2 1 4
@@ -4131,7 +3361,7 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4163,10 +3393,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _6
     store_var row
     load_var row
@@ -4192,7 +3419,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4219,16 +3446,13 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4254,16 +3478,13 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 3
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4292,20 +3513,15 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _7
-    load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var total
     load_const 1
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4344,10 +3560,7 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const null
     make_cell
     store_var row
@@ -4360,7 +3573,7 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var funcs
     load_const 0
     load_array_element
@@ -4415,10 +3628,7 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _8
     container_len
     store_var _12
@@ -4427,7 +3637,7 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }
@@ -4456,20 +3666,15 @@ function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
     load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _8
-    load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var count
     load_const 1
     add_int
     store_var count
     jump L0
 
-  L2:
+  L1:
     load_var count
     return
 }
@@ -4480,10 +3685,8 @@ function patterns_new_runtime.test_generic_backfills_wrapped() -> int {
     init_instance<1> user.patterns_new_runtime.BoxT .value
     store_var_load_var boxed
     call user.patterns_new_runtime.from_optional_box
-    store_var _3
     load_var boxed
     call user.patterns_new_runtime.from_union_box
-    load_var _3
     add_int
     store_var _2
     load_var boxed
@@ -4497,22 +3700,10 @@ function patterns_new_runtime.test_generic_backfills_wrapped() -> int {
 
 function patterns_new_runtime.test_let_array_rest_binds() -> int {
     load_const 3
-    load_const 4
-    load_const 5
-    load_type int
-    alloc_array 3
-    pop 1
-    load_const 3
     return
 }
 
 function patterns_new_runtime.test_let_array_rest_irrefutable() -> int {
-    load_const 1
-    load_const 2
-    load_const 3
-    load_type int
-    alloc_array 3
-    pop 1
     load_const 1
     return
 }
@@ -4649,118 +3840,13 @@ function patterns_new_runtime.test_match_alphabet() -> int {
     store_var_load_var _3
     load_const 26
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var _1
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 1
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 2
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 3
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 4
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 5
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 6
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 7
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 8
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 9
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 10
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 11
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 12
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 13
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 14
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 15
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 16
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 17
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 18
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 19
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 20
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 21
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 22
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 23
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 24
-    load_array_element
-    pop 1
-    load_var _1
-    load_const 25
-    load_array_element
-    pop 1
     load_var _1
     load_const 0
     load_array_element
@@ -4874,16 +3960,15 @@ function patterns_new_runtime.test_match_array_shadows_outer() -> int {
     load_const 5
     load_type int
     alloc_array 2
-    store_var_load_var _3
+    store_var_load_var _2
     is_type _[]
     pop_jump_if_false L0
-    load_var _3
+    load_var _2
     container_len
-    store_var_load_var _5
+    store_var_load_var _4
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -4891,28 +3976,20 @@ function patterns_new_runtime.test_match_array_shadows_outer() -> int {
     jump L2
 
   L1:
-    load_var _3
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _3
+    load_var _2
     load_const 0
     load_array_element
     store_var inner
 
   L2:
-    load_const 1
     load_const 10
-    mul_int
     load_var inner
     add_int
     return
 }
 
 function patterns_new_runtime.test_match_bind_type_ascription() -> int {
-    load_const 1
-    load_const 100
-    add_int
+    load_const 101
     return
 }
 
@@ -4926,8 +4003,7 @@ function patterns_new_runtime.test_match_chain_binding_guard() -> int {
     store_var_load_var n
     load_const 2
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -4978,8 +4054,7 @@ function patterns_new_runtime.test_match_chain_trailing_binding() -> int {
     store_var_load_var _9
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
@@ -4991,16 +4066,6 @@ function patterns_new_runtime.test_match_chain_trailing_binding() -> int {
     load_array_element
     store_var _13
     load_var _3
-    store_var rows
-    load_var _3
-    load_const 0
-    load_array_element
-    pop 1
-    load_var _8
-    load_const 0
-    load_array_element
-    pop 1
-    load_var rows
     load_const 0
     load_array_element
     load_const 0
@@ -5037,8 +4102,7 @@ function patterns_new_runtime.test_match_class_binds_inner_zip() -> int {
     load_var _7
     load_field .zip
     is_type 1
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_var _1
@@ -5048,11 +4112,6 @@ function patterns_new_runtime.test_match_class_binds_inner_zip() -> int {
     jump L2
 
   L1:
-    load_var _1
-    load_field .address
-    load_field .coordinate
-    load_field .zip
-    pop 1
     load_const 1
 
   L2:
@@ -5128,18 +4187,13 @@ function patterns_new_runtime.test_match_nested_array_projects_inner() -> int {
     store_var_load_var _9
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const 0
     jump L2
 
   L1:
-    load_var _7
-    load_const 0
-    load_array_element
-    pop 1
     load_var _1
     load_const 0
     load_array_element
@@ -5157,29 +4211,26 @@ function patterns_new_runtime.test_match_or_bare_bindings() -> int {
 
 function patterns_new_runtime.test_match_or_chain_narrows() -> int {
     load_const 10
-    store_var _2
-    load_var _2
+    store_var _1
+    load_var _1
     narrow_bind int, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 10
+    store_var _4
+    load_var _4
+    narrow_bind int, slot=2
+    pop_jump_if_false L1
+    load_var _4
+    load_const 2
+    mul_int
     jump L1
 
   L0:
-    load_const 10
-    store_var _5
-    load_var _5
-    narrow_bind int, slot=2
-    pop_jump_if_false L2
-    load_var _5
+    load_var _1
     load_const 2
     mul_int
-    jump L2
 
   L1:
-    load_var _2
-    load_const 2
-    mul_int
-
-  L2:
     return
 }
 
@@ -5344,8 +4395,7 @@ function patterns_new_runtime.unknown_arm_tested(x: unknown, gate: bool) -> stri
     load_const true
     pop_jump_if_false L0
     load_var gate
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L1
 
   L0:
     load_const "fell-through"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_projection_dest_calls/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_projection_dest_calls/bytecode.snap
@@ -76,8 +76,7 @@ function projection_dest_calls.pdc_call_base_nested_assignment() -> bool {
     load_field .title
     load_const "triage"
     call baml.ops.equals_equals
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var store
     load_field .calls
     load_const 1
@@ -93,14 +92,11 @@ function projection_dest_calls.pdc_eq_into_field_false() -> bool {
     store_var b
     load_const 1
     call user.projection_dest_calls.pdc_tag
-    store_var _2
     load_const 2
     call user.projection_dest_calls.pdc_tag
-    store_var _3
-    load_var2 2 3
     call baml.ops.equals_equals
     store_var _4
-    load_var2 1 4
+    load_var2 1 2
     store_field .flag
     load_var b
     load_field .flag
@@ -113,14 +109,11 @@ function projection_dest_calls.pdc_eq_into_field_true() -> bool {
     store_var b
     load_const 1
     call user.projection_dest_calls.pdc_tag
-    store_var _2
     load_const 1
     call user.projection_dest_calls.pdc_tag
-    store_var _3
-    load_var2 2 3
     call baml.ops.equals_equals
     store_var _4
-    load_var2 1 4
+    load_var2 1 2
     store_field .flag
     load_var b
     load_field .flag
@@ -165,14 +158,11 @@ function projection_dest_calls.pdc_ne_into_field_true() -> bool {
     store_var b
     load_const 1
     call user.projection_dest_calls.pdc_tag
-    store_var _2
     load_const 2
     call user.projection_dest_calls.pdc_tag
-    store_var _3
-    load_var2 2 3
     call baml.ops.equals_equals
     store_var _4
-    load_var2 1 4
+    load_var2 1 2
     unary_op !
     store_field .flag
     load_var b

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_projection_patterns/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_projection_patterns/bytecode.snap
@@ -157,51 +157,26 @@ function projection_patterns.Holder.classify(self: projection_patterns.Holder, v
     store_var _3
     load_var _3
     narrow_bind (#0 as projection_patterns.Holder).Item, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "item"
 
-  L2:
+  L1:
     return
 }
 
 function projection_patterns.Holder.is_item(self: projection_patterns.Holder, v: unknown) -> bool {
     load_var v
     is_type (#0 as projection_patterns.Holder).Item
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function projection_patterns.Labeled.is_label(self: projection_patterns.Labeled, v: unknown) -> bool {
     load_var v
     is_type (#0 as projection_patterns.Labeled).Label
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -210,8 +185,6 @@ function projection_patterns.Labeled.label_name(self: projection_patterns.Labele
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -220,8 +193,7 @@ function projection_patterns.bound_defaulted_default_fn() -> bool {
     alloc_instance user.projection_patterns.Plain
     load_const "x"
     call user.projection_patterns.is_label_of
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type projection_patterns.Plain
     alloc_instance user.projection_patterns.Plain
     load_const 5
@@ -237,8 +209,7 @@ function projection_patterns.bound_defaulted_pin_fn() -> bool {
     alloc_instance user.projection_patterns.Pinned
     load_const 5
     call user.projection_patterns.is_label_of
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_type projection_patterns.Pinned
     alloc_instance user.projection_patterns.Pinned
     load_const "x"
@@ -294,17 +265,14 @@ function projection_patterns.classify_for(h: #0, v: unknown) -> string {
     store_var _3
     load_var _3
     narrow_bind (#0 as projection_patterns.Holder).Item, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "item"
 
-  L2:
+  L1:
     return
 }
 
@@ -314,8 +282,6 @@ function projection_patterns.default_label_accepts_fn() -> bool {
     load_type projection_patterns.Labeled<Label = string>
     load_const "is_label"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -324,8 +290,6 @@ function projection_patterns.default_label_reflects_fn() -> string {
     load_type projection_patterns.Labeled<Label = string>
     load_const "label_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -335,42 +299,18 @@ function projection_patterns.default_label_rejects_fn() -> bool {
     load_type projection_patterns.Labeled<Label = string>
     load_const "is_label"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function projection_patterns.is_item_of(h: #0, v: unknown) -> bool {
     load_var v
     is_type (#0 as projection_patterns.Holder).Item
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function projection_patterns.is_label_of(t: #0, v: unknown) -> bool {
     load_var v
     is_type (#0 as projection_patterns.Labeled).Label
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -380,8 +320,6 @@ function projection_patterns.pinned_label_accepts_fn() -> bool {
     load_type projection_patterns.Labeled<Label = int>
     load_const "is_label"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -390,8 +328,6 @@ function projection_patterns.pinned_label_reflects_fn() -> string {
     load_type projection_patterns.Labeled<Label = int>
     load_const "label_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -401,8 +337,6 @@ function projection_patterns.pinned_label_rejects_default_fn() -> bool {
     load_type projection_patterns.Labeled<Label = int>
     load_const "is_label"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -412,8 +346,6 @@ function projection_patterns.self_item_accepts_own_fn() -> bool {
     load_type projection_patterns.Holder<Item = int>
     load_const "is_item"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -423,8 +355,6 @@ function projection_patterns.self_item_match_arm_fn() -> string {
     load_type projection_patterns.Holder<Item = int>
     load_const "classify"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -434,8 +364,6 @@ function projection_patterns.self_item_match_falls_through_fn() -> string {
     load_type projection_patterns.Holder<Item = int>
     load_const "classify"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -445,8 +373,6 @@ function projection_patterns.self_item_per_receiver_fn() -> bool {
     load_type projection_patterns.Holder<Item = string>
     load_const "is_item"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -456,7 +382,5 @@ function projection_patterns.self_item_rejects_other_fn() -> bool {
     load_type projection_patterns.Holder<Item = int>
     load_const "is_item"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_prompt_tag_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_prompt_tag_runtime/bytecode.snap
@@ -672,8 +672,6 @@ function prompt_tag_runtime.pt_media_string_interp_fn() -> string {
     load_type image
     load_var picture
     call baml.String.from
-    store_var _2
-    load_var _2
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_prompt_tag_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_prompt_tag_runtime/bytecode.snap
@@ -168,12 +168,10 @@ function prompt_tag_runtime.PtRenderPerson(client: ai.Client | null, on_event: (
     call user.prompt_tag_runtime.PtRenderPerson@spec
     store_var _8
     load_type prompt_tag_runtime.Person
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -302,12 +300,10 @@ function prompt_tag_runtime.PtStructuredGreeting(name: string, client: ai.Client
     call user.prompt_tag_runtime.PtStructuredGreeting@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -354,7 +350,7 @@ function prompt_tag_runtime.PtStructuredGreeting@spec(name: string) -> ai.Functi
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4o-mini"
     load_const <omitted>
     load_const <omitted>
@@ -373,7 +369,7 @@ function prompt_tag_runtime.PtStructuredGreeting@spec(name: string) -> ai.Functi
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _6
+    store_var _7
     load_const "PtStructuredGreeting"
     load_deref ?1
     load_const "name"
@@ -445,12 +441,10 @@ function prompt_tag_runtime.PtStructuredImage(photo: image, client: ai.Client | 
     call user.prompt_tag_runtime.PtStructuredImage@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -497,7 +491,7 @@ function prompt_tag_runtime.PtStructuredImage@spec(photo: image) -> ai.FunctionS
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4o-mini"
     load_const <omitted>
     load_const <omitted>
@@ -516,7 +510,7 @@ function prompt_tag_runtime.PtStructuredImage@spec(photo: image) -> ai.FunctionS
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _6
+    store_var _7
     load_const "PtStructuredImage"
     load_deref ?1
     load_const "photo"
@@ -674,11 +668,11 @@ function prompt_tag_runtime.pt_media_string_interp_fn() -> string {
     load_const "image/png"
     call baml.media.Image.from_url
     store_var picture
+    load_const "Image "
     load_type image
     load_var picture
     call baml.String.from
     store_var _2
-    load_const "Image "
     load_var _2
     bin_op +
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_promptast_accessors/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_promptast_accessors/bytecode.snap
@@ -103,10 +103,7 @@ function promptast_accessors.pa_message_metadata_survives_assembly() -> string {
     store_var _19
     load_var _19
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _19
     store_var m
     load_type string
@@ -133,7 +130,7 @@ function promptast_accessors.pa_message_metadata_survives_assembly() -> string {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_type string
     load_var out
     load_const ";"
@@ -212,126 +209,127 @@ function promptast_accessors.pa_message_parts_preserve_media() -> string {
     store_var _23
     load_var _23
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L14
-
-  L1:
+    pop_jump_if_true L17
     load_var _23
     store_var part
     load_var part
     store_var _28
     load_var _28
     narrow_bind string, slot=11
-    pop_jump_if_false L2
-    jump L13
-
-  L2:
+    pop_jump_if_true L16
     load_var part
     store_var _35
     load_var _35
     narrow_bind baml.media.Image, slot=13
-    pop_jump_if_false L3
-    jump L11
-
-  L3:
+    pop_jump_if_true L12
     load_var part
-    store_var _45
-    load_var _45
+    store_var _44
+    load_var _44
     narrow_bind baml.media.Audio, slot=16
-    pop_jump_if_false L4
-    jump L9
-
-  L4:
+    pop_jump_if_true L8
     load_var part
-    store_var _55
-    load_var _55
+    store_var _53
+    load_var _53
     narrow_bind baml.media.Video, slot=19
-    pop_jump_if_false L5
-    jump L7
-
-  L5:
+    pop_jump_if_true L4
     load_var part
     call baml.media.Pdf.url
-    store_var_load_var _69
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
-    load_const ""
-    store_var _69
+    jump_if_not_null_or_pop L1
+    jump L2
 
-  L6:
+  L1:
+    store_var _66
+    jump L3
+
+  L2:
+    load_const ""
+    store_var _66
+
+  L3:
     load_type string
-    load_var _69
+    load_var _66
     call baml.String.from
-    store_var _67
+    store_var _64
     load_type string
     load_var kinds
     load_const "pdf="
-    load_var _67
+    load_var _64
     bin_op +
     call baml.Array.push
     pop 1
     jump L0
 
-  L7:
-    load_var _55
+  L4:
+    load_var _53
     call baml.media.Video.url
-    store_var_load_var _60
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L8
-    load_const ""
-    store_var _60
+    jump_if_not_null_or_pop L5
+    jump L6
 
-  L8:
-    load_type string
-    load_var _60
-    call baml.String.from
+  L5:
     store_var _58
+    jump L7
+
+  L6:
+    load_const ""
+    store_var _58
+
+  L7:
+    load_type string
+    load_var _58
+    call baml.String.from
+    store_var _56
     load_type string
     load_var kinds
     load_const "video="
-    load_var _58
+    load_var _56
     bin_op +
     call baml.Array.push
     pop 1
     jump L0
 
-  L9:
-    load_var _45
+  L8:
+    load_var _44
     call baml.media.Audio.url
-    store_var_load_var _50
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L10
-    load_const ""
-    store_var _50
+    jump_if_not_null_or_pop L9
+    jump L10
+
+  L9:
+    store_var _49
+    jump L11
 
   L10:
+    load_const ""
+    store_var _49
+
+  L11:
     load_type string
-    load_var _50
+    load_var _49
     call baml.String.from
-    store_var _48
+    store_var _47
     load_type string
     load_var kinds
     load_const "audio="
-    load_var _48
+    load_var _47
     bin_op +
     call baml.Array.push
     pop 1
     jump L0
 
-  L11:
+  L12:
     load_var _35
     call baml.media.Image.url
-    store_var_load_var _40
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L12
+    jump_if_not_null_or_pop L13
+    jump L14
+
+  L13:
+    store_var _40
+    jump L15
+
+  L14:
     load_const ""
     store_var _40
 
-  L12:
+  L15:
     load_type string
     load_var _40
     call baml.String.from
@@ -345,7 +343,7 @@ function promptast_accessors.pa_message_parts_preserve_media() -> string {
     pop 1
     jump L0
 
-  L13:
+  L16:
     load_type string
     load_var _28
     call baml.String.from
@@ -359,7 +357,7 @@ function promptast_accessors.pa_message_parts_preserve_media() -> string {
     pop 1
     jump L0
 
-  L14:
+  L17:
     load_type string
     load_var kinds
     load_const "|"
@@ -385,10 +383,7 @@ function promptast_accessors.paa_fold_messages_fn() -> string {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var m
     load_var2 1 4
@@ -404,7 +399,7 @@ function promptast_accessors.paa_fold_messages_fn() -> string {
     store_var out
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_property_shorthand/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_property_shorthand/bytecode.snap
@@ -57,27 +57,18 @@ function property_shorthand.$init_test_ns_property_shorthand_property_shorthand(
 
 function property_shorthand.property_shorthand_catch() -> string {
     call user.property_shorthand.property_shorthand_throw
-    jump L2
+    jump L1
     load_var error
     is_type property_shorthand.PropertyShorthandError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
-    load_var error
-    load_const "error"
-    load_type string
-    load_type property_shorthand.PropertyShorthandError
-    alloc_map 1
-    pop 1
+  L0:
     load_var error
     load_field .message
 
-  L2:
+  L1:
     return
 }
 
@@ -97,19 +88,16 @@ function property_shorthand.property_shorthand_class_if_let(input: string | null
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
     jump L1
 
   L0:
-    load_const ""
-    jump L2
-
-  L1:
     load_var _2
     init_instance user.property_shorthand.PropertyShorthandBinder .value
     load_field .value
 
-  L2:
+  L1:
     return
 }
 
@@ -125,15 +113,10 @@ function property_shorthand.property_shorthand_destructure() -> string {
     alloc_map 1
     load_const "value"
     call baml.Map.get
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _6
 
   L0:
-    load_var _6
     return
 }
 
@@ -154,10 +137,7 @@ function property_shorthand.property_shorthand_for(names: string[]) -> string {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L4
     load_var output
     store_var _10
     load_type string
@@ -169,20 +149,24 @@ function property_shorthand.property_shorthand_for(names: string[]) -> string {
     alloc_map 1
     load_const "name"
     call baml.Map.get
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _12
+    jump L3
+
+  L2:
     load_const ""
     store_var _12
 
-  L2:
+  L3:
     load_var2 5 6
     bin_op +
     store_var output
     jump L0
 
-  L3:
+  L4:
     load_var output
     return
 }
@@ -192,14 +176,11 @@ function property_shorthand.property_shorthand_if_let(input: string | null) -> s
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const ""
+    jump L5
 
   L0:
-    load_const ""
-    jump L4
-
-  L1:
     load_var _2
     store_var_load_var name
     load_const "name"
@@ -216,33 +197,32 @@ function property_shorthand.property_shorthand_if_let(input: string | null) -> s
     alloc_map 1
     load_const "name"
     call baml.Map.get
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
     load_const ""
-    store_var _9
 
-  L2:
-    load_var _9
+  L1:
     store_var _8
     load_type string
     load_type string
     load_var shorthand
     load_const "name"
     call baml.Map.get
-    store_var_load_var _15
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    load_const ""
-    store_var _15
+    jump_if_not_null_or_pop L2
+    jump L3
+
+  L2:
+    store_var _14
+    jump L4
 
   L3:
-    load_var2 5 7
-    bin_op +
+    load_const ""
+    store_var _14
 
   L4:
+    load_var2 5 6
+    bin_op +
+
+  L5:
     return
 }
 
@@ -261,14 +241,11 @@ function property_shorthand.property_shorthand_match(input: string | null) -> st
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
     jump L1
 
   L0:
-    load_const ""
-    jump L3
-
-  L1:
     load_type string
     load_type string
     load_var _2
@@ -278,17 +255,10 @@ function property_shorthand.property_shorthand_match(input: string | null) -> st
     alloc_map 1
     load_const "name"
     call baml.Map.get
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
     load_const ""
-    store_var _6
 
-  L2:
-    load_var _6
-
-  L3:
+  L1:
     return
 }
 
@@ -325,15 +295,10 @@ function property_shorthand.property_shorthand_nested_block() -> string {
     alloc_map 1
     load_const "name"
     call baml.Map.get
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _4
 
   L0:
-    load_var _4
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_property_shorthand/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_property_shorthand/bytecode.snap
@@ -69,6 +69,12 @@ function property_shorthand.property_shorthand_catch() -> string {
 
   L1:
     load_var error
+    load_const "error"
+    load_type string
+    load_type property_shorthand.PropertyShorthandError
+    alloc_map 1
+    pop 1
+    load_var error
     load_field .message
 
   L2:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_property_shorthand_binders/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_property_shorthand_binders/bytecode.snap
@@ -124,15 +124,10 @@ function property_shorthand_binders.psb_lookup(m: map<string, string>) -> string
     load_var m
     load_const "key"
     call baml.Map.get
-    store_var_load_var _2
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "MISSING"
-    store_var _2
 
   L0:
-    load_var _2
     return
 }
 
@@ -143,17 +138,14 @@ function property_shorthand_binders.psb_quoted_catch_binder(s: string) -> string
     load_type int
     load_var _3
     call baml.String.from
-    jump L2
+    jump L1
     load_var key
     is_type baml.errors.ParseError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var key
     rethrow
 
-  L1:
+  L0:
     load_type string
     load_type baml.errors.ParseError
     load_var key
@@ -171,7 +163,7 @@ function property_shorthand_binders.psb_quoted_catch_binder(s: string) -> string
     unary_op !
     call baml.String.from
 
-  L2:
+  L1:
     return
 }
 
@@ -203,10 +195,7 @@ function property_shorthand_binders.psb_quoted_for_binder(xs: string[]) -> strin
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     load_const "key"
     load_type string
@@ -219,7 +208,7 @@ function property_shorthand_binders.psb_quoted_for_binder(xs: string[]) -> strin
     store_var out
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -229,14 +218,11 @@ function property_shorthand_binders.psb_quoted_if_let(v: string | null) -> strin
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "NONE"
     jump L1
 
   L0:
-    load_const "NONE"
-    jump L2
-
-  L1:
     load_var _2
     load_const "key"
     load_type string
@@ -244,7 +230,7 @@ function property_shorthand_binders.psb_quoted_if_let(v: string | null) -> strin
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
 
-  L2:
+  L1:
     return
 }
 
@@ -253,14 +239,11 @@ function property_shorthand_binders.psb_quoted_key_differs_from_binder(v: string
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "NONE"
     jump L1
 
   L0:
-    load_const "NONE"
-    jump L3
-
-  L1:
     load_type string
     load_type string
     load_var _2
@@ -270,17 +253,10 @@ function property_shorthand_binders.psb_quoted_key_differs_from_binder(v: string
     alloc_map 1
     load_const "other"
     call baml.Map.get
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
     load_const "MISSING"
-    store_var _6
 
-  L2:
-    load_var _6
-
-  L3:
+  L1:
     return
 }
 
@@ -289,14 +265,11 @@ function property_shorthand_binders.psb_quoted_match_arm(v: string | int) -> str
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "NONE"
     jump L1
 
   L0:
-    load_const "NONE"
-    jump L2
-
-  L1:
     load_var _2
     load_const "key"
     load_type string
@@ -304,28 +277,17 @@ function property_shorthand_binders.psb_quoted_match_arm(v: string | int) -> str
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
 
-  L2:
+  L1:
     return
 }
 
 function property_shorthand_binders.psb_quoted_nested_block_let() -> string {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const "NONE"
-    jump L2
-
-  L1:
     load_const "n"
     load_const "key"
     load_type string
     load_type string
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
-
-  L2:
     return
 }
 
@@ -346,17 +308,14 @@ function property_shorthand_binders.psb_shorthand_catch_binder(s: string) -> str
     load_type int
     load_var _3
     call baml.String.from
-    jump L2
+    jump L1
     load_var key
     is_type baml.errors.ParseError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var key
     rethrow
 
-  L1:
+  L0:
     load_type string
     load_type baml.errors.ParseError
     load_var key
@@ -374,7 +333,7 @@ function property_shorthand_binders.psb_shorthand_catch_binder(s: string) -> str
     unary_op !
     call baml.String.from
 
-  L2:
+  L1:
     return
 }
 
@@ -421,10 +380,7 @@ function property_shorthand_binders.psb_shorthand_for_binder(xs: string[]) -> st
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     load_const "key"
     load_type string
@@ -437,7 +393,7 @@ function property_shorthand_binders.psb_shorthand_for_binder(xs: string[]) -> st
     store_var out
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -447,14 +403,11 @@ function property_shorthand_binders.psb_shorthand_if_let(v: string | null) -> st
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "NONE"
     jump L1
 
   L0:
-    load_const "NONE"
-    jump L2
-
-  L1:
     load_var _2
     load_const "key"
     load_type string
@@ -462,7 +415,7 @@ function property_shorthand_binders.psb_shorthand_if_let(v: string | null) -> st
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
 
-  L2:
+  L1:
     return
 }
 
@@ -471,14 +424,11 @@ function property_shorthand_binders.psb_shorthand_match_arm(v: string | int) -> 
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "NONE"
     jump L1
 
   L0:
-    load_const "NONE"
-    jump L2
-
-  L1:
     load_var _2
     load_const "key"
     load_type string
@@ -486,28 +436,17 @@ function property_shorthand_binders.psb_shorthand_match_arm(v: string | int) -> 
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
 
-  L2:
+  L1:
     return
 }
 
 function property_shorthand_binders.psb_shorthand_nested_block_let() -> string {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const "NONE"
-    jump L2
-
-  L1:
     load_const "n"
     load_const "key"
     load_type string
     load_type string
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
-
-  L2:
     return
 }
 
@@ -523,29 +462,26 @@ function property_shorthand_binders.psb_shorthand_param(key: string) -> string {
 
 function property_shorthand_binders.psb_shorthand_uses_innermost_binder(v: string | null) -> string {
     load_var v
-    store_var _3
-    load_var _3
+    store_var _2
+    load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "outer"
     load_const "key"
     load_type string
     load_type string
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
-    jump L2
+    jump L1
 
-  L1:
-    load_var _3
+  L0:
+    load_var _2
     load_const "key"
     load_type string
     load_type string
     alloc_map 1
     call user.property_shorthand_binders.psb_lookup
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_provider_stdlib/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_provider_stdlib/bytecode.snap
@@ -40,7 +40,6 @@ function provider_stdlib.provider_schema_values() -> string {
     load_var schema
     load_const ".type"
     call baml.json.path
-    store_var _7
     load_type string
     load_var schema
     load_const ".properties.name.type"
@@ -62,7 +61,6 @@ function provider_stdlib.provider_schema_values() -> string {
     load_const "missing"
     call baml.json.path_or
     store_var _18
-    load_var _7
     load_const "|"
     bin_op +
     load_var _10

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_qualified_literals/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_qualified_literals/bytecode.snap
@@ -20,29 +20,21 @@ function qualified_literals.first_x(points: qualified_literals.QualPoint[]) -> i
     call baml.Array.at
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type qualified_literals.QualPoint
     load_var points
     load_const 0
     call baml.Array.at
     load_field .0
-    jump L2
+    jump L1
+
+  L0:
+    load_const null
 
   L1:
-    load_const null
+    jump_if_not_null_or_pop L2
+    load_const -1
 
   L2:
-    store_var_load_var _2
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    load_const -1
-    store_var _2
-
-  L3:
-    load_var _2
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_reflect_type_of_generic/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_reflect_type_of_generic/bytecode.snap
@@ -144,8 +144,6 @@ function reflect_type_of_generic.Box.describe(self: reflect_type_of_generic.Box<
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -162,8 +160,6 @@ function reflect_type_of_generic.Inner.name(self: reflect_type_of_generic.Inner<
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -172,8 +168,6 @@ function reflect_type_of_generic.InnerShow.show(self: reflect_type_of_generic.In
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -182,8 +176,6 @@ function reflect_type_of_generic.Leaf.describe(self: reflect_type_of_generic.Lea
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -206,8 +198,6 @@ function reflect_type_of_generic.array_of_int_fn() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -217,8 +207,6 @@ function reflect_type_of_generic.array_of_user_to_string_fn() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -255,8 +243,6 @@ function reflect_type_of_generic.describe() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -331,8 +317,6 @@ function reflect_type_of_generic.level1_str() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_request_preview_credentials/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_request_preview_credentials/bytecode.snap
@@ -69,12 +69,10 @@ function request_preview_credentials.PreviewShape(client: ai.Client | null, on_e
     call user.request_preview_credentials.PreviewShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_leaf_narrowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_leaf_narrowing/bytecode.snap
@@ -51,37 +51,28 @@ function runtime_leaf_narrowing.$init_test_ns_runtime_leaf_narrowing_runtime_lea
 function runtime_leaf_narrowing.classify_media_runtime_value(value: image | audio | video | pdf) -> string {
     load_var value
     is_type image
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var value
     is_type audio
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var value
     is_type video
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "pdf"
+    jump L3
+
+  L0:
+    load_const "video"
+    jump L3
+
+  L1:
+    load_const "audio"
     jump L3
 
   L2:
-    load_const "pdf"
-    jump L6
-
-  L3:
-    load_const "video"
-    jump L6
-
-  L4:
-    load_const "audio"
-    jump L6
-
-  L5:
     load_const "image"
 
-  L6:
+  L3:
     return
 }
 
@@ -90,20 +81,17 @@ function runtime_leaf_narrowing.classify_type_runtime_value(value: reflect.Type 
     store_var _2
     load_var _2
     narrow_bind reflect.Type, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "int"
     jump L1
 
   L0:
-    load_const "int"
-    jump L2
-
-  L1:
     load_var _2
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -112,20 +100,17 @@ function runtime_leaf_narrowing.if_let_binds_type_runtime_value() -> string {
     store_var _2
     load_var _2
     narrow_bind reflect.Type, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "not type"
     jump L1
 
   L0:
-    load_const "not type"
-    jump L2
-
-  L1:
     load_var _2
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -148,168 +133,45 @@ function runtime_leaf_narrowing.is_distinguishes_media_runtime_values() -> bool 
     store_var pdf_value
     load_var image_value
     is_type image
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
-    jump_if_false L6
-    pop 1
+    jump_if_false_or_pop L0
     load_var image_value
     is_type audio
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
     unary_op !
-
-  L6:
-    jump_if_false L9
-    pop 1
+    jump_if_false_or_pop L0
     load_var audio_value
     is_type audio
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
-    load_const false
-    jump L9
-
-  L8:
-    load_const true
-
-  L9:
-    jump_if_false L13
-    pop 1
+    jump_if_false_or_pop L0
     load_var audio_value
     is_type video
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_const false
-    jump L12
-
-  L11:
-    load_const true
-
-  L12:
     unary_op !
-
-  L13:
-    jump_if_false L16
-    pop 1
+    jump_if_false_or_pop L0
     load_var video_value
     is_type video
-    pop_jump_if_false L14
-    jump L15
-
-  L14:
-    load_const false
-    jump L16
-
-  L15:
-    load_const true
-
-  L16:
-    jump_if_false L20
-    pop 1
+    jump_if_false_or_pop L0
     load_var video_value
     is_type pdf
-    pop_jump_if_false L17
-    jump L18
-
-  L17:
-    load_const false
-    jump L19
-
-  L18:
-    load_const true
-
-  L19:
     unary_op !
-
-  L20:
-    jump_if_false L23
-    pop 1
+    jump_if_false_or_pop L0
     load_var pdf_value
     is_type pdf
-    pop_jump_if_false L21
-    jump L22
-
-  L21:
-    load_const false
-    jump L23
-
-  L22:
-    load_const true
-
-  L23:
-    jump_if_false L27
-    pop 1
+    jump_if_false_or_pop L0
     load_var pdf_value
     is_type image
-    pop_jump_if_false L24
-    jump L25
-
-  L24:
-    load_const false
-    jump L26
-
-  L25:
-    load_const true
-
-  L26:
     unary_op !
 
-  L27:
+  L0:
     return
 }
 
 function runtime_leaf_narrowing.is_type_rejects_non_type() -> bool {
     load_const 7
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function runtime_leaf_narrowing.is_type_runtime_value() -> bool {
     load_type int
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -320,28 +182,21 @@ function runtime_leaf_narrowing.match_distinguishes_media_runtime_values() -> bo
     call user.runtime_leaf_narrowing.classify_media_runtime_value
     load_const "image"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const "aGk="
     load_const "audio/mpeg"
     call baml.media.Audio.from_base64
     call user.runtime_leaf_narrowing.classify_media_runtime_value
     load_const "audio"
     cmp_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_const "aGk="
     load_const "video/mp4"
     call baml.media.Video.from_base64
     call user.runtime_leaf_narrowing.classify_media_runtime_value
     load_const "video"
     cmp_op ==
-
-  L1:
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L0
     load_const "aGk="
     load_const "application/pdf"
     call baml.media.Pdf.from_base64
@@ -349,7 +204,7 @@ function runtime_leaf_narrowing.match_distinguishes_media_runtime_values() -> bo
     load_const "pdf"
     cmp_op ==
 
-  L2:
+  L0:
     return
 }
 
@@ -358,8 +213,7 @@ function runtime_leaf_narrowing.match_recognizes_type_runtime_values() -> bool {
     call user.runtime_leaf_narrowing.classify_type_runtime_value
     load_const "string"
     cmp_op ==
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const 7
     call user.runtime_leaf_narrowing.classify_type_runtime_value
     load_const "int"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_render_identity/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_runtime_render_identity/bytecode.snap
@@ -91,12 +91,10 @@ function runtime_render_identity.Render(client: ai.Client | null, on_event: ((ai
     call user.runtime_render_identity.Render@spec
     store_var _8
     load_type #0
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -214,12 +212,10 @@ function runtime_render_identity.RenderPair(client: ai.Client | null, on_event: 
     call user.runtime_render_identity.RenderPair@spec
     store_var _8
     load_type runtime_render_identity.BoxRec<#0> | runtime_render_identity.BoxRec<#1>
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_self_frame_slot/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_self_frame_slot/bytecode.snap
@@ -256,8 +256,6 @@ function self_frame_slot.<(user.self_frame_slot.IntShelf as user.self_frame_slot
     load_type int
     load_var self
     call user.self_frame_slot.Store.describe
-    store_var _2
-    load_var _2
     bin_op +
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_self_frame_slot/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_self_frame_slot/bytecode.snap
@@ -177,17 +177,6 @@ function self_frame_slot.$init_test_ns_self_frame_slot_self_frame_slot(registry:
 function self_frame_slot.<(#0[] as user.self_frame_slot.Marked)>.is_self(self: #0[], other: unknown) -> bool {
     load_var other
     is_type #0[]
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -201,25 +190,12 @@ function self_frame_slot.<(#0[] as user.self_frame_slot.Marked)>.type_name(self:
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function self_frame_slot.<(int as user.self_frame_slot.Marked)>.is_self(self: int, other: unknown) -> bool {
     load_var other
     is_type int
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -233,25 +209,12 @@ function self_frame_slot.<(int as user.self_frame_slot.Marked)>.type_name(self: 
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function self_frame_slot.<(user.self_frame_slot.Crate<#0> as user.self_frame_slot.Marked)>.is_self(self: self_frame_slot.Crate<#0>, other: unknown) -> bool {
     load_var other
     is_type self_frame_slot.Crate<...>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -265,25 +228,12 @@ function self_frame_slot.<(user.self_frame_slot.Crate<#0> as user.self_frame_slo
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function self_frame_slot.<(user.self_frame_slot.Croc as user.self_frame_slot.Marked)>.is_self(self: self_frame_slot.Croc, other: unknown) -> bool {
     load_var other
     is_type self_frame_slot.Croc
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -297,18 +247,16 @@ function self_frame_slot.<(user.self_frame_slot.Croc as user.self_frame_slot.Mar
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
 function self_frame_slot.<(user.self_frame_slot.IntShelf as user.self_frame_slot.Store<int>)>.describe(self: self_frame_slot.IntShelf) -> string {
+    load_const "override->"
     load_type self_frame_slot.IntShelf
     load_type int
     load_var self
     call user.self_frame_slot.Store.describe
     store_var _2
-    load_const "override->"
     load_var _2
     bin_op +
     return
@@ -319,8 +267,6 @@ function self_frame_slot.Kinded.kind_name(self: self_frame_slot.Kinded) -> strin
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -335,51 +281,26 @@ function self_frame_slot.Kinded.match_kind(self: self_frame_slot.Kinded, other: 
     store_var _3
     load_var _3
     narrow_bind #0, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "other"
     jump L1
 
   L0:
-    load_const "other"
-    jump L2
-
-  L1:
     load_const "self"
 
-  L2:
+  L1:
     return
 }
 
 function self_frame_slot.Kinded.same_kind(self: self_frame_slot.Kinded, other: unknown) -> bool {
     load_var other
     is_type #0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
 function self_frame_slot.Kinded.same_kind_of(self: self_frame_slot.Kinded, other: self_frame_slot.Kinded) -> bool {
     load_var other
     is_type #0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    jump L2
-
-  L1:
-    load_const true
-
-  L2:
     return
 }
 
@@ -388,7 +309,6 @@ function self_frame_slot.Store.describe(self: self_frame_slot.Store<#1>) -> stri
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_type #1
     load_type baml.ToString
     load_const "to_string"
@@ -399,7 +319,6 @@ function self_frame_slot.Store.describe(self: self_frame_slot.Store<#1>) -> stri
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
-    load_var _5
     load_const "/"
     bin_op +
     load_var _7
@@ -416,8 +335,6 @@ function self_frame_slot.bin_describe_fn() -> string {
     load_type self_frame_slot.Store<float, Key = bool>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -428,8 +345,6 @@ function self_frame_slot.blanket_closure_kind_name_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "kind_namer"
     virtual_call nargs=1 ntypeargs=0
-    store_var f
-    load_var f
     call_indirect
     return
 }
@@ -448,8 +363,6 @@ function self_frame_slot.closure_kind_name_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "kind_namer"
     virtual_call nargs=1 ntypeargs=0
-    store_var f
-    load_var f
     call_indirect
     return
 }
@@ -459,8 +372,6 @@ function self_frame_slot.dog_kind_name_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "kind_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -470,8 +381,6 @@ function self_frame_slot.dog_match_kind_cat_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "match_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -481,8 +390,6 @@ function self_frame_slot.dog_match_kind_dog_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "match_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -492,8 +399,6 @@ function self_frame_slot.dog_same_kind_cat_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -503,8 +408,6 @@ function self_frame_slot.dog_same_kind_dog_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -514,8 +417,6 @@ function self_frame_slot.dog_same_kind_int_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -525,8 +426,6 @@ function self_frame_slot.dog_same_kind_of_cat_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind_of"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -536,8 +435,6 @@ function self_frame_slot.dog_same_kind_of_dog_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind_of"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -546,8 +443,6 @@ function self_frame_slot.existential_kind_name_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "kind_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -557,17 +452,12 @@ function self_frame_slot.free_impl_concrete_self_fn() -> bool {
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _2
-    load_var _2
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_const 5
     load_const "s"
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     unary_op !
 
   L0:
@@ -579,8 +469,6 @@ function self_frame_slot.free_impl_concrete_self_name_fn() -> string {
     load_type self_frame_slot.Marked
     load_const "type_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -597,10 +485,7 @@ function self_frame_slot.free_impl_generic_self_fn() -> bool {
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var _4
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var xs
     load_const "a"
     load_type string
@@ -608,8 +493,6 @@ function self_frame_slot.free_impl_generic_self_fn() -> bool {
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _6
-    load_var _6
     unary_op !
 
   L0:
@@ -623,8 +506,6 @@ function self_frame_slot.free_impl_generic_self_name_fn() -> string {
     load_type self_frame_slot.Marked
     load_const "type_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -640,10 +521,7 @@ function self_frame_slot.in_body_generic_self_fn() -> bool {
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var _4
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var ci
     load_const "s"
     load_type string
@@ -651,23 +529,16 @@ function self_frame_slot.in_body_generic_self_fn() -> bool {
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _6
-    load_var _6
     unary_op !
-
-  L0:
-    jump_if_false L1
-    pop 1
+    jump_if_false_or_pop L0
     load_var ci
     load_const 1
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _8
-    load_var _8
     unary_op !
 
-  L1:
+  L0:
     return
 }
 
@@ -678,8 +549,6 @@ function self_frame_slot.in_body_generic_self_name_fn() -> string {
     load_type self_frame_slot.Marked
     load_const "type_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -691,17 +560,12 @@ function self_frame_slot.in_body_self_fn() -> bool {
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _2
-    load_var _2
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var c
     load_const 1
     load_type self_frame_slot.Marked
     load_const "is_self"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var _4
     unary_op !
 
   L0:
@@ -717,8 +581,6 @@ function self_frame_slot.int_list_kind_name_fn() -> string {
     load_type self_frame_slot.Kinded
     load_const "kind_name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -734,8 +596,6 @@ function self_frame_slot.int_list_same_kind_int_list_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -751,8 +611,6 @@ function self_frame_slot.int_list_same_kind_string_list_fn() -> bool {
     load_type self_frame_slot.Kinded
     load_const "same_kind"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -761,7 +619,5 @@ function self_frame_slot.shelf_describe_fn() -> string {
     load_type self_frame_slot.Store<int, Key = string>
     load_const "describe"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_shell/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_shell/bytecode.snap
@@ -105,10 +105,8 @@ function shell.$init_test_ns_shell_shell(registry: testing.TestCollector) -> nul
 }
 
 function shell.b251_concat_println_shell_fn() -> bool {
-    call user.shell.b251_payload
-    store_var _2
     load_const "echo "
-    load_var _2
+    call user.shell.b251_payload
     bin_op +
     store_var cmd
     load_const "-> "
@@ -128,8 +126,7 @@ function shell.b251_concat_println_shell_fn() -> bool {
     call baml.String.length
     load_const 0
     cmp_int_op >
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var out
     load_const "hello_world"
     call baml.String.includes
@@ -162,8 +159,7 @@ function shell.b251_multi_let_fn() -> bool {
     call baml.String.length
     load_const 0
     cmp_int_op >
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var out
     load_const "hello_world"
     call baml.String.includes
@@ -178,10 +174,8 @@ function shell.b251_payload() -> string {
 }
 
 function shell.b251_println_discarded_fn() -> bool {
-    call user.shell.b251_payload
-    store_var _2
     load_const "echo "
-    load_var _2
+    call user.shell.b251_payload
     bin_op +
     store_var cmd
     load_const "-> "
@@ -201,8 +195,7 @@ function shell.b251_println_discarded_fn() -> bool {
     call baml.String.length
     load_const 0
     cmp_int_op >
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var out
     load_const "hello_world"
     call baml.String.includes
@@ -212,10 +205,8 @@ function shell.b251_println_discarded_fn() -> bool {
 }
 
 function shell.b251_println_twice_fn() -> bool {
-    call user.shell.b251_payload
-    store_var _2
     load_const "echo "
-    load_var _2
+    call user.shell.b251_payload
     bin_op +
     store_var cmd
     load_const "-> "
@@ -240,8 +231,7 @@ function shell.b251_println_twice_fn() -> bool {
     call baml.String.length
     load_const 0
     cmp_int_op >
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var out
     load_const "hello_world"
     call baml.String.includes
@@ -261,8 +251,6 @@ function shell.exec_echo_fn() -> bool {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _1
-    load_var _1
     load_const "Hello From Exec!"
     call baml.String.includes
     return
@@ -276,8 +264,6 @@ function shell.shell_echo_fn() -> bool {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _1
-    load_var _1
     load_const "hello_from_shell"
     call baml.String.includes
     return
@@ -325,8 +311,6 @@ function shell.shell_stdout_bytes_fn() -> bool {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _1
-    load_var _1
     load_const "hello"
     call baml.String.includes
     return
@@ -340,8 +324,6 @@ function shell.shell_with_variable_fn() -> bool {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     load_const "dynamic_value"
     call baml.String.includes
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_soundness/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_soundness/bytecode.snap
@@ -70,11 +70,9 @@ function soundness.$init_test_ns_soundness_soundness(registry: testing.TestColle
 }
 
 function soundness.call_result_right_operand_sub() -> int {
+    load_const 1
     load_const 2
     call user.soundness.sound_id
-    store_var _1
-    load_const 1
-    load_var _1
     sub_int
     return
 }
@@ -95,10 +93,6 @@ function soundness.cross_block_field_mutation_helper() -> int {
     load_var b
     load_field .v
     store_var t
-    load_const true
-    pop_jump_if_false L0
-
-  L0:
     load_var b
     load_const 2
     store_field .v
@@ -107,17 +101,11 @@ function soundness.cross_block_field_mutation_helper() -> int {
 }
 
 function soundness.cross_block_let_mutation_true(c: bool) -> int {
-    load_const 1
-    store_var a
-    load_var a
-    store_var b
     load_var c
-    pop_jump_if_false L0
-    load_const 2
-    store_var a
+    pop_jump_if_true L0
 
   L0:
-    load_var b
+    load_const 1
     return
 }
 
@@ -144,23 +132,7 @@ function soundness.multiple_defs_preserve_side_effects_helper() -> int {
 }
 
 function soundness.phi_right_operand_sub() -> int {
-    load_const true
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const 3
-    store_var _1
-    jump L2
-
-  L1:
-    load_const 7
-    store_var _1
-
-  L2:
-    load_const 100
-    load_var _1
-    bin_op -
+    load_const 93
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_spawn_name_object/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_spawn_name_object/bytecode.snap
@@ -27,8 +27,8 @@ function spawn_name_object.spawn_name_then_map_literal_body_fn() -> int {
     load_type int
     load_type never
     spawn
-    store_var _5
-    load_var _5
+    store_var _3
+    load_var _3
     await
     return
 }
@@ -40,8 +40,8 @@ function spawn_name_object.spawn_name_then_struct_body_parses_correctly_fn() -> 
     load_type spawn_name_object.B
     load_type never
     spawn
-    store_var _5
-    load_var _5
+    store_var _3
+    load_var _3
     await
     load_field .x
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_spawn_throws/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_spawn_throws/bytecode.snap
@@ -58,20 +58,17 @@ function spawn_throws.await_rethrows_caught_by_user_catch_fn() -> int {
     store_var _3
     load_var _3
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 99
 
-  L2:
+  L1:
     return
 }
 
@@ -114,20 +111,17 @@ function spawn_throws.caught_after_sleep_not_double_surfaced_fn() -> int {
     pop 1
     load_var _3
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 99
 
-  L2:
+  L1:
     return
 }
 
@@ -151,20 +145,17 @@ function spawn_throws.caught_not_preempted_by_unrelated_await_fn() -> int {
     pop 1
     load_var _3
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 99
 
-  L2:
+  L1:
     return
 }
 
@@ -178,20 +169,17 @@ function spawn_throws.racing_caught_not_double_surfaced_fn() -> int {
     store_var _3
     load_var _3
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 99
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
@@ -873,7 +873,6 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     load_type string | ai.ModelTurn
     load_var retry_outcome
     call baml.String.from
-    store_var _39
     load_type int
     load_var retry_inner
     load_field .attempts
@@ -902,7 +901,6 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     load_field .attempts
     call baml.String.from
     store_var _57
-    load_var _39
     bin_op +
     load_const ":"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
@@ -247,10 +247,7 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Scripted
     load_var self
     load_field .fail_open_attempts
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L11
-
-  L0:
+    pop_jump_if_true L6
     load_deref ?3
     load_var self
     load_field .fail_open_attempts
@@ -258,34 +255,22 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Scripted
     load_field .fail_pull_attempts
     add_int
     cmp_int_op <=
-    pop_jump_if_false L1
-    jump L9
-
-  L1:
+    pop_jump_if_true L4
     load_var self
     load_field .cancel_before_delta
-    pop_jump_if_false L2
-    jump L8
-
-  L2:
+    pop_jump_if_true L3
     load_var self
     load_field .unsafe_before_delta
-    pop_jump_if_false L3
-    jump L7
-
-  L3:
+    pop_jump_if_true L2
     load_var self
     load_field .fail_after_delta
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L0
     load_var self
     load_field .chunks
     call ai.stream.TurnStream.from_chunks
-    jump L10
+    jump L5
 
-  L5:
+  L0:
     load_const 0
     store_deref ?9
     load_var self
@@ -299,34 +284,29 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Scripted
     load_field .chunks
     load_const 0
     call baml.Array.at
-    store_var_load_var _38
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
+    jump_if_not_null_or_pop L1
     load_const "prefix"
-    store_var _38
 
-  L6:
-    load_var _38
+  L1:
     store_deref ?12
     load_var2 9 12
     load_var2 10 11
     load_var attempt
     make_closure .<lambda(ScriptedStreamClient.invoke_stream, 3)>, 5
     call ai.stream.TurnStream.from_event_source
-    jump L10
+    jump L5
 
-  L7:
+  L2:
     make_closure .<lambda(ScriptedStreamClient.invoke_stream, 2)>, 0
     call ai.stream.TurnStream.from_event_source
-    jump L10
+    jump L5
 
-  L8:
+  L3:
     make_closure .<lambda(ScriptedStreamClient.invoke_stream, 1)>, 0
     call ai.stream.TurnStream.from_event_source
-    jump L10
+    jump L5
 
-  L9:
+  L4:
     load_var self
     load_field .probe
     store_deref ?7
@@ -338,10 +318,10 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Scripted
     make_closure .<lambda(ScriptedStreamClient.invoke_stream, 0)>, 3
     call ai.stream.TurnStream.from_event_source
 
-  L10:
+  L5:
     return
 
-  L11:
+  L6:
     load_var self
     load_field .client_id
     load_const "failed while opening"
@@ -365,10 +345,7 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Syntheti
     store_field .attempts
     load_var self
     load_field .cancel_immediately
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "synthetic-invoke"
     load_const "retryable failure"
     load_const null
@@ -376,7 +353,7 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Syntheti
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L1:
+  L0:
     load_const "scripted non-stream cancellation"
     init_instance baml.panics.Cancelled .message
     throw
@@ -421,12 +398,10 @@ function streaming_composite_clients.CompositeStreamSpec(client: ai.Client | nul
     call user.streaming_composite_clients.CompositeStreamSpec@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -552,23 +527,16 @@ function streaming_composite_clients.composite_input() -> ai.ModelTurnInput {
 function streaming_composite_clients.drain_streaming(client_value: ai.stream.StreamingClient) -> string {
     call user.streaming_composite_clients.composite_input
     store_var _6
-    load_var2 1 4
+    load_var2 1 2
     load_type ai.stream.StreamingClient
     load_const "invoke_stream"
     virtual_call nargs=2 ntypeargs=0
-    store_var _5
-    load_var _5
     call ai.stream.TurnStream.final_turn
     call ai.ModelTurn.terminal_text
-    store_var_load_var _2
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _2
 
   L0:
-    load_var _2
     return
 }
 
@@ -577,91 +545,69 @@ function streaming_composite_clients.failure_name(error: unknown) -> string {
     store_var _2
     load_var _2
     narrow_bind ai.errors.NetworkFailure, slot=2
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var error
     store_var _7
     load_var _7
-    narrow_bind ai.errors.StepBudgetExceeded, slot=4
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    narrow_bind ai.errors.StepBudgetExceeded, slot=3
+    pop_jump_if_true L2
     load_var error
     store_var _12
     load_var _12
-    narrow_bind ai.errors.StreamingUnsupported, slot=6
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    narrow_bind ai.errors.StreamingUnsupported, slot=4
+    pop_jump_if_true L1
     load_var error
     store_var _17
     load_var _17
-    narrow_bind baml.panics.Cancelled, slot=8
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    narrow_bind baml.panics.Cancelled, slot=5
+    pop_jump_if_true L0
     load_type unknown
     load_var error
     call baml.String.from
     store_var _23
+    load_const "other:"
     load_type string
     load_var _23
     call baml.String.from
-    store_var _22
-    load_const "other:"
-    load_var _22
     bin_op +
-    jump L8
+    jump L4
 
-  L4:
+  L0:
+    load_const "Cancelled:"
     load_type string
     load_var _17
     load_field .message
     call baml.String.from
-    store_var _19
-    load_const "Cancelled:"
-    load_var _19
     bin_op +
-    jump L8
+    jump L4
 
-  L5:
+  L1:
+    load_const "StreamingUnsupported:"
     load_type string
     load_var _12
     load_field .client_id
     call baml.String.from
-    store_var _14
-    load_const "StreamingUnsupported:"
-    load_var _14
     bin_op +
-    jump L8
+    jump L4
 
-  L6:
+  L2:
+    load_const "StepBudgetExceeded:"
     load_type int
     load_var _7
     load_field .steps
     call baml.String.from
-    store_var _9
-    load_const "StepBudgetExceeded:"
-    load_var _9
     bin_op +
-    jump L8
+    jump L4
 
-  L7:
+  L3:
+    load_const "NetworkFailure:"
     load_type string
     load_var _2
     load_field .detail
     call baml.String.from
-    store_var _4
-    load_const "NetworkFailure:"
-    load_var _4
     bin_op +
 
-  L8:
+  L4:
     return
 }
 
@@ -703,7 +649,6 @@ function streaming_composite_clients.fallback_stream_advances_before_first_delta
     load_type string
     load_var _15
     call baml.String.from
-    store_var _14
     load_type string
     load_var probe
     load_field .events
@@ -714,7 +659,6 @@ function streaming_composite_clients.fallback_stream_advances_before_first_delta
     load_var _19
     call baml.String.from
     store_var _18
-    load_var _14
     load_const "|"
     bin_op +
     load_var _18
@@ -767,37 +711,33 @@ function streaming_composite_clients.fallback_stream_does_not_advance_after_delt
     store_var _17
     load_var _17
     narrow_bind string[], slot=7
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "done"
+    store_var first_delta
     jump L1
 
   L0:
-    load_const "done"
-    store_var first_delta
-    jump L2
-
-  L1:
     load_type string
     load_var _17
     load_const ""
     call baml.Array.join
     store_var first_delta
 
-  L2:
+  L1:
     load_var stream
     call ai.stream.TurnStream.next
     store_var outcome
-    jump L3
+    jump L2
     load_var e
     throw_if_panic
     load_var e
     call user.streaming_composite_clients.failure_name
     store_var outcome
 
-  L3:
+  L2:
     load_type string
     load_var first_delta
     call baml.String.from
-    store_var _26
     load_type string | ai.stream.Done | string[]
     load_var outcome
     call baml.String.from
@@ -816,7 +756,6 @@ function streaming_composite_clients.fallback_stream_does_not_advance_after_delt
     load_var _34
     call baml.String.from
     store_var _33
-    load_var _26
     load_const "|"
     bin_op +
     load_var _29
@@ -843,34 +782,28 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     load_const <omitted>
     load_var _4
     call ai.clients.Retry.new
-    store_var retry
     call user.streaming_composite_clients.composite_input
-    store_var _7
-    load_var2 2 6
     load_type ai.Client
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
     store_var retry_outcome
-    jump L2
+    jump L1
     load_var e
     store_var _8
     load_var _8
-    narrow_bind baml.panics.Cancelled, slot=7
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    narrow_bind baml.panics.Cancelled, slot=5
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_const "other"
     store_var retry_outcome
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const "cancelled"
     store_var retry_outcome
 
-  L2:
+  L1:
     load_const 0
     load_const true
     init_instance user.streaming_composite_clients.SyntheticInvokeClient .attempts, .cancel_immediately
@@ -878,34 +811,28 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     load_type ai.Client
     alloc_array 1
     call ai.clients.RoundRobin.new
-    store_var round_robin
     call user.streaming_composite_clients.composite_input
-    store_var _15
-    load_var2 9 12
     load_type ai.Client
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
     store_var round_robin_outcome
-    jump L5
+    jump L3
     load_var e
     store_var _16
     load_var _16
-    narrow_bind baml.panics.Cancelled, slot=13
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    narrow_bind baml.panics.Cancelled, slot=9
+    pop_jump_if_true L2
     load_var e
     throw_if_panic
     load_const "other"
     store_var round_robin_outcome
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const "cancelled"
     store_var round_robin_outcome
 
-  L5:
+  L3:
     load_const 0
     load_const true
     init_instance user.streaming_composite_clients.SyntheticInvokeClient .attempts, .cancel_immediately
@@ -916,7 +843,7 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     store_var fallback_backup
     call user.streaming_composite_clients.composite_input
     store_var _25
-    load_var2 14 15
+    load_var2 10 11
     load_type ai.Client
     alloc_array 2
     init_instance ai.clients.Fallback .members
@@ -925,26 +852,24 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
     store_var fallback_outcome
-    jump L8
+    jump L5
     load_var e
     store_var _26
     load_var _26
-    narrow_bind baml.panics.Cancelled, slot=19
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    narrow_bind baml.panics.Cancelled, slot=15
+    pop_jump_if_true L4
     load_var e
     throw_if_panic
     load_const "other"
     store_var fallback_outcome
-    jump L8
+    jump L5
 
-  L7:
+  L4:
     load_const "cancelled"
     store_var fallback_outcome
 
-  L8:
+  L5:
+    load_const "retry="
     load_type string | ai.ModelTurn
     load_var retry_outcome
     call baml.String.from
@@ -977,7 +902,6 @@ function streaming_composite_clients.nonstream_composites_preserve_cancellation_
     load_field .attempts
     call baml.String.from
     store_var _57
-    load_const "retry="
     load_var _39
     bin_op +
     load_const ":"
@@ -1034,10 +958,7 @@ function streaming_composite_clients.retry_stream_does_not_retry_after_delta_cas
     load_const <omitted>
     load_var _8
     call ai.clients.Retry.new
-    store_var retry
     call user.streaming_composite_clients.composite_input
-    store_var _10
-    load_var2 3 6
     load_type ai.stream.StreamingClient
     load_const "invoke_stream"
     virtual_call nargs=2 ntypeargs=0
@@ -1046,38 +967,34 @@ function streaming_composite_clients.retry_stream_does_not_retry_after_delta_cas
     call ai.stream.TurnStream.next
     store_var _13
     load_var _13
-    narrow_bind string[], slot=8
-    pop_jump_if_false L0
+    narrow_bind string[], slot=6
+    pop_jump_if_true L0
+    load_const "done"
+    store_var first
     jump L1
 
   L0:
-    load_const "done"
-    store_var first
-    jump L2
-
-  L1:
     load_type string
     load_var _13
     load_const ""
     call baml.Array.join
     store_var first
 
-  L2:
+  L1:
     load_var stream
     call ai.stream.TurnStream.next
     store_var second
-    jump L3
+    jump L2
     load_var e
     throw_if_panic
     load_var e
     call user.streaming_composite_clients.failure_name
     store_var second
 
-  L3:
+  L2:
     load_type string
     load_var first
     call baml.String.from
-    store_var _22
     load_type string | ai.stream.Done | string[]
     load_var second
     call baml.String.from
@@ -1096,7 +1013,6 @@ function streaming_composite_clients.retry_stream_does_not_retry_after_delta_cas
     load_var _30
     call baml.String.from
     store_var _29
-    load_var _22
     load_const "|"
     bin_op +
     load_var _25
@@ -1140,7 +1056,6 @@ function streaming_composite_clients.retry_stream_retries_before_first_delta_cas
     load_type string
     load_var _11
     call baml.String.from
-    store_var _10
     load_type string
     load_var probe
     load_field .events
@@ -1151,7 +1066,6 @@ function streaming_composite_clients.retry_stream_retries_before_first_delta_cas
     load_var _15
     call baml.String.from
     store_var _14
-    load_var _10
     load_const "|"
     bin_op +
     load_var _14
@@ -1191,7 +1105,6 @@ function streaming_composite_clients.retry_stream_retries_when_open_fails_case()
     load_type string
     load_var _11
     call baml.String.from
-    store_var _10
     load_type string
     load_var probe
     load_field .events
@@ -1202,7 +1115,6 @@ function streaming_composite_clients.retry_stream_retries_when_open_fails_case()
     load_var _15
     call baml.String.from
     store_var _14
-    load_var _10
     load_const "|"
     bin_op +
     load_var _14
@@ -1243,7 +1155,6 @@ function streaming_composite_clients.retry_stream_success_case() -> string {
     load_type string
     load_var _11
     call baml.String.from
-    store_var _10
     load_type string
     load_var probe
     load_field .events
@@ -1254,7 +1165,6 @@ function streaming_composite_clients.retry_stream_success_case() -> string {
     load_var _15
     call baml.String.from
     store_var _14
-    load_var _10
     load_const "|"
     bin_op +
     load_var _14
@@ -1316,7 +1226,6 @@ function streaming_composite_clients.round_robin_stream_rotates_once_per_stream_
     load_type string
     load_var _22
     call baml.String.from
-    store_var _21
     load_type string
     load_var probe
     load_field .events
@@ -1327,7 +1236,6 @@ function streaming_composite_clients.round_robin_stream_rotates_once_per_stream_
     load_var _26
     call baml.String.from
     store_var _25
-    load_var _21
     load_const "|"
     bin_op +
     load_var _25
@@ -1426,7 +1334,6 @@ function streaming_composite_clients.streaming_composites_do_not_retry_unsafe_fa
     load_type string
     load_var outcome
     call baml.String.from
-    store_var _14
     load_type string
     load_var probe
     load_field .events
@@ -1437,7 +1344,6 @@ function streaming_composite_clients.streaming_composites_do_not_retry_unsafe_fa
     load_var _18
     call baml.String.from
     store_var _17
-    load_var _14
     load_const "|"
     bin_op +
     load_var _17
@@ -1661,7 +1567,6 @@ function streaming_composite_clients.streaming_composites_nest_as_capabilities_c
     load_type string
     load_var _18
     call baml.String.from
-    store_var _17
     load_type string
     load_var probe
     load_field .events
@@ -1672,7 +1577,6 @@ function streaming_composite_clients.streaming_composites_nest_as_capabilities_c
     load_var _22
     call baml.String.from
     store_var _21
-    load_var _17
     load_const "|"
     bin_op +
     load_var _21
@@ -1715,28 +1619,24 @@ function streaming_composite_clients.streaming_composites_propagate_cancellation
     init_instance ai.clients.Fallback .members
     call user.streaming_composite_clients.drain_streaming
     store_var outcome
-    jump L2
+    jump L1
     load_var e
     store_var _16
     load_var _16
     narrow_bind baml.panics.Cancelled, slot=6
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _16
     call user.streaming_composite_clients.failure_name
     store_var outcome
 
-  L2:
+  L1:
     load_type string
     load_var outcome
     call baml.String.from
-    store_var _20
     load_type string
     load_var probe
     load_field .events
@@ -1747,7 +1647,6 @@ function streaming_composite_clients.streaming_composites_propagate_cancellation
     load_var _24
     call baml.String.from
     store_var _23
-    load_var _20
     load_const "|"
     bin_op +
     load_var _23

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_parsing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_parsing/bytecode.snap
@@ -30,12 +30,10 @@ function streaming_parsing.ExtractDoc(input: string, client: ai.Client | null, o
     call user.streaming_parsing.ExtractDoc@spec
     store_var _9
     load_type streaming_parsing.Doc
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -82,10 +80,10 @@ function streaming_parsing.ExtractDoc@spec(input: string) -> ai.FunctionSpec<str
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.streaming_parsing.StreamParseClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "ExtractDoc"
     load_deref ?1
     load_const "input"
@@ -157,12 +155,10 @@ function streaming_parsing.SayHello(input: string, client: ai.Client | null, on_
     call user.streaming_parsing.SayHello@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -209,10 +205,10 @@ function streaming_parsing.SayHello@spec(input: string) -> ai.FunctionSpec<strin
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.streaming_parsing.StreamParseClient
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "SayHello"
     load_deref ?1
     load_const "input"

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_sse_primitives/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_sse_primitives/bytecode.snap
@@ -191,21 +191,18 @@ function streaming_sse_primitives.sse_custom_headers_fn() -> bool {
     load_var events
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var events
     load_const "\"data\":\"authed\""
     call assert.contains
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }
 
@@ -252,17 +249,14 @@ function streaming_sse_primitives.sse_empty_stream_returns_null_fn() -> string {
     load_var first
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "unexpected-data"
     jump L1
 
   L0:
-    load_const "unexpected-data"
-    jump L2
-
-  L1:
     load_const "got-null"
 
-  L2:
+  L1:
     return
 }
 
@@ -309,10 +303,7 @@ function streaming_sse_primitives.sse_event_fields_in_json_fn() -> bool {
     load_var events
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type streaming_sse_primitives.SseJsonEvent[]
     load_var events
     call baml.json.from_string
@@ -346,12 +337,12 @@ function streaming_sse_primitives.sse_event_fields_in_json_fn() -> bool {
     call assert.equal
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }
 
@@ -398,10 +389,7 @@ function streaming_sse_primitives.sse_event_id_null_when_not_set_fn() -> bool {
     load_var events
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type streaming_sse_primitives.SseJsonEvent[]
     load_var events
     call baml.json.from_string
@@ -422,12 +410,12 @@ function streaming_sse_primitives.sse_event_id_null_when_not_set_fn() -> bool {
     call assert.is_true
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }
 
@@ -479,10 +467,7 @@ function streaming_sse_primitives.sse_fetch_and_next_returns_events_fn() -> bool
     load_var events
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var events
     load_const "\"data\":\"hello\""
     call assert.contains
@@ -492,12 +477,12 @@ function streaming_sse_primitives.sse_fetch_and_next_returns_events_fn() -> bool
     call assert.contains
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }
 
@@ -535,19 +520,16 @@ function streaming_sse_primitives.sse_fetch_error_on_bad_status_fn() -> bool {
     load_const "expected fetch_sse on a 500 response to throw"
     call baml.sys.panic
     store_var ok
-    jump L2
+    jump L1
     load_var e
     store_var _13
     load_var _13
     narrow_bind baml.errors.Io, slot=6
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _13
     load_field .message
     load_const "500"
@@ -556,7 +538,7 @@ function streaming_sse_primitives.sse_fetch_error_on_bad_status_fn() -> bool {
     load_const true
     store_var ok
 
-  L2:
+  L1:
     load_var _4
     call baml.future.Future.cancel
     pop 1
@@ -598,19 +580,16 @@ function streaming_sse_primitives.sse_http_4xx_error_fn() -> bool {
     load_const "expected fetch_sse on a 403 response to throw"
     call baml.sys.panic
     store_var ok
-    jump L2
+    jump L1
     load_var e
     store_var _13
     load_var _13
     narrow_bind baml.errors.Io, slot=6
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _13
     load_field .message
     load_const "403"
@@ -619,7 +598,7 @@ function streaming_sse_primitives.sse_http_4xx_error_fn() -> bool {
     load_const true
     store_var ok
 
-  L2:
+  L1:
     load_var _4
     call baml.future.Future.cancel
     pop 1
@@ -683,20 +662,17 @@ function streaming_sse_primitives.sse_large_event_payload_fn() -> bool {
     load_var events
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var2 6 1
     call assert.contains
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }
 
@@ -746,17 +722,14 @@ function streaming_sse_primitives.sse_next_after_close_returns_null_fn() -> stri
     load_var after_close
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "unexpected-data"
     jump L1
 
   L0:
-    load_const "unexpected-data"
-    jump L2
-
-  L1:
     load_const "null-after-close"
 
-  L2:
+  L1:
     return
 }
 
@@ -811,10 +784,7 @@ function streaming_sse_primitives.sse_next_returns_null_when_done_fn() -> bool {
     load_var first
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var second
     load_const null
     call baml.ops.equals_equals
@@ -825,12 +795,12 @@ function streaming_sse_primitives.sse_next_returns_null_when_done_fn() -> bool {
     call assert.contains
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }
 
@@ -877,20 +847,17 @@ function streaming_sse_primitives.sse_post_with_body_fn() -> bool {
     load_var events
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var events
     load_const "\"data\":\"ok\""
     call assert.contains
     pop 1
     load_const true
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const false
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_string_regressions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_string_regressions/bytecode.snap
@@ -77,10 +77,7 @@ function string_regressions.strregr_iterate_by_character() -> string {
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var out
     load_const "["
     load_var _3
@@ -91,7 +88,7 @@ function string_regressions.strregr_iterate_by_character() -> string {
     store_var out
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_strings/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_strings/bytecode.snap
@@ -1260,9 +1260,7 @@ function strings.$init_test_ns_strings_strings(registry: testing.TestCollector) 
 }
 
 function strings.strings_concat() -> string {
-    load_const "Hello"
-    load_const " World"
-    bin_op +
+    load_const "Hello World"
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_structured_prompt_requests/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_structured_prompt_requests/bytecode.snap
@@ -182,12 +182,10 @@ function structured_prompt_requests.AudioShape(sound: audio, client: ai.Client |
     call user.structured_prompt_requests.AudioShape@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -234,7 +232,7 @@ function structured_prompt_requests.AudioShape@spec(sound: audio) -> ai.Function
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gemini-2.5-flash"
     load_const <omitted>
     load_const <omitted>
@@ -250,7 +248,7 @@ function structured_prompt_requests.AudioShape@spec(sound: audio) -> ai.Function
     load_const <omitted>
     load_const <omitted>
     call google.GeminiClient.new
-    store_var _6
+    store_var _7
     load_const "AudioShape"
     load_deref ?1
     load_const "sound"
@@ -322,12 +320,10 @@ function structured_prompt_requests.ChatMediaShape(photo: image, client: ai.Clie
     call user.structured_prompt_requests.ChatMediaShape@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -374,10 +370,10 @@ function structured_prompt_requests.ChatMediaShape@spec(photo: image) -> ai.Func
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.structured_prompt_requests.UnroutableChat
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "ChatMediaShape"
     load_deref ?1
     load_const "photo"
@@ -448,12 +444,10 @@ function structured_prompt_requests.ExplicitRolesShape(client: ai.Client | null,
     call user.structured_prompt_requests.ExplicitRolesShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -565,12 +559,10 @@ function structured_prompt_requests.FirstShape(client: ai.Client | null, on_even
     call user.structured_prompt_requests.FirstShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -683,12 +675,10 @@ function structured_prompt_requests.GenericShape(client: ai.Client | null, on_ev
     call user.structured_prompt_requests.GenericShape@spec
     store_var _8
     load_type structured_prompt_requests.Outer<#0>
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -813,12 +803,10 @@ function structured_prompt_requests.Greet(name: string, suffix: string, client: 
     call user.structured_prompt_requests.Greet@spec
     store_var _11
     load_type string
-    load_var2 6 7
+    load_var2 5 6
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _8
-    load_var _8
     load_field .value
     return
 }
@@ -899,14 +887,14 @@ function structured_prompt_requests.Greet@spec(name: string, suffix: string) -> 
     store_var _4
     load_var2 1 2
     make_closure .<lambda(Greet@spec, 0)>, 2
-    store_var _5
+    store_var _7
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _6
+    store_var _8
     load_global user.structured_prompt_requests.PreviewResponses
     call ai.clients.resolve
-    store_var _8
+    store_var _10
     load_const "Greet"
     load_var2 3 4
     load_var2 5 6
@@ -981,12 +969,10 @@ function structured_prompt_requests.MediaAll(photo: image, sound: audio, documen
     call user.structured_prompt_requests.MediaAll@spec
     store_var _12
     load_type string
-    load_var2 8 9
+    load_var2 7 8
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _9
-    load_var _9
     load_field .value
     return
 }
@@ -1044,7 +1030,7 @@ function structured_prompt_requests.MediaAll@spec(photo: image, sound: audio, do
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _7
+    store_var _11
     load_const "gemini-2.5-flash"
     load_const <omitted>
     load_const <omitted>
@@ -1060,7 +1046,7 @@ function structured_prompt_requests.MediaAll@spec(photo: image, sound: audio, do
     load_const <omitted>
     load_const <omitted>
     call google.GeminiClient.new
-    store_var _9
+    store_var _13
     load_const "MediaAll"
     load_deref ?1
     load_deref ?2
@@ -1141,12 +1127,10 @@ function structured_prompt_requests.MediaImageAudioPdf(photo: image, sound: audi
     call user.structured_prompt_requests.MediaImageAudioPdf@spec
     store_var _11
     load_type string
-    load_var2 7 8
+    load_var2 6 7
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _8
-    load_var _8
     load_field .value
     return
 }
@@ -1201,7 +1185,7 @@ function structured_prompt_requests.MediaImageAudioPdf@spec(photo: image, sound:
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _6
+    store_var _9
     load_const "gemini-2.5-flash"
     load_const <omitted>
     load_const <omitted>
@@ -1217,7 +1201,7 @@ function structured_prompt_requests.MediaImageAudioPdf@spec(photo: image, sound:
     load_const <omitted>
     load_const <omitted>
     call google.GeminiClient.new
-    store_var _8
+    store_var _11
     load_const "MediaImageAudioPdf"
     load_deref ?1
     load_deref ?2
@@ -1295,12 +1279,10 @@ function structured_prompt_requests.MediaImagePdf(photo: image, document: pdf, c
     call user.structured_prompt_requests.MediaImagePdf@spec
     store_var _10
     load_type string
-    load_var2 6 7
+    load_var2 5 6
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _7
-    load_var _7
     load_field .value
     return
 }
@@ -1350,7 +1332,7 @@ function structured_prompt_requests.MediaImagePdf@spec(photo: image, document: p
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _5
+    store_var _7
     load_const "gemini-2.5-flash"
     load_const <omitted>
     load_const <omitted>
@@ -1366,7 +1348,7 @@ function structured_prompt_requests.MediaImagePdf@spec(photo: image, document: p
     load_const <omitted>
     load_const <omitted>
     call google.GeminiClient.new
-    store_var _7
+    store_var _9
     load_const "MediaImagePdf"
     load_deref ?1
     load_deref ?2
@@ -1440,12 +1422,10 @@ function structured_prompt_requests.MediaShape(photo: image, client: ai.Client |
     call user.structured_prompt_requests.MediaShape@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -1492,10 +1472,10 @@ function structured_prompt_requests.MediaShape@spec(photo: image) -> ai.Function
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.structured_prompt_requests.UnroutableResponses
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "MediaShape"
     load_deref ?1
     load_const "photo"
@@ -1566,12 +1546,10 @@ function structured_prompt_requests.PreludeShape(client: ai.Client | null, on_ev
     call user.structured_prompt_requests.PreludeShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -1684,12 +1662,10 @@ function structured_prompt_requests.RequestShape(input: string, client: ai.Clien
     call user.structured_prompt_requests.RequestShape@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -1736,7 +1712,7 @@ function structured_prompt_requests.RequestShape@spec(input: string) -> ai.Funct
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_const "gpt-4o-mini"
     load_const <omitted>
     load_const <omitted>
@@ -1755,7 +1731,7 @@ function structured_prompt_requests.RequestShape@spec(input: string) -> ai.Funct
     load_const <omitted>
     load_const <omitted>
     call openai.ResponsesClient.new
-    store_var _6
+    store_var _7
     load_const "RequestShape"
     load_deref ?1
     load_const "input"
@@ -1826,12 +1802,10 @@ function structured_prompt_requests.RoledShape(client: ai.Client | null, on_even
     call user.structured_prompt_requests.RoledShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -1960,12 +1934,10 @@ function structured_prompt_requests.RolelessImageShape(photo: image, client: ai.
     call user.structured_prompt_requests.RolelessImageShape@spec
     store_var _9
     load_type string
-    load_var2 5 6
+    load_var2 4 5
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -2012,10 +1984,10 @@ function structured_prompt_requests.RolelessImageShape@spec(photo: image) -> ai.
     load_type ai.tools.Tool
     alloc_array 0
     call ai.tools.Toolbox.new
-    store_var _4
+    store_var _5
     load_global user.structured_prompt_requests.PreviewResponses
     call ai.clients.resolve
-    store_var _6
+    store_var _7
     load_const "RolelessImageShape"
     load_deref ?1
     load_const "photo"
@@ -2086,12 +2058,10 @@ function structured_prompt_requests.RolelessShape(client: ai.Client | null, on_e
     call user.structured_prompt_requests.RolelessShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -2203,12 +2173,10 @@ function structured_prompt_requests.WhitespaceShape(client: ai.Client | null, on
     call user.structured_prompt_requests.WhitespaceShape@spec
     store_var _8
     load_type string
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_tagged_template_runtime/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_tagged_template_runtime/bytecode.snap
@@ -120,14 +120,11 @@ function tagged_template_runtime.tt_cap(body: () -> baml.TaggedString throws nev
     store_var _6
     load_var _6
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "?"
     jump L1
 
   L0:
-    load_const "?"
-    jump L2
-
-  L1:
     load_var t
     load_field .parts
     load_const 0
@@ -140,7 +137,7 @@ function tagged_template_runtime.tt_cap(body: () -> baml.TaggedString throws nev
     load_array_element
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -174,14 +171,11 @@ function tagged_template_runtime.tt_fmt(body: (string) -> baml.TaggedString thro
     store_var _6
     load_var _6
     narrow_bind string, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "?"
     jump L1
 
   L0:
-    load_const "?"
-    jump L2
-
-  L1:
     load_var t
     load_field .parts
     load_const 0
@@ -194,7 +188,7 @@ function tagged_template_runtime.tt_fmt(body: (string) -> baml.TaggedString thro
     load_array_element
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -396,10 +390,7 @@ function tagged_template_runtime.tt_render(body: () -> baml.TaggedString throws 
     store_var _7
     load_var2 5 6
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var out
     store_var _22
     load_var t
@@ -415,7 +406,7 @@ function tagged_template_runtime.tt_render(body: () -> baml.TaggedString throws 
     bin_op +
     return
 
-  L2:
+  L1:
     load_var t
     load_field .values
     load_var i
@@ -423,19 +414,16 @@ function tagged_template_runtime.tt_render(body: () -> baml.TaggedString throws 
     store_var _13
     load_var _13
     narrow_bind string, slot=8
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_const "?"
     store_var v
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_var _13
     store_var v
 
-  L5:
+  L3:
     load_var2 3 2
     load_field .parts
     load_var i

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_task_group/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_task_group/bytecode.snap
@@ -195,20 +195,17 @@ function task_group.group_cancel_cancels_member() -> int {
     pop 1
     load_var _10
     await
-    jump L2
+    jump L1
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const 0
 
-  L2:
+  L1:
     return
 }
 
@@ -344,10 +341,8 @@ function task_group.queues_excess_and_all_complete() -> int {
     store_var _46
     load_var _10
     await
-    store_var _50
     load_var _19
     await
-    load_var _50
     add_int
     store_var _49
     load_var _28

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_time/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_time/bytecode.snap
@@ -525,16 +525,13 @@ function time.$init_test_ns_time_time(registry: testing.TestCollector) -> null {
 function time.plain_date_to_plain_datetime_with_time() -> string {
     load_const "1979-05-27"
     call baml.time.PlainDate.parse
-    store_var d
     load_const "07:32:00"
     call baml.time.PlainTime.parse
     store_var t
-    load_var2 2 3
+    load_var t
     call baml.time.PlainDate.to_plain_datetime
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_to_json_interface/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_to_json_interface/bytecode.snap
@@ -192,8 +192,6 @@ function to_json_interface.point_via_method_str() -> string {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _2
-    load_var _2
     call baml.json.stringify
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_to_string_interface/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_to_string_interface/bytecode.snap
@@ -106,6 +106,7 @@ function to_string_interface.<(user.to_string_interface.DmcGreeter as baml.ToStr
 }
 
 function to_string_interface.<(user.to_string_interface.IouPoint as baml.ToString)>.to_string(self: to_string_interface.IouPoint) -> string {
+    load_const "("
     load_type int
     load_var self
     load_field .x
@@ -116,7 +117,6 @@ function to_string_interface.<(user.to_string_interface.IouPoint as baml.ToStrin
     load_field .y
     call baml.String.from
     store_var _8
-    load_const "("
     load_var _5
     bin_op +
     load_const ", "
@@ -129,6 +129,7 @@ function to_string_interface.<(user.to_string_interface.IouPoint as baml.ToStrin
 }
 
 function to_string_interface.<(user.to_string_interface.OvrPoint as baml.ToString)>.to_string(self: to_string_interface.OvrPoint) -> string {
+    load_const "("
     load_type int
     load_var self
     load_field .x
@@ -139,7 +140,6 @@ function to_string_interface.<(user.to_string_interface.OvrPoint as baml.ToStrin
     load_field .y
     call baml.String.from
     store_var _8
-    load_const "("
     load_var _5
     bin_op +
     load_const ", "
@@ -157,8 +157,6 @@ function to_string_interface.dmc_render() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_to_string_interface/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_to_string_interface/bytecode.snap
@@ -111,13 +111,11 @@ function to_string_interface.<(user.to_string_interface.IouPoint as baml.ToStrin
     load_var self
     load_field .x
     call baml.String.from
-    store_var _5
     load_type int
     load_var self
     load_field .y
     call baml.String.from
     store_var _8
-    load_var _5
     bin_op +
     load_const ", "
     bin_op +
@@ -134,13 +132,11 @@ function to_string_interface.<(user.to_string_interface.OvrPoint as baml.ToStrin
     load_var self
     load_field .x
     call baml.String.from
-    store_var _5
     load_type int
     load_var self
     load_field .y
     call baml.String.from
     store_var _8
-    load_var _5
     bin_op +
     load_const ", "
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_tostring_sugar/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_tostring_sugar/bytecode.snap
@@ -105,6 +105,7 @@ function tostring_sugar.$init_test_ns_tostring_sugar_tostring_sugar(registry: te
 }
 
 function tostring_sugar.<(user.tostring_sugar.PointShow as baml.ToString)>.to_string(self: tostring_sugar.PointShow) -> string {
+    load_const "("
     load_type int
     load_var self
     load_field .x
@@ -115,7 +116,6 @@ function tostring_sugar.<(user.tostring_sugar.PointShow as baml.ToString)>.to_st
     load_field .y
     call baml.String.from
     store_var _8
-    load_const "("
     load_var _5
     bin_op +
     load_const ", "
@@ -160,8 +160,6 @@ function tostring_sugar.implementor_to_string_fn() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -250,8 +248,6 @@ function tostring_sugar.widget_to_string_fn() -> string {
     load_type tostring_sugar.MyShow
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_tostring_sugar/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_tostring_sugar/bytecode.snap
@@ -110,13 +110,11 @@ function tostring_sugar.<(user.tostring_sugar.PointShow as baml.ToString)>.to_st
     load_var self
     load_field .x
     call baml.String.from
-    store_var _5
     load_type int
     load_var self
     load_field .y
     call baml.String.from
     store_var _8
-    load_var _5
     bin_op +
     load_const ", "
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_truthiness/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_truthiness/bytecode.snap
@@ -352,74 +352,64 @@ function truthiness.$init_test_ns_truthiness_truthiness(registry: testing.TestCo
 function truthiness.tr_and(a: string | null, b: int) -> bool {
     load_var a
     unary_op truthy
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     jump L1
 
   L0:
-    store_var _0
+    store_var _3
     jump L2
 
   L1:
     load_var b
-    store_var _0
-    load_var _0
+    store_var _3
+    load_var _3
     unary_op truthy
-    store_var _0
+    store_var _3
 
   L2:
-    load_var _0
+    load_var _3
     return
 }
 
 function truthiness.tr_bigint(v: bigint) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_bytes(v: uint8array) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_closure(v: ((int) -> int throws never) | null) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
@@ -432,14 +422,11 @@ function truthiness.tr_countdown(n: int) -> int {
   L0:
     load_var remaining
     unary_op truthy
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var steps
     return
 
-  L2:
+  L1:
     load_var remaining
     load_const 1
     sub_int
@@ -454,17 +441,14 @@ function truthiness.tr_countdown(n: int) -> int {
 function truthiness.tr_float(v: float) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
@@ -477,50 +461,44 @@ function truthiness.tr_float_nan() -> string {
 function truthiness.tr_frag(instructions: string | null) -> string {
     load_var instructions
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const ""
     jump L1
 
   L0:
-    load_const ""
-    jump L2
-
-  L1:
+    load_const "<x>"
     load_type string
     load_var instructions
     call baml.String.from
     store_var _4
-    load_const "<x>"
     load_var _4
     bin_op +
     load_const "</x>"
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_frag_not(instructions: string | null) -> string {
     load_var instructions
-    unary_op !
-    pop_jump_if_false L0
+    unary_op truthy
+    pop_jump_if_true L0
+    load_const ""
     jump L1
 
   L0:
+    load_const "<x>"
     load_type string
     load_var instructions
     call baml.String.from
     store_var _4
-    load_const "<x>"
     load_var _4
     bin_op +
     load_const "</x>"
     bin_op +
-    jump L2
 
   L1:
-    load_const ""
-
-  L2:
     return
 }
 
@@ -531,86 +509,74 @@ function truthiness.tr_generic_conditions() -> string {
     load_const 0
     call user.truthiness.tr_id
     unary_op truthy
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var r
     load_const "i0-F;"
     bin_op +
     store_var r
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var r
     load_const "i0-T;"
     bin_op +
     store_var r
 
-  L2:
+  L1:
     load_type string
     load_const ""
     call user.truthiness.tr_id
     unary_op truthy
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var r
     load_const "s-F;"
+    bin_op +
+    store_var r
+    jump L3
+
+  L2:
+    load_var r
+    load_const "s-T;"
+    bin_op +
+    store_var r
+
+  L3:
+    load_type string
+    load_const "x"
+    call user.truthiness.tr_id
+    unary_op truthy
+    pop_jump_if_true L4
+    load_var r
+    load_const "x-F;"
     bin_op +
     store_var r
     jump L5
 
   L4:
     load_var r
-    load_const "s-T;"
-    bin_op +
-    store_var r
-
-  L5:
-    load_type string
-    load_const "x"
-    call user.truthiness.tr_id
-    unary_op truthy
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_var r
-    load_const "x-F;"
-    bin_op +
-    store_var r
-    jump L8
-
-  L7:
-    load_var r
     load_const "x-T;"
     bin_op +
     store_var r
 
-  L8:
+  L5:
     load_type int
     load_const 0
     call user.truthiness.tr_id
-    unary_op !
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
-    load_var r
-    load_const "n0-F;"
-    bin_op +
-    store_var r
-    jump L11
-
-  L10:
+    unary_op truthy
+    pop_jump_if_true L6
     load_var r
     load_const "n0-T;"
     bin_op +
     store_var r
+    jump L7
 
-  L11:
+  L6:
+    load_var r
+    load_const "n0-F;"
+    bin_op +
+    store_var r
+
+  L7:
     load_var r
     return
 }
@@ -618,25 +584,22 @@ function truthiness.tr_generic_conditions() -> string {
 function truthiness.tr_guard(v: int, label: string | null) -> string {
     load_var label
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_type int
+    load_var v
+    call baml.String.from
+    load_const "-plain"
+    bin_op +
     jump L1
 
   L0:
     load_type int
     load_var v
     call baml.String.from
-    load_const "-plain"
-    bin_op +
-    jump L2
-
-  L1:
-    load_type int
-    load_var v
-    call baml.String.from
     load_const "-labeled"
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -648,93 +611,78 @@ function truthiness.tr_id(v: #0) -> #0 {
 function truthiness.tr_instance(v: truthiness.TrPoint | null) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_int(v: int) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_list(v: int[]) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_literal_union(v: "" | "x" | null) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "none"
     jump L1
 
   L0:
-    load_const "none"
-    jump L2
-
-  L1:
+    load_const "<"
     load_type "x"
     load_var v
     call baml.String.from
     store_var _4
-    load_const "<"
     load_var _4
     bin_op +
     load_const ">"
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_map(v: map<string, int>) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
@@ -747,53 +695,49 @@ function truthiness.tr_not(v: string | null) -> bool {
 function truthiness.tr_opt_bool(v: bool | null) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_or(a: string | null, b: int) -> bool {
     load_var a
     unary_op truthy
-    jump_if_false L0
-    store_var _0
+    jump_if_true_or_pop L0
     jump L1
 
   L0:
-    pop 1
-    load_var b
-    store_var _0
-    load_var _0
-    unary_op truthy
-    store_var _0
+    store_var _3
+    jump L2
 
   L1:
-    load_var _0
+    load_var b
+    store_var _3
+    load_var _3
+    unary_op truthy
+    store_var _3
+
+  L2:
+    load_var _3
     return
 }
 
 function truthiness.tr_pick(v: bool) -> string {
     load_var v
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
@@ -824,33 +768,27 @@ function truthiness.tr_run_map_nonempty() -> string {
 function truthiness.tr_string(v: string) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }
 
 function truthiness.tr_variant(v: truthiness.TrColor | null) -> string {
     load_var v
     unary_op truthy
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "F"
     jump L1
 
   L0:
-    load_const "F"
-    jump L2
-
-  L1:
     load_const "T"
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_truthiness/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_truthiness/bytecode.snap
@@ -470,8 +470,6 @@ function truthiness.tr_frag(instructions: string | null) -> string {
     load_type string
     load_var instructions
     call baml.String.from
-    store_var _4
-    load_var _4
     bin_op +
     load_const "</x>"
     bin_op +
@@ -492,8 +490,6 @@ function truthiness.tr_frag_not(instructions: string | null) -> string {
     load_type string
     load_var instructions
     call baml.String.from
-    store_var _4
-    load_var _4
     bin_op +
     load_const "</x>"
     bin_op +
@@ -662,8 +658,6 @@ function truthiness.tr_literal_union(v: "" | "x" | null) -> string {
     load_type "x"
     load_var v
     call baml.String.from
-    store_var _4
-    load_var _4
     bin_op +
     load_const ">"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_error_repro/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_error_repro/bytecode.snap
@@ -1022,15 +1022,10 @@ function type_error_repro.map_with_repeated_string_alias_union_key_body() -> int
     load_var counts
     load_const "x"
     call baml.Map.get
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const 0
-    store_var _5
 
   L0:
-    load_var _5
     return
 }
 
@@ -1051,15 +1046,10 @@ function type_error_repro.map_with_string_alias_key_body() -> int {
     load_var counts
     load_const "x"
     call baml.Map.get
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const 0
-    store_var _5
 
   L0:
-    load_var _5
     return
 }
 
@@ -1190,29 +1180,12 @@ function type_error_repro.optional_index_with_null_index_body() -> int | null {
     load_const 30
     load_type int
     alloc_array 3
-    store_var_load_var arr
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
+    pop_jump_if_true L0
 
   L0:
     load_const null
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var2 1 2
-    load_array_element
-    jump L3
-
-  L2:
-    load_const null
-
-  L3:
     return
 }
 
@@ -1225,26 +1198,20 @@ function type_error_repro.optional_index_with_valid_index_body() -> int | null {
     store_var_load_var arr
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_const 1
-    store_var_load_var _6
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var2 1 2
+    pop_jump_if_true L0
+    load_var arr
+    load_const 1
     load_array_element
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_const null
 
-  L3:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_reflection/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_reflection/bytecode.snap
@@ -76,12 +76,10 @@ function type_reflection.GetBar(client: ai.Client | null, on_event: ((ai.events.
     call user.type_reflection.GetBar@spec
     store_var _8
     load_type type_reflection.Bar
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }
@@ -193,12 +191,10 @@ function type_reflection.GetFoo(client: ai.Client | null, on_event: ((ai.events.
     call user.type_reflection.GetFoo@spec
     store_var _8
     load_type type_reflection.Foo
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _5
-    load_var _5
     load_field .value
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_value_narrowing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_type_value_narrowing/bytecode.snap
@@ -168,27 +168,10 @@ function type_value_narrowing.classify_mixed_list() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L7
-
-  L1:
+    pop_jump_if_true L2
     load_var _7
     is_type reflect.Type
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_const false
-    jump L4
-
-  L3:
-    load_const true
-
-  L4:
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L1
     load_type string
     load_var out
     load_const "S"
@@ -196,7 +179,7 @@ function type_value_narrowing.classify_mixed_list() -> string {
     pop 1
     jump L0
 
-  L6:
+  L1:
     load_type string
     load_var out
     load_const "T"
@@ -204,7 +187,7 @@ function type_value_narrowing.classify_mixed_list() -> string {
     pop 1
     jump L0
 
-  L7:
+  L2:
     load_type string
     load_var out
     load_const ","
@@ -213,74 +196,32 @@ function type_value_narrowing.classify_mixed_list() -> string {
 }
 
 function type_value_narrowing.non_type_is_not_type() -> string {
+    load_type bool
     load_const 7
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _8
-    jump L2
-
-  L1:
-    load_const true
-    store_var _8
-
-  L2:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
+    store_var _5
+    load_type bool
     load_const "int"
     is_type reflect.Type
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _12
-    jump L5
-
-  L4:
-    load_const true
-    store_var _12
-
-  L5:
-    load_type bool
-    load_var _12
     call baml.String.from
-    store_var _11
+    store_var _9
+    load_type bool
     load_const 1
     load_const 2
     load_type int
     alloc_array 2
     is_type reflect.Type
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _16
-    jump L8
-
-  L7:
-    load_const true
-    store_var _16
-
-  L8:
-    load_type bool
-    load_var _16
     call baml.String.from
-    store_var _15
-    load_var _7
+    store_var _13
+    load_var _5
     load_const "|"
     bin_op +
-    load_var _11
+    load_var _9
     bin_op +
     load_const "|"
     bin_op +
-    load_var _15
+    load_var _13
     bin_op +
     return
 }
@@ -288,57 +229,40 @@ function type_value_narrowing.non_type_is_not_type() -> string {
 function type_value_narrowing.optional_type_absent() -> string {
     load_const null
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
     store_var is_t
-    jump L2
-
-  L1:
-    load_const true
-    store_var is_t
-
-  L2:
     load_const null
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     narrow_bind reflect.Type, slot=2
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_type bool
     load_var is_t
     call baml.String.from
     load_const "|none"
     bin_op +
-    jump L5
+    jump L1
 
-  L4:
-    load_var _4
+  L0:
+    load_var _3
     store_var t
     load_type bool
     load_var is_t
     call baml.String.from
-    store_var _7
     load_var t
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _11
-    load_type string
-    load_var _11
-    call baml.String.from
     store_var _10
-    load_var _7
+    load_type string
+    load_var _10
+    call baml.String.from
+    store_var _9
     load_const "|"
     bin_op +
-    load_var _10
+    load_var _9
     bin_op +
 
-  L5:
+  L1:
     return
 }
 
@@ -347,41 +271,25 @@ function type_value_narrowing.optional_type_present() -> string {
     store_var v
     load_var v
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
     store_var is_t
-    jump L2
-
-  L1:
-    load_const true
-    store_var is_t
-
-  L2:
     load_var v
     store_var _4
     load_var _4
     narrow_bind reflect.Type, slot=3
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L0
     load_type bool
     load_var is_t
     call baml.String.from
     load_const "|none"
     bin_op +
-    jump L5
+    jump L1
 
-  L4:
+  L0:
     load_var _4
     store_var t
     load_type bool
     load_var is_t
     call baml.String.from
-    store_var _7
     load_var t
     load_type baml.ToString
     load_const "to_string"
@@ -391,13 +299,12 @@ function type_value_narrowing.optional_type_present() -> string {
     load_var _11
     call baml.String.from
     store_var _10
-    load_var _7
     load_const "|"
     bin_op +
     load_var _10
     bin_op +
 
-  L5:
+  L1:
     return
 }
 
@@ -423,27 +330,21 @@ function type_value_narrowing.render_mixed_list() -> string {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _7
     store_var item
     load_var item
     store_var _12
     load_var _12
     narrow_bind reflect.Type, slot=5
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type string
     load_var2 1 4
     call baml.Array.push
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_var _12
     load_type baml.ToString
     load_const "to_string"
@@ -455,7 +356,7 @@ function type_value_narrowing.render_mixed_list() -> string {
     pop 1
     jump L0
 
-  L4:
+  L2:
     load_type string
     load_var out
     load_const ","
@@ -475,7 +376,6 @@ function type_value_narrowing.type_equality() -> string {
     load_type bool
     load_var _8
     call baml.String.from
-    store_var _7
     load_var2 1 2
     call baml.ops.equals_equals
     store_var _13
@@ -491,7 +391,6 @@ function type_value_narrowing.type_equality() -> string {
     unary_op !
     call baml.String.from
     store_var _17
-    load_var _7
     load_const "|"
     bin_op +
     load_var _12
@@ -506,64 +405,20 @@ function type_value_narrowing.type_equality() -> string {
 function type_value_narrowing.type_is_type() -> string {
     load_type int
     store_var v
+    load_type bool
     load_var v
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _6
-    jump L2
-
-  L1:
-    load_const true
-    store_var _6
-
-  L2:
-    load_type bool
-    load_var _6
     call baml.String.from
-    store_var _5
+    load_type bool
     load_var v
     is_type int
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _10
-    jump L5
-
-  L4:
-    load_const true
-    store_var _10
-
-  L5:
-    load_type bool
-    load_var _10
     call baml.String.from
     store_var _9
+    load_type bool
     load_var v
     is_type string
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _14
-    jump L8
-
-  L7:
-    load_const true
-    store_var _14
-
-  L8:
-    load_type bool
-    load_var _14
     call baml.String.from
     store_var _13
-    load_var _5
     load_const "|"
     bin_op +
     load_var _9
@@ -576,64 +431,20 @@ function type_value_narrowing.type_is_type() -> string {
 }
 
 function type_value_narrowing.type_of_various_is_type() -> string {
+    load_type bool
     load_type string
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _8
-    jump L2
-
-  L1:
-    load_const true
-    store_var _8
-
-  L2:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
+    load_type bool
     load_type int[]
     is_type reflect.Type
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _12
-    jump L5
-
-  L4:
-    load_const true
-    store_var _12
-
-  L5:
-    load_type bool
-    load_var _12
     call baml.String.from
     store_var _11
+    load_type bool
     load_type map<string, int>
     is_type reflect.Type
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const false
-    store_var _16
-    jump L8
-
-  L7:
-    load_const true
-    store_var _16
-
-  L8:
-    load_type bool
-    load_var _16
     call baml.String.from
     store_var _15
-    load_var _7
     load_const "|"
     bin_op +
     load_var _11
@@ -650,66 +461,33 @@ function type_value_narrowing.type_to_string_after_narrowing() -> string {
     store_var _2
     load_var _2
     narrow_bind reflect.Type, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "unreachable"
     jump L1
 
   L0:
-    load_const "unreachable"
-    jump L2
-
-  L1:
     load_var _2
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
 function type_value_narrowing.union_holding_int_is() -> string {
+    load_type bool
     load_const 42
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _4
-    jump L2
-
-  L1:
-    load_const true
-    store_var _4
-
-  L2:
-    load_type bool
-    load_var _4
     call baml.String.from
-    store_var _3
+    load_type bool
     load_const 42
     is_type int
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _8
-    jump L5
-
-  L4:
-    load_const true
-    store_var _8
-
-  L5:
-    load_type bool
-    load_var _8
     call baml.String.from
-    store_var _7
-    load_var _3
+    store_var _6
     load_const "|"
     bin_op +
-    load_var _7
+    load_var _6
     bin_op +
     return
 }
@@ -717,45 +495,15 @@ function type_value_narrowing.union_holding_int_is() -> string {
 function type_value_narrowing.union_holding_type_is() -> string {
     load_type int
     store_var v
+    load_type bool
     load_var v
     is_type reflect.Type
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_const false
-    store_var _4
-    jump L2
-
-  L1:
-    load_const true
-    store_var _4
-
-  L2:
-    load_type bool
-    load_var _4
     call baml.String.from
-    store_var _3
+    load_type bool
     load_var v
     is_type int
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_const false
-    store_var _8
-    jump L5
-
-  L4:
-    load_const true
-    store_var _8
-
-  L5:
-    load_type bool
-    load_var _8
     call baml.String.from
     store_var _7
-    load_var _3
     load_const "|"
     bin_op +
     load_var _7
@@ -765,31 +513,26 @@ function type_value_narrowing.union_holding_type_is() -> string {
 
 function type_value_narrowing.union_if_let_int() -> string {
     load_const 9
-    store_var _2
-    load_var _2
+    store_var _1
+    load_var _1
     narrow_bind reflect.Type, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "not-a-type"
     jump L1
 
   L0:
-    load_const "not-a-type"
-    jump L2
-
-  L1:
-    load_var _2
+    load_var _1
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
-    load_type string
-    load_var _5
-    call baml.String.from
     store_var _4
     load_const "type:"
+    load_type string
     load_var _4
+    call baml.String.from
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -798,28 +541,23 @@ function type_value_narrowing.union_if_let_type() -> string {
     store_var _2
     load_var _2
     narrow_bind reflect.Type, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "not-a-type"
     jump L1
 
   L0:
-    load_const "not-a-type"
-    jump L2
-
-  L1:
     load_var _2
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
+    load_const "type:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "type:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -828,34 +566,27 @@ function type_value_narrowing.union_match_int_first(v: reflect.Type | int) -> st
     store_var _2
     load_var _2
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var v
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
+    load_const "type:"
     load_type string
     load_var _9
     call baml.String.from
-    store_var _8
-    load_const "type:"
-    load_var _8
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
+    load_const "int:"
     load_type int
     load_var _2
     call baml.String.from
-    store_var _4
-    load_const "int:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -864,34 +595,27 @@ function type_value_narrowing.union_match_type_first(v: reflect.Type | int) -> s
     store_var _2
     load_var _2
     narrow_bind reflect.Type, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
+    load_const "int:"
     load_type int
     load_var v
     call baml.String.from
-    store_var _8
-    load_const "int:"
-    load_var _8
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _2
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
+    load_const "type:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "type:"
-    load_var _4
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -900,51 +624,39 @@ function type_value_narrowing.union_three_way(v: reflect.Type | int | string) ->
     store_var _2
     load_var _2
     narrow_bind reflect.Type, slot=2
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var v
     store_var _7
     load_var _7
-    narrow_bind string, slot=5
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    narrow_bind string, slot=4
+    pop_jump_if_true L0
+    load_const "int:"
     load_type int
     load_var v
     call baml.String.from
-    store_var _13
-    load_const "int:"
-    load_var _13
     bin_op +
-    jump L4
+    jump L2
 
-  L2:
+  L0:
+    load_const "string:"
     load_type string
     load_var _7
     call baml.String.from
-    store_var _9
-    load_const "string:"
-    load_var _9
     bin_op +
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _2
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
+    load_const "type:"
     load_type string
     load_var _5
     call baml.String.from
-    store_var _4
-    load_const "type:"
-    load_var _4
     bin_op +
 
-  L4:
+  L2:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_typed_inputs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_typed_inputs/bytecode.snap
@@ -169,16 +169,13 @@ function typed_inputs.sum(arr: int[]) -> int {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 4
     add_int
     store_var total
     jump L0
 
-  L2:
+  L1:
     load_var total
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_typed_outputs/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_typed_outputs/bytecode.snap
@@ -167,18 +167,15 @@ function typed_outputs.optional_class_value() -> int {
     store_var result
     load_var result
     is_type typed_outputs.OutputData
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const -1
     jump L1
 
   L0:
-    load_const -1
-    jump L2
-
-  L1:
     load_var result
     load_field .0
 
-  L2:
+  L1:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_union_pattern_binding/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_union_pattern_binding/bytecode.snap
@@ -56,27 +56,21 @@ function union_pattern_binding.upb_let_else_first_member() -> int {
     store_var _4
     load_var _4
     narrow_bind union_pattern_binding.WlA, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var _3
     store_var _5
     load_var _5
     narrow_bind union_pattern_binding.WlB, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const 0
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var _3
     load_type union_pattern_binding.WlHasV
     virtual_load_field .v
 
-  L3:
+  L1:
     return
 }
 
@@ -87,27 +81,21 @@ function union_pattern_binding.upb_let_else_non_member() -> int {
     store_var _4
     load_var _4
     narrow_bind union_pattern_binding.WlA, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var _3
     store_var _5
     load_var _5
     narrow_bind union_pattern_binding.WlB, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const -1
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var _3
     load_type union_pattern_binding.WlHasV
     virtual_load_field .v
 
-  L3:
+  L1:
     return
 }
 
@@ -119,27 +107,21 @@ function union_pattern_binding.upb_let_else_second_member() -> int {
     store_var _4
     load_var _4
     narrow_bind union_pattern_binding.WlA, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var _3
     store_var _5
     load_var _5
     narrow_bind union_pattern_binding.WlB, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const 0
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var _3
     load_type union_pattern_binding.WlHasV
     virtual_load_field .v
 
-  L3:
+  L1:
     return
 }
 
@@ -151,27 +133,21 @@ function union_pattern_binding.upb_match_arm_first_member() -> int {
     store_var _3
     load_var _3
     narrow_bind union_pattern_binding.WlA, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var _2
     store_var _4
     load_var _4
     narrow_bind union_pattern_binding.WlB, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const 0
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var _2
     load_type union_pattern_binding.WlHasV
     virtual_load_field .v
 
-  L3:
+  L1:
     return
 }
 
@@ -183,27 +159,21 @@ function union_pattern_binding.upb_match_arm_second_member() -> int {
     store_var _3
     load_var _3
     narrow_bind union_pattern_binding.WlA, slot=2
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L0
     load_var _2
     store_var _4
     load_var _4
     narrow_bind union_pattern_binding.WlB, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const 0
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var _2
     load_type union_pattern_binding.WlHasV
     virtual_load_field .v
 
-  L3:
+  L1:
     return
 }
 
@@ -213,17 +183,14 @@ function union_pattern_binding.upb_single_typed_let_else() -> int {
     store_var _3
     load_var _3
     narrow_bind union_pattern_binding.WlA, slot=1
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 0
     jump L1
 
   L0:
-    load_const 0
-    jump L2
-
-  L1:
     load_var _3
     load_field .v
 
-  L2:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_unknown_error/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_unknown_error/bytecode.snap
@@ -130,17 +130,14 @@ function unknown_error.ue_callback_origin() -> bool {
 function unknown_error.ue_callback_preserves_context() -> bool {
     load_const user.unknown_error.ue_callback_origin
     call user.unknown_error.ue_callback_boundary
-    jump L2
+    jump L1
     load_var error
     is_type baml.errors.UnknownError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
+  L0:
     load_type baml.errors.StackFrame
     load_type never
     load_var _2
@@ -149,7 +146,7 @@ function unknown_error.ue_callback_preserves_context() -> bool {
     make_closure .<lambda(ue_callback_preserves_context, 0)>, 0
     call baml.Array.some
 
-  L2:
+  L1:
     return
 }
 
@@ -187,37 +184,31 @@ function unknown_error.ue_chained_origin() -> bool {
 
 function unknown_error.ue_context_survives_gc() -> bool {
     call user.unknown_error.ue_gc_normalized
-    jump L4
+    jump L2
     load_var error
     is_type baml.errors.UnknownError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
+  L0:
     load_var _2
     call baml.errors.Context.root_cause
     load_field .error
     store_var _6
     load_var _6
     narrow_bind unknown_error.UeRootCause, slot=3
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_const false
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _6
     load_field .message
     load_const "root"
     cmp_op ==
 
-  L4:
+  L2:
     return
 }
 
@@ -234,14 +225,11 @@ function unknown_error.ue_from_does_not_double_wrap() -> bool {
     store_var _6
     load_var _6
     narrow_bind baml.errors.UnknownError, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_type string
     load_var _6
     load_field .message
@@ -251,12 +239,11 @@ function unknown_error.ue_from_does_not_double_wrap() -> bool {
     load_var source
     load_field .message
     container_len
-    store_var _12
-    load_var _12
+    store_var _13
+    load_var _13
     load_const 2
     cmp_int_op ==
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L1
     load_type string
     load_var source
     load_field .message
@@ -265,7 +252,7 @@ function unknown_error.ue_from_does_not_double_wrap() -> bool {
     load_const "outer"
     call baml.ops.equals_equals
 
-  L2:
+  L1:
     return
 }
 
@@ -279,14 +266,11 @@ function unknown_error.ue_from_known_preserves_identity() -> bool {
     store_var _5
     load_var _5
     narrow_bind unknown_error.UeKnownError, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_var _5
     load_const "changed"
     store_field .message
@@ -295,7 +279,7 @@ function unknown_error.ue_from_known_preserves_identity() -> bool {
     load_const "changed"
     cmp_op ==
 
-  L2:
+  L1:
     return
 }
 
@@ -313,14 +297,11 @@ function unknown_error.ue_from_recovers_wrapped_known() -> bool {
     store_var _8
     load_var _8
     narrow_bind unknown_error.UeKnownError, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_var _8
     load_const "changed"
     store_field .message
@@ -329,7 +310,7 @@ function unknown_error.ue_from_recovers_wrapped_known() -> bool {
     load_const "changed"
     cmp_op ==
 
-  L2:
+  L1:
     return
 }
 
@@ -375,7 +356,6 @@ function unknown_error.ue_interface_boundary(runner: unknown_error.UeRunner) -> 
     load_type unknown_error.UeRunner
     load_const "run"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L0
     load_var error
     throw_if_panic
@@ -386,24 +366,20 @@ function unknown_error.ue_interface_boundary(runner: unknown_error.UeRunner) -> 
     throw
 
   L0:
-    load_var _0
     return
 }
 
 function unknown_error.ue_interface_dispatch_preserves_context() -> bool {
     alloc_instance user.unknown_error.UeRunnerImpl
     call user.unknown_error.ue_interface_boundary
-    jump L2
+    jump L1
     load_var error
     is_type baml.errors.UnknownError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
+  L0:
     load_type baml.errors.StackFrame
     load_type never
     load_var _2
@@ -412,7 +388,7 @@ function unknown_error.ue_interface_dispatch_preserves_context() -> bool {
     make_closure .<lambda(ue_interface_dispatch_preserves_context, 0)>, 0
     call baml.Array.some
 
-  L2:
+  L1:
     return
 }
 
@@ -444,52 +420,43 @@ function unknown_error.ue_origin() -> bool {
 
 function unknown_error.ue_preserves_cause_chain() -> bool {
     call user.unknown_error.ue_chained_normalized
-    jump L4
+    jump L2
     load_var error
     is_type baml.errors.UnknownError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
+  L0:
     load_var _2
     call baml.errors.Context.root_cause
     load_field .error
     store_var _6
     load_var _6
     narrow_bind string, slot=3
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_const false
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _6
     load_const "root"
     cmp_op ==
 
-  L4:
+  L2:
     return
 }
 
 function unknown_error.ue_preserves_origin_trace() -> bool {
     call user.unknown_error.ue_normalized
-    jump L2
+    jump L1
     load_var error
     is_type baml.errors.UnknownError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
+  L0:
     load_type baml.errors.StackFrame
     load_type never
     load_var _2
@@ -498,7 +465,7 @@ function unknown_error.ue_preserves_origin_trace() -> bool {
     make_closure .<lambda(ue_preserves_origin_trace, 0)>, 0
     call baml.Array.some
 
-  L2:
+  L1:
     return
 }
 
@@ -526,17 +493,14 @@ function unknown_error.ue_reflect_origin() -> bool {
 function unknown_error.ue_reflect_preserves_context() -> bool {
     load_const user.unknown_error.ue_reflect_origin
     call user.unknown_error.ue_reflect_boundary
-    jump L2
+    jump L1
     load_var error
     is_type baml.errors.UnknownError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var error
     rethrow
 
-  L1:
+  L0:
     load_type baml.errors.StackFrame
     load_type never
     load_var _3
@@ -545,7 +509,7 @@ function unknown_error.ue_reflect_preserves_context() -> bool {
     make_closure .<lambda(ue_reflect_preserves_context, 0)>, 0
     call baml.Array.some
 
-  L2:
+  L1:
     return
 }
 
@@ -559,8 +523,6 @@ function unknown_error.ue_to_string_is_stable() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -579,14 +541,11 @@ function unknown_error.ue_with_message_recovers_wrapped_known() -> bool {
     store_var _8
     load_var _8
     narrow_bind unknown_error.UeKnownError, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L2
-
-  L1:
     load_var _8
     load_const "changed"
     store_field .message
@@ -595,7 +554,7 @@ function unknown_error.ue_with_message_recovers_wrapped_known() -> bool {
     load_const "changed"
     cmp_op ==
 
-  L2:
+  L1:
     return
 }
 
@@ -612,24 +571,20 @@ function unknown_error.ue_with_message_wraps_once() -> bool {
     store_var _6
     load_var _6
     narrow_bind baml.errors.UnknownError, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const false
     jump L1
 
   L0:
-    load_const false
-    jump L4
-
-  L1:
     load_var _6
     store_var_load_var wrapper
     load_field .message
     container_len
-    store_var _11
-    load_var _11
+    store_var _14
+    load_var _14
     load_const 2
     cmp_int_op ==
-    jump_if_false L2
-    pop 1
+    jump_if_false_or_pop L1
     load_type string
     load_var wrapper
     load_field .message
@@ -637,10 +592,7 @@ function unknown_error.ue_with_message_wraps_once() -> bool {
     call baml.Array.at
     load_const "inner"
     call baml.ops.equals_equals
-
-  L2:
-    jump_if_false L3
-    pop 1
+    jump_if_false_or_pop L1
     load_type string
     load_var wrapper
     load_field .message
@@ -648,10 +600,7 @@ function unknown_error.ue_with_message_wraps_once() -> bool {
     call baml.Array.at
     load_const "outer"
     call baml.ops.equals_equals
-
-  L3:
-    jump_if_false L4
-    pop 1
+    jump_if_false_or_pop L1
     load_type unknown
     load_var wrapper
     load_field .data
@@ -659,6 +608,6 @@ function unknown_error.ue_with_message_wraps_once() -> bool {
     load_const "raw"
     cmp_op ==
 
-  L4:
+  L1:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_let/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_let/bytecode.snap
@@ -483,6 +483,9 @@ function while_let.drain(start: int) -> int {
   L2:
     load_var cur
     load_field .0
+    pop 1
+    load_var cur
+    load_field .0
     store_var value
     load_var2 3 4
     add_int
@@ -536,6 +539,10 @@ function while_let.drain_array() -> int {
     return
 
   L2:
+    load_var xs
+    load_const 0
+    load_array_element
+    pop 1
     load_var2 2 1
     load_const 0
     load_array_element
@@ -562,6 +569,7 @@ function while_let.drain_nested() -> int {
     pop_jump_if_false L1
     load_var cur
     load_field .0
+    store_var_load_var _5
     is_type while_let.WlInner
     pop_jump_if_false L1
     jump L2
@@ -571,11 +579,14 @@ function while_let.drain_nested() -> int {
     return
 
   L2:
+    load_var _5
+    load_field .value
+    pop 1
     load_var cur
     load_field .0
     load_field .value
     store_var value
-    load_var2 2 3
+    load_var2 2 4
     add_int
     store_var total
     load_var value

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_let/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_let/bytecode.snap
@@ -136,10 +136,7 @@ function while_let.Counter.next(self: while_let.Counter) -> int | null {
     load_field .n
     load_const 0
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .n
     store_var cur
@@ -149,12 +146,12 @@ function while_let.Counter.next(self: while_let.Counter) -> int | null {
     bin_op -
     store_field .n
     load_var cur
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -172,22 +169,16 @@ function while_let.alternate() -> int {
     store_var _4
     load_var _4
     narrow_bind while_let.WlA, slot=4
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
     store_var _5
     load_var _5
     narrow_bind while_let.WlB, slot=5
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var total
     return
 
-  L3:
+  L1:
     load_var _3
     store_var x
     load_var2 2 6
@@ -200,10 +191,7 @@ function while_let.alternate() -> int {
     virtual_load_field .v
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var x
     load_type while_let.WlHasV
     virtual_load_field .v
@@ -213,7 +201,7 @@ function while_let.alternate() -> int {
     store_var cur
     jump L0
 
-  L5:
+  L2:
     alloc_instance user.while_let.WlStop
     store_var cur
     jump L0
@@ -221,48 +209,36 @@ function while_let.alternate() -> int {
 
 function while_let.body_local() -> int {
     load_const 2
-    store_var cur
 
   L0:
-    load_var cur
-    store_var _3
-    load_var _3
-    narrow_bind int, slot=2
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    store_var _2
+    load_var _2
+    narrow_bind int, slot=1
+    pop_jump_if_true L1
     load_const 50
     return
 
-  L2:
-    load_var _3
+  L1:
+    load_var _2
     store_var_load_var v
     load_const 10
     mul_int
     load_const 1000000
     cmp_int_op >
-    pop_jump_if_false L3
-    load_const null
-    store_var cur
+    pop_jump_if_true L2
 
-  L3:
+  L2:
     load_var v
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var v
     load_const 1
     sub_int
-    store_var cur
     jump L0
 
-  L5:
+  L3:
     load_const null
-    store_var cur
     jump L0
 }
 
@@ -285,27 +261,21 @@ function while_let.check(x: int | null) -> int {
   L0:
     load_var x
     store_var _3
-    load_var _3
+    load_var x
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var touched
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var touched
     return
 
-  L3:
+  L1:
     alloc_instance user.while_let.Empty
     throw
 
-  L4:
+  L2:
     load_var _3
     store_var v
     load_var touched
@@ -335,17 +305,14 @@ function while_let.collect() -> int {
     store_var _4
     load_var _4
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var fns
     load_type baml.iter.Iterable<Error = never, Item = () -> void throws never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
-  L2:
+  L1:
     load_var _13
     load_type baml.iter.Iterator<Error = never, Item = () -> void throws never>
     load_const "next"
@@ -353,20 +320,17 @@ function while_let.collect() -> int {
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _14
     call_indirect
     pop 1
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_deref ?1
     return
 
-  L5:
+  L3:
     load_const null
     make_cell
     store_var v
@@ -381,16 +345,13 @@ function while_let.collect() -> int {
     load_deref ?4
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L4
     load_deref ?4
     load_const 1
     sub_int
     jump L0
 
-  L7:
+  L4:
     load_const null
     jump L0
 }
@@ -409,15 +370,12 @@ function while_let.count_evals() -> int {
     store_var _4
     load_var _4
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var c
     load_field .calls
     return
 
-  L2:
+  L1:
     load_var2 2 3
     add_int
     store_var total
@@ -433,14 +391,11 @@ function while_let.countdown(n: int) -> int {
     store_var _4
     load_var _4
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var total
     return
 
-  L2:
+  L1:
     load_var _4
     store_var v
     load_var2 2 4
@@ -449,16 +404,13 @@ function while_let.countdown(n: int) -> int {
     load_var v
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var v
     load_const 1
     sub_int
     jump L0
 
-  L4:
+  L2:
     load_const null
     jump L0
 }
@@ -473,17 +425,11 @@ function while_let.drain(start: int) -> int {
   L0:
     load_var cur
     is_type while_let.Item
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var total
     return
 
-  L2:
-    load_var cur
-    load_field .0
-    pop 1
+  L1:
     load_var cur
     load_field .0
     store_var value
@@ -493,10 +439,7 @@ function while_let.drain(start: int) -> int {
     load_var value
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var value
     load_const 1
     sub_int
@@ -504,7 +447,7 @@ function while_let.drain(start: int) -> int {
     store_var cur
     jump L0
 
-  L4:
+  L2:
     load_const null
     store_var cur
     jump L0
@@ -531,18 +474,13 @@ function while_let.drain_array() -> int {
     store_var_load_var _4
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_var total
     return
 
   L2:
-    load_var xs
-    load_const 0
-    load_array_element
-    pop 1
     load_var2 2 1
     load_const 0
     load_array_element
@@ -569,33 +507,25 @@ function while_let.drain_nested() -> int {
     pop_jump_if_false L1
     load_var cur
     load_field .0
-    store_var_load_var _5
     is_type while_let.WlInner
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_var total
     return
 
   L2:
-    load_var _5
-    load_field .value
-    pop 1
     load_var cur
     load_field .0
     load_field .value
     store_var value
-    load_var2 2 4
+    load_var2 2 3
     add_int
     store_var total
     load_var value
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L3
     load_var value
     load_const 1
     sub_int
@@ -604,7 +534,7 @@ function while_let.drain_nested() -> int {
     store_var cur
     jump L0
 
-  L4:
+  L3:
     load_const null
     store_var cur
     jump L0
@@ -617,31 +547,25 @@ function while_let.early(start: int) -> int {
     store_var _3
     load_var _3
     narrow_bind int, slot=2
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+    load_const -1
+    jump L3
 
   L1:
-    load_const -1
-    jump L5
-
-  L2:
     load_var _3
     store_var_load_var v
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var v
     load_const 1
     sub_int
     jump L0
 
-  L4:
+  L2:
     load_const 99
 
-  L5:
+  L3:
     return
 }
 
@@ -656,26 +580,23 @@ function while_let.find_five(start: int) -> int {
     store_var _4
     load_var _4
     narrow_bind int, slot=4
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var _4
     store_var_load_var v
     load_const 5
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var v
     load_const 1
     add_int
     store_var cur
     jump L0
 
-  L2:
+  L1:
     load_var v
     store_var found
 
-  L3:
+  L2:
     load_var found
     return
 }
@@ -687,28 +608,22 @@ function while_let.loop_throws(start: int) -> int {
     store_var _3
     load_var _3
     narrow_bind int, slot=2
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 0
     return
 
-  L2:
+  L1:
     load_var _3
     store_var_load_var v
     load_const 2
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var v
     load_const 1
     sub_int
     jump L0
 
-  L4:
+  L2:
     alloc_instance user.while_let.WlBoom
     throw
 }
@@ -720,28 +635,22 @@ function while_let.loop_throws2(start: int) -> int {
     store_var _3
     load_var _3
     narrow_bind int, slot=2
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 0
     return
 
-  L2:
+  L1:
     load_var _3
     store_var_load_var v
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var v
     load_const 1
     sub_int
     jump L0
 
-  L4:
+  L2:
     alloc_instance user.while_let.WlBoom2
     throw
 }
@@ -757,23 +666,20 @@ function while_let.nested() -> int {
     store_var _3
     load_var _3
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var result
     return
 
-  L2:
+  L1:
     load_var _3
     store_var o
     load_const 10
 
-  L3:
+  L2:
     store_var _6
     load_var _6
     narrow_bind int, slot=5
-    pop_jump_if_false L5
+    pop_jump_if_false L3
     load_var _6
     store_var i
     load_var result
@@ -783,16 +689,13 @@ function while_let.nested() -> int {
     load_var i
     load_const 8
     cmp_int_op <=
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var i
     load_const 1
     sub_int
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var result
     load_const 100
     add_int
@@ -800,17 +703,14 @@ function while_let.nested() -> int {
     load_var o
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L4
     load_var o
     load_const 1
     sub_int
     store_var outer
     jump L0
 
-  L7:
+  L4:
     load_const null
     store_var outer
     jump L0
@@ -827,16 +727,13 @@ function while_let.run() -> int {
     store_var _3
     load_var _3
     narrow_bind int, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var total
     load_const 7
     add_int
     return
 
-  L2:
+  L1:
     load_var2 2 3
     add_int
     store_var total
@@ -851,20 +748,17 @@ function while_let.scope() -> int {
     load_const 3
 
   L0:
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     narrow_bind int, slot=2
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var acc
     load_const 999
     add_int
     return
 
-  L2:
-    load_var _4
+  L1:
+    load_var _3
     store_var v
     load_var2 1 3
     add_int
@@ -872,16 +766,13 @@ function while_let.scope() -> int {
     load_var v
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var v
     load_const 1
     sub_int
     jump L0
 
-  L4:
+  L2:
     load_const null
     jump L0
 }
@@ -897,22 +788,16 @@ function while_let.sum_odds_below(n: int) -> int {
     store_var _4
     load_var _4
     narrow_bind int, slot=4
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var total
     return
 
-  L2:
+  L1:
     load_var _4
     store_var_load_var v
     load_var n
     cmp_int_op >=
-    pop_jump_if_false L3
-    jump L5
-
-  L3:
+    pop_jump_if_true L2
     load_var v
     load_const 1
     add_int
@@ -922,16 +807,13 @@ function while_let.sum_odds_below(n: int) -> int {
     mod_int
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L4
-    jump L0
-
-  L4:
+    pop_jump_if_true L0
     load_var2 3 5
     add_int
     store_var total
     jump L0
 
-  L5:
+  L2:
     load_const null
     store_var cur
     jump L0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_loops/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_loops/bytecode.snap
@@ -94,22 +94,14 @@ function while_loops.while_loops_break_at_two() -> int {
 function while_loops.while_loops_break_nested() -> int {
     load_const 5
     store_var a
-    load_const true
-    pop_jump_if_false L1
-    load_const true
-    pop_jump_if_false L0
     load_var a
     load_const 1
     add_int
     store_var a
-
-  L0:
     load_var a
     load_const 1
     add_int
     store_var a
-
-  L1:
     load_var a
     return
 }
@@ -139,30 +131,14 @@ function while_loops.while_loops_break_nested_var(x: bool, y: bool) -> int {
 
 function while_loops.while_loops_continue_nested() -> int {
     load_const true
-    store_var execute
 
   L0:
-    load_var execute
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_const 5
     return
 
-  L2:
+  L1:
     load_const false
-    pop_jump_if_false L3
-    jump L2
-
-  L3:
-    load_const false
-    pop_jump_if_false L4
-    jump L0
-
-  L4:
-    load_const false
-    store_var execute
     jump L0
 }
 
@@ -171,8 +147,6 @@ function while_loops.while_loops_count_down(n: int) -> int {
     store_var result
 
   L0:
-    load_const true
-    pop_jump_if_false L1
     load_var2 2 1
     add_int
     store_var result
@@ -183,8 +157,6 @@ function while_loops.while_loops_count_down(n: int) -> int {
     load_const 0
     cmp_int_op ==
     pop_jump_if_false L0
-
-  L1:
     load_var result
     return
 }
@@ -194,15 +166,10 @@ function while_loops.while_loops_factorial_break(limit: int) -> int {
     store_var result
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var limit
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 1
     mul_int
     store_var result
@@ -212,7 +179,7 @@ function while_loops.while_loops_factorial_break(limit: int) -> int {
     store_var limit
     jump L0
 
-  L2:
+  L1:
     load_var result
     return
 }
@@ -225,14 +192,11 @@ function while_loops.while_loops_factorial_continue(limit: int) -> int {
 
   L0:
     load_var should_continue
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var result
     return
 
-  L2:
+  L1:
     load_var2 2 1
     mul_int
     store_var result
@@ -242,10 +206,7 @@ function while_loops.while_loops_factorial_continue(limit: int) -> int {
     store_var_load_var limit
     load_const 0
     cmp_int_op !=
-    pop_jump_if_false L3
-    jump L0
-
-  L3:
+    pop_jump_if_true L0
     load_const false
     store_var should_continue
     jump L0
@@ -261,14 +222,11 @@ function while_loops.while_loops_fib(n: int) -> int {
     load_var n
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var a
     return
 
-  L2:
+  L1:
     load_var n
     load_const 1
     sub_int
@@ -287,26 +245,20 @@ function while_loops.while_loops_gcd(a: int, b: int) -> int {
   L0:
     load_var2 1 2
     cmp_int_op !=
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var a
     return
 
-  L2:
+  L1:
     load_var2 1 2
     cmp_int_op >
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var2 2 1
     sub_int
     store_var b
     jump L0
 
-  L4:
+  L2:
     load_var2 1 2
     sub_int
     store_var a

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_with_timeout/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_with_timeout/bytecode.snap
@@ -36,20 +36,17 @@ function with_timeout.with_timeout_expires() -> string {
     load_var _2
     make_closure .<lambda(with_timeout_expires, 0)>, 0
     call baml.future.with_timeout
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Timeout
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "timed out"
 
-  L2:
+  L1:
     return
 }
 
@@ -62,30 +59,24 @@ function with_timeout.with_timeout_preserves_body_error() -> string {
     load_var _2
     make_closure .<lambda(with_timeout_preserves_body_error, 0)>, 0
     call baml.future.with_timeout
-    jump L4
+    jump L2
     load_var e
     is_type baml.errors.Timeout
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_const "io"
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "timed out"
 
-  L4:
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -845,7 +845,6 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     load_type string
     load_var kind
     call baml.String.from
-    store_var _81
     load_var t
     load_type baml.ToString
     load_const "to_string"
@@ -866,7 +865,6 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     load_var kind
     call baml.String.from
     store_var _90
-    load_var _81
     bin_op +
     load_const " output for "
     bin_op +
@@ -890,7 +888,6 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     load_type string
     load_var kind
     call baml.String.from
-    store_var _65
     load_var parts
     container_len
     store_var _69
@@ -902,7 +899,6 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     load_var kind
     call baml.String.from
     store_var _71
-    load_var _65
     bin_op +
     load_const " output, got "
     bin_op +
@@ -5823,8 +5819,6 @@ function ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _11
-    load_var _11
     bin_op +
     load_const "` cannot be rendered as an LLM output schema"
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -8,34 +8,29 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     load_var ?2
     make_cell
     store_var ?2
-    load_var ?6
+    load_var ?5
     make_cell
-    store_var ?6
-    load_var ?22
+    store_var ?5
+    load_var ?21
     make_cell
-    store_var ?22
+    store_var ?21
     load_deref ?1
     call ai.Agent._validated_schema_attempts
     store_var schema_attempts
     load_deref ?1
     load_field .client
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_deref ?2
     load_field .default_client
-    store_var _5
 
   L0:
-    load_var _5
     store_var selected
     load_type #0
     load_deref ?2
     call ai.Journal.new
-    store_deref ?6
+    store_deref ?5
     load_deref ?1
-    load_deref ?6
+    load_deref ?5
     load_const 0
     call ai.Agent._emit_from
     store_var seen
@@ -57,21 +52,18 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     load_deref ?1
     load_field .max_steps
     cmp_int_op <
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L2
     load_var steps
     init_instance ai.errors.StepBudgetExceeded .steps
     throw
 
-  L3:
+  L2:
     load_type #0
     load_deref ?1
     load_var selected
     load_deref ?2
-    load_deref ?6
-    load_var2 9 3
+    load_deref ?5
+    load_var2 8 3
     call ai.Agent._attempt_turn
     store_var turn
     load_var steps
@@ -79,7 +71,7 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     add_int
     store_var steps
     load_deref ?1
-    load_deref ?6
+    load_deref ?5
     load_var seen
     call ai.Agent._emit_from
     store_var seen
@@ -88,66 +80,54 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     store_var calls
     load_var calls
     container_len
-    store_var _29
-    load_var _29
+    store_var _30
+    load_var _30
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L4
-    jump L10
-
-  L4:
+    pop_jump_if_true L7
     load_var turn
     call ai.ModelTurn.terminal_text
-    store_var_load_var _100
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L5
+    jump_if_not_null_or_pop L3
     load_const ""
-    store_var _100
 
-  L5:
-    load_var _100
+  L3:
     store_var candidate
     load_type #0
     load_deref ?1
     load_var turn
     call ai.Agent._has_media_output
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L4
     load_type #0
     load_var candidate
     call baml.sap.parse
     store_var value
-    jump L8
+    jump L5
     load_var e
     throw_if_panic
     load_var selected
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _114
-    load_var2 39 34
+    load_var candidate
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
-  L7:
+  L4:
     load_var selected
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _108
+    store_var _107
     load_type #0
     load_deref ?1
-    load_var2 11 37
+    load_var2 10 33
     call ai.Agent._media_value
     store_var value
 
-  L8:
+  L5:
     load_var value
     call baml.json.to_json
-    jump L9
+    jump L6
     load_var e
     throw_if_panic
     load_type never
@@ -156,30 +136,30 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     call baml.errors.UnknownError.with_message
     throw
 
-  L9:
+  L6:
     call baml.json.stringify
-    store_var _125
-    load_deref ?6
-    load_var _125
+    store_var _124
+    load_deref ?5
+    load_var _124
     init_instance ai.events.FinalProduced .value_json
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
     pop 1
     load_deref ?1
-    load_deref ?6
+    load_deref ?5
     load_var seen
     call ai.Agent._emit_from
     store_var seen
     load_var value
-    load_deref ?6
+    load_deref ?5
     load_var total
     load_type #0
     init_instance<1> ai.RunResult .value, .journal, .usage
     return
 
-  L10:
-    load_deref ?6
+  L7:
+    load_deref ?5
     call ai.Journal.entries
     container_len
     store_var before
@@ -199,47 +179,47 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     call baml.future.all
     await
     pop 1
-    jump L11
+    jump L8
     load_var e
     throw_if_panic
     load_deref ?1
-    load_deref ?6
+    load_deref ?5
     load_var seen
     call ai.Agent._emit_from
     store_var seen
     load_var e
     rethrow
 
-  L11:
+  L8:
     load_deref ?1
-    load_deref ?6
+    load_deref ?5
     load_var seen
     call ai.Agent._emit_from
     store_var seen
-    load_deref ?6
+    load_deref ?5
     call ai.Journal.entries
     store_var entries
     load_var before
     store_var i
 
-  L12:
+  L9:
     load_var i
-    store_var _50
+    store_var _51
     load_var entries
     container_len
-    store_var _51
-    load_var2 19 20
+    store_var _52
+    load_var2 18 19
     cmp_int_op <
     pop_jump_if_false L1
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
-    load_var2 17 18
+    load_var2 16 17
     call baml.Array.at
-    store_var _55
-    load_var _55
-    narrow_bind ai.events.ToolFailed, slot=21
-    pop_jump_if_false L14
-    load_var _55
-    store_deref ?22
+    store_var _56
+    load_var _56
+    narrow_bind ai.events.ToolFailed, slot=20
+    pop_jump_if_false L11
+    load_var _56
+    store_deref ?21
     load_type ai.content.ToolUse
     load_type never
     load_var calls
@@ -247,64 +227,56 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     load_var f
     make_closure .<lambda(Agent.run, 2)>, captures=1, ntypeargs=1
     call baml.Array.find
-    store_var _61
-    load_var _61
-    narrow_bind ai.content.ToolUse, slot=23
-    pop_jump_if_false L14
-    load_var _61
+    store_var _62
+    load_var _62
+    narrow_bind ai.content.ToolUse, slot=22
+    pop_jump_if_false L11
+    load_var _62
     store_var known
     load_type string
     load_var known
     load_field .name
     call baml.String.from
-    store_var _65
     load_type string
-    load_deref ?22
+    load_deref ?21
     load_field .message
     call baml.String.from
-    store_var _68
-    load_var _65
+    store_var _69
     load_const "|"
     bin_op +
-    load_var _68
+    load_var _69
     bin_op +
     store_var key
     load_type string
     load_type int
-    load_var2 10 25
+    load_var2 9 24
     call baml.Map.get
-    store_var_load_var _73
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L13
+    jump_if_not_null_or_pop L10
     load_const 0
-    store_var _73
 
-  L13:
-    load_var _73
+  L10:
     load_const 1
     add_int
     store_var n
     load_type string
     load_type int
-    load_var2 10 25
+    load_var2 9 24
     load_var n
     call baml.Map.set
     pop 1
     load_var n
     load_const 3
     cmp_int_op >=
-    pop_jump_if_false L14
-    jump L15
+    pop_jump_if_true L12
 
-  L14:
+  L11:
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L12
+    jump L9
 
-  L15:
+  L12:
     load_var known
     load_field .id
     store_var _87
@@ -316,11 +288,11 @@ function ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<
     call baml.String.from
     store_var _92
     load_type string
-    load_deref ?22
+    load_deref ?21
     load_field .message
     call baml.String.from
     store_var _95
-    load_var2 30 31
+    load_var2 27 28
     load_const "the same tool call failed "
     load_var _92
     bin_op +
@@ -364,7 +336,7 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     store_var _15
     load_var _15
     narrow_bind ai.events.Usage, slot=11
-    pop_jump_if_false L3
+    pop_jump_if_false L7
     load_var _15
     store_var u
     load_var total
@@ -386,57 +358,65 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     store_var _20
     load_var _20
     narrow_bind int, slot=13
-    pop_jump_if_false L1
+    pop_jump_if_false L3
     load_var _20
     store_var ci
     load_var total
     load_field .cached_input_tokens
-    store_var_load_var _23
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
+    jump L1
+
+  L0:
+    store_var _23
+    jump L2
+
+  L1:
     load_const 0
     store_var _23
 
-  L0:
+  L2:
     load_var2 5 15
     load_var ci
     bin_op +
     store_field .cached_input_tokens
 
-  L1:
+  L3:
     load_var u
     load_field .reasoning_tokens
-    store_var _28
-    load_var _28
+    store_var _27
+    load_var _27
     narrow_bind int, slot=16
-    pop_jump_if_false L3
-    load_var _28
+    pop_jump_if_false L7
+    load_var _27
     store_var rt
     load_var total
     load_field .reasoning_tokens
-    store_var_load_var _31
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
-    load_const 0
-    store_var _31
+    jump_if_not_null_or_pop L4
+    jump L5
 
-  L2:
+  L4:
+    store_var _30
+    jump L6
+
+  L5:
+    load_const 0
+    store_var _30
+
+  L6:
     load_var2 5 18
     load_var rt
     bin_op +
     store_field .reasoning_tokens
 
-  L3:
+  L7:
     load_var turn
     load_field .content
-    store_var _37
+    store_var _35
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _38
+    store_var _36
     load_var2 20 21
     init_instance ai.events.AssistantMessage .content, .client_id
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
@@ -447,47 +427,41 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     load_type baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _40
+    store_var _38
 
-  L4:
-    load_var _40
+  L8:
+    load_var _38
     load_type baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _41
-    load_var _41
+    store_var _39
+    load_var _39
     is_type baml.iter.Done
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L9
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 19 23
     call baml.Array.push
     pop 1
-    jump L4
+    jump L8
 
-  L6:
+  L9:
     load_var turn
     call ai.ModelTurn.tool_uses
     load_type baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _49
+    store_var _47
 
-  L7:
-    load_var _49
+  L10:
+    load_var _47
     load_type baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _50
-    load_var _50
+    store_var _48
+    load_var _48
     is_type baml.iter.Done
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
-    load_var _50
+    pop_jump_if_true L11
+    load_var _48
     store_var u
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 19 26
@@ -499,32 +473,27 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     init_instance ai.events.ToolRequested .id, .name, .args
     call baml.Array.push
     pop 1
-    jump L7
+    jump L10
 
-  L9:
+  L11:
     load_var turn
     load_field .usage
-    store_var _61
-    load_var _61
+    store_var _59
+    load_var _59
     narrow_bind ai.events.Usage, slot=27
-    pop_jump_if_false L10
+    pop_jump_if_false L12
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 19 27
     call baml.Array.push
     pop 1
 
-  L10:
+  L12:
     load_var turn
     call ai.ModelTurn.terminal_text
-    store_var_load_var _67
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L11
+    jump_if_not_null_or_pop L13
     load_const ""
-    store_var _67
 
-  L11:
-    load_var _67
+  L13:
     store_var candidate
     load_var turn
     call ai.ModelTurn.tool_uses
@@ -533,52 +502,30 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     load_var _74
     load_const 0
     cmp_int_op >
-    jump_if_false L12
-    jump L13
-
-  L12:
-    pop 1
+    jump_if_true_or_pop L14
     load_var turn
     load_field .stop_reason
     load_const ai.content.StopReason.MaxTokens
     alloc_variant ai.content.StopReason
     call baml.ops.equals_equals
-
-  L13:
-    jump_if_false L14
-    jump L15
-
-  L14:
-    pop 1
+    jump_if_true_or_pop L14
     load_var turn
     load_field .stop_reason
     load_const ai.content.StopReason.Refused
     alloc_variant ai.content.StopReason
     call baml.ops.equals_equals
-
-  L15:
-    jump_if_false L16
-    jump L17
-
-  L16:
-    pop 1
+    jump_if_true_or_pop L14
     load_type #0
     load_var2 1 7
     load_var candidate
     call ai.Agent._parses
 
-  L17:
-    pop_jump_if_false L18
-    jump L21
-
-  L18:
+  L14:
+    pop_jump_if_true L16
     load_var attempts_left
     load_const 1
     cmp_int_op >
-    pop_jump_if_false L19
-    jump L20
-
-  L19:
+    pop_jump_if_true L15
     load_var2 4 19
     call ai.Journal.append_all
     pop 1
@@ -586,12 +533,11 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _103
-    load_var2 33 28
+    load_var candidate
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
-  L20:
+  L15:
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var batch
     load_const "The reply did not match the required schema. Answer again with only the corrected value."
@@ -608,9 +554,9 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     load_const 1
     sub_int
     call ai.Agent._attempt_turn
-    jump L24
+    jump L19
 
-  L21:
+  L16:
     load_var2 4 19
     call ai.Journal.append_all
     pop 1
@@ -619,43 +565,40 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     discriminant
     load_const StopReason.MaxTokens
     cmp_int_op ==
-    pop_jump_if_false L22
-    jump L26
+    pop_jump_if_false L17
+    jump L21
 
-  L22:
+  L17:
     load_var turn
     load_field .stop_reason
     discriminant
     load_const StopReason.Refused
     cmp_int_op ==
-    pop_jump_if_false L23
-    jump L25
+    pop_jump_if_false L18
+    jump L20
 
-  L23:
+  L18:
     load_var turn
 
-  L24:
+  L19:
     return
 
-  L25:
+  L20:
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _91
-    load_var _91
     load_const "the model declined to answer"
     load_const null
     init_instance ai.errors.Refused .provider, .reason, .raw_body
     throw
 
-  L26:
+  L21:
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _87
-    load_var2 31 7
+    load_var turn
     load_field .stop_reason
     load_var candidate
     init_instance ai.errors.FinishReasonError .provider, .finish_reason, .raw_output
@@ -685,8 +628,7 @@ function ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
     store_var _11
     load_var2 8 9
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
 
   L1:
     load_var entries
@@ -700,62 +642,38 @@ function ai.Agent._emit_from(self: ai.Agent, j: ai.Journal, seen: int) -> int {
     store_var _15
     load_var _15
     narrow_bind ai.events.RunStarted, slot=10
-    pop_jump_if_false L3
-    jump L11
-
-  L3:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.UserMessage, slot=10
-    pop_jump_if_false L4
-    jump L11
-
-  L4:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.AssistantMessage, slot=10
-    pop_jump_if_false L5
-    jump L11
-
-  L5:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.ToolRequested, slot=10
-    pop_jump_if_false L6
-    jump L11
-
-  L6:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.ToolCompleted, slot=10
-    pop_jump_if_false L7
-    jump L11
-
-  L7:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.ToolFailed, slot=10
-    pop_jump_if_false L8
-    jump L11
-
-  L8:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.Usage, slot=10
-    pop_jump_if_false L9
-    jump L11
-
-  L9:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.LLMCall, slot=10
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L3
     load_var _15
     narrow_bind ai.events.FinalProduced, slot=10
-    pop_jump_if_false L12
+    pop_jump_if_false L4
 
-  L11:
+  L3:
     load_var2 10 6
     call_indirect
     pop 1
 
-  L12:
+  L4:
     load_var i
     load_const 1
     add_int
@@ -775,78 +693,65 @@ function ai.Agent._has_media_output(self: ai.Agent, turn: ai.ModelTurn) -> bool 
     load_var _8
     load_const 0
     call baml.Array.at
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _6
 
   L0:
-    load_var _6
     store_var_load_var form
     load_const ""
     cmp_op ==
-    pop_jump_if_false L1
-    jump L7
-
-  L1:
+    pop_jump_if_true L5
     load_var form
     load_const "mixed"
     cmp_op ==
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    pop_jump_if_true L4
     load_var form
     load_const "mixedlist"
     cmp_op ==
-
-  L3:
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L4
     load_var shape
     load_const ":"
     call baml.String.split
-    store_var _24
+    store_var _23
     load_type string
-    load_var _24
+    load_var _23
     load_const 1
     call baml.Array.at
-    store_var_load_var _22
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L5
-    load_const ""
-    store_var _22
+    jump_if_not_null_or_pop L1
+    jump L2
 
-  L5:
-    load_var2 2 9
+  L1:
+    store_var _21
+    jump L3
+
+  L2:
+    load_const ""
+    store_var _21
+
+  L3:
+    load_var2 2 8
     call ai.internal._media_of_kind
     container_len
-    store_var _19
-    load_var _19
+    store_var _18
+    load_var _18
     load_const 0
     cmp_int_op >
-    jump L8
+    jump L6
 
-  L6:
+  L4:
     load_var turn
     call ai.internal._media_mixed_parts
     container_len
-    store_var _17
-    load_var _17
+    store_var _16
+    load_var _16
     load_const 0
     cmp_int_op >
-    jump L8
+    jump L6
 
-  L7:
+  L5:
     load_const false
 
-  L8:
+  L6:
     return
 }
 
@@ -864,330 +769,293 @@ function ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: str
     load_var _10
     load_const 0
     call baml.Array.at
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _8
 
   L0:
-    load_var _8
     store_var form
     load_var shape
     load_const ":"
     call baml.String.split
-    store_var _16
+    store_var _15
     load_type string
-    load_var _16
+    load_var _15
     load_const 1
     call baml.Array.at
-    store_var_load_var _14
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L1
     load_const ""
-    store_var _14
 
   L1:
-    load_var _14
     store_var kind
     load_var form
     is_type "mixedlist"
-    pop_jump_if_false L2
-    jump L22
-
-  L2:
+    pop_jump_if_true L13
     load_var form
     is_type "mixed"
-    pop_jump_if_false L3
-    jump L14
-
-  L3:
+    pop_jump_if_true L8
     load_var form
     is_type "list"
-    pop_jump_if_false L4
-    jump L13
-
-  L4:
-    load_var2 2 9
+    pop_jump_if_true L7
+    load_var2 2 8
     call ai.internal._media_of_kind
     store_var parts
-    load_var2 2 9
+    load_var2 2 8
     load_var provider
     call ai.internal._media_reject_mixed
     pop 1
     load_var parts
     container_len
-    store_var _57
-    load_var _57
+    store_var _55
+    load_var _55
     load_const 1
     cmp_int_op !=
-    pop_jump_if_false L5
-    jump L9
-
-  L5:
+    pop_jump_if_true L4
     load_const null
     store_var only
     load_var parts
     load_type baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _97
+    store_var _95
 
-  L6:
-    load_var _97
+  L2:
+    load_var _95
     load_type baml.iter.Iterator<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _98
-    load_var _98
+    store_var _96
+    load_var _96
     is_type baml.iter.Done
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
-    load_var _98
+    pop_jump_if_true L3
+    load_var _96
     store_var only
-    jump L6
+    jump L2
 
-  L8:
+  L3:
     load_var only
     store_var payload
-    jump L23
+    jump L14
 
-  L9:
+  L4:
     load_var form
     load_const "one"
     cmp_op ==
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L5
+    load_const "Expected zero or one "
     load_type string
     load_var kind
     call baml.String.from
-    store_var _83
+    store_var _81
     load_var t
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _87
+    store_var _85
     load_type string
-    load_var _87
+    load_var _85
     call baml.String.from
-    store_var _86
+    store_var _84
     load_var parts
     container_len
-    store_var _90
+    store_var _88
     load_type int
-    load_var _90
+    load_var _88
     call baml.String.from
-    store_var _89
+    store_var _87
     load_type string
     load_var kind
     call baml.String.from
-    store_var _92
-    load_const "Expected zero or one "
-    load_var _83
+    store_var _90
+    load_var _81
     bin_op +
     load_const " output for "
     bin_op +
-    load_var _86
+    load_var _84
     bin_op +
     load_const ", got "
     bin_op +
-    load_var _89
+    load_var _87
     bin_op +
     load_const ". Use "
     bin_op +
-    load_var _92
+    load_var _90
     bin_op +
     load_const "[] for multiple outputs."
     bin_op +
-    store_var _59
-    jump L12
+    store_var _57
+    jump L6
 
-  L11:
+  L5:
+    load_const "Expected exactly one "
     load_type string
     load_var kind
     call baml.String.from
-    store_var _67
+    store_var _65
     load_var parts
     container_len
-    store_var _71
+    store_var _69
     load_type int
-    load_var _71
+    load_var _69
     call baml.String.from
-    store_var _70
+    store_var _68
     load_type string
     load_var kind
     call baml.String.from
-    store_var _73
-    load_const "Expected exactly one "
-    load_var _67
+    store_var _71
+    load_var _65
     bin_op +
     load_const " output, got "
     bin_op +
-    load_var _70
+    load_var _68
     bin_op +
     load_const ". Use "
     bin_op +
-    load_var _73
+    load_var _71
     bin_op +
     load_const "[] for multiple outputs."
     bin_op +
-    store_var _59
+    store_var _57
 
-  L12:
-    load_var2 3 24
+  L6:
+    load_var2 3 22
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
-  L13:
-    load_var2 2 9
+  L7:
+    load_var2 2 8
     load_var provider
     call ai.internal._media_reject_mixed
     pop 1
-    load_var2 2 9
+    load_var2 2 8
     call ai.internal._media_of_kind
     store_var payload
-    jump L23
+    jump L14
 
-  L14:
+  L8:
     load_var turn
     call ai.internal._media_mixed_parts
     store_var items
     load_var items
     container_len
-    store_var _25
-    load_var _25
+    store_var _23
+    load_var _23
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L15
-    jump L18
-
-  L15:
+    pop_jump_if_true L10
     load_var items
     call ai.internal._media_all_text
-    pop_jump_if_false L16
-    jump L17
-
-  L16:
+    pop_jump_if_true L9
     load_var t
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _42
+    store_var _40
     load_type string
-    load_var _42
+    load_var _40
     call baml.String.from
-    store_var _41
+    store_var _39
     load_var items
     container_len
-    store_var _45
+    store_var _43
     load_type int
-    load_var _45
+    load_var _43
     call baml.String.from
-    store_var _44
+    store_var _42
     load_var provider
     load_const "Expected one text or image output for "
-    load_var _41
+    load_var _39
     bin_op +
     load_const ", got "
     bin_op +
-    load_var _44
+    load_var _42
     bin_op +
     load_const " parts. Use (image | string)[] to preserve mixed outputs."
     bin_op +
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
-  L17:
+  L9:
     load_var items
     call ai.internal._media_join_text
     store_var payload
-    jump L23
+    jump L14
 
-  L18:
+  L10:
     load_const null
     store_var only
     load_var items
     load_type baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _28
+    store_var _26
 
-  L19:
-    load_var _28
+  L11:
+    load_var _26
     load_type baml.iter.Iterator<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _29
-    load_var _29
+    store_var _27
+    load_var _27
     is_type baml.iter.Done
-    pop_jump_if_false L20
-    jump L21
-
-  L20:
-    load_var _29
+    pop_jump_if_true L12
+    load_var _27
     store_var only
-    jump L19
+    jump L11
 
-  L21:
+  L12:
     load_var only
     store_var payload
-    jump L23
+    jump L14
 
-  L22:
+  L13:
     load_var turn
     call ai.internal._media_mixed_parts
     store_var payload
 
-  L23:
+  L14:
     load_type #0
     load_var payload
     call baml.json.from_json
-    jump L24
+    jump L15
     load_var e
     throw_if_panic
     load_type string
     load_var kind
     call baml.String.from
-    store_var _111
+    store_var _109
     load_var t
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _115
+    store_var _113
     load_type string
-    load_var _115
+    load_var _113
     call baml.String.from
-    store_var _114
+    store_var _112
     load_type baml.json.DecodeError
     load_var e
     call baml.String.from
-    store_var _118
+    store_var _116
     load_type string
-    load_var _118
+    load_var _116
     call baml.String.from
-    store_var _117
+    store_var _115
     load_var provider
     load_const "the "
-    load_var _111
+    load_var _109
     bin_op +
     load_const " output did not fit "
     bin_op +
-    load_var _114
+    load_var _112
     bin_op +
     load_const ": "
     bin_op +
-    load_var _117
+    load_var _115
     bin_op +
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
-  L24:
+  L15:
     return
 }
 
@@ -1195,28 +1063,25 @@ function ai.Agent._parses(self: ai.Agent, turn: ai.ModelTurn, candidate: string)
     load_type #0
     load_var2 1 2
     call ai.Agent._has_media_output
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_type #0
     load_var candidate
     call baml.sap.parse
     pop 1
-    jump L1
+    jump L0
     load_var e
     throw_if_panic
     load_const false
-    jump L3
+    jump L2
+
+  L0:
+    load_const true
+    jump L2
 
   L1:
     load_const true
-    jump L3
 
   L2:
-    load_const true
-
-  L3:
     return
 }
 
@@ -1227,21 +1092,18 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     store_var _7
     load_var _7
     narrow_bind ai.tools.Tool, slot=5
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var call
     load_field .id
-    store_var _42
+    store_var _41
     load_type string
     load_var call
     load_field .name
     call baml.String.from
-    store_var _44
-    load_var2 4 17
+    store_var _43
+    load_var2 4 16
     load_const "tool is not in the active toolbox: "
-    load_var _44
+    load_var _43
     bin_op +
     init_instance ai.events.ToolFailed .id, .message
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
@@ -1249,15 +1111,15 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     call ai.Journal.append_all
     pop 1
     load_const null
-    jump L10
+    jump L7
 
-  L1:
+  L0:
     load_var _7
     store_var t
     load_var2 6 3
     load_field .args
     call ai.tools.Tool.call
-    jump L8
+    jump L5
     load_var e
     throw_if_panic
     load_var call
@@ -1276,77 +1138,66 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     pop 1
     load_var t
     load_field .on_error
-    store_var_load_var _20
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
+    jump_if_not_null_or_pop L1
     load_var self
     load_field .tool_errors
-    store_var _20
 
-  L2:
-    load_var _20
+  L1:
     load_const ai.tools.ErrorMode.Raise
     alloc_variant ai.tools.ErrorMode
     call baml.ops.equals_equals
-    pop_jump_if_false L3
+    pop_jump_if_true L2
+    load_const null
+    jump L5
+
+  L2:
+    load_var e
+    store_var _23
+    load_var _23
+    narrow_bind ai.errors.Failure, slot=11
+    pop_jump_if_true L3
+    load_const null
+    store_var classified
     jump L4
 
   L3:
-    load_const null
-    jump L8
+    load_var _23
+    store_var classified
 
   L4:
-    load_var e
-    store_var _24
-    load_var _24
-    narrow_bind ai.errors.Failure, slot=12
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
-    load_const null
-    store_var classified
-    jump L7
-
-  L6:
-    load_var _24
-    store_var classified
-
-  L7:
     load_var call
     load_field .id
-    store_var _27
+    store_var _26
     load_var call
     load_field .name
-    store_var _28
+    store_var _27
     load_type unknown
     load_var e
     call baml.String.from
-    store_var _29
-    load_var2 13 14
-    load_var2 15 11
+    store_var _28
+    load_var2 12 13
+    load_var2 14 10
     init_instance ai.errors.ToolFailedError .id, .name, .message, .cause
     throw
 
-  L8:
-    store_var _32
-    load_var _32
-    narrow_bind string, slot=16
-    pop_jump_if_false L9
+  L5:
+    store_var _31
+    load_var _31
+    narrow_bind string, slot=15
+    pop_jump_if_false L6
     load_var2 4 3
     load_field .id
-    load_var _32
+    load_var _31
     init_instance ai.events.ToolCompleted .id, .output
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
     pop 1
 
-  L9:
+  L6:
     load_const null
 
-  L10:
+  L7:
     return
 }
 
@@ -1355,15 +1206,12 @@ function ai.Agent._validated_schema_attempts(self: ai.Agent) -> int {
     load_field .schema_attempts
     load_const 1
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .schema_attempts
     return
 
-  L1:
+  L0:
     load_const "Agent schema_attempts must be at least 1"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -1414,21 +1262,26 @@ function ai.Agent.new(max_steps: int, schema_attempts: int, client: ai.Client | 
     load_var schema_attempts
     load_const 1
     cmp_int_op <
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L5
+    load_var max_steps
+    store_var _13
+    load_var schema_attempts
+    store_var _14
+    load_var client
+    store_var _15
+    load_var tool_errors
+    store_var _16
     load_type unknown
     load_var on_event
     call ai.events.guard
-    store_var _13
-    load_var2 1 2
-    load_var2 3 4
-    load_var _13
+    store_var _17
+    load_var2 6 7
+    load_var2 8 9
+    load_var _17
     init_instance ai.Agent .max_steps, .schema_attempts, .client, .tool_errors, .on_event
     return
 
-  L6:
+  L5:
     load_const "Agent schema_attempts must be at least 1"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -1543,41 +1396,34 @@ function ai.FunctionSpec.build_request(self: ai.FunctionSpec<#0>, client: ai.Cli
 
   L0:
     load_var client
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L1
     load_var self
     load_field .default_client
-    store_var _5
 
   L1:
-    load_var _5
     store_var selected
     load_var self
     load_field .prompt_template
-    store_var _8
+    store_var _7
     load_type #0
     load_var self
     call ai.Journal.new
-    store_var _9
+    store_var _8
     load_type #0
     load_var self
     call ai.FunctionSpec.tools
-    store_var _11
+    store_var _10
     load_type #0
     load_var self
     call ai.FunctionSpec.output_type
-    store_var _13
-    load_var2 4 6
-    load_var2 7 8
-    load_var _13
+    store_var _12
+    load_var2 3 4
+    load_var2 5 6
+    load_var _12
     init_instance ai.ModelTurnInput .prompt, .journal, .toolbox, .output_type
     load_type ai.Client
     load_const "render"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1607,12 +1453,10 @@ function ai.FunctionSpec.call(self: ai.FunctionSpec<#0>, client: ai.Client | nul
     call ai.Agent.new
     store_var _7
     load_type #0
-    load_var2 5 1
+    load_var2 4 1
     load_type ai.Runner<Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure>
     load_const "run"
     virtual_call nargs=2 ntypeargs=1
-    store_var _6
-    load_var _6
     load_field .value
     return
 }
@@ -1623,8 +1467,6 @@ function ai.FunctionSpec.client_id(self: ai.FunctionSpec<#0>) -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1685,10 +1527,7 @@ function ai.Journal.append_all(self: ai.Journal, events: (ai.events.RunStarted |
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var self
     load_field .log
@@ -1697,7 +1536,7 @@ function ai.Journal.append_all(self: ai.Journal, events: (ai.events.RunStarted |
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_const null
     return
 }
@@ -1744,10 +1583,7 @@ function ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Image | baml.medi
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var _9
     load_var _9
@@ -1760,7 +1596,7 @@ function ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Image | baml.medi
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1783,10 +1619,7 @@ function ai.ModelTurn.terminal_text(self: ai.ModelTurn) -> string | null {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var _9
     load_var _9
@@ -1797,7 +1630,7 @@ function ai.ModelTurn.terminal_text(self: ai.ModelTurn) -> string | null {
     store_var out
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1821,10 +1654,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var _9
     load_var _9
@@ -1836,7 +1666,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -1859,20 +1689,17 @@ function ai.clients.<(ai.clients.Fallback as ai.Client)>.id(self: ai.clients.Fal
     store_var _5
     load_var _5
     narrow_bind ai.Client, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "fallback"
     jump L1
 
   L0:
-    load_const "fallback"
-    jump L2
-
-  L1:
     load_var _5
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -1899,10 +1726,7 @@ function ai.clients.<(ai.clients.Fallback as ai.Client)>.invoke(self: ai.clients
     load_var _10
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var turn
     store_var _11
     load_type ai.events.LLMCall
@@ -1915,12 +1739,12 @@ function ai.clients.<(ai.clients.Fallback as ai.Client)>.invoke(self: ai.clients
     init_spread .content, .stop_reason, .usage
     load_var _12
     init_field .calls
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_var turn
 
-  L3:
+  L2:
     return
 }
 
@@ -1932,11 +1756,8 @@ function ai.clients.<(ai.clients.Fallback as ai.Client)>.render(self: ai.clients
     call baml.Array.at
     store_var _7
     load_var _7
-    narrow_bind ai.Client, slot=5
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    narrow_bind ai.Client, slot=4
+    pop_jump_if_true L0
     load_const "fallback"
     load_const null
     load_const "Fallback needs at least one member"
@@ -1944,21 +1765,19 @@ function ai.clients.<(ai.clients.Fallback as ai.Client)>.render(self: ai.clients
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L1:
-    load_var2 5 2
+  L0:
+    load_var2 4 2
     load_type ai.Client
     load_const "render"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var e
     call ai.errors.normalize
     throw
 
-  L2:
-    load_var _0
+  L1:
     return
 }
 
@@ -2008,8 +1827,6 @@ function ai.clients.<(ai.clients.Retry as ai.Client)>.id(self: ai.clients.Retry)
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2037,10 +1854,7 @@ function ai.clients.<(ai.clients.Retry as ai.Client)>.invoke(self: ai.clients.Re
     load_var _11
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var turn
     store_var _12
     load_type ai.events.LLMCall
@@ -2053,12 +1867,12 @@ function ai.clients.<(ai.clients.Retry as ai.Client)>.invoke(self: ai.clients.Re
     init_spread .content, .stop_reason, .usage
     load_var _13
     init_field .calls
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_var turn
 
-  L3:
+  L2:
     return
 }
 
@@ -2069,7 +1883,6 @@ function ai.clients.<(ai.clients.Retry as ai.Client)>.render(self: ai.clients.Re
     load_type ai.Client
     load_const "render"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L0
     load_var e
     throw_if_panic
@@ -2078,7 +1891,6 @@ function ai.clients.<(ai.clients.Retry as ai.Client)>.render(self: ai.clients.Re
     throw
 
   L0:
-    load_var _0
     return
 }
 
@@ -2131,20 +1943,17 @@ function ai.clients.<(ai.clients.RoundRobin as ai.Client)>.id(self: ai.clients.R
     store_var _5
     load_var _5
     narrow_bind ai.Client, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const "round-robin"
     jump L1
 
   L0:
-    load_const "round-robin"
-    jump L2
-
-  L1:
     load_var _5
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -2156,10 +1965,7 @@ function ai.clients.<(ai.clients.RoundRobin as ai.Client)>.invoke(self: ai.clien
     load_var _5
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_var self
     load_field .counter
     store_var _9
@@ -2175,16 +1981,13 @@ function ai.clients.<(ai.clients.RoundRobin as ai.Client)>.invoke(self: ai.clien
     load_type ai.Client
     load_var self
     load_field .members
-    load_var2 6 7
+    load_var2 5 6
     mod_int
     call baml.Array.at
     store_var _17
     load_var _17
-    narrow_bind ai.Client, slot=8
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    narrow_bind ai.Client, slot=7
+    pop_jump_if_true L0
     load_const "roundrobin"
     load_const null
     load_const "RoundRobin needs at least one member"
@@ -2192,24 +1995,22 @@ function ai.clients.<(ai.clients.RoundRobin as ai.Client)>.invoke(self: ai.clien
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L2:
-    load_var2 8 2
+  L0:
+    load_var2 7 2
     load_type ai.Client
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    jump L3
+    jump L1
     load_var e
     throw_if_panic
     load_var e
     call ai.errors.normalize_invoke
     throw
 
-  L3:
-    load_var _0
+  L1:
     return
 
-  L4:
+  L2:
     load_const "roundrobin"
     load_const null
     load_const "RoundRobin needs at least one member"
@@ -2226,11 +2027,8 @@ function ai.clients.<(ai.clients.RoundRobin as ai.Client)>.render(self: ai.clien
     call baml.Array.at
     store_var _7
     load_var _7
-    narrow_bind ai.Client, slot=5
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    narrow_bind ai.Client, slot=4
+    pop_jump_if_true L0
     load_const "roundrobin"
     load_const null
     load_const "RoundRobin needs at least one member"
@@ -2238,21 +2036,19 @@ function ai.clients.<(ai.clients.RoundRobin as ai.Client)>.render(self: ai.clien
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L1:
-    load_var2 5 2
+  L0:
+    load_var2 4 2
     load_type ai.Client
     load_const "render"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var e
     call ai.errors.normalize
     throw
 
-  L2:
-    load_var _0
+  L1:
     return
 }
 
@@ -2264,10 +2060,7 @@ function ai.clients.<(ai.clients.RoundRobin as ai.stream.StreamingClient)>.invok
     load_var _5
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_var self
     load_field .counter
     store_var _9
@@ -2284,26 +2077,20 @@ function ai.clients.<(ai.clients.RoundRobin as ai.stream.StreamingClient)>.invok
     load_type ai.Client
     load_var self
     load_field .members
-    load_var2 6 7
+    load_var2 5 6
     mod_int
     call baml.Array.at
     store_var _12
     load_var _12
     store_var _16
     load_var _16
-    narrow_bind ai.stream.StreamingClient, slot=9
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    narrow_bind ai.stream.StreamingClient, slot=8
+    pop_jump_if_true L1
     load_var _12
     store_var _18
     load_var _18
-    narrow_bind ai.Client, slot=10
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    narrow_bind ai.Client, slot=9
+    pop_jump_if_true L0
     load_const "roundrobin"
     load_const null
     load_const "RoundRobin needs at least one member"
@@ -2311,34 +2098,30 @@ function ai.clients.<(ai.clients.RoundRobin as ai.stream.StreamingClient)>.invok
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L3:
+  L0:
     load_var _18
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _21
-    load_var _21
     init_instance ai.errors.StreamingUnsupported .client_id
     throw
 
-  L4:
-    load_var2 9 2
+  L1:
+    load_var2 8 2
     load_type ai.stream.StreamingClient
     load_const "invoke_stream"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    jump L5
+    jump L2
     load_var e
     throw_if_panic
     load_var e
     call ai.errors.normalize_invoke
     throw
 
-  L5:
-    load_var _0
+  L2:
     return
 
-  L6:
+  L3:
     load_const "roundrobin"
     load_const null
     load_const "RoundRobin needs at least one member"
@@ -2352,54 +2135,42 @@ function ai.clients.Backoff.delay_ms(self: ai.clients.Backoff, attempt: int, f: 
     store_var _5
     load_var _5
     narrow_bind ai.errors.RateLimited, slot=4
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_var _5
     load_field .retry_after_ms
 
-  L2:
+  L1:
     store_var _7
     load_var _7
     narrow_bind int, slot=5
-    pop_jump_if_false L3
-    jump L9
-
-  L3:
+    pop_jump_if_true L5
     load_var self
     load_field .initial_ms
     store_var d
     load_const 1
     store_var i
 
-  L4:
+  L2:
     load_var2 7 2
     cmp_int_op <
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L4
     load_var2 6 1
     load_field .max_ms
     cmp_int_op >
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L3
     load_var d
-    jump L10
+    jump L6
 
-  L7:
+  L3:
     load_var self
     load_field .max_ms
-    jump L10
+    jump L6
 
-  L8:
+  L4:
     load_var2 6 1
     load_field .multiplier
     mul_int
@@ -2408,12 +2179,12 @@ function ai.clients.Backoff.delay_ms(self: ai.clients.Backoff, attempt: int, f: 
     load_const 1
     add_int
     store_var i
-    jump L4
+    jump L2
 
-  L9:
+  L5:
     load_var _7
 
-  L10:
+  L6:
     return
 }
 
@@ -2457,10 +2228,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
     store_var _8
     load_var _8
     narrow_bind ai.Client, slot=5
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "fallback"
     load_const null
     load_const "Fallback needs at least one member"
@@ -2468,71 +2236,61 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L1:
+  L0:
     load_var _8
     store_var c
     load_var2 6 2
     load_type ai.Client
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
-    jump L7
+    jump L4
     load_var e
     store_var _11
     load_var _11
     narrow_bind ai.errors.Failure, slot=8
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     throw_if_panic
     load_var e
     rethrow
 
-  L3:
+  L1:
     load_var _11
     store_var f
     load_var index
     load_const 1
     add_int
-    store_var _15
+    store_var _14
     load_var self
     load_field .members
     container_len
-    store_var _16
+    store_var _15
     load_var2 10 11
     cmp_int_op <
-    jump_if_false L4
-    pop 1
+    pop_jump_if_false L2
     load_var f
     load_type ai.errors.Failure
     load_const "retry_safety"
     virtual_call nargs=1 ntypeargs=0
-    store_var _18
-    load_var _18
     load_const ai.errors.RetrySafety.Safe
     alloc_variant ai.errors.RetrySafety
     call baml.ops.equals_equals
+    pop_jump_if_true L3
 
-  L4:
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+  L2:
     load_var e
     rethrow
 
-  L6:
+  L3:
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _21
-    load_var2 14 9
+    load_var f
     call ai.clients._failed_leg_call
     store_var _20
     load_type ai.events.LLMCall
-    load_var2 4 13
+    load_var2 4 12
     call baml.Array.push
     pop 1
     load_var2 1 2
@@ -2542,7 +2300,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
     load_var failed
     call ai.clients.Fallback._try
 
-  L7:
+  L4:
     return
 }
 
@@ -2553,65 +2311,52 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
     load_type ai.Client
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
-    jump L7
+    jump L4
     load_var e
     store_var _7
     load_var _7
     narrow_bind ai.errors.Failure, slot=6
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_var _7
     store_var f
     load_var remaining
     load_const 1
     cmp_int_op >
-    jump_if_false L2
-    pop 1
+    pop_jump_if_false L1
     load_var f
     load_type ai.errors.Failure
     load_const "retry_safety"
     virtual_call nargs=1 ntypeargs=0
-    store_var _12
-    load_var _12
     load_const ai.errors.RetrySafety.Safe
     alloc_variant ai.errors.RetrySafety
     call baml.ops.equals_equals
-
-  L2:
-    jump_if_false L3
-    pop 1
+    pop_jump_if_false L1
     load_var2 7 1
     load_field .retry_if
     call_indirect
+    pop_jump_if_true L2
 
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+  L1:
     load_var e
     rethrow
 
-  L5:
+  L2:
     load_var self
     load_field .inner
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _17
-    load_var2 10 7
+    load_var f
     call ai.clients._failed_leg_call
     store_var _16
     load_type ai.events.LLMCall
-    load_var2 4 9
+    load_var2 4 8
     call baml.Array.push
     pop 1
     load_var self
@@ -2627,11 +2372,11 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
     call baml.time.Duration.from_milliseconds
     sys_op baml.sys.sleep
     pop 1
-    jump L6
+    jump L3
     load_var se
     throw_if_panic
 
-  L6:
+  L3:
     load_var2 1 2
     load_var remaining
     load_const 1
@@ -2639,7 +2384,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
     load_var failed
     call ai.clients.Retry._attempt
 
-  L7:
+  L4:
     return
 }
 
@@ -2668,31 +2413,32 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
     store_var backoff
 
   L2:
+    load_var max_attempts
+    store_var _8
     load_var retry_if
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L3
     load_const ai.clients.default_retry_judgment
-    store_var _9
 
   L3:
-    load_var _9
-    store_var _8
+    store_var _9
     load_var backoff
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L4
+    jump L5
+
+  L4:
+    store_var _12
+    jump L6
+
+  L5:
     load_const <omitted>
     load_const <omitted>
     load_const <omitted>
     call ai.clients.Backoff.new
     store_var _12
 
-  L4:
-    load_var2 1 2
-    load_var2 5 7
+  L6:
+    load_var2 1 5
+    load_var2 6 7
     init_instance ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff
     return
 }
@@ -2704,16 +2450,13 @@ function ai.clients.RoundRobin.new(members: ai.Client[]) -> ai.clients.RoundRobi
     load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var members
     load_const 0
     init_instance ai.clients.RoundRobin .members, .counter
     return
 
-  L1:
+  L0:
     load_const "roundrobin"
     load_const null
     load_const "RoundRobin needs at least one member"
@@ -2728,20 +2471,17 @@ function ai.clients.StreamRelay.close_current(self: ai.clients.StreamRelay) -> v
     store_var _3
     load_var _3
     narrow_bind ai.stream.TurnStream, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_var _3
     call ai.stream.TurnStream._finish
     pop 1
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -2755,149 +2495,122 @@ function ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.s
     store_var _4
     load_var2 2 3
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L32
-
-  L0:
+    pop_jump_if_true L22
     load_var self
     load_field .terminal_cursor
-    store_var _15
+    store_var _14
     load_var self
     load_field .terminal
     container_len
-    store_var _16
+    store_var _15
     load_var2 5 6
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L30
-
-  L1:
+    pop_jump_if_true L20
     load_var self
     load_field .finished
-    pop_jump_if_false L2
-    jump L29
-
-  L2:
+    pop_jump_if_true L19
     load_var self
     load_field .current
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L5
+    pop_jump_if_false L1
     load_var self
     load_field .open
     call_indirect
     store_var opened
+    jump L0
+    load_var e
+    throw_if_panic
+    load_var e
+    init_instance ai.clients.StreamRelayError .error
+    store_var opened
+
+  L0:
+    load_var opened
+    store_var _30
+    load_var _30
+    narrow_bind ai.clients.StreamRelayError, slot=9
+    pop_jump_if_true L18
+    load_var opened
+    store_var _34
+    load_var _34
+    narrow_bind ai.stream.TurnStream, slot=10
+    pop_jump_if_false L1
+    load_var2 1 10
+    store_field .current
+
+  L1:
+    load_var self
+    load_field .current
+    store_var _37
+    load_var _37
+    narrow_bind ai.stream.TurnStream, slot=11
+    pop_jump_if_true L2
+    load_const "StreamRelay has no current stream"
+    call baml.sys.panic
+    jump L26
+
+  L2:
+    load_var _37
+    store_var stream
+    load_var stream
+    call ai.stream.TurnStream.next
+    store_var next
     jump L3
     load_var e
     throw_if_panic
     load_var e
     init_instance ai.clients.StreamRelayError .error
-    store_var opened
+    store_var next
 
   L3:
-    load_var opened
-    store_var _32
-    load_var _32
-    narrow_bind ai.clients.StreamRelayError, slot=10
-    pop_jump_if_false L4
-    jump L28
-
-  L4:
-    load_var opened
-    store_var _36
-    load_var _36
-    narrow_bind ai.stream.TurnStream, slot=11
-    pop_jump_if_false L5
-    load_var2 1 11
-    store_field .current
-
-  L5:
-    load_var self
-    load_field .current
-    store_var _39
-    load_var _39
-    narrow_bind ai.stream.TurnStream, slot=12
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_const "StreamRelay has no current stream"
-    call baml.sys.panic
-    jump L34
-
-  L7:
-    load_var _39
-    store_var stream
-    load_var stream
-    call ai.stream.TurnStream.next
-    store_var next
-    jump L8
-    load_var e
-    throw_if_panic
-    load_var e
-    init_instance ai.clients.StreamRelayError .error
-    store_var next
-
-  L8:
     load_var next
-    store_var _44
-    load_var _44
-    narrow_bind string[], slot=16
-    pop_jump_if_false L9
-    jump L26
-
-  L9:
+    store_var _42
+    load_var _42
+    narrow_bind string[], slot=15
+    pop_jump_if_true L14
     load_var next
-    store_var _51
-    load_var _51
-    narrow_bind ai.stream.Done, slot=19
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
-    load_var2 1 14
+    store_var _48
+    load_var _48
+    narrow_bind ai.stream.Done, slot=18
+    pop_jump_if_true L4
+    load_var2 1 13
     load_field .error
     call ai.clients.StreamRelay.recover
     pop 1
     load_var self
     call ai.clients.StreamRelay.next_event
-    jump L34
+    jump L26
 
-  L11:
-    load_var _51
+  L4:
+    load_var _48
     store_var done
     load_var stream
     call ai.stream.TurnStream.final_turn
     store_var final
-    jump L12
+    jump L5
     load_var e
     throw_if_panic
     load_var e
     init_instance ai.clients.StreamRelayError .error
     store_var final
 
-  L12:
+  L5:
     load_var final
-    store_var _56
-    load_var _56
-    narrow_bind ai.clients.StreamRelayError, slot=23
-    pop_jump_if_false L13
-    jump L25
-
-  L13:
+    store_var _53
+    load_var _53
+    narrow_bind ai.clients.StreamRelayError, slot=22
+    pop_jump_if_true L13
     load_var final
-    store_var _60
-    load_var _60
-    narrow_bind ai.ModelTurn, slot=24
-    pop_jump_if_false L14
-    jump L15
-
-  L14:
+    store_var _57
+    load_var _57
+    narrow_bind ai.ModelTurn, slot=23
+    pop_jump_if_true L6
     load_var done
-    jump L34
+    jump L26
 
-  L15:
-    load_var _60
+  L6:
+    load_var _57
     store_var turn
     load_var self
     load_const true
@@ -2907,72 +2620,63 @@ function ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.s
     load_type baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _63
+    store_var _60
 
-  L16:
-    load_var _63
+  L7:
+    load_var _60
     load_type baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _64
-    load_var _64
+    store_var _61
+    load_var _61
     is_type baml.iter.Done
-    pop_jump_if_false L17
-    jump L18
-
-  L17:
+    pop_jump_if_true L8
     load_type ai.events.LLMCall
     load_var self
     load_field .calls
-    load_var _64
+    load_var _61
     call baml.Array.push
     pop 1
-    jump L16
+    jump L7
 
-  L18:
+  L8:
     load_var turn
     load_field .stop_reason
-    store_var _73
+    store_var _70
     load_var turn
     load_field .usage
     load_const null
     cmp_op ==
-    pop_jump_if_false L19
-    jump L20
-
-  L19:
+    pop_jump_if_true L9
     load_var turn
     load_field .usage
     load_field .0
-    store_var _74
-    jump L21
+    store_var _71
+    jump L10
 
-  L20:
+  L9:
     load_const null
-    store_var _74
+    store_var _71
 
-  L21:
+  L10:
     load_var turn
     load_field .usage
     load_const null
     cmp_op ==
-    pop_jump_if_false L22
-    jump L23
-
-  L22:
+    pop_jump_if_true L11
     load_var turn
     load_field .usage
     load_field .1
-    store_var _78
-    jump L24
+    store_var _75
+    jump L12
 
-  L23:
+  L11:
     load_const null
-    store_var _78
+    store_var _75
 
-  L24:
-    load_var2 1 28
-    load_var2 29 30
+  L12:
+    load_var2 1 27
+    load_var2 28 29
     init_instance ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens
     alloc_instance ai.stream.TurnDone
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
@@ -2980,24 +2684,24 @@ function ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.s
     store_field .terminal
     load_var self
     call ai.clients.StreamRelay.next_event
-    jump L34
+    jump L26
 
-  L25:
-    load_var2 1 23
+  L13:
+    load_var2 1 22
     load_field .error
     call ai.clients.StreamRelay.recover
     pop 1
     load_var self
     call ai.clients.StreamRelay.next_event
-    jump L34
+    jump L26
 
-  L26:
-    load_var _44
+  L14:
+    load_var _42
     store_var batch
     load_var self
     load_const true
     store_field .emitted
-    load_var2 1 17
+    load_var2 1 16
     store_field .pending_text
     load_var self
     load_const 1
@@ -3006,73 +2710,76 @@ function ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.s
     load_var batch
     load_const 0
     call baml.Array.at
-    store_var_load_var _47
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L27
+    jump_if_not_null_or_pop L15
+    jump L16
+
+  L15:
+    store_var _45
+    jump L17
+
+  L16:
     load_const "StreamRelay received an empty batch"
     call baml.sys.panic
-    store_var _47
+    store_var _45
 
-  L27:
-    load_var _47
+  L17:
+    load_var _45
     init_instance ai.stream.TextDelta .text
-    jump L34
+    jump L26
 
-  L28:
-    load_var2 1 10
+  L18:
+    load_var2 1 9
     load_field .error
     call ai.clients.StreamRelay.recover
     pop 1
     load_var self
     call ai.clients.StreamRelay.next_event
-    jump L34
+    jump L26
 
-  L29:
+  L19:
     alloc_instance ai.stream.Done
-    jump L34
+    jump L26
 
-  L30:
+  L20:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
     load_var self
     load_field .terminal
     load_var self
     load_field .terminal_cursor
     call baml.Array.at
-    store_var_load_var _19
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L31
+    jump_if_not_null_or_pop L21
     load_const "StreamRelay lost a terminal event"
     call baml.sys.panic
-    store_var _19
 
-  L31:
+  L21:
     load_var self
     copy 0
     load_field .terminal_cursor
     load_const 1
     bin_op +
     store_field .terminal_cursor
-    load_var _19
-    jump L34
+    jump L26
 
-  L32:
+  L22:
     load_type string
     load_var self
     load_field .pending_text
     load_var self
     load_field .pending_cursor
     call baml.Array.at
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L33
+    jump_if_not_null_or_pop L23
+    jump L24
+
+  L23:
+    store_var _7
+    jump L25
+
+  L24:
     load_const "StreamRelay lost a pending delta"
     call baml.sys.panic
     store_var _7
 
-  L33:
+  L25:
     load_var self
     copy 0
     load_field .pending_cursor
@@ -3085,7 +2792,7 @@ function ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.s
     load_var _7
     init_instance ai.stream.TextDelta .text
 
-  L34:
+  L26:
     return
 }
 
@@ -3097,34 +2804,25 @@ function ai.clients.StreamRelay.recover(self: ai.clients.StreamRelay, error: ai.
     store_var _4
     load_var _4
     narrow_bind baml.errors.Timeout, slot=4
-    pop_jump_if_false L0
-    jump L8
-
-  L0:
+    pop_jump_if_true L3
     load_var _3
     store_var _7
     load_var _7
     narrow_bind ai.errors.Failure, slot=6
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
-    store_var _21
-    load_var _21
+    store_var _20
+    load_var _20
     narrow_bind baml.errors.UnknownError, slot=10
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_var self
     call ai.clients.StreamRelay.close_current
     pop 1
     load_var _3
     throw
 
-  L3:
-    load_var _21
+  L0:
+    load_var _20
     store_var unknown_error
     load_var self
     call ai.clients.StreamRelay.close_current
@@ -3132,37 +2830,23 @@ function ai.clients.StreamRelay.recover(self: ai.clients.StreamRelay, error: ai.
     load_var unknown_error
     throw
 
-  L4:
+  L1:
     load_var _7
     store_var failure
     load_var self
     load_field .emitted
-    unary_op !
-    jump_if_false L5
-    pop 1
+    pop_jump_if_true L2
     load_var2 7 1
     load_field .retry
     call_indirect
-
-  L5:
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_var self
-    call ai.clients.StreamRelay.close_current
-    pop 1
-    load_var failure
-    throw
-
-  L7:
+    pop_jump_if_false L2
     load_var self
     load_field .calls
-    store_var _15
+    store_var _14
     load_const null
     load_var failure
     call ai.clients._failed_leg_call
-    store_var _16
+    store_var _15
     load_type ai.events.LLMCall
     load_var2 8 9
     call baml.Array.push
@@ -3176,7 +2860,14 @@ function ai.clients.StreamRelay.recover(self: ai.clients.StreamRelay, error: ai.
     load_const null
     return
 
-  L8:
+  L2:
+    load_var self
+    call ai.clients.StreamRelay.close_current
+    pop 1
+    load_var failure
+    throw
+
+  L3:
     load_var _4
     store_var timeout
     load_var self
@@ -3191,266 +2882,213 @@ function ai.clients._failed_leg_call(client_name: string | null, f: ai.errors.Fa
     store_var _4
     load_var _4
     narrow_bind ai.errors.RateLimited, slot=4
-    pop_jump_if_false L0
-    jump L15
-
-  L0:
+    pop_jump_if_true L7
     load_var f
     store_var _6
     load_var _6
     narrow_bind ai.errors.NetworkFailure, slot=5
-    pop_jump_if_false L1
-    jump L14
-
-  L1:
+    pop_jump_if_true L6
     load_var f
     store_var _8
     load_var _8
     narrow_bind ai.errors.InvalidRequest, slot=6
-    pop_jump_if_false L2
-    jump L13
-
-  L2:
+    pop_jump_if_true L5
     load_var f
     store_var _10
     load_var _10
     narrow_bind ai.errors.PreviewUnsupported, slot=7
-    pop_jump_if_false L3
-    jump L12
-
-  L3:
+    pop_jump_if_true L4
     load_var f
     store_var _12
     load_var _12
     narrow_bind ai.errors.Refused, slot=8
-    pop_jump_if_false L4
-    jump L11
-
-  L4:
+    pop_jump_if_true L3
     load_var f
     store_var _14
     load_var _14
     narrow_bind ai.errors.ParseFailed, slot=9
-    pop_jump_if_false L5
-    jump L10
-
-  L5:
+    pop_jump_if_true L2
     load_var f
     store_var _16
     load_var _16
     narrow_bind ai.errors.FinishReasonError, slot=10
-    pop_jump_if_false L6
-    jump L9
-
-  L6:
+    pop_jump_if_true L1
     load_var f
     store_var _18
     load_var _18
     narrow_bind ai.errors.StreamingUnsupported, slot=11
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
+    pop_jump_if_true L0
     load_const "unknown"
     store_var provider
-    jump L16
+    jump L8
 
-  L8:
+  L0:
     load_var _18
     load_field .client_id
     store_var provider
-    jump L16
+    jump L8
 
-  L9:
+  L1:
     load_var _16
     load_field .provider
     store_var provider
-    jump L16
+    jump L8
 
-  L10:
+  L2:
     load_var _14
     load_field .provider
     store_var provider
-    jump L16
+    jump L8
 
-  L11:
+  L3:
     load_var _12
     load_field .provider
     store_var provider
-    jump L16
+    jump L8
 
-  L12:
+  L4:
     load_var _10
     load_field .provider
     store_var provider
-    jump L16
+    jump L8
 
-  L13:
+  L5:
     load_var _8
     load_field .provider
     store_var provider
-    jump L16
+    jump L8
 
-  L14:
+  L6:
     load_var _6
     load_field .provider
     store_var provider
-    jump L16
+    jump L8
 
-  L15:
+  L7:
     load_var _4
     load_field .provider
     store_var provider
 
-  L16:
+  L8:
     load_var f
     store_var _21
     load_var _21
     narrow_bind ai.errors.RateLimited, slot=13
-    pop_jump_if_false L17
-    jump L22
-
-  L17:
+    pop_jump_if_true L11
     load_var f
     store_var _23
     load_var _23
     narrow_bind ai.errors.NetworkFailure, slot=14
-    pop_jump_if_false L18
-    jump L21
-
-  L18:
+    pop_jump_if_true L10
     load_var f
     store_var _25
     load_var _25
     narrow_bind ai.errors.InvalidRequest, slot=15
-    pop_jump_if_false L19
-    jump L20
-
-  L19:
+    pop_jump_if_true L9
     load_const null
     store_var status
-    jump L23
+    jump L12
 
-  L20:
+  L9:
     load_var _25
     load_field .status_code
     store_var status
-    jump L23
+    jump L12
 
-  L21:
+  L10:
     load_var _23
     load_field .status_code
     store_var status
-    jump L23
+    jump L12
 
-  L22:
+  L11:
     load_var _21
     load_field .status_code
     store_var status
 
-  L23:
+  L12:
     load_var f
     store_var _28
     load_var _28
     narrow_bind ai.errors.RateLimited, slot=17
-    pop_jump_if_false L24
-    jump L31
-
-  L24:
+    pop_jump_if_true L16
     load_var f
     store_var _30
     load_var _30
     narrow_bind ai.errors.NetworkFailure, slot=18
-    pop_jump_if_false L25
-    jump L30
-
-  L25:
+    pop_jump_if_true L15
     load_var f
     store_var _32
     load_var _32
     narrow_bind ai.errors.InvalidRequest, slot=19
-    pop_jump_if_false L26
-    jump L29
-
-  L26:
+    pop_jump_if_true L14
     load_var f
     store_var _34
     load_var _34
     narrow_bind ai.errors.Refused, slot=20
-    pop_jump_if_false L27
-    jump L28
-
-  L27:
+    pop_jump_if_true L13
     load_const null
     store_var raw
-    jump L32
+    jump L17
 
-  L28:
+  L13:
     load_var _34
     load_field .raw_body
     store_var raw
-    jump L32
+    jump L17
 
-  L29:
+  L14:
     load_var _32
     load_field .raw_body
     store_var raw
-    jump L32
+    jump L17
 
-  L30:
+  L15:
     load_var _30
     load_field .raw_body
     store_var raw
-    jump L32
+    jump L17
 
-  L31:
+  L16:
     load_var _28
     load_field .raw_body
     store_var raw
 
-  L32:
+  L17:
     load_var client_name
-    store_var_load_var _37
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L33
+    jump_if_not_null_or_pop L18
     load_var provider
-    store_var _37
 
-  L33:
-    load_var _37
+  L18:
     store_var _36
     load_var provider
-    store_var _39
+    store_var _38
     load_var status
-    store_var _42
-    load_var _42
-    narrow_bind int, slot=25
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
-    load_const null
     store_var _41
-    jump L36
+    load_var _41
+    narrow_bind int, slot=24
+    pop_jump_if_true L19
+    load_const null
+    store_var _40
+    jump L20
 
-  L35:
-    load_var _42
+  L19:
+    load_var _41
     load_type string
     load_type string
     alloc_map 0
     load_var raw
     init_instance ai.events.HttpResponse .status, .headers, .body
-    store_var _41
+    store_var _40
 
-  L36:
-    load_var2 21 23
+  L20:
+    load_var2 21 22
     load_const null
     load_const null
     load_const null
     init_instance ai.events.Timing .start_time_utc_ms, .duration_ms, .ttft_ms
     load_const null
-    load_var _41
+    load_var _40
     load_const null
     load_const false
     load_const null
@@ -3463,53 +3101,41 @@ function ai.clients.default_retry_judgment(f: ai.errors.Failure) -> bool {
     store_var _2
     load_var _2
     narrow_bind ai.errors.Refused, slot=2
-    pop_jump_if_false L0
-    jump L7
-
-  L0:
+    pop_jump_if_true L3
     load_var f
     store_var _3
     load_var _3
     narrow_bind ai.errors.InvalidRequest, slot=3
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var f
     store_var _4
     load_var _4
     narrow_bind ai.errors.ParseFailed, slot=4
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L1
     load_var f
     store_var _5
     load_var _5
     narrow_bind ai.errors.FinishReasonError, slot=5
-    pop_jump_if_false L3
+    pop_jump_if_true L0
+    load_const true
+    jump L4
+
+  L0:
+    load_const false
+    jump L4
+
+  L1:
+    load_const false
+    jump L4
+
+  L2:
+    load_const false
     jump L4
 
   L3:
-    load_const true
-    jump L8
+    load_const false
 
   L4:
-    load_const false
-    jump L8
-
-  L5:
-    load_const false
-    jump L8
-
-  L6:
-    load_const false
-    jump L8
-
-  L7:
-    load_const false
-
-  L8:
     return
 }
 
@@ -3518,22 +3144,16 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
     store_var _2
     load_var _2
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var selector
     store_var _5
     load_var _5
     narrow_bind baml.env.Ref, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var selector
-    jump L6
+    jump L3
 
-  L2:
+  L0:
     load_var _5
     store_var named
     load_var named
@@ -3541,10 +3161,7 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
     store_var _8
     load_var _8
     narrow_bind string, slot=5
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_type string
     load_var named
     load_field .name
@@ -3580,16 +3197,16 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L4:
+  L1:
     load_var _8
     call ai.internal._from_shorthand
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_var _2
     call ai.internal._from_shorthand
 
-  L6:
+  L3:
     return
 }
 
@@ -3601,41 +3218,32 @@ function ai.content.Media.kind(self: ai.content.Media) -> string {
     store_var _3
     load_var _3
     narrow_bind baml.media.Image, slot=3
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L2
     load_var _2
     store_var _4
     load_var _4
     narrow_bind baml.media.Audio, slot=4
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var _2
     store_var _5
     load_var _5
     narrow_bind baml.media.Video, slot=5
-    pop_jump_if_false L2
+    pop_jump_if_true L0
+    load_const "pdf"
+    jump L3
+
+  L0:
+    load_const "video"
+    jump L3
+
+  L1:
+    load_const "audio"
     jump L3
 
   L2:
-    load_const "pdf"
-    jump L6
-
-  L3:
-    load_const "video"
-    jump L6
-
-  L4:
-    load_const "audio"
-    jump L6
-
-  L5:
     load_const "image"
 
-  L6:
+  L3:
     return
 }
 
@@ -3783,27 +3391,15 @@ function ai.errors.classify_http(provider: string, status_code: int, body: strin
     load_var status_code
     load_const 429
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L2
     load_var status_code
     load_const 408
     cmp_int_op ==
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    pop_jump_if_true L1
     load_var status_code
     load_const 500
     cmp_int_op >=
-
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_type int
     load_var status_code
     call baml.String.from
@@ -3814,9 +3410,9 @@ function ai.errors.classify_http(provider: string, status_code: int, body: strin
     bin_op +
     load_var body
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
-    jump L7
+    jump L3
 
-  L5:
+  L1:
     load_type int
     load_var status_code
     call baml.String.from
@@ -3827,9 +3423,9 @@ function ai.errors.classify_http(provider: string, status_code: int, body: strin
     bin_op +
     load_var2 2 3
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
-    jump L7
+    jump L3
 
-  L6:
+  L2:
     load_var headers
     call ai.internal._retry_after_ms
     store_var _7
@@ -3837,7 +3433,7 @@ function ai.errors.classify_http(provider: string, status_code: int, body: strin
     load_var2 2 3
     init_instance ai.errors.RateLimited .provider, .retry_after_ms, .status_code, .raw_body
 
-  L7:
+  L3:
     return
 }
 
@@ -3846,179 +3442,146 @@ function ai.errors.normalize(error: ai.errors.Failure | baml.errors.Timeout | ba
     store_var _2
     load_var _2
     narrow_bind ai.errors.Failure, slot=2
-    pop_jump_if_false L0
-    jump L21
-
-  L0:
+    pop_jump_if_true L10
     load_var error
     store_var _4
     load_var _4
     narrow_bind baml.errors.UnknownError, slot=3
-    pop_jump_if_false L1
-    jump L20
-
-  L1:
+    pop_jump_if_true L9
     load_var error
     store_var _8
     load_var _8
     narrow_bind baml.errors.Timeout, slot=4
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
+    pop_jump_if_true L8
     load_var error
     store_var _10
     load_var _10
     narrow_bind reflect.errors.CompilationError, slot=5
-    pop_jump_if_false L3
-    jump L18
-
-  L3:
+    pop_jump_if_true L7
     load_var error
     store_var _12
     load_var _12
     narrow_bind baml.errors.InvalidArgument, slot=6
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
+    pop_jump_if_true L6
     load_var error
     store_var _15
     load_var _15
     narrow_bind baml.errors.ParseError, slot=7
-    pop_jump_if_false L5
-    jump L16
-
-  L5:
+    pop_jump_if_true L5
     load_var error
     store_var _18
     load_var _18
     narrow_bind baml.json.SerializationError, slot=8
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
+    pop_jump_if_true L4
     load_var error
     store_var _21
     load_var _21
     narrow_bind baml.errors.AccessError, slot=9
-    pop_jump_if_false L7
-    jump L14
-
-  L7:
+    pop_jump_if_true L3
     load_var error
     store_var _24
     load_var _24
     narrow_bind baml.errors.Unsupported, slot=10
-    pop_jump_if_false L8
-    jump L13
-
-  L8:
+    pop_jump_if_true L2
     load_var error
     store_var _27
     load_var _27
     narrow_bind baml.errors.Io, slot=11
-    pop_jump_if_false L9
-    jump L12
-
-  L9:
+    pop_jump_if_true L1
     load_var error
     store_var _30
     load_var _30
     narrow_bind baml.json.ParseError, slot=12
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L0
     load_const "client"
     load_var error
     load_field .message
     load_const null
     load_const null
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
-    jump L22
+    jump L11
 
-  L11:
+  L0:
     load_const "client"
     load_var _30
     load_field .message
     load_const null
     load_const null
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
-    jump L22
+    jump L11
 
-  L12:
+  L1:
     load_const "client"
     load_var _27
     load_field .message
     load_const null
     load_const null
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
-    jump L22
+    jump L11
 
-  L13:
+  L2:
     load_const "client"
     load_const null
     load_var _24
     load_field .message
     load_const null
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
-    jump L22
+    jump L11
 
-  L14:
+  L3:
     load_const "client"
     load_const null
     load_var _21
     load_field .message
     load_const null
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
-    jump L22
+    jump L11
 
-  L15:
+  L4:
     load_const "client"
     load_const null
     load_var _18
     load_field .message
     load_const null
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
-    jump L22
+    jump L11
 
-  L16:
+  L5:
     load_const "client"
     load_const null
     load_var _15
     load_field .message
     load_const null
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
-    jump L22
+    jump L11
 
-  L17:
+  L6:
     load_const "client"
     load_const null
     load_var _12
     load_field .message
     load_const null
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
-    jump L22
+    jump L11
 
-  L18:
+  L7:
     load_var _10
-    jump L22
+    jump L11
 
-  L19:
+  L8:
     load_var _8
-    jump L22
+    jump L11
 
-  L20:
+  L9:
     load_type ai.errors.Failure
     load_var _4
     call baml.errors.UnknownError.from
-    jump L22
+    jump L11
 
-  L21:
+  L10:
     load_var _2
 
-  L22:
+  L11:
     return
 }
 
@@ -4036,21 +3599,18 @@ function ai.events.guard(listener: ((ai.events.RunStarted | ai.events.UserMessag
     store_var _2
     load_var _2
     narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws #0, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_var _2
     store_deref ?3
     load_type #0
     load_var cb
     make_closure .<lambda(guard, 0)>, captures=1, ntypeargs=1
 
-  L2:
+  L1:
     return
 }
 
@@ -4158,17 +3718,14 @@ function ai.internal._configured(value: string) -> string | null {
     call baml.String.trim
     load_const ""
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var value
     jump L1
 
   L0:
-    load_var value
-    jump L2
-
-  L1:
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -4187,10 +3744,7 @@ function ai.internal._flush_orphaned_calls(out: (ai.events.RunStarted | ai.event
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 1 4
     load_const "No result provided"
@@ -4199,7 +3753,7 @@ function ai.internal._flush_orphaned_calls(out: (ai.events.RunStarted | ai.event
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_type string
     load_var pending
     call baml.Array.clear
@@ -4215,10 +3769,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     store_var _3
     load_var _3
     narrow_bind int, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type string
     load_var shorthand
     call baml.String.from
@@ -4242,7 +3793,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L1:
+  L0:
     load_var _3
     store_var index
     load_var shorthand
@@ -4263,80 +3814,44 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     store_var model
     load_var prefix
     is_type "openai"
-    pop_jump_if_false L2
-    jump L25
-
-  L2:
+    pop_jump_if_true L12
     load_var prefix
     is_type "openai-chat"
-    pop_jump_if_false L3
-    jump L24
-
-  L3:
+    pop_jump_if_true L11
     load_var prefix
     is_type "openai-images"
-    pop_jump_if_false L4
-    jump L23
-
-  L4:
+    pop_jump_if_true L10
     load_var prefix
     is_type "azure"
-    pop_jump_if_false L5
-    jump L22
-
-  L5:
+    pop_jump_if_true L9
     load_var prefix
     is_type "ollama"
-    pop_jump_if_false L6
-    jump L21
-
-  L6:
+    pop_jump_if_true L8
     load_var prefix
     is_type "openrouter"
-    pop_jump_if_false L7
-    jump L20
-
-  L7:
+    pop_jump_if_true L7
     load_var prefix
     is_type "anthropic"
-    pop_jump_if_false L8
-    jump L19
-
-  L8:
+    pop_jump_if_true L6
     load_var prefix
     is_type "google"
-    pop_jump_if_false L9
-    jump L18
-
-  L9:
+    pop_jump_if_true L5
     load_var prefix
     is_type "vertex"
-    pop_jump_if_false L10
-    jump L17
-
-  L10:
+    pop_jump_if_true L4
     load_var prefix
     is_type "bedrock"
-    pop_jump_if_false L11
-    jump L16
-
-  L11:
+    pop_jump_if_true L3
     load_var prefix
     is_type "ai-gateway-images"
-    pop_jump_if_false L12
-    jump L15
-
-  L12:
+    pop_jump_if_true L2
     load_var prefix
     is_type "claude-code"
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
+    pop_jump_if_true L1
     load_const null
-    jump L26
+    jump L13
 
-  L14:
+  L1:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4346,9 +3861,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call claude_code.ClaudeCodeClient.new
-    jump L26
+    jump L13
 
-  L15:
+  L2:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4361,9 +3876,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call vercel.AiGatewayImageClient.new
-    jump L26
+    jump L13
 
-  L16:
+  L3:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4384,9 +3899,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call aws.BedrockClient.new
-    jump L26
+    jump L13
 
-  L17:
+  L4:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4408,9 +3923,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call google.VertexClient.new
-    jump L26
+    jump L13
 
-  L18:
+  L5:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4426,9 +3941,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call google.GeminiClient.new
-    jump L26
+    jump L13
 
-  L19:
+  L6:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4446,9 +3961,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call anthropic.Client.new
-    jump L26
+    jump L13
 
-  L20:
+  L7:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4462,9 +3977,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call openai.OpenRouterClient.new
-    jump L26
+    jump L13
 
-  L21:
+  L8:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4478,9 +3993,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call openai.OllamaClient.new
-    jump L26
+    jump L13
 
-  L22:
+  L9:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4498,9 +4013,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call openai.AzureClient.new
-    jump L26
+    jump L13
 
-  L23:
+  L10:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4519,9 +4034,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call openai.ImageClient.new
-    jump L26
+    jump L13
 
-  L24:
+  L11:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4538,9 +4053,9 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     load_const <omitted>
     call openai.ChatClient.new
-    jump L26
+    jump L13
 
-  L25:
+  L12:
     load_var model
     load_const <omitted>
     load_const <omitted>
@@ -4560,14 +4075,11 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     load_const <omitted>
     call openai.ResponsesClient.new
 
-  L26:
+  L13:
     store_var _36
     load_var _36
     narrow_bind ai.Client, slot=8
-    pop_jump_if_false L27
-    jump L28
-
-  L27:
+    pop_jump_if_true L14
     load_type string
     load_var prefix
     call baml.String.from
@@ -4609,7 +4121,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     init_instance ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body
     throw
 
-  L28:
+  L14:
     load_var _36
     return
 }
@@ -4628,18 +4140,13 @@ function ai.internal._header(headers: map<string, string>, lower: string, canoni
     load_type string
     load_var2 1 2
     call baml.Map.get
-    store_var_load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_type string
     load_type string
     load_var2 1 3
     call baml.Map.get
-    store_var _4
 
   L0:
-    load_var _4
     return
 }
 
@@ -4650,43 +4157,39 @@ function ai.internal._int_header(headers: map<string, string>, lower: string, ca
     store_var _5
     load_var _5
     narrow_bind string, slot=4
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var _5
     call baml.String.trim
     call baml.Int.parse
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.ParseError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const null
 
-  L2:
+  L1:
     store_var _11
     load_var _11
     narrow_bind int, slot=6
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var _11
     store_var_load_var value
     load_const 0
     cmp_int_op >=
-    pop_jump_if_false L3
+    pop_jump_if_true L3
+
+  L2:
+    load_const null
     jump L4
 
   L3:
-    load_const null
-    jump L5
-
-  L4:
     load_var value
 
-  L5:
+  L4:
     return
 }
 
@@ -4705,32 +4208,17 @@ function ai.internal._media_all_text(items: baml.json.json[]) -> bool {
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
     is_type string
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L0
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
 
   L2:
-    load_const false
-    jump L4
-
-  L3:
-    load_const true
-
-  L4:
-    unary_op !
-    pop_jump_if_false L0
-    load_const false
-    jump L6
-
-  L5:
-    load_const true
-
-  L6:
     return
 }
 
@@ -4772,10 +4260,7 @@ function ai.internal._media_join_text(items: baml.json.json[]) -> baml.json.json
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _4
     store_var _8
     load_var _8
@@ -4786,7 +4271,7 @@ function ai.internal._media_join_text(items: baml.json.json[]) -> baml.json.json
     store_var out
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -4796,261 +4281,189 @@ function ai.internal._media_mime_type(explicit: string | null, source_value: str
     store_var _4
     load_var _4
     narrow_bind string, slot=4
-    pop_jump_if_false L0
-    jump L45
-
-  L0:
+    pop_jump_if_true L21
     load_var source_value
     call baml.String.to_lower_case
     store_var source
     load_var source
     load_const ".jpg"
     call baml.String.includes
-    jump_if_false L1
-    jump L2
-
-  L1:
-    pop 1
+    pop_jump_if_true L20
     load_var source
     load_const ".jpeg"
     call baml.String.includes
-
-  L2:
-    pop_jump_if_false L3
-    jump L44
-
-  L3:
+    pop_jump_if_true L20
     load_var source
     load_const ".png"
     call baml.String.includes
-    pop_jump_if_false L4
-    jump L43
-
-  L4:
+    pop_jump_if_true L19
     load_var source
     load_const ".webp"
     call baml.String.includes
-    pop_jump_if_false L5
-    jump L42
-
-  L5:
+    pop_jump_if_true L18
     load_var source
     load_const ".gif"
     call baml.String.includes
-    pop_jump_if_false L6
-    jump L41
-
-  L6:
+    pop_jump_if_true L17
     load_var source
     load_const ".svg"
     call baml.String.includes
-    pop_jump_if_false L7
-    jump L40
-
-  L7:
+    pop_jump_if_true L16
     load_var source
     load_const ".wav"
     call baml.String.includes
-    pop_jump_if_false L8
-    jump L39
-
-  L8:
+    pop_jump_if_true L15
     load_var source
     load_const ".mp3"
     call baml.String.includes
-    pop_jump_if_false L9
-    jump L38
-
-  L9:
+    pop_jump_if_true L14
     load_var source
     load_const ".flac"
     call baml.String.includes
-    pop_jump_if_false L10
-    jump L37
-
-  L10:
+    pop_jump_if_true L13
     load_var source
     load_const ".ogg"
     call baml.String.includes
-    pop_jump_if_false L11
-    jump L36
-
-  L11:
+    pop_jump_if_true L12
     load_var source
     load_const ".webm"
     call baml.String.includes
-    pop_jump_if_false L12
-    jump L33
-
-  L12:
+    pop_jump_if_true L10
     load_var source
     load_const ".mov"
     call baml.String.includes
-    pop_jump_if_false L13
-    jump L32
-
-  L13:
+    pop_jump_if_true L9
     load_var source
     load_const ".mp4"
     call baml.String.includes
-    pop_jump_if_false L14
-    jump L29
-
-  L14:
+    pop_jump_if_true L7
     load_var source
     load_const ".avi"
     call baml.String.includes
-    pop_jump_if_false L15
-    jump L28
-
-  L15:
+    pop_jump_if_true L6
     load_var source
     load_const ".mkv"
     call baml.String.includes
-    pop_jump_if_false L16
-    jump L25
-
-  L16:
+    pop_jump_if_true L4
     load_var source
     load_const ".pdf"
     call baml.String.includes
-    pop_jump_if_false L17
-    jump L24
-
-  L17:
+    pop_jump_if_true L3
     load_var kind
     load_const "audio"
     cmp_op ==
-    pop_jump_if_false L18
-    jump L23
-
-  L18:
+    pop_jump_if_true L2
     load_var kind
     load_const "video"
     cmp_op ==
-    pop_jump_if_false L19
-    jump L22
-
-  L19:
+    pop_jump_if_true L1
     load_var kind
     load_const "pdf"
     cmp_op ==
-    pop_jump_if_false L20
-    jump L21
+    pop_jump_if_true L0
+    load_const "image/png"
+    jump L22
+
+  L0:
+    load_const "application/pdf"
+    jump L22
+
+  L1:
+    load_const "video/mp4"
+    jump L22
+
+  L2:
+    load_const "audio/mpeg"
+    jump L22
+
+  L3:
+    load_const "application/pdf"
+    jump L22
+
+  L4:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_true L5
+    load_const "video/x-matroska"
+    jump L22
+
+  L5:
+    load_const "audio/x-matroska"
+    jump L22
+
+  L6:
+    load_const "video/x-msvideo"
+    jump L22
+
+  L7:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_true L8
+    load_const "video/mp4"
+    jump L22
+
+  L8:
+    load_const "audio/mp4"
+    jump L22
+
+  L9:
+    load_const "video/quicktime"
+    jump L22
+
+  L10:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_true L11
+    load_const "video/webm"
+    jump L22
+
+  L11:
+    load_const "audio/webm"
+    jump L22
+
+  L12:
+    load_const "audio/ogg"
+    jump L22
+
+  L13:
+    load_const "audio/flac"
+    jump L22
+
+  L14:
+    load_const "audio/mpeg"
+    jump L22
+
+  L15:
+    load_const "audio/wav"
+    jump L22
+
+  L16:
+    load_const "image/svg+xml"
+    jump L22
+
+  L17:
+    load_const "image/gif"
+    jump L22
+
+  L18:
+    load_const "image/webp"
+    jump L22
+
+  L19:
+    load_const "image/png"
+    jump L22
 
   L20:
-    load_const "image/png"
-    jump L46
+    load_const "image/jpeg"
+    jump L22
 
   L21:
-    load_const "application/pdf"
-    jump L46
-
-  L22:
-    load_const "video/mp4"
-    jump L46
-
-  L23:
-    load_const "audio/mpeg"
-    jump L46
-
-  L24:
-    load_const "application/pdf"
-    jump L46
-
-  L25:
-    load_var kind
-    load_const "audio"
-    cmp_op ==
-    pop_jump_if_false L26
-    jump L27
-
-  L26:
-    load_const "video/x-matroska"
-    jump L46
-
-  L27:
-    load_const "audio/x-matroska"
-    jump L46
-
-  L28:
-    load_const "video/x-msvideo"
-    jump L46
-
-  L29:
-    load_var kind
-    load_const "audio"
-    cmp_op ==
-    pop_jump_if_false L30
-    jump L31
-
-  L30:
-    load_const "video/mp4"
-    jump L46
-
-  L31:
-    load_const "audio/mp4"
-    jump L46
-
-  L32:
-    load_const "video/quicktime"
-    jump L46
-
-  L33:
-    load_var kind
-    load_const "audio"
-    cmp_op ==
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
-    load_const "video/webm"
-    jump L46
-
-  L35:
-    load_const "audio/webm"
-    jump L46
-
-  L36:
-    load_const "audio/ogg"
-    jump L46
-
-  L37:
-    load_const "audio/flac"
-    jump L46
-
-  L38:
-    load_const "audio/mpeg"
-    jump L46
-
-  L39:
-    load_const "audio/wav"
-    jump L46
-
-  L40:
-    load_const "image/svg+xml"
-    jump L46
-
-  L41:
-    load_const "image/gif"
-    jump L46
-
-  L42:
-    load_const "image/webp"
-    jump L46
-
-  L43:
-    load_const "image/png"
-    jump L46
-
-  L44:
-    load_const "image/jpeg"
-    jump L46
-
-  L45:
     load_var _4
 
-  L46:
+  L22:
     return
 }
 
@@ -5073,20 +4486,14 @@ function ai.internal._media_mixed_parts(turn: ai.ModelTurn) -> baml.json.json[] 
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _5
     store_var b
     load_var b
     store_var _9
     load_var _9
     narrow_bind ai.content.Text, slot=6
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var b
     store_var _17
     load_var _17
@@ -5108,7 +4515,7 @@ function ai.internal._media_mixed_parts(turn: ai.ModelTurn) -> baml.json.json[] 
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_var _9
     store_var_load_var t
     load_field .text
@@ -5123,7 +4530,7 @@ function ai.internal._media_mixed_parts(turn: ai.ModelTurn) -> baml.json.json[] 
     pop 1
     jump L0
 
-  L4:
+  L2:
     load_var items
     return
 }
@@ -5147,10 +4554,7 @@ function ai.internal._media_of_kind(turn: ai.ModelTurn, kind: string) -> baml.js
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _6
     store_var _10
     load_var _10
@@ -5172,7 +4576,7 @@ function ai.internal._media_of_kind(turn: ai.ModelTurn, kind: string) -> baml.js
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var out
     return
 }
@@ -5195,20 +4599,14 @@ function ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provi
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _7
     store_var b
     load_var b
     store_var _11
     load_var _11
     narrow_bind ai.content.Media, slot=8
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var b
     store_var _16
     load_var _16
@@ -5226,7 +4624,7 @@ function ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provi
     store_var unexpected
     jump L0
 
-  L3:
+  L1:
     load_var _11
     call ai.content.Media.kind
     load_var kind
@@ -5238,18 +4636,15 @@ function ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provi
     store_var unexpected
     jump L0
 
-  L4:
+  L2:
     load_var unexpected
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_const null
     return
 
-  L6:
+  L3:
     load_type string
     load_var kind
     call baml.String.from
@@ -5284,157 +4679,106 @@ function ai.internal._media_shape(t: reflect.Type) -> string {
     load_var t
     load_type image
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L27
-
-  L0:
+    pop_jump_if_true L10
     load_var t
     load_type audio
     call baml.ops.equals_equals
-    pop_jump_if_false L1
-    jump L26
-
-  L1:
+    pop_jump_if_true L9
     load_var t
     load_type video
     call baml.ops.equals_equals
-    pop_jump_if_false L2
-    jump L25
-
-  L2:
+    pop_jump_if_true L8
     load_var t
     load_type pdf
     call baml.ops.equals_equals
-    pop_jump_if_false L3
-    jump L24
-
-  L3:
+    pop_jump_if_true L7
     load_var t
     load_type image | null
     call baml.ops.equals_equals
-    pop_jump_if_false L4
-    jump L23
-
-  L4:
+    pop_jump_if_true L6
     load_var t
     load_type audio | null
     call baml.ops.equals_equals
-    pop_jump_if_false L5
-    jump L22
-
-  L5:
+    pop_jump_if_true L5
     load_var t
     load_type video | null
     call baml.ops.equals_equals
-    pop_jump_if_false L6
-    jump L21
-
-  L6:
+    pop_jump_if_true L4
     load_var t
     load_type pdf | null
     call baml.ops.equals_equals
-    pop_jump_if_false L7
-    jump L20
-
-  L7:
+    pop_jump_if_true L3
     load_var t
     load_type image[]
     call baml.ops.equals_equals
-    jump_if_false L8
-    jump L9
-
-  L8:
-    pop 1
+    pop_jump_if_true L2
     load_var t
     load_type image[] | null
     call baml.ops.equals_equals
-
-  L9:
-    pop_jump_if_false L10
-    jump L19
-
-  L10:
+    pop_jump_if_true L2
     load_var t
     load_type (string | image)[]
     call baml.ops.equals_equals
-    jump_if_false L11
-    jump L12
-
-  L11:
-    pop 1
+    pop_jump_if_true L1
     load_var t
     load_type (string | image)[] | null
     call baml.ops.equals_equals
-
-  L12:
-    pop_jump_if_false L13
-    jump L18
-
-  L13:
+    pop_jump_if_true L1
     load_var t
     load_type string | image
     call baml.ops.equals_equals
-    jump_if_false L14
-    jump L15
-
-  L14:
-    pop 1
+    pop_jump_if_true L0
     load_var t
     load_type string | image | null
     call baml.ops.equals_equals
-
-  L15:
-    pop_jump_if_false L16
-    jump L17
-
-  L16:
+    pop_jump_if_true L0
     load_const ""
-    jump L28
+    jump L11
 
-  L17:
+  L0:
     load_const "mixed:image"
-    jump L28
+    jump L11
 
-  L18:
+  L1:
     load_const "mixedlist:image"
-    jump L28
+    jump L11
 
-  L19:
+  L2:
     load_const "list:image"
-    jump L28
+    jump L11
 
-  L20:
+  L3:
     load_const "opt:pdf"
-    jump L28
+    jump L11
 
-  L21:
+  L4:
     load_const "opt:video"
-    jump L28
+    jump L11
 
-  L22:
+  L5:
     load_const "opt:audio"
-    jump L28
+    jump L11
 
-  L23:
+  L6:
     load_const "opt:image"
-    jump L28
+    jump L11
 
-  L24:
+  L7:
     load_const "one:pdf"
-    jump L28
+    jump L11
 
-  L25:
+  L8:
     load_const "one:video"
-    jump L28
+    jump L11
 
-  L26:
+  L9:
     load_const "one:audio"
-    jump L28
+    jump L11
 
-  L27:
+  L10:
     load_const "one:image"
 
-  L28:
+  L11:
     return
 }
 
@@ -5443,14 +4787,11 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     store_var _3
     load_var _3
     narrow_bind map<string, baml.json.json>, slot=3
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_var patch
+    jump L6
 
   L0:
-    load_var patch
-    jump L10
-
-  L1:
     load_var _3
     store_var patch_object
     load_type string
@@ -5461,7 +4802,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     store_var _6
     load_var _6
     narrow_bind map<string, baml.json.json>, slot=6
-    pop_jump_if_false L4
+    pop_jump_if_false L2
     load_var _6
     store_var base_object
     load_type string
@@ -5473,7 +4814,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
-  L2:
+  L1:
     load_var _11
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -5481,10 +4822,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _12
     store_var key
     load_type string
@@ -5498,9 +4836,9 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     load_var _18
     call baml.Map.set
     pop 1
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_type string
     load_type baml.json.json
     load_var patch_object
@@ -5510,7 +4848,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     virtual_call nargs=1 ntypeargs=0
     store_var _27
 
-  L5:
+  L3:
     load_var _27
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -5518,10 +4856,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     store_var _28
     load_var _28
     is_type baml.iter.Done
-    pop_jump_if_false L6
-    jump L9
-
-  L6:
+    pop_jump_if_true L5
     load_var _28
     store_var key
     load_type string
@@ -5532,10 +4867,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     load_var value
     load_const null
     cmp_op ==
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
+    pop_jump_if_true L4
     load_type string
     load_type baml.json.json
     load_var2 5 14
@@ -5549,20 +4881,20 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
     load_var _43
     call baml.Map.set
     pop 1
-    jump L5
+    jump L3
 
-  L8:
+  L4:
     load_type string
     load_type baml.json.json
     load_var2 5 14
     call baml.Map.delete
     pop 1
-    jump L5
+    jump L3
 
-  L9:
+  L5:
     load_var out
 
-  L10:
+  L6:
     return
 }
 
@@ -5585,31 +4917,17 @@ function ai.internal._redact_after(text: string, marker: string) -> string {
     store_var rest
 
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_var out
-    jump L4
-
-  L2:
     load_var2 4 2
     call baml.String.index_of
     store_var _6
     load_var _6
     narrow_bind int, slot=5
-    pop_jump_if_false L3
-    jump L5
-
-  L3:
+    pop_jump_if_true L1
     load_var2 3 4
     bin_op +
-
-  L4:
     return
 
-  L5:
+  L1:
     load_var _6
     store_var _9
     load_var marker
@@ -5676,10 +4994,7 @@ function ai.internal._redact_value_end(tail: string) -> int {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 4
     call baml.String.index_of
     store_var _11
@@ -5695,7 +5010,7 @@ function ai.internal._redact_value_end(tail: string) -> int {
     store_var cut
     jump L0
 
-  L2:
+  L1:
     load_var cut
     return
 }
@@ -5705,236 +5020,191 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     store_var _6
     load_var _6
     narrow_bind string, slot=6
-    pop_jump_if_false L0
-    jump L24
-
-  L0:
+    pop_jump_if_true L13
     load_var inline
     load_const ""
     cmp_op !=
-    pop_jump_if_false L1
-    jump L23
-
-  L1:
+    pop_jump_if_true L12
     load_var url
     store_var _40
     load_var _40
-    narrow_bind string, slot=19
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    narrow_bind string, slot=18
+    pop_jump_if_true L0
     load_const "media has no URL, file, or base64 content"
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L3:
+  L0:
     load_var _40
     store_var media_url
     load_var media_url
     load_const "data:"
     call baml.String.starts_with
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
+    pop_jump_if_true L8
     load_var fetch_url
-    unary_op !
-    jump_if_false L5
-    jump L6
-
-  L5:
-    pop 1
+    pop_jump_if_false L7
     load_var media_url
     load_const "gs://"
     call baml.String.starts_with
-
-  L6:
-    pop_jump_if_false L7
-    jump L16
-
-  L7:
+    pop_jump_if_true L7
     load_const 30
     call baml.time.Duration.from_seconds
-    store_var _69
-    load_var2 20 32
+    store_var _68
+    load_var2 19 29
     call baml.http.fetch
     store_var response
-    jump L10
+    jump L2
     load_var e
-    store_var _70
-    load_var _70
-    narrow_bind baml.errors.Timeout, slot=33
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    store_var _69
+    load_var _69
+    narrow_bind baml.errors.Timeout, slot=30
+    pop_jump_if_true L1
     load_var e
     throw_if_panic
     load_type string
     load_var media_url
     call baml.String.from
-    store_var _76
+    store_var _75
     load_type baml.errors.Io
     load_var e
     call baml.String.from
-    store_var _80
-    load_type string
-    load_var _80
-    call baml.String.from
     store_var _79
+    load_type string
+    load_var _79
+    call baml.String.from
+    store_var _78
     load_const "media"
     load_const "media URL "
-    load_var _76
+    load_var _75
     bin_op +
     load_const " could not be fetched: "
     bin_op +
-    load_var _79
+    load_var _78
     bin_op +
     load_const null
     load_const null
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L9:
-    load_var _70
+  L1:
+    load_var _69
     throw
 
-  L10:
+  L2:
     load_var response
     call baml.http.Response.ok
-    unary_op !
-    pop_jump_if_false L11
-    jump L15
+    pop_jump_if_true L3
+    load_type string
+    load_var media_url
+    call baml.String.from
+    store_var _87
+    load_type int
+    load_var response
+    load_field .status_code
+    call baml.String.from
+    store_var _90
+    load_const "media"
+    load_const "media URL "
+    load_var _87
+    bin_op +
+    load_const " returned HTTP "
+    bin_op +
+    load_var _90
+    bin_op +
+    load_const null
+    load_const null
+    init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
+    throw
 
-  L11:
+  L3:
     load_type string
     load_type string
     load_var response
     load_field .headers
     load_const "content-type"
     call baml.Map.get
-    store_var_load_var _96
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L12
+    jump_if_not_null_or_pop L4
     load_var mime
-    store_var _96
 
-  L12:
-    load_var _96
+  L4:
     store_var response_mime
     load_var response
     sys_op baml.http.Response.bytes
-    jump L13
+    jump L5
     load_var e
     throw_if_panic
     load_type string
     load_var media_url
     call baml.String.from
-    store_var _108
+    store_var _105
     load_type baml.errors.Io | baml.errors.Timeout
     load_var e
     call baml.String.from
-    store_var _112
+    store_var _109
     load_type string
-    load_var _112
+    load_var _109
     call baml.String.from
-    store_var _111
+    store_var _108
     load_const "media"
     load_const "media URL "
-    load_var _108
+    load_var _105
     bin_op +
     load_const " body could not be read: "
     bin_op +
-    load_var _111
+    load_var _108
     bin_op +
     load_const null
     load_const null
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L13:
+  L5:
     call baml.Uint8Array.to_base64
-    store_var _115
+    store_var _112
     load_var response_mime
     load_const ";"
     call baml.String.split
-    store_var _120
+    store_var _117
     load_type string
-    load_var _120
+    load_var _117
     load_const 0
     call baml.Array.at
-    store_var_load_var _118
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L14
+    jump_if_not_null_or_pop L6
     load_var mime
-    store_var _118
 
-  L14:
-    load_var _118
+  L6:
     call baml.String.trim
-    store_var _116
+    store_var _113
     load_const null
-    load_var2 45 46
+    load_var2 41 42
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
-    jump L27
+    jump L16
 
-  L15:
-    load_type string
-    load_var media_url
-    call baml.String.from
-    store_var _89
-    load_type int
-    load_var response
-    load_field .status_code
-    call baml.String.from
-    store_var _92
-    load_const "media"
-    load_const "media URL "
-    load_var _89
-    bin_op +
-    load_const " returned HTTP "
-    bin_op +
-    load_var _92
-    bin_op +
-    load_const null
-    load_const null
-    init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
-    throw
-
-  L16:
+  L7:
     load_var media_url
     load_const null
     load_var mime
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
-    jump L27
+    jump L16
 
-  L17:
+  L8:
     load_var media_url
     load_const ";base64,"
     call baml.String.index_of
     store_var _44
     load_var _44
-    narrow_bind int, slot=21
-    pop_jump_if_false L18
-    jump L22
-
-  L18:
+    narrow_bind int, slot=20
+    pop_jump_if_true L11
     load_var media_url
     call baml.String.length
     load_const 48
     cmp_int_op >
-    pop_jump_if_false L19
-    jump L20
-
-  L19:
+    pop_jump_if_true L9
     load_var media_url
     store_var preview
-    jump L21
+    jump L10
 
-  L20:
+  L9:
     load_var media_url
     load_const 0
     load_const 48
@@ -5947,7 +5217,7 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     bin_op +
     store_var preview
 
-  L21:
+  L10:
     load_type string
     load_var preview
     call baml.String.from
@@ -5958,7 +5228,7 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L22:
+  L11:
     load_var _44
     store_var_load_var separator
     load_const 8
@@ -5967,33 +5237,30 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     load_var media_url
     call baml.String.length
     store_var _49
-    load_var2 20 24
+    load_const null
+    load_var2 19 22
     load_var _49
     call baml.String.slice
-    store_var _46
     load_var media_url
     load_const 5
     load_var separator
     call baml.String.slice
-    store_var _50
-    load_const null
-    load_var2 23 26
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
-    jump L27
+    jump L16
 
-  L23:
+  L12:
     load_const null
     load_var2 3 4
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
-    jump L27
+    jump L16
 
-  L24:
+  L13:
     load_var _6
     store_var_load_var path
     load_const "r"
     sys_op baml.fs.open
     store_var handle
-    jump L25
+    jump L14
     load_var e
     throw_if_panic
     load_type string
@@ -6018,16 +5285,14 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L25:
+  L14:
     load_var handle
     load_type baml.io.Read
     load_const "bytes"
     virtual_call nargs=1 ntypeargs=0
-    store_var _24
-    load_var _24
     call baml.Uint8Array.to_base64
     store_var data
-    jump L26
+    jump L15
     load_var e
     throw_if_panic
     load_var handle
@@ -6055,7 +5320,7 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L26:
+  L15:
     load_var handle
     sys_op baml.fs.File.close
     pop 1
@@ -6063,7 +5328,7 @@ function ai.internal._resolve_media_content(url: string | null, file: string | n
     load_var2 13 4
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
 
-  L27:
+  L16:
     return
 }
 
@@ -6072,63 +5337,48 @@ function ai.internal._resolve_media_preview_content(url: string | null, file: st
     store_var _5
     load_var _5
     narrow_bind string, slot=5
-    pop_jump_if_false L0
-    jump L10
-
-  L0:
+    pop_jump_if_true L5
     load_var inline
     load_const ""
     cmp_op !=
-    pop_jump_if_false L1
-    jump L8
-
-  L1:
+    pop_jump_if_true L3
     load_var url
     store_var _13
     load_var _13
     narrow_bind string, slot=7
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L0
     load_const "media-preview"
     load_const "request preview received media without inline data, a file, or a URL"
     init_instance ai.errors.PreviewUnsupported .provider, .detail
     throw
 
-  L3:
+  L0:
     load_var _13
     store_var media_url
     load_var media_url
     load_const "data:"
     call baml.String.starts_with
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_var media_url
     load_const null
     load_var mime
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
-    jump L9
+    jump L4
 
-  L5:
+  L1:
     load_var media_url
     load_const ";base64,"
     call baml.String.index_of
     store_var _17
     load_var _17
     narrow_bind int, slot=9
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L2
     load_const "media-preview"
     load_const "request preview cannot represent a non-base64 data URL"
     init_instance ai.errors.PreviewUnsupported .provider, .detail
     throw
 
-  L7:
+  L2:
     load_var _17
     store_var_load_var separator
     load_const 8
@@ -6137,29 +5387,26 @@ function ai.internal._resolve_media_preview_content(url: string | null, file: st
     load_var media_url
     call baml.String.length
     store_var _22
-    load_var2 8 12
+    load_const null
+    load_var2 8 11
     load_var _22
     call baml.String.slice
-    store_var _19
     load_var media_url
     load_const 5
     load_var separator
     call baml.String.slice
-    store_var _23
-    load_const null
-    load_var2 11 14
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
-    jump L9
+    jump L4
 
-  L8:
+  L3:
     load_const null
     load_var2 3 4
     init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
 
-  L9:
+  L4:
     return
 
-  L10:
+  L5:
     load_type string
     load_var _5
     call baml.String.from
@@ -6179,21 +5426,18 @@ function ai.internal._resolve_pending_call(pending: string[], id: string) -> voi
     store_var _5
     load_var _5
     narrow_bind int, slot=3
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_type string
     load_var2 1 3
     call baml.Array.remove_at
     pop 1
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -6202,7 +5446,7 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
     store_var _2
     load_var _2
     narrow_bind map<string, string>, slot=2
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var _2
     store_var_load_var h
     load_const "retry-after-ms"
@@ -6211,10 +5455,7 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
     store_var _6
     load_var _6
     narrow_bind int, slot=4
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L2
     load_var h
     load_const "retry-after"
     load_const "Retry-After"
@@ -6222,23 +5463,22 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
     store_var _10
     load_var _10
     narrow_bind int, slot=5
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+
+  L0:
+    load_const null
+    jump L3
 
   L1:
-    load_const null
-    jump L4
-
-  L2:
     load_var _10
     load_const 1000
     mul_int
-    jump L4
+    jump L3
 
-  L3:
+  L2:
     load_var _6
 
-  L4:
+  L3:
     return
 }
 
@@ -6268,10 +5508,7 @@ function ai.internal._schema_for_signature(handler: reflect.AnyFunction<Returns 
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _7
     store_var a
     load_var a
@@ -6294,7 +5531,7 @@ function ai.internal._schema_for_signature(handler: reflect.AnyFunction<Returns 
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_const "object"
     load_var2 3 4
     load_const false
@@ -6347,28 +5584,19 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L3
     load_var _5
     store_var block
     load_var block
     store_var _9
     load_var _9
     narrow_bind ai.content.Text, slot=7
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L2
     load_var block
     store_var _17
     load_var _17
     narrow_bind ai.content.Reasoning, slot=9
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var block
     store_var _22
     load_var _22
@@ -6380,7 +5608,7 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     pop 1
     jump L0
 
-  L4:
+  L1:
     load_var _17
     store_var reasoning
     load_var keep_reasoning
@@ -6391,7 +5619,7 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     pop 1
     jump L0
 
-  L5:
+  L2:
     load_var _9
     store_var_load_var text
     load_field .text
@@ -6405,7 +5633,7 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     pop 1
     jump L0
 
-  L6:
+  L3:
     load_var out
     return
 }
@@ -6424,49 +5652,37 @@ function ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> 
     store_var _7
     load_var2 5 6
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L16
-
-  L1:
+    pop_jump_if_true L10
     load_var first_role
     load_const 0
     cmp_int_op <
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L2
     load_var first_role
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var parts
     load_const 0
     load_array_element
     call baml.String.trim
     load_const ""
     cmp_op !=
-    jump L6
+    jump L3
 
-  L4:
+  L1:
     load_const true
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const true
 
-  L6:
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
+  L3:
+    pop_jump_if_true L4
     load_var2 1 2
     call ai.internal.assemble_prompt
-    jump L15
+    jump L9
 
-  L8:
+  L4:
     load_const ""
     load_type string
     alloc_array 1
@@ -6477,7 +5693,7 @@ function ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> 
     virtual_call nargs=1 ntypeargs=0
     store_var _28
 
-  L9:
+  L5:
     load_var _28
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -6485,17 +5701,14 @@ function ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> 
     store_var _29
     load_var _29
     is_type baml.iter.Done
-    pop_jump_if_false L10
-    jump L11
-
-  L10:
+    pop_jump_if_true L6
     load_type string
-    load_var2 7 9
+    load_var2 8 10
     call baml.Array.push
     pop 1
-    jump L9
+    jump L5
 
-  L11:
+  L6:
     load_const "system"
     load_const "1"
     load_const "__baml_synthetic_role"
@@ -6512,7 +5725,7 @@ function ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> 
     virtual_call nargs=1 ntypeargs=0
     store_var _38
 
-  L12:
+  L7:
     load_var _38
     load_type baml.iter.Iterator<Error = never, Item = unknown>
     load_const "next"
@@ -6520,48 +5733,35 @@ function ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> 
     store_var _39
     load_var _39
     is_type baml.iter.Done
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
+    pop_jump_if_true L8
     load_type unknown
-    load_var2 10 12
+    load_var2 11 13
     call baml.Array.push
     pop 1
-    jump L12
+    jump L7
 
-  L14:
-    load_var2 7 10
+  L8:
+    load_var2 8 11
     call ai.internal.assemble_prompt
 
-  L15:
+  L9:
     return
 
-  L16:
+  L10:
     load_var first_role
     load_const 0
     cmp_int_op <
-    jump_if_false L19
-    pop 1
+    pop_jump_if_false L11
     load_var2 2 4
     load_array_element
     is_type ai.Role
-    pop_jump_if_false L17
-    jump L18
-
-  L17:
-    load_const false
-    jump L19
-
-  L18:
-    load_const true
-
-  L19:
-    pop_jump_if_false L20
+    store_var _10
+    load_var _10
+    pop_jump_if_false L11
     load_var i
     store_var first_role
 
-  L20:
+  L11:
     load_var i
     load_const 1
     add_int
@@ -6599,14 +5799,11 @@ function ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     store_var _4
     load_var _4
     narrow_bind reflect.enum.Type, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L3
-
-  L1:
     load_var _4
     call reflect.enum.Type.values
     container_len
@@ -6614,22 +5811,19 @@ function ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     load_var _7
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L4
-
-  L2:
+    pop_jump_if_true L2
     load_const null
 
-  L3:
+  L1:
     return
 
-  L4:
+  L2:
+    load_const "empty enum `"
     load_var return_type
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
-    load_const "empty enum `"
     load_var _11
     bin_op +
     load_const "` cannot be rendered as an LLM output schema"
@@ -6676,39 +5870,36 @@ function ai.mcp.Connection._request(self: ai.mcp.Connection, method: string, par
     load_deref ?1
     load_field .timeout_ms
     call baml.time.Duration.from_milliseconds
-    store_var _9
+    store_var _10
     load_type baml.json.json
     load_type ai.errors.InvalidRequest | ai.errors.NetworkFailure
     load_var2 7 1
     load_var2 4 2
     make_closure .<lambda(Connection._request, 0)>, 3
     call baml.future.with_timeout
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.Timeout
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_type string
     load_deref ?1
     load_field .server_name
     call baml.String.from
-    store_var _17
+    store_var _18
     load_type int
     load_deref ?1
     load_field .timeout_ms
     call baml.String.from
-    store_var _22
+    store_var _23
     load_const "mcp/"
-    load_var _17
+    load_var _18
     bin_op +
     load_const "reading from the MCP server timed out after "
-    load_var _22
+    load_var _23
     bin_op +
     load_const "ms"
     bin_op +
@@ -6717,7 +5908,7 @@ function ai.mcp.Connection._request(self: ai.mcp.Connection, method: string, par
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L2:
+  L1:
     return
 }
 
@@ -6803,10 +5994,7 @@ function ai.mcp.Connection.call_tool(self: ai.mcp.Connection, name: string, args
     store_var _13
     load_var _13
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _13
     store_var item
     load_type string
@@ -6829,7 +6017,7 @@ function ai.mcp.Connection.call_tool(self: ai.mcp.Connection, name: string, args
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_type string
     load_var texts
     load_const "\n"
@@ -6840,14 +6028,11 @@ function ai.mcp.Connection.call_tool(self: ai.mcp.Connection, name: string, args
     load_const ".isError"
     load_const false
     call baml.json.path_or
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var joined
     return
 
-  L4:
+  L2:
     load_type string
     load_var name
     call baml.String.from
@@ -6993,10 +6178,7 @@ function ai.mcp.Connection.tools(self: ai.mcp.Connection) -> ai.tools.Tool[] {
     store_var _10
     load_var _10
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L2
     load_var _10
     store_var t
     load_type string
@@ -7017,7 +6199,7 @@ function ai.mcp.Connection.tools(self: ai.mcp.Connection) -> ai.tools.Tool[] {
     load_var _19
     call baml.json.from_json
     store_var schema
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_type string
@@ -7025,7 +6207,7 @@ function ai.mcp.Connection.tools(self: ai.mcp.Connection) -> ai.tools.Tool[] {
     alloc_map 0
     store_var schema
 
-  L2:
+  L1:
     load_type string
     load_var t
     load_const ".description"
@@ -7048,7 +6230,7 @@ function ai.mcp.Connection.tools(self: ai.mcp.Connection) -> ai.tools.Tool[] {
     pop 1
     jump L0
 
-  L3:
+  L2:
     load_var out
     return
 }
@@ -7109,11 +6291,29 @@ function ai.stream.Stream.final(self: ai.stream.Stream<#0, #1>) -> #1 {
   L0:
     load_var self
     load_field ._finished
-    unary_op !
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L2
+    load_var self
+    load_field ._next_text
+    call_indirect
+    store_var _3
+    load_var _3
+    load_const null
+    cmp_op ==
+    pop_jump_if_true L1
+    load_var2 1 1
+    load_field ._text
+    load_var _3
+    bin_op +
+    store_field ._text
+    jump L0
 
   L1:
+    load_var self
+    load_const true
+    store_field ._finished
+    jump L0
+
+  L2:
     load_var self
     load_field ._cache
     load_var self
@@ -7122,51 +6322,13 @@ function ai.stream.Stream.final(self: ai.stream.Stream<#0, #1>) -> #1 {
     load_type #1
     sys_op baml.sap._ParseCache._parse_final
     return
-
-  L2:
-    load_var self
-    load_field ._next_text
-    call_indirect
-    store_var _4
-    load_var _4
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
-    load_var2 1 1
-    load_field ._text
-    load_var _4
-    bin_op +
-    store_field ._text
-    jump L0
-
-  L4:
-    load_var self
-    load_const true
-    store_field ._finished
-    jump L0
 }
 
 function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const "unreachable"
-    call baml.sys.panic
-    jump L8
-
-  L2:
     load_var self
     load_field ._finished
-    pop_jump_if_false L3
-    jump L7
-
-  L3:
+    pop_jump_if_true L2
     load_var self
     load_field ._next_text
     call_indirect
@@ -7174,10 +6336,7 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
     load_var _3
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L1
     load_var2 1 1
     load_field ._text
     load_var _3
@@ -7193,96 +6352,78 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
     store_var parsed
     load_var parsed
     is_type baml.sap._NoYield
-    pop_jump_if_false L5
-    jump L0
-
-  L5:
+    pop_jump_if_true L0
     load_var parsed
-    jump L8
+    jump L3
 
-  L6:
+  L1:
     load_var self
     load_const true
     store_field ._finished
     alloc_instance ai.stream.Done
-    jump L8
+    jump L3
 
-  L7:
+  L2:
     alloc_instance ai.stream.Done
 
-  L8:
+  L3:
     return
 }
 
 function ai.stream.TurnStream._capture_batch(self: ai.stream.TurnStream, batch: string) -> void {
     load_var self
     load_field ._capture_sse
-    unary_op !
-    pop_jump_if_false L0
-    jump L8
-
-  L0:
+    pop_jump_if_false L5
     load_var self
     load_field ._wire_call
-    store_var _6
-    load_var _6
+    store_var _5
+    load_var _5
     narrow_bind ai.events.LLMCall, slot=3
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const null
-    jump L8
+    jump L5
 
-  L2:
-    load_var _6
+  L0:
+    load_var _5
     store_var call
     load_var batch
     call ai.stream.decode_sse_batch
     store_var decoded
-    jump L3
+    jump L1
     load_var e
     throw_if_panic
     load_type ai.stream.SseEvent
     alloc_array 0
     store_var decoded
 
-  L3:
+  L1:
     load_var call
     load_field .sse_responses
-    store_var_load_var _12
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L2
     load_type ai.events.SseEventRecord
     alloc_array 0
-    store_var _12
 
-  L4:
-    load_var _12
+  L2:
     store_var records
     load_var decoded
     load_type baml.iter.Iterable<Error = never, Item = ai.stream.SseEvent>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _16
+    store_var _14
 
-  L5:
-    load_var _16
+  L3:
+    load_var _14
     load_type baml.iter.Iterator<Error = never, Item = ai.stream.SseEvent>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _17
-    load_var _17
+    store_var _15
+    load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
-    load_var _17
+    pop_jump_if_true L4
+    load_var _15
     store_var e
     load_type ai.events.SseEventRecord
-    load_var2 7 11
+    load_var2 7 10
     load_field .event
     load_var e
     load_field .data
@@ -7291,14 +6432,14 @@ function ai.stream.TurnStream._capture_batch(self: ai.stream.TurnStream, batch: 
     init_instance ai.events.SseEventRecord .event, .data, .id
     call baml.Array.push
     pop 1
-    jump L5
+    jump L3
 
-  L7:
+  L4:
     load_var2 4 7
     store_field .sse_responses
     load_const null
 
-  L8:
+  L5:
     return
 }
 
@@ -7308,58 +6449,42 @@ function ai.stream.TurnStream._check_terminal(self: ai.stream.TurnStream) -> voi
     store_var _3
     load_var _3
     narrow_bind string, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const null
+    jump L4
 
   L0:
-    load_const null
-    jump L3
-
-  L1:
     load_var _3
     store_var provider
     load_var self
     load_field ._saw_terminal
-    unary_op !
-    pop_jump_if_false L2
-    jump L4
-
-  L2:
-    load_const null
-
-  L3:
-    return
-
-  L4:
+    pop_jump_if_true L3
     load_var self
     load_field ._text
     load_const ""
     cmp_op ==
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L1
     load_var self
     load_field ._text
     store_var partial
-    jump L7
+    jump L2
 
-  L6:
+  L1:
     load_const null
     store_var partial
 
-  L7:
+  L2:
     load_var self
     load_field ._text
     call baml.String.length
-    store_var _15
-    load_type int
-    load_var _15
-    call baml.String.from
     store_var _14
+    load_type int
+    load_var _14
+    call baml.String.from
+    store_var _13
     load_var provider
     load_const "stream ended before the provider's terminal event: the connection closed after "
-    load_var _14
+    load_var _13
     bin_op +
     load_const " characters of assistant text with no end-of-turn event, so the turn is truncated"
     bin_op +
@@ -7367,6 +6492,12 @@ function ai.stream.TurnStream._check_terminal(self: ai.stream.TurnStream) -> voi
     load_var partial
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
+
+  L3:
+    load_const null
+
+  L4:
+    return
 }
 
 function ai.stream.TurnStream._finish(self: ai.stream.TurnStream) -> void {
@@ -7378,20 +6509,17 @@ function ai.stream.TurnStream._finish(self: ai.stream.TurnStream) -> void {
     store_var _3
     load_var _3
     narrow_bind baml.http.SseStream, slot=2
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const null
     jump L1
 
   L0:
-    load_const null
-    jump L2
-
-  L1:
     load_var _3
     sys_op baml.http.SseStream.close
     pop 1
     load_const null
 
-  L2:
+  L1:
     return
 }
 
@@ -7401,77 +6529,59 @@ function ai.stream.TurnStream._stamp_first_delta(self: ai.stream.TurnStream) -> 
     store_var _3
     load_var _3
     narrow_bind ai.events.LLMCall, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const null
+    jump L4
 
   L0:
-    load_const null
-    jump L7
-
-  L1:
     load_var _3
     store_var_load_var call
     load_field .timing
     load_field .ttft_ms
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_const null
-    jump L7
+    jump L4
 
-  L3:
+  L1:
     load_var self
     load_field ._ttft_from
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L2
     load_var self
     load_field ._call_started
-    store_var _8
 
-  L4:
-    load_var _8
-    store_var _11
-    load_var _11
-    narrow_bind baml.time.Instant, slot=5
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+  L2:
+    store_var _10
+    load_var _10
+    narrow_bind baml.time.Instant, slot=4
+    pop_jump_if_true L3
     load_const null
-    jump L7
+    jump L4
 
-  L6:
-    load_var _11
+  L3:
+    load_var _10
     call baml.time.Instant.elapsed
     call baml.time.Duration.to_milliseconds
-    store_var _14
+    store_var _13
     load_var call
     load_field .timing
-    load_var _14
+    load_var _13
     store_field .ttft_ms
     load_const null
 
-  L7:
+  L4:
     return
 }
 
 function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.ModelTurn {
   L0:
-    load_const true
-    pop_jump_if_false L1
     load_var self
     call ai.stream.TurnStream.next
     store_var _3
     load_var _3
     narrow_bind ai.stream.Done, slot=2
     pop_jump_if_false L0
-
-  L1:
     load_var self
     call ai.stream.TurnStream._check_terminal
     pop 1
@@ -7480,94 +6590,88 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
     load_const null
     call baml.ops.equals_equals
     unary_op !
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    pop_jump_if_true L1
     load_var self
     load_field ._output_tokens
     load_const null
     call baml.ops.equals_equals
     unary_op !
-
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_const null
     store_var usage
-    jump L8
+    jump L6
 
-  L5:
+  L1:
     load_var self
     load_field ._input_tokens
-    store_var_load_var _13
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
+    jump_if_not_null_or_pop L2
     load_const 0
-    store_var _13
 
-  L6:
-    load_var _13
+  L2:
     store_var _12
     load_var self
     load_field ._output_tokens
-    store_var_load_var _17
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
-    load_const 0
-    store_var _17
+    jump_if_not_null_or_pop L3
+    jump L4
 
-  L7:
-    load_var2 4 6
+  L3:
+    store_var _16
+    jump L5
+
+  L4:
+    load_const 0
+    store_var _16
+
+  L5:
+    load_var2 4 5
     load_const null
     load_const null
     init_instance ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens
     store_var usage
 
-  L8:
+  L6:
     load_var self
     load_field ._wire_call
-    store_var _21
-    load_var _21
-    narrow_bind ai.events.LLMCall, slot=7
-    pop_jump_if_false L9
-    load_var _21
+    store_var _19
+    load_var _19
+    narrow_bind ai.events.LLMCall, slot=6
+    pop_jump_if_false L7
+    load_var _19
     store_var_load_var call
     load_field .timing
     load_field .duration_ms
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L9
+    pop_jump_if_false L7
     load_var self
     load_field ._call_started
-    store_var _26
-    load_var _26
-    narrow_bind baml.time.Instant, slot=9
-    pop_jump_if_false L9
-    load_var _26
+    store_var _24
+    load_var _24
+    narrow_bind baml.time.Instant, slot=8
+    pop_jump_if_false L7
+    load_var _24
     call baml.time.Instant.elapsed
     call baml.time.Duration.to_milliseconds
-    store_var _29
+    store_var _27
     load_var call
     load_field .timing
-    load_var _29
+    load_var _27
     store_field .duration_ms
 
-  L9:
+  L7:
     load_var self
     load_field ._stop_reason
-    store_var_load_var _34
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L10
+    jump_if_not_null_or_pop L8
+    jump L9
+
+  L8:
+    store_var _32
+    jump L10
+
+  L9:
     load_const ai.content.StopReason.Complete
     alloc_variant ai.content.StopReason
-    store_var _34
+    store_var _32
 
   L10:
     load_var self
@@ -7575,7 +6679,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
     init_instance ai.content.Text .text
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
     alloc_array 1
-    load_var2 11 3
+    load_var2 10 3
     load_var self
     load_field ._calls
     init_instance ai.ModelTurn .content, .stop_reason, .usage, .calls
@@ -7675,22 +6779,11 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     store_var ready
 
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const "unreachable"
-    call baml.sys.panic
-    jump L31
-
-  L2:
     load_var self
     load_field ._done
-    pop_jump_if_false L3
-    jump L30
+    pop_jump_if_true L15
 
-  L3:
+  L1:
     load_var self
     load_field ._pcursor
     store_var _5
@@ -7700,38 +6793,26 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     store_var _6
     load_var2 3 4
     cmp_int_op <
-    pop_jump_if_false L4
-    jump L21
-
-  L4:
+    pop_jump_if_true L9
     load_var ready
     container_len
     store_var _40
     load_var _40
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L5
-    jump L20
-
-  L5:
+    pop_jump_if_true L8
     load_var self
     load_field ._event_source
     store_var _42
     load_var _42
     narrow_bind () -> ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone | ai.stream.Done throws ai.errors.Failure | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError, slot=18
-    pop_jump_if_false L6
-    jump L15
-
-  L6:
+    pop_jump_if_true L6
     load_var self
     load_field ._sse
     store_var _55
     load_var _55
     narrow_bind baml.http.SseStream, slot=21
-    pop_jump_if_false L7
-    jump L10
-
-  L7:
+    pop_jump_if_true L3
     load_type string
     load_var self
     load_field ._chunks
@@ -7741,17 +6822,14 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     store_var _83
     load_var _83
     narrow_bind string, slot=27
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    pop_jump_if_true L2
     load_var self
     call ai.stream.TurnStream._finish
     pop 1
     alloc_instance ai.stream.Done
-    jump L31
+    jump L16
 
-  L9:
+  L2:
     load_var _83
     store_var c
     load_var self
@@ -7779,19 +6857,16 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     load_var c
     load_type string
     alloc_array 1
-    jump L31
+    jump L16
 
-  L10:
+  L3:
     load_var _55
     sys_op baml.http.SseStream.next
     store_var _57
     load_var _57
     load_const null
     cmp_op ==
-    pop_jump_if_false L11
-    jump L14
-
-  L11:
+    pop_jump_if_true L5
     load_var _57
     store_var batch
     load_var2 1 23
@@ -7810,7 +6885,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     virtual_call nargs=1 ntypeargs=0
     store_var _70
 
-  L12:
+  L4:
     load_var _70
     load_type baml.iter.Iterator<Error = never, Item = ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta>
     load_const "next"
@@ -7818,19 +6893,16 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     store_var _71
     load_var _71
     is_type baml.iter.Done
-    pop_jump_if_false L13
-    jump L0
-
-  L13:
+    pop_jump_if_true L0
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
     load_var self
     load_field ._pending
     load_var _71
     call baml.Array.push
     pop 1
-    jump L12
+    jump L4
 
-  L14:
+  L5:
     load_var self
     call ai.stream.TurnStream._finish
     pop 1
@@ -7838,9 +6910,9 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     call ai.stream.TurnStream._check_terminal
     pop 1
     alloc_instance ai.stream.Done
-    jump L31
+    jump L16
 
-  L15:
+  L6:
     load_var _42
     call_indirect
     store_var _44
@@ -7848,29 +6920,20 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     store_var _46
     load_var _46
     narrow_bind ai.stream.TextDelta, slot=20
-    pop_jump_if_false L16
-    jump L19
-
-  L16:
+    pop_jump_if_true L7
     load_var _46
     narrow_bind ai.stream.TurnMeta, slot=20
-    pop_jump_if_false L17
-    jump L19
-
-  L17:
+    pop_jump_if_true L7
     load_var _46
     narrow_bind ai.stream.TurnDone, slot=20
-    pop_jump_if_false L18
-    jump L19
-
-  L18:
+    pop_jump_if_true L7
     load_var self
     call ai.stream.TurnStream._finish
     pop 1
     load_var _44
-    jump L31
+    jump L16
 
-  L19:
+  L7:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
     load_var self
     load_field ._pending
@@ -7879,11 +6942,11 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     pop 1
     jump L0
 
-  L20:
+  L8:
     load_var ready
-    jump L31
+    jump L16
 
-  L21:
+  L9:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
     load_var self
     load_field ._pending
@@ -7901,23 +6964,17 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     store_var _12
     load_var _12
     narrow_bind ai.stream.TextDelta, slot=6
-    pop_jump_if_false L22
-    jump L29
-
-  L22:
+    pop_jump_if_true L14
     load_var e
     store_var _24
     load_var _24
     narrow_bind ai.stream.TurnMeta, slot=10
-    pop_jump_if_false L23
-    jump L26
-
-  L23:
+    pop_jump_if_true L11
     load_var e
     store_var _35
     load_var _35
     narrow_bind ai.stream.TurnDone, slot=15
-    pop_jump_if_false L3
+    pop_jump_if_false L1
     load_var self
     load_const true
     store_field ._saw_terminal
@@ -7930,50 +6987,47 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     load_var _38
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L24
-    jump L25
-
-  L24:
+    pop_jump_if_true L10
     alloc_instance ai.stream.Done
-    jump L31
+    jump L16
 
-  L25:
+  L10:
     load_var ready
-    jump L31
+    jump L16
 
-  L26:
+  L11:
     load_var _24
     store_var_load_var m
     load_field .stop_reason
     store_var _27
     load_var _27
     narrow_bind ai.content.StopReason, slot=12
-    pop_jump_if_false L27
+    pop_jump_if_false L12
     load_var2 1 12
     store_field ._stop_reason
 
-  L27:
+  L12:
     load_var m
     load_field .input_tokens
     store_var _30
     load_var _30
     narrow_bind int, slot=13
-    pop_jump_if_false L28
+    pop_jump_if_false L13
     load_var2 1 13
     store_field ._input_tokens
 
-  L28:
+  L13:
     load_var m
     load_field .output_tokens
     store_var _33
     load_var _33
     narrow_bind int, slot=14
-    pop_jump_if_false L3
+    pop_jump_if_false L1
     load_var2 1 14
     store_field ._output_tokens
-    jump L3
+    jump L1
 
-  L29:
+  L14:
     load_var _12
     store_var d
     load_var self
@@ -7998,12 +7052,12 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string[] | ai.
     load_field .text
     call baml.Array.push
     pop 1
-    jump L3
+    jump L1
 
-  L30:
+  L15:
     alloc_instance ai.stream.Done
 
-  L31:
+  L16:
     return
 }
 
@@ -8015,18 +7069,18 @@ function ai.stream.decode_sse_batch(batch: string) -> ai.stream.SseEvent[] {
 }
 
 function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.StreamingClient | null, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never) | null) -> ai.stream.Stream<#0, #1> {
+    load_var ?9
+    make_cell
+    store_var ?9
     load_var ?10
     make_cell
     store_var ?10
     load_var ?11
     make_cell
     store_var ?11
-    load_var ?12
+    load_var ?14
     make_cell
-    store_var ?12
-    load_var ?15
-    make_cell
-    store_var ?15
+    store_var ?14
     load_var client
     load_const <omitted>
     cmp_op ==
@@ -8047,66 +7101,71 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
     load_var spec
     call ai.FunctionSpec.tools
     call ai.tools.Toolbox.is_empty
-    unary_op !
-    pop_jump_if_false L2
-    jump L9
+    pop_jump_if_true L2
+    load_type #1
+    load_var spec
+    call ai.FunctionSpec.name
+    store_var _13
+    load_type string
+    load_var _13
+    call baml.String.from
+    store_var _12
+    load_const "streaming does not run the tool loop yet: "
+    load_var _12
+    bin_op +
+    load_const " has a non-empty toolbox"
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
 
   L2:
     load_var client
-    store_var _18
-    load_var _18
+    store_var _17
+    load_var client
     narrow_bind ai.stream.StreamingClient, slot=7
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L4
     load_var spec
     load_field .default_client
-    store_var _21
-    load_var _21
+    store_var _20
+    load_var _20
     narrow_bind ai.stream.StreamingClient, slot=8
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var spec
     load_field .default_client
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _24
-    load_var _24
     init_instance ai.errors.StreamingUnsupported .client_id
     throw
 
+  L3:
+    load_var _20
+    store_var selected
+    jump L5
+
+  L4:
+    load_var _17
+    store_var selected
+
   L5:
-    load_var _21
-    store_var selected
-    jump L7
-
-  L6:
-    load_var _18
-    store_var selected
-
-  L7:
     load_var selected
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_deref ?10
+    store_deref ?9
     load_type unknown
     load_var on_event
     call ai.events.guard
-    store_deref ?11
+    store_deref ?10
     load_const false
-    store_deref ?12
-    load_deref ?11
-    store_var _31
-    load_var _31
-    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never, slot=13
-    pop_jump_if_false L8
-    load_var _31
-    store_var _34
+    store_deref ?11
+    load_deref ?10
+    store_var _30
+    load_var _30
+    narrow_bind (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never, slot=12
+    pop_jump_if_false L6
+    load_var _30
+    store_var _33
     load_type #1
     load_var spec
     call ai.FunctionSpec.name
@@ -8114,67 +7173,50 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
     load_var spec
     call ai.FunctionSpec.arguments
     init_instance ai.events.RunStarted .spec_name, .arguments
-    load_var _34
+    load_var _33
     call_indirect
     pop 1
 
-  L8:
+  L6:
     load_var spec
     load_field .prompt_template
-    store_var _42
+    store_var _41
     load_type #1
     load_var spec
     call ai.Journal.new
-    store_var _43
+    store_var _42
     load_type #1
     load_var spec
     call ai.FunctionSpec.tools
-    store_var _45
+    store_var _44
     load_type #1
     load_var spec
     call ai.FunctionSpec.output_type
-    store_var _47
-    load_var2 6 16
-    load_var2 17 18
-    load_var _47
+    store_var _46
+    load_var2 6 15
+    load_var2 16 17
+    load_var _46
     init_instance ai.ModelTurnInput .prompt, .journal, .toolbox, .output_type
     load_type ai.stream.StreamingClient
     load_const "invoke_stream"
     virtual_call nargs=2 ntypeargs=0
-    store_deref ?15
+    store_deref ?14
     load_type #0
     load_type #1
     sys_op baml.sap._new_parse_cache
-    store_var _50
+    store_var _49
     load_type #0
     load_type #1
-    load_var2 15 12
-    load_var2 11 10
+    load_var2 14 11
+    load_var2 10 9
     make_closure .<lambda(from_spec, 0)>, captures=4, ntypeargs=2
-    load_var _50
+    load_var _49
     load_const ""
     load_const false
     load_type #0
     load_type #1
     init_instance<2> ai.stream.Stream ._next_text, ._cache, ._text, ._finished
     return
-
-  L9:
-    load_type #1
-    load_var spec
-    call ai.FunctionSpec.name
-    store_var _14
-    load_type string
-    load_var _14
-    call baml.String.from
-    store_var _13
-    load_const "streaming does not run the tool loop yet: "
-    load_var _13
-    bin_op +
-    load_const " has a non-empty toolbox"
-    bin_op +
-    init_instance baml.errors.InvalidArgument .message
-    throw
 }
 
 function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> string {
@@ -8183,19 +7225,13 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
     store_var _4
     load_var _4
     narrow_bind (map<string, unknown>) -> string throws unknown, slot=3
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_var self
     load_field .handler
     store_var _8
     load_var _8
     narrow_bind reflect.AnyFunction<Returns = unknown, Throws = unknown>, slot=4
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_type string
     load_var self
     load_field .name
@@ -8209,24 +7245,21 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L2:
+  L0:
     load_type unknown
     load_type unknown
     load_var2 4 2
     call reflect.call_any
-    jump L5
+    jump L2
     load_var e
     store_var _15
     load_var _15
     narrow_bind reflect.InvalidArgumentError, slot=6
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L4:
+  L1:
     load_var _15
     store_var bad
     load_type string
@@ -8252,16 +7285,16 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L5:
+  L2:
     call baml.json.to_json
     call baml.json.stringify
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_var2 2 3
     call_indirect
 
-  L7:
+  L4:
     return
 }
 
@@ -8314,20 +7347,14 @@ function ai.tools.Toolbox.new(tools: ai.tools.Tool[]) -> ai.tools.Toolbox {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_var _4
     store_var t
     load_type string
     load_var2 2 5
     load_field .name
     call baml.Array.includes
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type string
     load_var2 2 5
     load_field .name
@@ -8335,7 +7362,7 @@ function ai.tools.Toolbox.new(tools: ai.tools.Tool[]) -> ai.tools.Toolbox {
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_type string
     load_var t
     load_field .name
@@ -8347,7 +7374,7 @@ function ai.tools.Toolbox.new(tools: ai.tools.Tool[]) -> ai.tools.Toolbox {
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L4:
+  L2:
     load_var tools
     init_instance ai.tools.Toolbox .entries
     return
@@ -8365,10 +7392,7 @@ function ai.tools.raw_tool(name: string, description: string, input_schema: map<
     load_var name
     load_const "__baml_return_output"
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 1 2
     load_var input_schema
     load_const null
@@ -8376,7 +7400,7 @@ function ai.tools.raw_tool(name: string, description: string, input_schema: map<
     init_instance ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error
     return
 
-  L2:
+  L1:
     load_const "the tool name __baml_return_output is reserved"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -8411,68 +7435,45 @@ function ai.tools.tool(handler: reflect.AnyFunction<Returns = unknown, Throws = 
     call reflect.signature
     store_var sig
     load_var name
-    store_var_load_var _10
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L3
     load_var sig
     load_field .name
-    store_var _10
 
   L3:
-    load_var _10
-    store_var _12
-    load_var _12
-    narrow_bind string, slot=7
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    store_var _11
+    load_var _11
+    narrow_bind string, slot=6
+    pop_jump_if_true L4
     load_const "anonymous tool needs a name"
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L5:
-    load_var _12
+  L4:
+    load_var _11
     store_var_load_var n
     load_const "__baml_return_output"
     cmp_op ==
-    pop_jump_if_false L6
-    jump L9
-
-  L6:
+    pop_jump_if_true L6
     load_var description
-    store_var_load_var _21
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
+    jump_if_not_null_or_pop L5
     load_var sig
     load_field .docstring
-    store_var _21
-
-  L7:
-    load_var _21
-    store_var_load_var _19
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L8
+    jump_if_not_null_or_pop L5
     load_const ""
-    store_var _19
 
-  L8:
-    load_var _19
-    store_var _18
+  L5:
+    store_var _17
     load_var handler
     call ai.internal._schema_for_signature
-    store_var _24
-    load_var2 8 9
-    load_var2 12 1
+    store_var _21
+    load_var2 7 8
+    load_var2 9 1
     load_const null
     load_var on_error
     init_instance ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error
     return
 
-  L9:
+  L6:
     load_const "the tool name __baml_return_output is reserved"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -8511,20 +7512,17 @@ function ai.wire.credential_sources(cred: string | baml.env.Ref | null, canonica
     load_var _15
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L2
     load_type string
     load_var names
     load_const ", "
     call baml.Array.join
-    jump L4
+    jump L3
 
-  L3:
+  L2:
     load_const "(no environment variable was named)"
 
-  L4:
+  L3:
     return
 }
 
@@ -8532,18 +7530,15 @@ function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.j
     load_var overrides
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var2 1 2
+    call ai.internal._merge_json
     jump L1
 
   L0:
-    load_var2 1 2
-    call ai.internal._merge_json
-    jump L2
-
-  L1:
     load_var base
 
-  L2:
+  L1:
     return
 }
 
@@ -8569,10 +7564,7 @@ function ai.wire.redact_request_headers(headers: map<string, string>) -> map<str
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L16
-
-  L1:
+    pop_jump_if_true L3
     load_var _7
     store_var name
     load_var name
@@ -8581,87 +7573,50 @@ function ai.wire.redact_request_headers(headers: map<string, string>) -> map<str
     load_var lower
     load_const "authorization"
     cmp_op ==
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    jump_if_true_or_pop L1
     load_var lower
     load_const "proxy-authorization"
     cmp_op ==
-
-  L3:
-    jump_if_false L4
-    jump L5
-
-  L4:
-    pop 1
+    jump_if_true_or_pop L1
     load_var lower
     load_const "x-api-key"
     cmp_op ==
-
-  L5:
-    jump_if_false L6
-    jump L7
-
-  L6:
-    pop 1
+    jump_if_true_or_pop L1
     load_var lower
     load_const "api-key"
     cmp_op ==
-
-  L7:
-    jump_if_false L8
-    jump L9
-
-  L8:
-    pop 1
+    jump_if_true_or_pop L1
     load_var lower
     load_const "x-goog-api-key"
     cmp_op ==
-
-  L9:
-    jump_if_false L10
-    jump L11
-
-  L10:
-    pop 1
+    jump_if_true_or_pop L1
     load_var lower
     load_const "x-amz-security-token"
     cmp_op ==
-
-  L11:
-    jump_if_false L12
-    jump L13
-
-  L12:
-    pop 1
+    jump_if_true_or_pop L1
     load_var lower
     load_const "cookie"
     cmp_op ==
 
-  L13:
-    pop_jump_if_false L14
-    jump L15
-
-  L14:
+  L1:
+    pop_jump_if_true L2
     load_type string
     load_type string
     load_var2 1 5
     call baml.Map.get
-    store_var _35
-    load_var _35
+    store_var _41
+    load_var _41
     narrow_bind string, slot=7
     pop_jump_if_false L0
     load_type string
     load_type string
     load_var2 2 5
-    load_var _35
+    load_var _41
     call baml.Map.set
     pop 1
     jump L0
 
-  L15:
+  L2:
     load_type string
     load_type string
     load_var2 2 5
@@ -8670,7 +7625,7 @@ function ai.wire.redact_request_headers(headers: map<string, string>) -> map<str
     pop 1
     jump L0
 
-  L16:
+  L3:
     load_var out
     return
 }
@@ -8700,78 +7655,56 @@ function ai.wire.resolve_credential(cred: string | baml.env.Ref | null, env_fall
     store_var _4
     load_var _4
     narrow_bind string, slot=3
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_var cred
     store_var _7
     load_var _7
     narrow_bind baml.env.Ref, slot=4
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_const null
-    jump L5
+    jump L3
 
-  L2:
+  L0:
     load_var _7
     call baml.env.Ref.get
-    store_var_load_var _10
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L1
     load_const ""
-    store_var _10
 
-  L3:
-    load_var _10
+  L1:
     call ai.internal._configured
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_var _4
     call ai.internal._configured
 
-  L5:
-    store_var _13
-    load_var _13
+  L3:
+    store_var _12
+    load_var _12
+    narrow_bind string, slot=5
+    pop_jump_if_true L6
+    load_var env_fallback
+    store_var _14
+    load_var _14
     narrow_bind string, slot=6
-    pop_jump_if_false L6
-    jump L10
+    pop_jump_if_true L4
+    load_const null
+    jump L7
+
+  L4:
+    load_var _14
+    sys_op baml.env.get
+    jump_if_not_null_or_pop L5
+    load_const ""
+
+  L5:
+    call ai.internal._configured
+    jump L7
 
   L6:
-    load_var env_fallback
-    store_var _15
-    load_var _15
-    narrow_bind string, slot=7
-    pop_jump_if_false L7
-    jump L8
+    load_var _12
 
   L7:
-    load_const null
-    jump L11
-
-  L8:
-    load_var _15
-    sys_op baml.env.get
-    store_var_load_var _18
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L9
-    load_const ""
-    store_var _18
-
-  L9:
-    load_var _18
-    call ai.internal._configured
-    jump L11
-
-  L10:
-    load_var _13
-
-  L11:
     return
 }
 
@@ -8780,207 +7713,150 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
     store_var _3
     load_var _3
     narrow_bind baml.media.Image, slot=3
-    pop_jump_if_false L0
-    jump L11
-
-  L0:
+    pop_jump_if_true L5
     load_var media
-    store_var _18
-    load_var _18
-    narrow_bind baml.media.Audio, slot=12
-    pop_jump_if_false L1
-    jump L8
-
-  L1:
+    store_var _16
+    load_var _16
+    narrow_bind baml.media.Audio, slot=10
+    pop_jump_if_true L3
     load_var media
-    store_var _33
-    load_var _33
-    narrow_bind baml.media.Video, slot=21
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    store_var _29
+    load_var _29
+    narrow_bind baml.media.Video, slot=17
+    pop_jump_if_true L1
     load_var media
     call baml.media.Pdf.file
-    store_var_load_var _52
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L0
     load_var media
     call baml.media.Pdf.url
-    store_var _52
-
-  L3:
-    load_var _52
-    store_var_load_var _50
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _50
 
-  L4:
-    load_var _50
+  L0:
     store_var source
     load_var media
     call baml.media.Pdf.url
-    store_var _56
+    store_var _48
     load_var media
     call baml.media.Pdf.file
-    store_var _57
+    store_var _49
     load_var media
     call baml.media.Pdf.base64
-    store_var _58
+    store_var _50
     load_var media
     call baml.media.Pdf.mime_type
     load_var source
     load_const "pdf"
     call ai.internal._media_mime_type
-    store_var _59
-    load_var2 33 34
-    load_var2 35 36
+    store_var _51
+    load_var2 25 26
+    load_var2 27 28
     load_var fetch_url
     call ai.internal._resolve_media_content
-    jump L14
+    jump L7
 
-  L5:
-    load_var _33
+  L1:
+    load_var _29
     store_var video
     load_var video
     call baml.media.Video.file
-    store_var_load_var _38
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
+    jump_if_not_null_or_pop L2
     load_var video
     call baml.media.Video.url
-    store_var _38
-
-  L6:
-    load_var _38
-    store_var_load_var _36
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
+    jump_if_not_null_or_pop L2
     load_const ""
-    store_var _36
 
-  L7:
-    load_var _36
+  L2:
     store_var source
     load_var video
     call baml.media.Video.url
-    store_var _42
+    store_var _36
     load_var video
     call baml.media.Video.file
-    store_var _43
+    store_var _37
     load_var video
     call baml.media.Video.base64
-    store_var _44
+    store_var _38
     load_var video
     call baml.media.Video.mime_type
     load_var source
     load_const "video"
     call ai.internal._media_mime_type
-    store_var _45
-    load_var2 26 27
-    load_var2 28 29
+    store_var _39
+    load_var2 20 21
+    load_var2 22 23
     load_var fetch_url
     call ai.internal._resolve_media_content
-    jump L14
+    jump L7
 
-  L8:
-    load_var _18
+  L3:
+    load_var _16
     store_var audio
     load_var audio
     call baml.media.Audio.file
-    store_var_load_var _23
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L9
+    jump_if_not_null_or_pop L4
     load_var audio
     call baml.media.Audio.url
-    store_var _23
-
-  L9:
-    load_var _23
-    store_var_load_var _21
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L10
+    jump_if_not_null_or_pop L4
     load_const ""
-    store_var _21
 
-  L10:
-    load_var _21
+  L4:
     store_var source
     load_var audio
     call baml.media.Audio.url
-    store_var _27
+    store_var _23
     load_var audio
     call baml.media.Audio.file
-    store_var _28
+    store_var _24
     load_var audio
     call baml.media.Audio.base64
-    store_var _29
+    store_var _25
     load_var audio
     call baml.media.Audio.mime_type
     load_var source
     load_const "audio"
     call ai.internal._media_mime_type
-    store_var _30
-    load_var2 17 18
-    load_var2 19 20
+    store_var _26
+    load_var2 13 14
+    load_var2 15 16
     load_var fetch_url
     call ai.internal._resolve_media_content
-    jump L14
+    jump L7
 
-  L11:
+  L5:
     load_var _3
     store_var image
     load_var image
     call baml.media.Image.file
-    store_var_load_var _8
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L12
+    jump_if_not_null_or_pop L6
     load_var image
     call baml.media.Image.url
-    store_var _8
-
-  L12:
-    load_var _8
-    store_var_load_var _6
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L13
+    jump_if_not_null_or_pop L6
     load_const ""
-    store_var _6
 
-  L13:
-    load_var _6
+  L6:
     store_var source
     load_var image
     call baml.media.Image.url
-    store_var _12
+    store_var _10
     load_var image
     call baml.media.Image.file
-    store_var _13
+    store_var _11
     load_var image
     call baml.media.Image.base64
-    store_var _14
+    store_var _12
     load_var image
     call baml.media.Image.mime_type
     load_var source
     load_const "image"
     call ai.internal._media_mime_type
-    store_var _15
+    store_var _13
+    load_var2 6 7
     load_var2 8 9
-    load_var2 10 11
     load_var fetch_url
     call ai.internal._resolve_media_content
 
-  L14:
+  L7:
     return
 }
 
@@ -8989,203 +7865,146 @@ function ai.wire.resolve_media_preview(media: baml.media.Image | baml.media.Audi
     store_var _2
     load_var _2
     narrow_bind baml.media.Image, slot=2
-    pop_jump_if_false L0
-    jump L11
-
-  L0:
+    pop_jump_if_true L5
     load_var media
-    store_var _17
-    load_var _17
-    narrow_bind baml.media.Audio, slot=11
-    pop_jump_if_false L1
-    jump L8
-
-  L1:
+    store_var _15
+    load_var _15
+    narrow_bind baml.media.Audio, slot=9
+    pop_jump_if_true L3
     load_var media
-    store_var _32
-    load_var _32
-    narrow_bind baml.media.Video, slot=20
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    store_var _28
+    load_var _28
+    narrow_bind baml.media.Video, slot=16
+    pop_jump_if_true L1
     load_var media
     call baml.media.Pdf.file
-    store_var_load_var _51
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L0
     load_var media
     call baml.media.Pdf.url
-    store_var _51
-
-  L3:
-    load_var _51
-    store_var_load_var _49
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _49
 
-  L4:
-    load_var _49
+  L0:
     store_var source
     load_var media
     call baml.media.Pdf.url
-    store_var _55
+    store_var _47
     load_var media
     call baml.media.Pdf.file
-    store_var _56
+    store_var _48
     load_var media
     call baml.media.Pdf.base64
-    store_var _57
+    store_var _49
     load_var media
     call baml.media.Pdf.mime_type
     load_var source
     load_const "pdf"
     call ai.internal._media_mime_type
-    store_var _58
-    load_var2 32 33
-    load_var2 34 35
+    store_var _50
+    load_var2 24 25
+    load_var2 26 27
     call ai.internal._resolve_media_preview_content
-    jump L14
+    jump L7
 
-  L5:
-    load_var _32
+  L1:
+    load_var _28
     store_var video
     load_var video
     call baml.media.Video.file
-    store_var_load_var _37
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L6
+    jump_if_not_null_or_pop L2
     load_var video
     call baml.media.Video.url
-    store_var _37
-
-  L6:
-    load_var _37
-    store_var_load_var _35
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
+    jump_if_not_null_or_pop L2
     load_const ""
-    store_var _35
 
-  L7:
-    load_var _35
+  L2:
     store_var source
     load_var video
     call baml.media.Video.url
-    store_var _41
+    store_var _35
     load_var video
     call baml.media.Video.file
-    store_var _42
+    store_var _36
     load_var video
     call baml.media.Video.base64
-    store_var _43
+    store_var _37
     load_var video
     call baml.media.Video.mime_type
     load_var source
     load_const "video"
     call ai.internal._media_mime_type
-    store_var _44
-    load_var2 25 26
-    load_var2 27 28
+    store_var _38
+    load_var2 19 20
+    load_var2 21 22
     call ai.internal._resolve_media_preview_content
-    jump L14
+    jump L7
 
-  L8:
-    load_var _17
+  L3:
+    load_var _15
     store_var audio
     load_var audio
     call baml.media.Audio.file
-    store_var_load_var _22
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L9
+    jump_if_not_null_or_pop L4
     load_var audio
     call baml.media.Audio.url
-    store_var _22
-
-  L9:
-    load_var _22
-    store_var_load_var _20
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L10
+    jump_if_not_null_or_pop L4
     load_const ""
-    store_var _20
 
-  L10:
-    load_var _20
+  L4:
     store_var source
     load_var audio
     call baml.media.Audio.url
-    store_var _26
+    store_var _22
     load_var audio
     call baml.media.Audio.file
-    store_var _27
+    store_var _23
     load_var audio
     call baml.media.Audio.base64
-    store_var _28
+    store_var _24
     load_var audio
     call baml.media.Audio.mime_type
     load_var source
     load_const "audio"
     call ai.internal._media_mime_type
-    store_var _29
-    load_var2 16 17
-    load_var2 18 19
+    store_var _25
+    load_var2 12 13
+    load_var2 14 15
     call ai.internal._resolve_media_preview_content
-    jump L14
+    jump L7
 
-  L11:
+  L5:
     load_var _2
     store_var image
     load_var image
     call baml.media.Image.file
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L12
+    jump_if_not_null_or_pop L6
     load_var image
     call baml.media.Image.url
-    store_var _7
-
-  L12:
-    load_var _7
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L13
+    jump_if_not_null_or_pop L6
     load_const ""
-    store_var _5
 
-  L13:
-    load_var _5
+  L6:
     store_var source
     load_var image
     call baml.media.Image.url
-    store_var _11
+    store_var _9
     load_var image
     call baml.media.Image.file
-    store_var _12
+    store_var _10
     load_var image
     call baml.media.Image.base64
-    store_var _13
+    store_var _11
     load_var image
     call baml.media.Image.mime_type
     load_var source
     load_const "image"
     call ai.internal._media_mime_type
-    store_var _14
+    store_var _12
+    load_var2 5 6
     load_var2 7 8
-    load_var2 9 10
     call ai.internal._resolve_media_preview_content
 
-  L14:
+  L7:
     return
 }
 
@@ -9211,51 +8030,36 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L12
-
-  L1:
+    pop_jump_if_true L6
     load_var _7
     store_var event
     load_var event
     store_var _11
     load_var _11
     narrow_bind ai.events.AssistantMessage, slot=8
-    pop_jump_if_false L2
-    jump L9
-
-  L2:
+    pop_jump_if_true L4
     load_var event
     store_var _38
     load_var _38
     narrow_bind ai.events.UserMessage, slot=15
-    pop_jump_if_false L3
-    jump L8
-
-  L3:
+    pop_jump_if_true L3
     load_var event
     store_var _46
     load_var _46
     narrow_bind ai.events.ToolCompleted, slot=17
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L2
     load_var event
     store_var _54
     load_var _54
     narrow_bind ai.events.ToolFailed, slot=19
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L1
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     load_var2 3 7
     call baml.Array.push
     pop 1
     jump L0
 
-  L6:
+  L1:
     load_var _54
     store_var failed
     load_var2 4 20
@@ -9268,7 +8072,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     pop 1
     jump L0
 
-  L7:
+  L2:
     load_var _46
     store_var completed
     load_var2 4 18
@@ -9281,7 +8085,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     pop 1
     jump L0
 
-  L8:
+  L3:
     load_var _38
     store_var user
     load_var2 3 4
@@ -9293,7 +8097,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     pop 1
     jump L0
 
-  L9:
+  L4:
     load_var _11
     store_var assistant
     load_var2 3 4
@@ -9327,7 +8131,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     virtual_call nargs=1 ntypeargs=0
     store_var _28
 
-  L10:
+  L5:
     load_var _28
     load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>
     load_const "next"
@@ -9335,23 +8139,20 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
     store_var _29
     load_var _29
     is_type baml.iter.Done
-    pop_jump_if_false L11
-    jump L0
-
-  L11:
+    pop_jump_if_true L0
     load_var _29
     store_var _33
     load_var _33
     narrow_bind ai.content.ToolUse, slot=14
-    pop_jump_if_false L10
+    pop_jump_if_false L5
     load_type string
     load_var2 4 14
     load_field .id
     call baml.Array.push
     pop 1
-    jump L10
+    jump L5
 
-  L12:
+  L6:
     load_var2 3 4
     call ai.internal._flush_orphaned_calls
     pop 1
@@ -9371,34 +8172,28 @@ function ai.wire.send_as(req: baml.http.Request, provider: string, request_timeo
   L0:
     load_var request_timeout_ms
     store_var _6
-    load_var _6
+    load_var request_timeout_ms
     narrow_bind int, slot=5
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_const null
+    store_var timeout
     jump L2
 
   L1:
-    load_const null
-    store_var timeout
-    jump L3
-
-  L2:
     load_var _6
     call baml.time.Duration.from_milliseconds
     store_var timeout
 
-  L3:
+  L2:
     load_var2 1 4
     call baml.http.send
     store_var resp
-    jump L6
+    jump L4
     load_var e
     store_var _12
     load_var _12
     narrow_bind baml.errors.Timeout, slot=8
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var e
     throw_if_panic
     load_type baml.errors.InvalidArgument | baml.errors.Io
@@ -9419,23 +8214,20 @@ function ai.wire.send_as(req: baml.http.Request, provider: string, request_timeo
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L5:
+  L3:
     load_var _12
     throw
 
-  L6:
+  L4:
     load_var resp
     sys_op baml.http.Response.text
     store_var text
-    jump L9
+    jump L6
     load_var e
     store_var _23
     load_var _23
     narrow_bind baml.errors.Timeout, slot=13
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
+    pop_jump_if_true L5
     load_var e
     throw_if_panic
     load_var provider
@@ -9445,38 +8237,34 @@ function ai.wire.send_as(req: baml.http.Request, provider: string, request_timeo
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L8:
+  L5:
     load_var _23
     throw
 
-  L9:
+  L6:
     load_var resp
     call baml.http.Response.ok
-    unary_op !
-    pop_jump_if_false L10
-    jump L12
-
-  L10:
-    load_type #0
-    load_var text
-    call baml.json.from_string
-    jump L11
-    load_var e
-    throw_if_panic
-    load_var2 2 11
-    init_instance ai.errors.ParseFailed .provider, .raw_output
-    throw
-
-  L11:
-    return
-
-  L12:
+    pop_jump_if_true L7
     load_var2 2 6
     load_field .status_code
     load_var2 11 6
     load_field .headers
     call ai.errors.classify_http
     throw
+
+  L7:
+    load_type #0
+    load_var text
+    call baml.json.from_string
+    jump L8
+    load_var e
+    throw_if_panic
+    load_var2 2 11
+    init_instance ai.errors.ParseFailed .provider, .raw_output
+    throw
+
+  L8:
+    return
 }
 
 function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_name: string, capture_wire: bool, request_timeout_ms: int | null) -> ai.wire.SentAs<#0> {
@@ -9500,34 +8288,28 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
     store_var started
     load_var request_timeout_ms
     store_var _10
-    load_var _10
+    load_var request_timeout_ms
     narrow_bind int, slot=8
-    pop_jump_if_false L2
+    pop_jump_if_true L2
+    load_const null
+    store_var timeout
     jump L3
 
   L2:
-    load_const null
-    store_var timeout
-    jump L4
-
-  L3:
     load_var _10
     call baml.time.Duration.from_milliseconds
     store_var timeout
 
-  L4:
+  L3:
     load_var2 1 7
     call baml.http.send
     store_var resp
-    jump L7
+    jump L5
     load_var e
     store_var _16
     load_var _16
     narrow_bind baml.errors.Timeout, slot=11
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L4
     load_var e
     throw_if_panic
     load_type baml.errors.InvalidArgument | baml.errors.Io
@@ -9548,23 +8330,20 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L6:
+  L4:
     load_var _16
     throw
 
-  L7:
+  L5:
     load_var resp
     sys_op baml.http.Response.text
     store_var text
-    jump L10
+    jump L7
     load_var e
     store_var _27
     load_var _27
     narrow_bind baml.errors.Timeout, slot=16
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    pop_jump_if_true L6
     load_var e
     throw_if_panic
     load_var provider
@@ -9574,89 +8353,87 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
     init_instance ai.errors.NetworkFailure .provider, .detail, .status_code, .raw_body
     throw
 
-  L9:
+  L6:
     load_var _27
     throw
 
-  L10:
+  L7:
     load_var resp
     call baml.http.Response.ok
-    unary_op !
-    pop_jump_if_false L11
-    jump L19
+    pop_jump_if_true L8
+    load_var2 2 9
+    load_field .status_code
+    load_var2 14 9
+    load_field .headers
+    call ai.errors.classify_http
+    throw
 
-  L11:
+  L8:
     load_type #0
     load_var text
     call baml.json.from_string
     store_var value
-    jump L12
+    jump L9
     load_var e
     throw_if_panic
     load_var2 2 14
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
-  L12:
+  L9:
     load_var started
     call baml.time.Instant.to_timestamp_milliseconds
-    store_var _44
+    store_var _43
     load_var started
     call baml.time.Instant.elapsed
     call baml.time.Duration.to_milliseconds
-    store_var _45
+    store_var _44
     load_var capture_wire
-    pop_jump_if_false L13
-    jump L14
-
-  L13:
+    pop_jump_if_true L10
     load_const null
-    store_var _47
-    jump L15
+    store_var _46
+    jump L11
 
-  L14:
+  L10:
     load_var req
     load_field .method
-    store_var _48
+    store_var _47
     load_var req
     load_field .url
     call ai.wire.redact_url_secrets
-    store_var _49
+    store_var _48
     load_var req
     load_field .headers
     call ai.wire.redact_request_headers
-    store_var _51
+    store_var _50
     load_var2 22 23
     load_var2 24 1
     load_field .body
     init_instance baml.http.Request .method, .url, .headers, .body
-    store_var _47
+    store_var _46
 
-  L15:
+  L11:
     load_var resp
     load_field .status_code
-    store_var _55
+    store_var _54
     load_var resp
     load_field .headers
-    store_var _56
+    store_var _55
     load_var capture_wire
-    pop_jump_if_false L16
-    jump L17
-
-  L16:
+    pop_jump_if_true L12
     load_const null
-    store_var _57
-    jump L18
+    store_var _56
+    jump L13
 
-  L17:
+  L12:
     load_var text
     call ai.wire.redact_url_secrets
-    store_var _57
+    store_var _56
 
-  L18:
+  L13:
     load_var2 17 3
     load_var2 2 19
-    load_var _45
+    load_var _44
     load_const null
     init_instance ai.events.Timing .start_time_utc_ms, .duration_ms, .ttft_ms
     load_var2 21 25
@@ -9669,12 +8446,4 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
     load_type #0
     init_instance<1> ai.wire.SentAs .value, .call
     return
-
-  L19:
-    load_var2 2 9
-    load_field .status_code
-    load_var2 14 9
-    load_field .headers
-    call ai.errors.classify_http
-    throw
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
@@ -254,6 +254,7 @@ fn ai.clients.resolve(selector: string | baml.env.Ref | ai.Client) -> ai.Client 
     let _25: string
     let _26: reflect.Type
     let _27: ai.Client // existing
+    let _28: string
 
     bb0: {
         _2 = copy _1;
@@ -284,11 +285,12 @@ fn ai.clients.resolve(selector: string | baml.env.Ref | ai.Client) -> ai.Client 
     bb5: {
         _19 = copy _6.0;
         _20 = load_type(string);
+        _28 = const "client selector env.";
         _18 = call const fn baml.String.from<copy _20>(copy _19) -> [bb6];
     }
 
     bb6: {
-        _17 = const "client selector env." + copy _18;
+        _17 = copy _28 + copy _18;
         _16 = copy _17 + const " is not set: point it at a \"provider/model\" string (valid prefixes are ";
         _22 = call const fn ai.internal._shorthand_prefixes() -> [bb7];
     }
@@ -571,15 +573,14 @@ fn ai.clients._failed_leg_call(client_name: string | null, f: ai.errors.Failure)
     let _35: ai.errors.Refused // e
     let _36: string
     let _37: string
-    let _38: bool
-    let _39: string
-    let _40: ai.events.Timing
-    let _41: null | ai.events.HttpResponse
-    let _42: int | null
-    let _43: int // s
-    let _44: int
-    let _45: map<string, string>
-    let _46: string | null
+    let _38: string
+    let _39: ai.events.Timing
+    let _40: null | ai.events.HttpResponse
+    let _41: int | null
+    let _42: int // s
+    let _43: int
+    let _44: map<string, string>
+    let _45: string | null
 
     bb0: {
         _4 = copy _2;
@@ -762,9 +763,7 @@ fn ai.clients._failed_leg_call(client_name: string | null, f: ai.errors.Failure)
     }
 
     bb33: {
-        _37 = copy _1;
-        _38 = copy _37 == const null;
-        branch copy _38 -> [bb34, bb35];
+        _37 = short_circuit(??) copy _1 -> [eval: bb34, join: bb35];
     }
 
     bb34: {
@@ -774,28 +773,28 @@ fn ai.clients._failed_leg_call(client_name: string | null, f: ai.errors.Failure)
 
     bb35: {
         _36 = copy _37;
-        _39 = copy _3;
-        _40 = ai.events.Timing { const null, const null, const null };
-        _42 = copy _20;
-        _42 = narrow_bind copy _42 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb37, bb36];
+        _38 = copy _3;
+        _39 = ai.events.Timing { const null, const null, const null };
+        _41 = copy _20;
+        _41 = narrow_bind copy _41 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb37, bb36];
     }
 
     bb36: {
-        _41 = const null;
+        _40 = const null;
         goto -> bb38;
     }
 
     bb37: {
+        _42 = copy _41;
         _43 = copy _42;
-        _44 = copy _43;
-        _45 = {  }: map<string, string>;
-        _46 = copy _27;
-        _41 = ai.events.HttpResponse { copy _44, copy _45, copy _46 };
+        _44 = {  }: map<string, string>;
+        _45 = copy _27;
+        _40 = ai.events.HttpResponse { copy _43, copy _44, copy _45 };
         goto -> bb38;
     }
 
     bb38: {
-        _0 = ai.events.LLMCall { copy _36, copy _39, copy _40, const null, copy _41, const null, const false, const null };
+        _0 = ai.events.LLMCall { copy _36, copy _38, copy _39, const null, copy _40, const null, const false, const null };
         goto -> bb39;
     }
 
@@ -814,12 +813,11 @@ fn ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: null | ((
     let _5: bool
     let _6: bool
     let _7: bool
-    let _8: (ai.errors.Failure) -> bool throws never
+    let _8: int
     let _9: (ai.errors.Failure) -> bool throws never
-    let _10: bool
+    let _10: (ai.errors.Failure) -> bool throws never
     let _11: ai.clients.Backoff
     let _12: ai.clients.Backoff
-    let _13: bool
 
     bb0: {
         _5 = copy _2 == const <omitted>;
@@ -852,21 +850,18 @@ fn ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: null | ((
     }
 
     bb6: {
-        _9 = copy _3;
-        _10 = copy _9 == const null;
-        branch copy _10 -> [bb7, bb8];
+        _8 = copy _2;
+        _10 = short_circuit(??) copy _3 -> [eval: bb7, join: bb8];
     }
 
     bb7: {
-        _9 = const fn ai.clients.default_retry_judgment;
+        _10 = const fn ai.clients.default_retry_judgment;
         goto -> bb8;
     }
 
     bb8: {
-        _8 = copy _9;
-        _12 = copy _4;
-        _13 = copy _12 == const null;
-        branch copy _13 -> [bb9, bb10];
+        _9 = copy _10;
+        _12 = short_circuit(??) copy _4 -> [eval: bb9, join: bb10];
     }
 
     bb9: {
@@ -875,7 +870,7 @@ fn ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: null | ((
 
     bb10: {
         _11 = copy _12;
-        _0 = ai.clients.Retry { copy _1, copy _2, copy _8, copy _11 };
+        _0 = ai.clients.Retry { copy _1, copy _8, copy _9, copy _11 };
         goto -> bb11;
     }
 
@@ -897,8 +892,8 @@ fn ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnInput, r
     let _8: ai.errors.Failure // f
     let _9: bool
     let _10: bool
-    let _11: bool
-    let _12: ai.errors.RetrySafety
+    let _11: ai.errors.RetrySafety
+    let _12: bool
     let _13: (ai.errors.Failure) -> bool throws never
     let _14: ai.errors.Failure
     let _15: int
@@ -921,7 +916,7 @@ fn ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnInput, r
 
     bb0: {
         _6 = copy _1.0;
-        _0 = virtual_call invoke as ai.Client(copy _6, copy _2) -> [bb20, unwind: bb1];
+        _0 = virtual_call invoke as ai.Client(copy _6, copy _2) -> [bb19, unwind: bb1];
     }
 
     bb1: {
@@ -939,30 +934,30 @@ fn ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnInput, r
 
     bb4: {
         _8 = copy _7;
-        _11 = copy _3 > const 1_i64;
-        _10 = short_circuit(&&) copy _11 -> [eval: bb5, join: bb7];
+        _9 = copy _3 > const 1_i64;
+        branch copy _9 -> [bb5, bb10];
     }
 
     bb5: {
-        _12 = virtual_call retry_safety as ai.errors.Failure(copy _8) -> [bb6];
+        _11 = virtual_call retry_safety as ai.errors.Failure(copy _8) -> [bb6];
     }
 
     bb6: {
-        _10 = call const fn baml.ops.equals_equals(copy _12, const ai.errors.RetrySafety.Safe) -> [bb7];
+        _10 = call const fn baml.ops.equals_equals(copy _11, const ai.errors.RetrySafety.Safe) -> [bb7];
     }
 
     bb7: {
-        _9 = short_circuit(&&) copy _10 -> [eval: bb8, join: bb9];
+        branch copy _10 -> [bb8, bb10];
     }
 
     bb8: {
         _13 = copy _1.2;
         _14 = copy _8;
-        _9 = call copy _13(copy _14) -> [bb9];
+        _12 = call copy _13(copy _14) -> [bb9];
     }
 
     bb9: {
-        branch copy _9 -> [bb11, bb10];
+        branch copy _12 -> [bb11, bb10];
     }
 
     bb10: {
@@ -999,7 +994,7 @@ fn ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnInput, r
     }
 
     bb16: {
-        _24 = sys_op const fn baml.sys.sleep(copy _26) -> bb19 unwind bb17;
+        _24 = sys_op const fn baml.sys.sleep(copy _26) -> bb18 unwind bb17;
     }
 
     bb17: {
@@ -1007,16 +1002,11 @@ fn ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnInput, r
     }
 
     bb18: {
-        _24 = const null;
-        goto -> bb19;
+        _31 = copy _3 - const 1_i64;
+        _0 = call const fn ai.clients.Retry._attempt(copy _1, copy _2, copy _31, copy _4) -> [bb19];
     }
 
     bb19: {
-        _31 = copy _3 - const 1_i64;
-        _0 = call const fn ai.clients.Retry._attempt(copy _1, copy _2, copy _31, copy _4) -> [bb20];
-    }
-
-    bb20: {
         return;
     }
 }
@@ -1230,10 +1220,10 @@ fn .<lambda(Retry.invoke_stream, 1)>(failure: ai.errors.Failure) -> bool {
     let _2: bool
     let _3: bool
     let _4: bool
-    let _5: bool
+    let _5: int
     let _6: bool
-    let _7: int
-    let _8: ai.errors.RetrySafety
+    let _7: ai.errors.RetrySafety
+    let _8: bool
     let _9: (ai.errors.Failure) -> bool throws never
     let _10: int // attempt
     let _11: int
@@ -1250,103 +1240,89 @@ fn .<lambda(Retry.invoke_stream, 1)>(failure: ai.errors.Failure) -> bool {
 
     bb0: {
         _3 = is_type(copy _1, ai.errors.StreamingUnsupported);
-        branch copy _3 -> [bb2, bb1];
+        _2 = copy _3;
+        goto -> bb1;
     }
 
     bb1: {
-        _2 = const false;
-        goto -> bb3;
+        branch copy _2 -> [bb12, bb2];
     }
 
     bb2: {
-        _2 = const true;
-        goto -> bb3;
+        _5 = copy capture[0];
+        _4 = copy _5 > const 1_i64;
+        branch copy _4 -> [bb3, bb8];
     }
 
     bb3: {
-        branch copy _2 -> [bb14, bb4];
+        _7 = virtual_call retry_safety as ai.errors.Failure(copy _1) -> [bb4];
     }
 
     bb4: {
-        _7 = copy capture[0];
-        _6 = copy _7 > const 1_i64;
-        _5 = short_circuit(&&) copy _6 -> [eval: bb5, join: bb7];
+        _6 = call const fn baml.ops.equals_equals(copy _7, const ai.errors.RetrySafety.Safe) -> [bb5];
     }
 
     bb5: {
-        _8 = virtual_call retry_safety as ai.errors.Failure(copy _1) -> [bb6];
+        branch copy _6 -> [bb6, bb8];
     }
 
     bb6: {
-        _5 = call const fn baml.ops.equals_equals(copy _8, const ai.errors.RetrySafety.Safe) -> [bb7];
+        _9 = copy capture[1].2;
+        _8 = call copy _9(copy _1) -> [bb7];
     }
 
     bb7: {
-        _4 = short_circuit(&&) copy _5 -> [eval: bb8, join: bb9];
+        branch copy _8 -> [bb9, bb8];
     }
 
     bb8: {
-        _9 = copy capture[1].2;
-        _4 = call copy _9(copy _1) -> [bb9];
+        _0 = const false;
+        goto -> bb16;
     }
 
     bb9: {
-        branch copy _4 -> [bb11, bb10];
-    }
-
-    bb10: {
-        _0 = const false;
-        goto -> bb19;
-    }
-
-    bb11: {
         _12 = copy capture[1].1;
         _13 = copy capture[0];
         _11 = copy _12 - copy _13;
         _10 = copy _11 + const 1_i64;
         _18 = copy capture[1].3;
         _19 = copy _10;
-        _17 = call const fn ai.clients.Backoff.delay_ms(copy _18, copy _19, copy _1) -> [bb12, unwind: bb15];
+        _17 = call const fn ai.clients.Backoff.delay_ms(copy _18, copy _19, copy _1) -> [bb10, unwind: bb13];
+    }
+
+    bb10: {
+        _16 = call const fn baml.time.Duration.from_milliseconds(copy _17) -> [bb11, unwind: bb13];
+    }
+
+    bb11: {
+        _14 = sys_op const fn baml.sys.sleep(copy _16) -> bb15 unwind bb13;
     }
 
     bb12: {
-        _16 = call const fn baml.time.Duration.from_milliseconds(copy _17) -> [bb13, unwind: bb15];
+        _0 = const false;
+        goto -> bb16;
     }
 
     bb13: {
-        _14 = sys_op const fn baml.sys.sleep(copy _16) -> bb18 unwind bb15;
+        _20 = copy _15;
+        _20 = narrow_bind copy _20 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["panics"], name: "Cancelled" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb14];
     }
 
     bb14: {
-        _0 = const false;
-        goto -> bb19;
+        throw_if_panic copy _15 -> bb15;
     }
 
     bb15: {
-        _20 = copy _15;
-        _20 = narrow_bind copy _20 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["panics"], name: "Cancelled" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb16];
+        capture[0] = copy capture[0] - const 1_i64;
+        _0 = const true;
+        goto -> bb16;
     }
 
     bb16: {
-        throw_if_panic copy _15 -> bb17;
-    }
-
-    bb17: {
-        _14 = const null;
-        goto -> bb18;
-    }
-
-    bb18: {
-        capture[0] = copy capture[0] - const 1_i64;
-        _0 = const true;
-        goto -> bb19;
-    }
-
-    bb19: {
         return;
     }
 
-    bb20: {
+    bb17: {
         _21 = copy _20;
         throw copy _21;
     }
@@ -1690,10 +1666,10 @@ fn ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurnInput,
     let _11: unknown
     let _12: ai.errors.Failure // f
     let _13: bool
-    let _14: bool
+    let _14: int
     let _15: int
-    let _16: int
-    let _17: (ai.Client[]) -> int throws never
+    let _16: (ai.Client[]) -> int throws never
+    let _17: bool
     let _18: ai.errors.RetrySafety
     let _19: int
     let _20: ai.events.LLMCall
@@ -1739,15 +1715,15 @@ fn ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurnInput,
 
     bb7: {
         _12 = copy _11;
-        _15 = copy _3 + const 1_i64;
-        _17 = copy _1.0;
-        _16 = len(_17);
+        _14 = copy _3 + const 1_i64;
+        _16 = copy _1.0;
+        _15 = len(_16);
         goto -> bb8;
     }
 
     bb8: {
-        _14 = copy _15 < copy _16;
-        _13 = short_circuit(&&) copy _14 -> [eval: bb9, join: bb11];
+        _13 = copy _14 < copy _15;
+        branch copy _13 -> [bb9, bb12];
     }
 
     bb9: {
@@ -1755,11 +1731,11 @@ fn ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurnInput,
     }
 
     bb10: {
-        _13 = call const fn baml.ops.equals_equals(copy _18, const ai.errors.RetrySafety.Safe) -> [bb11];
+        _17 = call const fn baml.ops.equals_equals(copy _18, const ai.errors.RetrySafety.Safe) -> [bb11];
     }
 
     bb11: {
-        branch copy _13 -> [bb13, bb12];
+        branch copy _17 -> [bb13, bb12];
     }
 
     bb12: {
@@ -2057,24 +2033,24 @@ fn .<lambda(Fallback.invoke_stream, 1)>(failure: ai.errors.Failure) -> bool {
     let _0: bool // _0 // return
     let _1: ai.errors.Failure // failure // param
     let _2: bool
-    let _3: bool
+    let _3: int
     let _4: int
     let _5: int
-    let _6: int
-    let _7: (ai.Client[]) -> int throws never
+    let _6: (ai.Client[]) -> int throws never
+    let _7: bool
     let _8: ai.errors.RetrySafety
 
     bb0: {
-        _5 = copy capture[0];
-        _4 = copy _5 + const 1_i64;
-        _7 = copy capture[1].0;
-        _6 = len(_7);
+        _4 = copy capture[0];
+        _3 = copy _4 + const 1_i64;
+        _6 = copy capture[1].0;
+        _5 = len(_6);
         goto -> bb1;
     }
 
     bb1: {
-        _3 = copy _4 < copy _6;
-        _2 = short_circuit(&&) copy _3 -> [eval: bb2, join: bb4];
+        _2 = copy _3 < copy _5;
+        branch copy _2 -> [bb2, bb5];
     }
 
     bb2: {
@@ -2082,11 +2058,11 @@ fn .<lambda(Fallback.invoke_stream, 1)>(failure: ai.errors.Failure) -> bool {
     }
 
     bb3: {
-        _2 = call const fn baml.ops.equals_equals(copy _8, const ai.errors.RetrySafety.Safe) -> [bb4];
+        _7 = call const fn baml.ops.equals_equals(copy _8, const ai.errors.RetrySafety.Safe) -> [bb4];
     }
 
     bb4: {
-        branch copy _2 -> [bb6, bb5];
+        branch copy _7 -> [bb6, bb5];
     }
 
     bb5: {
@@ -2153,21 +2129,20 @@ fn ai.clients.StreamRelay.recover(self: ai.clients.StreamRelay, error: baml.erro
     let _8: ai.errors.Failure // failure
     let _9: bool
     let _10: bool
-    let _11: bool
-    let _12: (ai.errors.Failure) -> bool throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _13: ai.errors.Failure
-    let _14: int
-    let _15: (ai.events.LLMCall[], ai.events.LLMCall) -> int throws never
-    let _16: ai.events.LLMCall
-    let _17: ai.errors.Failure
-    let _18: reflect.Type
+    let _11: (ai.errors.Failure) -> bool throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _12: ai.errors.Failure
+    let _13: int
+    let _14: (ai.events.LLMCall[], ai.events.LLMCall) -> int throws never
+    let _15: ai.events.LLMCall
+    let _16: ai.errors.Failure
+    let _17: reflect.Type
+    let _18: void
     let _19: void
-    let _20: void
-    let _21: baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _22: baml.errors.UnknownError // unknown_error
-    let _23: void
-    let _24: reflect.errors.CompilationError // compilation
-    let _25: void
+    let _20: baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _21: baml.errors.UnknownError // unknown_error
+    let _22: void
+    let _23: reflect.errors.CompilationError // compilation
+    let _24: void
 
     bb0: {
         _3 = call const fn ai.errors.normalize_invoke(copy _2) -> [bb1];
@@ -2184,76 +2159,75 @@ fn ai.clients.StreamRelay.recover(self: ai.clients.StreamRelay, error: baml.erro
     }
 
     bb3: {
-        _21 = copy _3;
-        _21 = narrow_bind copy _21 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
+        _20 = copy _3;
+        _20 = narrow_bind copy _20 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
     }
 
     bb4: {
-        _24 = copy _3;
-        _25 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb5];
+        _23 = copy _3;
+        _24 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb5];
     }
 
     bb5: {
-        throw copy _24;
+        throw copy _23;
     }
 
     bb6: {
-        _22 = copy _21;
-        _23 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb7];
+        _21 = copy _20;
+        _22 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb7];
     }
 
     bb7: {
-        throw copy _22;
+        throw copy _21;
     }
 
     bb8: {
         _8 = copy _7;
-        _11 = copy _1.3;
-        _10 = !copy _11;
-        _9 = short_circuit(&&) copy _10 -> [eval: bb9, join: bb10];
+        _9 = copy _1.3;
+        branch copy _9 -> [bb16, bb9];
     }
 
     bb9: {
-        _12 = copy _1.1;
-        _13 = copy _8;
-        _9 = call copy _12(copy _13) -> [bb10];
+        _11 = copy _1.1;
+        _12 = copy _8;
+        _10 = call copy _11(copy _12) -> [bb10];
     }
 
     bb10: {
-        branch copy _9 -> [bb13, bb11];
+        branch copy _10 -> [bb11, bb16];
     }
 
     bb11: {
-        _20 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb12];
+        _14 = copy _1.9;
+        _16 = copy _8;
+        _15 = call const fn ai.clients._failed_leg_call(const null, copy _16) -> [bb12];
     }
 
     bb12: {
-        throw copy _8;
+        _17 = load_type(ai.events.LLMCall);
+        _13 = call const fn baml.Array.push<copy _17>(copy _14, copy _15) -> [bb13];
     }
 
     bb13: {
-        _15 = copy _1.9;
-        _17 = copy _8;
-        _16 = call const fn ai.clients._failed_leg_call(const null, copy _17) -> [bb14];
+        _18 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb14];
     }
 
     bb14: {
-        _18 = load_type(ai.events.LLMCall);
-        _14 = call const fn baml.Array.push<copy _18>(copy _15, copy _16) -> [bb15];
+        _1.2 = const null;
+        _0 = const null;
+        goto -> bb15;
     }
 
     bb15: {
-        _19 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb16];
+        return;
     }
 
     bb16: {
-        _1.2 = const null;
-        _0 = const null;
-        goto -> bb17;
+        _19 = call const fn ai.clients.StreamRelay.close_current(copy _1) -> [bb17];
     }
 
     bb17: {
-        return;
+        throw copy _8;
     }
 
     bb18: {
@@ -2280,80 +2254,77 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     let _9: (string[], int) -> string | null throws never
     let _10: int
     let _11: reflect.Type
-    let _12: bool
-    let _13: string
-    let _14: bool
+    let _12: string
+    let _13: bool
+    let _14: int
     let _15: int
-    let _16: int
-    let _17: ((ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta)[]) -> int throws never
-    let _18: ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta // event
-    let _19: ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta
-    let _20: null | ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta
-    let _21: ((ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta)[], int) -> null | ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta throws never
-    let _22: int
-    let _23: reflect.Type
+    let _16: ((ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta)[]) -> int throws never
+    let _17: ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta // event
+    let _18: ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta
+    let _19: null | ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta
+    let _20: ((ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta)[], int) -> null | ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta throws never
+    let _21: int
+    let _22: reflect.Type
+    let _23: bool
     let _24: bool
-    let _25: bool
-    let _26: bool
-    let _27: null | ai.stream.TurnStream
-    let _28: ai.clients.StreamRelayError | ai.stream.TurnStream // opened
-    let _29: unknown // e
-    let _30: () -> ai.stream.TurnStream throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _31: baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _32: ai.clients.StreamRelayError | ai.stream.TurnStream
-    let _33: ai.clients.StreamRelayError // failed
-    let _34: void
-    let _35: baml.errors.AccessError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | baml.errors.Unsupported | baml.json.DecodeError | baml.json.ParseError | baml.json.SerializationError | reflect.errors.CompilationError | ai.errors.Failure
-    let _36: ai.clients.StreamRelayError | ai.stream.TurnStream
-    let _37: ai.stream.TurnStream // stream
-    let _38: null | ai.stream.TurnStream
-    let _39: null | ai.stream.TurnStream
-    let _40: ai.stream.TurnStream // stream
-    let _41: ai.clients.StreamRelayError | ai.stream.Done | string[] // next
-    let _42: unknown // e
-    let _43: baml.errors.Io | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _44: ai.clients.StreamRelayError | ai.stream.Done | string[]
-    let _45: string[] // batch
-    let _46: string
-    let _47: string
-    let _48: string | null
-    let _49: reflect.Type
-    let _50: bool
-    let _51: ai.clients.StreamRelayError | ai.stream.Done | string[]
-    let _52: ai.stream.Done // done
-    let _53: ai.ModelTurn | ai.clients.StreamRelayError // final
-    let _54: unknown // e
-    let _55: baml.errors.Io | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _56: ai.ModelTurn | ai.clients.StreamRelayError
-    let _57: ai.clients.StreamRelayError // failed
-    let _58: void
-    let _59: baml.errors.AccessError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | baml.errors.Unsupported | baml.json.DecodeError | baml.json.ParseError | baml.json.SerializationError | reflect.errors.CompilationError | ai.errors.Failure
-    let _60: ai.ModelTurn | ai.clients.StreamRelayError
-    let _61: ai.ModelTurn // turn
-    let _62: ai.events.LLMCall[]
-    let _63: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
-    let _64: unknown
-    let _65: bool
-    let _66: ai.events.LLMCall
-    let _67: ai.events.LLMCall // call
-    let _68: int
-    let _69: (ai.events.LLMCall[], ai.events.LLMCall) -> int throws never
-    let _70: ai.events.LLMCall
-    let _71: reflect.Type
-    let _72: ai.stream.TurnMeta
-    let _73: ai.content.StopReason
-    let _74: int | null
-    let _75: null | ai.events.Usage
-    let _76: bool
-    let _77: null | ai.events.Usage
-    let _78: int | null
-    let _79: null | ai.events.Usage
-    let _80: bool
-    let _81: null | ai.events.Usage
-    let _82: ai.stream.TurnDone
-    let _83: ai.clients.StreamRelayError // failed
-    let _84: void
-    let _85: baml.errors.AccessError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | baml.errors.Unsupported | baml.json.DecodeError | baml.json.ParseError | baml.json.SerializationError | reflect.errors.CompilationError | ai.errors.Failure
+    let _25: null | ai.stream.TurnStream
+    let _26: ai.clients.StreamRelayError | ai.stream.TurnStream // opened
+    let _27: unknown // e
+    let _28: () -> ai.stream.TurnStream throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _29: baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _30: ai.clients.StreamRelayError | ai.stream.TurnStream
+    let _31: ai.clients.StreamRelayError // failed
+    let _32: void
+    let _33: baml.errors.AccessError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | baml.errors.Unsupported | baml.json.DecodeError | baml.json.ParseError | baml.json.SerializationError | reflect.errors.CompilationError | ai.errors.Failure
+    let _34: ai.clients.StreamRelayError | ai.stream.TurnStream
+    let _35: ai.stream.TurnStream // stream
+    let _36: null | ai.stream.TurnStream
+    let _37: null | ai.stream.TurnStream
+    let _38: ai.stream.TurnStream // stream
+    let _39: ai.clients.StreamRelayError | ai.stream.Done | string[] // next
+    let _40: unknown // e
+    let _41: baml.errors.Io | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _42: ai.clients.StreamRelayError | ai.stream.Done | string[]
+    let _43: string[] // batch
+    let _44: string
+    let _45: string
+    let _46: string | null
+    let _47: reflect.Type
+    let _48: ai.clients.StreamRelayError | ai.stream.Done | string[]
+    let _49: ai.stream.Done // done
+    let _50: ai.ModelTurn | ai.clients.StreamRelayError // final
+    let _51: unknown // e
+    let _52: baml.errors.Io | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _53: ai.ModelTurn | ai.clients.StreamRelayError
+    let _54: ai.clients.StreamRelayError // failed
+    let _55: void
+    let _56: baml.errors.AccessError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | baml.errors.Unsupported | baml.json.DecodeError | baml.json.ParseError | baml.json.SerializationError | reflect.errors.CompilationError | ai.errors.Failure
+    let _57: ai.ModelTurn | ai.clients.StreamRelayError
+    let _58: ai.ModelTurn // turn
+    let _59: ai.events.LLMCall[]
+    let _60: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
+    let _61: unknown
+    let _62: bool
+    let _63: ai.events.LLMCall
+    let _64: ai.events.LLMCall // call
+    let _65: int
+    let _66: (ai.events.LLMCall[], ai.events.LLMCall) -> int throws never
+    let _67: ai.events.LLMCall
+    let _68: reflect.Type
+    let _69: ai.stream.TurnMeta
+    let _70: ai.content.StopReason
+    let _71: int | null
+    let _72: null | ai.events.Usage
+    let _73: bool
+    let _74: null | ai.events.Usage
+    let _75: int | null
+    let _76: null | ai.events.Usage
+    let _77: bool
+    let _78: null | ai.events.Usage
+    let _79: ai.stream.TurnDone
+    let _80: ai.clients.StreamRelayError // failed
+    let _81: void
+    let _82: baml.errors.AccessError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.errors.Timeout | baml.errors.UnknownError | baml.errors.Unsupported | baml.json.DecodeError | baml.json.ParseError | baml.json.SerializationError | reflect.errors.CompilationError | ai.errors.Failure
 
     bb0: {
         _3 = copy _1.5;
@@ -2368,34 +2339,34 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     }
 
     bb2: {
-        _15 = copy _1.7;
-        _17 = copy _1.6;
-        _16 = len(_17);
+        _14 = copy _1.7;
+        _16 = copy _1.6;
+        _15 = len(_16);
         goto -> bb3;
     }
 
     bb3: {
-        _14 = copy _15 < copy _16;
-        branch copy _14 -> [bb9, bb4];
+        _13 = copy _14 < copy _15;
+        branch copy _13 -> [bb9, bb4];
     }
 
     bb4: {
-        _25 = copy _1.8;
-        branch copy _25 -> [bb8, bb5];
+        _23 = copy _1.8;
+        branch copy _23 -> [bb8, bb5];
     }
 
     bb5: {
-        _27 = copy _1.2;
-        _26 = call const fn baml.ops.equals_equals(copy _27, const null) -> [bb6];
+        _25 = copy _1.2;
+        _24 = call const fn baml.ops.equals_equals(copy _25, const null) -> [bb6];
     }
 
     bb6: {
-        branch copy _26 -> [bb7, bb22];
+        branch copy _24 -> [bb7, bb22];
     }
 
     bb7: {
-        _30 = copy _1.0;
-        _28 = call copy _30() -> [bb19, unwind: bb17];
+        _28 = copy _1.0;
+        _26 = call copy _28() -> [bb19, unwind: bb17];
     }
 
     bb8: {
@@ -2404,26 +2375,24 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     }
 
     bb9: {
-        _21 = copy _1.6;
-        _22 = copy _1.7;
-        _23 = load_type(ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone);
-        _20 = call const fn baml.Array.at<copy _23>(copy _21, copy _22) -> [bb10];
+        _20 = copy _1.6;
+        _21 = copy _1.7;
+        _22 = load_type(ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone);
+        _19 = call const fn baml.Array.at<copy _22>(copy _20, copy _21) -> [bb10];
     }
 
     bb10: {
-        _19 = copy _20;
-        _24 = copy _19 == const null;
-        branch copy _24 -> [bb11, bb12];
+        _18 = short_circuit(??) copy _19 -> [eval: bb11, join: bb12];
     }
 
     bb11: {
-        _19 = call const fn baml.sys.panic(const "StreamRelay lost a terminal event") -> [bb12];
+        _18 = call const fn baml.sys.panic(const "StreamRelay lost a terminal event") -> [bb12];
     }
 
     bb12: {
-        _18 = copy _19;
+        _17 = copy _18;
         _1.7 = copy _1.7 + const 1_i64;
-        _0 = copy _18;
+        _0 = copy _17;
         goto -> bb56;
     }
 
@@ -2435,9 +2404,7 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     }
 
     bb14: {
-        _7 = copy _8;
-        _12 = copy _7 == const null;
-        branch copy _12 -> [bb15, bb16];
+        _7 = short_circuit(??) copy _8 -> [eval: bb15, join: bb16];
     }
 
     bb15: {
@@ -2448,41 +2415,41 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
         _6 = copy _7;
         _1.5 = copy _1.5 + const 1_i64;
         _1.3 = const true;
-        _13 = copy _6;
-        _0 = ai.stream.TextDelta { copy _13 };
+        _12 = copy _6;
+        _0 = ai.stream.TextDelta { copy _12 };
         goto -> bb56;
     }
 
     bb17: {
-        throw_if_panic copy _29 -> bb18;
+        throw_if_panic copy _27 -> bb18;
     }
 
     bb18: {
-        _31 = copy _29;
-        _28 = ai.clients.StreamRelayError { copy _31 };
+        _29 = copy _27;
+        _26 = ai.clients.StreamRelayError { copy _29 };
         goto -> bb19;
     }
 
     bb19: {
-        _32 = copy _28;
-        _32 = narrow_bind copy _32 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["clients"], name: "StreamRelayError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb20];
+        _30 = copy _26;
+        _30 = narrow_bind copy _30 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["clients"], name: "StreamRelayError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb20];
     }
 
     bb20: {
-        _36 = copy _28;
-        _36 = narrow_bind copy _36 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnStream" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb21, bb22];
+        _34 = copy _26;
+        _34 = narrow_bind copy _34 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnStream" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb21, bb22];
     }
 
     bb21: {
-        _37 = copy _36;
-        _1.2 = copy _37;
+        _35 = copy _34;
+        _1.2 = copy _35;
         goto -> bb22;
     }
 
     bb22: {
-        _38 = copy _1.2;
-        _39 = copy _38;
-        _39 = narrow_bind copy _39 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnStream" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb24, bb23];
+        _36 = copy _1.2;
+        _37 = copy _36;
+        _37 = narrow_bind copy _37 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnStream" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb24, bb23];
     }
 
     bb23: {
@@ -2490,14 +2457,14 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     }
 
     bb24: {
-        _40 = copy _39;
-        _41 = call const fn ai.stream.TurnStream.next(copy _40) -> [bb29, unwind: bb27];
+        _38 = copy _37;
+        _39 = call const fn ai.stream.TurnStream.next(copy _38) -> [bb29, unwind: bb27];
     }
 
     bb25: {
-        _33 = copy _32;
-        _35 = copy _33.0;
-        _34 = call const fn ai.clients.StreamRelay.recover(copy _1, copy _35) -> [bb26];
+        _31 = copy _30;
+        _33 = copy _31.0;
+        _32 = call const fn ai.clients.StreamRelay.recover(copy _1, copy _33) -> [bb26];
     }
 
     bb26: {
@@ -2505,29 +2472,29 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     }
 
     bb27: {
-        throw_if_panic copy _42 -> bb28;
+        throw_if_panic copy _40 -> bb28;
     }
 
     bb28: {
-        _43 = copy _42;
-        _41 = ai.clients.StreamRelayError { copy _43 };
+        _41 = copy _40;
+        _39 = ai.clients.StreamRelayError { copy _41 };
         goto -> bb29;
     }
 
     bb29: {
-        _44 = copy _41;
-        _44 = narrow_bind copy _44 as List(String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb30];
+        _42 = copy _39;
+        _42 = narrow_bind copy _42 as List(String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb30];
     }
 
     bb30: {
-        _51 = copy _41;
-        _51 = narrow_bind copy _51 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb33, bb31];
+        _48 = copy _39;
+        _48 = narrow_bind copy _48 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb33, bb31];
     }
 
     bb31: {
-        _83 = copy _41;
-        _85 = copy _83.0;
-        _84 = call const fn ai.clients.StreamRelay.recover(copy _1, copy _85) -> [bb32];
+        _80 = copy _39;
+        _82 = copy _80.0;
+        _81 = call const fn ai.clients.StreamRelay.recover(copy _1, copy _82) -> [bb32];
     }
 
     bb32: {
@@ -2535,132 +2502,130 @@ fn ai.clients.StreamRelay.next_event(self: ai.clients.StreamRelay) -> ai.stream.
     }
 
     bb33: {
-        _52 = copy _51;
-        _53 = call const fn ai.stream.TurnStream.final_turn(copy _40) -> [bb40, unwind: bb38];
+        _49 = copy _48;
+        _50 = call const fn ai.stream.TurnStream.final_turn(copy _38) -> [bb40, unwind: bb38];
     }
 
     bb34: {
-        _45 = copy _44;
+        _43 = copy _42;
         _1.3 = const true;
-        _1.4 = copy _45;
+        _1.4 = copy _43;
         _1.5 = const 1_i64;
-        _49 = load_type(string);
-        _48 = call const fn baml.Array.at<copy _49>(copy _45, const 0_i64) -> [bb35];
+        _47 = load_type(string);
+        _46 = call const fn baml.Array.at<copy _47>(copy _43, const 0_i64) -> [bb35];
     }
 
     bb35: {
-        _47 = copy _48;
-        _50 = copy _47 == const null;
-        branch copy _50 -> [bb36, bb37];
+        _45 = short_circuit(??) copy _46 -> [eval: bb36, join: bb37];
     }
 
     bb36: {
-        _47 = call const fn baml.sys.panic(const "StreamRelay received an empty batch") -> [bb37];
+        _45 = call const fn baml.sys.panic(const "StreamRelay received an empty batch") -> [bb37];
     }
 
     bb37: {
-        _46 = copy _47;
-        _0 = ai.stream.TextDelta { copy _46 };
+        _44 = copy _45;
+        _0 = ai.stream.TextDelta { copy _44 };
         goto -> bb56;
     }
 
     bb38: {
-        throw_if_panic copy _54 -> bb39;
+        throw_if_panic copy _51 -> bb39;
     }
 
     bb39: {
-        _55 = copy _54;
-        _53 = ai.clients.StreamRelayError { copy _55 };
+        _52 = copy _51;
+        _50 = ai.clients.StreamRelayError { copy _52 };
         goto -> bb40;
     }
 
     bb40: {
-        _56 = copy _53;
-        _56 = narrow_bind copy _56 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["clients"], name: "StreamRelayError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb54, bb41];
+        _53 = copy _50;
+        _53 = narrow_bind copy _53 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["clients"], name: "StreamRelayError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb54, bb41];
     }
 
     bb41: {
-        _60 = copy _53;
-        _60 = narrow_bind copy _60 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: [], name: "ModelTurn" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb43, bb42];
+        _57 = copy _50;
+        _57 = narrow_bind copy _57 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: [], name: "ModelTurn" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb43, bb42];
     }
 
     bb42: {
-        _0 = copy _52;
+        _0 = copy _49;
         goto -> bb56;
     }
 
     bb43: {
-        _61 = copy _60;
+        _58 = copy _57;
         _1.8 = const true;
-        _62 = copy _61.3;
-        _63 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _62) -> [bb44];
+        _59 = copy _58.3;
+        _60 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _59) -> [bb44];
     }
 
     bb44: {
-        _64 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>(copy _63) -> [bb45];
+        _61 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>(copy _60) -> [bb45];
     }
 
     bb45: {
-        _65 = is_type(copy _64, baml.iter.Done);
-        branch copy _65 -> [bb47, bb46];
+        _62 = is_type(copy _61, baml.iter.Done);
+        branch copy _62 -> [bb47, bb46];
     }
 
     bb46: {
-        _66 = copy _64;
-        fresh_cell(_67);
-        _67 = copy _66;
-        _69 = copy _1.9;
-        _70 = copy _67;
-        _71 = load_type(ai.events.LLMCall);
-        _68 = call const fn baml.Array.push<copy _71>(copy _69, copy _70) -> [bb44];
+        _63 = copy _61;
+        fresh_cell(_64);
+        _64 = copy _63;
+        _66 = copy _1.9;
+        _67 = copy _64;
+        _68 = load_type(ai.events.LLMCall);
+        _65 = call const fn baml.Array.push<copy _68>(copy _66, copy _67) -> [bb44];
     }
 
     bb47: {
-        _73 = copy _61.1;
-        _75 = copy _61.2;
-        _76 = copy _75 == const null;
-        branch copy _76 -> [bb49, bb48];
+        _70 = copy _58.1;
+        _72 = copy _58.2;
+        _73 = copy _72 == const null;
+        branch copy _73 -> [bb49, bb48];
     }
 
     bb48: {
-        _77 = copy _61.2;
-        _74 = copy _77.0;
+        _74 = copy _58.2;
+        _71 = copy _74.0;
         goto -> bb50;
     }
 
     bb49: {
-        _74 = const null;
+        _71 = const null;
         goto -> bb50;
     }
 
     bb50: {
-        _79 = copy _61.2;
-        _80 = copy _79 == const null;
-        branch copy _80 -> [bb52, bb51];
+        _76 = copy _58.2;
+        _77 = copy _76 == const null;
+        branch copy _77 -> [bb52, bb51];
     }
 
     bb51: {
-        _81 = copy _61.2;
-        _78 = copy _81.1;
+        _78 = copy _58.2;
+        _75 = copy _78.1;
         goto -> bb53;
     }
 
     bb52: {
-        _78 = const null;
+        _75 = const null;
         goto -> bb53;
     }
 
     bb53: {
-        _72 = ai.stream.TurnMeta { copy _73, copy _74, copy _78 };
-        _82 = ai.stream.TurnDone {  };
-        _1.6 = [copy _72, copy _82]: ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone[];
+        _69 = ai.stream.TurnMeta { copy _70, copy _71, copy _75 };
+        _79 = ai.stream.TurnDone {  };
+        _1.6 = [copy _69, copy _79]: ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone[];
         _0 = call const fn ai.clients.StreamRelay.next_event(copy _1) -> [bb56];
     }
 
     bb54: {
-        _57 = copy _56;
-        _59 = copy _57.0;
-        _58 = call const fn ai.clients.StreamRelay.recover(copy _1, copy _59) -> [bb55];
+        _54 = copy _53;
+        _56 = copy _54.0;
+        _55 = call const fn ai.clients.StreamRelay.recover(copy _1, copy _56) -> [bb55];
     }
 
     bb55: {
@@ -2749,6 +2714,8 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
     let _22: reflect.Type
     let _23: reflect.Type
     let _24: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _25: string
+    let _26: string
 
     bb0: {
         _4 = copy _2 == const <omitted>;
@@ -2801,11 +2768,12 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
 
     bb10: {
         _13 = load_type(string);
+        _25 = const "media output could not be encoded: ";
         _10 = call const fn baml.String.from<copy _13>(copy _11) -> [bb11];
     }
 
     bb11: {
-        _9 = const "media output could not be encoded: " + copy _10;
+        _9 = copy _25 + copy _10;
         _8 = baml.errors.InvalidArgument { copy _9 };
         throw copy _8;
     }
@@ -2821,11 +2789,12 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
 
     bb14: {
         _23 = load_type(string);
+        _26 = const "media output could not be decoded: ";
         _20 = call const fn baml.String.from<copy _23>(copy _21) -> [bb15];
     }
 
     bb15: {
-        _19 = const "media output could not be decoded: " + copy _20;
+        _19 = copy _26 + copy _20;
         _18 = baml.errors.InvalidArgument { copy _19 };
         throw copy _18;
     }
@@ -3217,6 +3186,8 @@ fn ai.errors.classify_http(provider: string, status_code: int, body: string, hea
     let _13: string
     let _14: string
     let _15: reflect.Type
+    let _16: string
+    let _17: string
 
     bb0: {
         _5 = copy _4 == const <omitted>;
@@ -3230,55 +3201,53 @@ fn ai.errors.classify_http(provider: string, status_code: int, body: string, hea
 
     bb2: {
         _6 = copy _2 == const 429_i64;
-        branch copy _6 -> [bb10, bb3];
+        branch copy _6 -> [bb9, bb3];
     }
 
     bb3: {
-        _9 = copy _2 == const 408_i64;
-        _8 = short_circuit(||) copy _9 -> [eval: bb4, join: bb5];
+        _8 = copy _2 == const 408_i64;
+        branch copy _8 -> [bb7, bb4];
     }
 
     bb4: {
-        _8 = copy _2 >= const 500_i64;
-        goto -> bb5;
+        _9 = copy _2 >= const 500_i64;
+        branch copy _9 -> [bb7, bb5];
     }
 
     bb5: {
-        branch copy _8 -> [bb8, bb6];
+        _15 = load_type(int);
+        _17 = const "http ";
+        _14 = call const fn baml.String.from<copy _15>(copy _2) -> [bb6];
     }
 
     bb6: {
-        _15 = load_type(int);
-        _14 = call const fn baml.String.from<copy _15>(copy _2) -> [bb7];
+        _13 = copy _17 + copy _14;
+        _0 = ai.errors.InvalidRequest { copy _1, copy _2, copy _13, copy _3 };
+        goto -> bb11;
     }
 
     bb7: {
-        _13 = const "http " + copy _14;
-        _0 = ai.errors.InvalidRequest { copy _1, copy _2, copy _13, copy _3 };
-        goto -> bb12;
+        _12 = load_type(int);
+        _16 = const "http ";
+        _11 = call const fn baml.String.from<copy _12>(copy _2) -> [bb8];
     }
 
     bb8: {
-        _12 = load_type(int);
-        _11 = call const fn baml.String.from<copy _12>(copy _2) -> [bb9];
+        _10 = copy _16 + copy _11;
+        _0 = ai.errors.NetworkFailure { copy _1, copy _10, copy _2, copy _3 };
+        goto -> bb11;
     }
 
     bb9: {
-        _10 = const "http " + copy _11;
-        _0 = ai.errors.NetworkFailure { copy _1, copy _10, copy _2, copy _3 };
-        goto -> bb12;
+        _7 = call const fn ai.internal._retry_after_ms(copy _4) -> [bb10];
     }
 
     bb10: {
-        _7 = call const fn ai.internal._retry_after_ms(copy _4) -> [bb11];
+        _0 = ai.errors.RateLimited { copy _1, copy _7, copy _2, copy _3 };
+        goto -> bb11;
     }
 
     bb11: {
-        _0 = ai.errors.RateLimited { copy _1, copy _7, copy _2, copy _3 };
-        goto -> bb12;
-    }
-
-    bb12: {
         return;
     }
 }
@@ -3434,6 +3403,8 @@ fn ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     let _64: string
     let _65: string
     let _66: reflect.Type
+    let _67: string
+    let _68: string
 
     bb0: {
         _2 = call const fn baml.String.index_of(copy _1, const "/") -> [bb1];
@@ -3446,11 +3417,12 @@ fn ai.internal._from_shorthand(shorthand: string) -> ai.Client {
 
     bb2: {
         _63 = load_type(string);
+        _68 = const "client \"";
         _62 = call const fn baml.String.from<copy _63>(copy _1) -> [bb3];
     }
 
     bb3: {
-        _61 = const "client \"" + copy _62;
+        _61 = copy _68 + copy _62;
         _60 = copy _61 + const "\" is not a \"provider/model\" string (no \"/\"); valid prefixes are ";
         _65 = call const fn ai.internal._shorthand_prefixes() -> [bb4];
     }
@@ -3615,11 +3587,12 @@ fn ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     bb35: {
         _48 = copy _5;
         _49 = load_type(string);
+        _67 = const "no builtin provider for prefix \"";
         _47 = call const fn baml.String.from<copy _49>(copy _48) -> [bb36];
     }
 
     bb36: {
-        _46 = const "no builtin provider for prefix \"" + copy _47;
+        _46 = copy _67 + copy _47;
         _45 = copy _46 + const "\" in client \"";
         _51 = load_type(string);
         _50 = call const fn baml.String.from<copy _51>(copy _1) -> [bb37];
@@ -3877,8 +3850,8 @@ fn ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> ai.Pro
     let _6: int
     let _7: int
     let _8: bool
-    let _9: bool
-    let _10: int
+    let _9: int
+    let _10: bool
     let _11: unknown
     let _12: unknown[]
     let _13: int
@@ -4037,9 +4010,9 @@ fn ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> ai.Pro
     }
 
     bb21: {
-        _10 = copy _3;
-        _9 = copy _10 < const 0_i64;
-        _8 = short_circuit(&&) copy _9 -> [eval: bb22, join: bb25];
+        _9 = copy _3;
+        _8 = copy _9 < const 0_i64;
+        branch copy _8 -> [bb22, bb25];
     }
 
     bb22: {
@@ -4047,29 +4020,20 @@ fn ai.internal.assemble_llm_prompt(parts: string[], values: unknown[]) -> ai.Pro
         _13 = copy _4;
         _11 = copy _12[_13];
         _14 = is_type(copy _11, ai.Role);
-        branch copy _14 -> [bb24, bb23];
+        _10 = copy _14;
+        goto -> bb23;
     }
 
     bb23: {
-        _8 = const false;
-        goto -> bb25;
+        branch copy _10 -> [bb24, bb25];
     }
 
     bb24: {
-        _8 = const true;
+        _3 = copy _4;
         goto -> bb25;
     }
 
     bb25: {
-        branch copy _8 -> [bb26, bb27];
-    }
-
-    bb26: {
-        _3 = copy _4;
-        goto -> bb27;
-    }
-
-    bb27: {
         _4 = copy _4 + const 1_i64;
         goto -> bb1;
     }
@@ -4085,9 +4049,8 @@ fn ai.internal._header(headers: map<string, string>, lower: string, canonical: s
     let _5: string | null
     let _6: reflect.Type
     let _7: reflect.Type
-    let _8: bool
+    let _8: reflect.Type
     let _9: reflect.Type
-    let _10: reflect.Type
 
     bb0: {
         _6 = load_type(string);
@@ -4096,15 +4059,13 @@ fn ai.internal._header(headers: map<string, string>, lower: string, canonical: s
     }
 
     bb1: {
-        _4 = copy _5;
-        _8 = copy _4 == const null;
-        branch copy _8 -> [bb2, bb3];
+        _4 = short_circuit(??) copy _5 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
+        _8 = load_type(string);
         _9 = load_type(string);
-        _10 = load_type(string);
-        _4 = call const fn baml.Map.get<copy _9, copy _10>(copy _1, copy _3) -> [bb3];
+        _4 = call const fn baml.Map.get<copy _8, copy _9>(copy _1, copy _3) -> [bb3];
     }
 
     bb3: {
@@ -4313,16 +4274,16 @@ fn ai.internal._media_shape(t: reflect.Type) -> string {
     let _16: bool
     let _17: reflect.Type
     let _18: bool
-    let _19: bool
-    let _20: reflect.Type
+    let _19: reflect.Type
+    let _20: bool
     let _21: reflect.Type
     let _22: bool
-    let _23: bool
-    let _24: reflect.Type
+    let _23: reflect.Type
+    let _24: bool
     let _25: reflect.Type
     let _26: bool
-    let _27: bool
-    let _28: reflect.Type
+    let _27: reflect.Type
+    let _28: bool
     let _29: reflect.Type
 
     bb0: {
@@ -4430,16 +4391,16 @@ fn ai.internal._media_shape(t: reflect.Type) -> string {
     }
 
     bb24: {
-        _20 = load_type(image[]);
+        _19 = load_type(image[]);
         goto -> bb25;
     }
 
     bb25: {
-        _19 = call const fn baml.ops.equals_equals(copy _1, copy _20) -> [bb26];
+        _18 = call const fn baml.ops.equals_equals(copy _1, copy _19) -> [bb26];
     }
 
     bb26: {
-        _18 = short_circuit(||) copy _19 -> [eval: bb27, join: bb29];
+        branch copy _18 -> [bb45, bb27];
     }
 
     bb27: {
@@ -4448,24 +4409,24 @@ fn ai.internal._media_shape(t: reflect.Type) -> string {
     }
 
     bb28: {
-        _18 = call const fn baml.ops.equals_equals(copy _1, copy _21) -> [bb29];
+        _20 = call const fn baml.ops.equals_equals(copy _1, copy _21) -> [bb29];
     }
 
     bb29: {
-        branch copy _18 -> [bb45, bb30];
+        branch copy _20 -> [bb45, bb30];
     }
 
     bb30: {
-        _24 = load_type((string | image)[]);
+        _23 = load_type((string | image)[]);
         goto -> bb31;
     }
 
     bb31: {
-        _23 = call const fn baml.ops.equals_equals(copy _1, copy _24) -> [bb32];
+        _22 = call const fn baml.ops.equals_equals(copy _1, copy _23) -> [bb32];
     }
 
     bb32: {
-        _22 = short_circuit(||) copy _23 -> [eval: bb33, join: bb35];
+        branch copy _22 -> [bb44, bb33];
     }
 
     bb33: {
@@ -4474,24 +4435,24 @@ fn ai.internal._media_shape(t: reflect.Type) -> string {
     }
 
     bb34: {
-        _22 = call const fn baml.ops.equals_equals(copy _1, copy _25) -> [bb35];
+        _24 = call const fn baml.ops.equals_equals(copy _1, copy _25) -> [bb35];
     }
 
     bb35: {
-        branch copy _22 -> [bb44, bb36];
+        branch copy _24 -> [bb44, bb36];
     }
 
     bb36: {
-        _28 = load_type(string | image);
+        _27 = load_type(string | image);
         goto -> bb37;
     }
 
     bb37: {
-        _27 = call const fn baml.ops.equals_equals(copy _1, copy _28) -> [bb38];
+        _26 = call const fn baml.ops.equals_equals(copy _1, copy _27) -> [bb38];
     }
 
     bb38: {
-        _26 = short_circuit(||) copy _27 -> [eval: bb39, join: bb41];
+        branch copy _26 -> [bb43, bb39];
     }
 
     bb39: {
@@ -4500,11 +4461,11 @@ fn ai.internal._media_shape(t: reflect.Type) -> string {
     }
 
     bb40: {
-        _26 = call const fn baml.ops.equals_equals(copy _1, copy _29) -> [bb41];
+        _28 = call const fn baml.ops.equals_equals(copy _1, copy _29) -> [bb41];
     }
 
     bb41: {
-        branch copy _26 -> [bb43, bb42];
+        branch copy _28 -> [bb43, bb42];
     }
 
     bb42: {
@@ -4798,7 +4759,6 @@ fn ai.internal._media_all_text(items: baml.json.json[]) -> bool {
     let _6: baml.json.json // i
     let _7: bool
     let _8: bool
-    let _9: bool
 
     bb0: {
         _2 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _1) -> [bb1];
@@ -4810,43 +4770,33 @@ fn ai.internal._media_all_text(items: baml.json.json[]) -> bool {
 
     bb2: {
         _4 = is_type(copy _3, baml.iter.Done);
-        branch copy _4 -> [bb8, bb3];
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
         _5 = copy _3;
         fresh_cell(_6);
         _6 = copy _5;
-        _9 = is_type(copy _6, string);
-        branch copy _9 -> [bb5, bb4];
+        _8 = is_type(copy _6, string);
+        _7 = copy _8;
+        goto -> bb4;
     }
 
     bb4: {
-        _8 = const false;
-        goto -> bb6;
+        branch copy _7 -> [bb1, bb5];
     }
 
     bb5: {
-        _8 = const true;
-        goto -> bb6;
+        _0 = const false;
+        goto -> bb7;
     }
 
     bb6: {
-        _7 = !copy _8;
-        branch copy _7 -> [bb7, bb1];
+        _0 = const true;
+        goto -> bb7;
     }
 
     bb7: {
-        _0 = const false;
-        goto -> bb9;
-    }
-
-    bb8: {
-        _0 = const true;
-        goto -> bb9;
-    }
-
-    bb9: {
         return;
     }
 }
@@ -4944,6 +4894,7 @@ fn ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provider: s
     let _35: reflect.Type
     let _36: string
     let _37: reflect.Type
+    let _38: string
 
     bb0: {
         _4 = const 0_i64;
@@ -5023,11 +4974,12 @@ fn ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provider: s
 
     bb14: {
         _32 = load_type(string);
+        _38 = const "Expected only ";
         _31 = call const fn baml.String.from<copy _32>(copy _2) -> [bb15];
     }
 
     bb15: {
-        _30 = const "Expected only " + copy _31;
+        _30 = copy _38 + copy _31;
         _29 = copy _30 + const " output parts, got ";
         _34 = copy _4;
         _35 = load_type(int);
@@ -5091,19 +5043,19 @@ fn ai.internal._media_mime_type(explicit: string | null, source_value: string, k
     }
 
     bb2: {
-        _8 = call const fn baml.String.includes(copy _6, const ".jpg") -> [bb3];
+        _7 = call const fn baml.String.includes(copy _6, const ".jpg") -> [bb3];
     }
 
     bb3: {
-        _7 = short_circuit(||) copy _8 -> [eval: bb4, join: bb5];
+        branch copy _7 -> [bb61, bb4];
     }
 
     bb4: {
-        _7 = call const fn baml.String.includes(copy _6, const ".jpeg") -> [bb5];
+        _8 = call const fn baml.String.includes(copy _6, const ".jpeg") -> [bb5];
     }
 
     bb5: {
-        branch copy _7 -> [bb61, bb6];
+        branch copy _8 -> [bb61, bb6];
     }
 
     bb6: {
@@ -5435,66 +5387,70 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     let _61: string
     let _62: reflect.Type
     let _63: bool
-    let _64: bool
-    let _65: string
-    let _66: baml.http.Response // response
-    let _67: unknown // e
-    let _68: string
-    let _69: baml.time.Duration
-    let _70: unknown
-    let _71: baml.errors.Timeout // timeout
-    let _72: ai.errors.NetworkFailure
+    let _64: string
+    let _65: baml.http.Response // response
+    let _66: unknown // e
+    let _67: string
+    let _68: baml.time.Duration
+    let _69: unknown
+    let _70: baml.errors.Timeout // timeout
+    let _71: ai.errors.NetworkFailure
+    let _72: string
     let _73: string
     let _74: string
     let _75: string
     let _76: string
-    let _77: string
-    let _78: reflect.Type
+    let _77: reflect.Type
+    let _78: string
     let _79: string
-    let _80: string
+    let _80: reflect.Type
     let _81: reflect.Type
-    let _82: reflect.Type
-    let _83: bool
-    let _84: bool
-    let _85: ai.errors.NetworkFailure
+    let _82: bool
+    let _83: ai.errors.NetworkFailure
+    let _84: string
+    let _85: string
     let _86: string
     let _87: string
     let _88: string
-    let _89: string
+    let _89: reflect.Type
     let _90: string
-    let _91: reflect.Type
-    let _92: string
-    let _93: int
-    let _94: reflect.Type
-    let _95: string // response_mime
-    let _96: string
-    let _97: string | null
-    let _98: (map<string, string>, string) -> string | null throws never
-    let _99: reflect.Type
-    let _100: reflect.Type
-    let _101: bool
-    let _102: uint8array // body
-    let _103: unknown // e
-    let _104: ai.errors.NetworkFailure
+    let _91: int
+    let _92: reflect.Type
+    let _93: string // response_mime
+    let _94: string
+    let _95: string | null
+    let _96: (map<string, string>, string) -> string | null throws never
+    let _97: reflect.Type
+    let _98: reflect.Type
+    let _99: uint8array // body
+    let _100: unknown // e
+    let _101: ai.errors.NetworkFailure
+    let _102: string
+    let _103: string
+    let _104: string
     let _105: string
     let _106: string
-    let _107: string
+    let _107: reflect.Type
     let _108: string
     let _109: string
     let _110: reflect.Type
-    let _111: string
+    let _111: reflect.Type
     let _112: string
-    let _113: reflect.Type
-    let _114: reflect.Type
+    let _113: string
+    let _114: string
     let _115: string
-    let _116: string
-    let _117: string
-    let _118: string
-    let _119: string | null
-    let _120: string[]
-    let _121: reflect.Type
-    let _122: bool
-    let _123: baml.errors.InvalidArgument
+    let _116: string | null
+    let _117: string[]
+    let _118: reflect.Type
+    let _119: baml.errors.InvalidArgument
+    let _120: string
+    let _121: string
+    let _122: null
+    let _123: string
+    let _124: string
+    let _125: string
+    let _126: string
+    let _127: null
 
     bb0: {
         _6 = copy _2;
@@ -5512,8 +5468,8 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     }
 
     bb3: {
-        _123 = baml.errors.InvalidArgument { const "media has no URL, file, or base64 content" };
-        throw copy _123;
+        _119 = baml.errors.InvalidArgument { const "media has no URL, file, or base64 content" };
+        throw copy _119;
     }
 
     bb4: {
@@ -5526,8 +5482,7 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     }
 
     bb6: {
-        _64 = !copy _5;
-        _63 = short_circuit(||) copy _64 -> [eval: bb7, join: bb8];
+        branch copy _5 -> [bb7, bb27];
     }
 
     bb7: {
@@ -5539,103 +5494,100 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     }
 
     bb9: {
-        _68 = copy _41;
-        _69 = call const fn baml.time.Duration.from_seconds(const 30_i64) -> [bb10, unwind: bb60];
+        _67 = copy _41;
+        _68 = call const fn baml.time.Duration.from_seconds(const 30_i64) -> [bb10, unwind: bb60];
     }
 
     bb10: {
-        _66 = call const fn baml.http.fetch(copy _68, copy _69) -> [bb11, unwind: bb60];
+        _65 = call const fn baml.http.fetch(copy _67, copy _68) -> [bb11, unwind: bb60];
     }
 
     bb11: {
-        _84 = call const fn baml.http.Response.ok(copy _66) -> [bb12];
+        _82 = call const fn baml.http.Response.ok(copy _65) -> [bb12];
     }
 
     bb12: {
-        _83 = !copy _84;
-        branch copy _83 -> [bb24, bb13];
+        branch copy _82 -> [bb16, bb13];
     }
 
     bb13: {
-        _98 = copy _66.1;
-        _99 = load_type(string);
-        _100 = load_type(string);
-        _97 = call const fn baml.Map.get<copy _99, copy _100>(copy _98, const "content-type") -> [bb14];
+        _88 = copy _41;
+        _89 = load_type(string);
+        _125 = const "media URL ";
+        _87 = call const fn baml.String.from<copy _89>(copy _88) -> [bb14];
     }
 
     bb14: {
-        _96 = copy _97;
-        _101 = copy _96 == const null;
-        branch copy _101 -> [bb15, bb16];
+        _86 = copy _125 + copy _87;
+        _85 = copy _86 + const " returned HTTP ";
+        _91 = copy _65.0;
+        _92 = load_type(int);
+        _90 = call const fn baml.String.from<copy _92>(copy _91) -> [bb15];
     }
 
     bb15: {
-        _96 = copy _4;
-        goto -> bb16;
+        _84 = copy _85 + copy _90;
+        _83 = ai.errors.NetworkFailure { const "media", copy _84, const null, const null };
+        throw copy _83;
     }
 
     bb16: {
-        _95 = copy _96;
-        _102 = sys_op const fn baml.http.Response.bytes(copy _66) -> bb17 unwind bb67;
+        _96 = copy _65.1;
+        _97 = load_type(string);
+        _98 = load_type(string);
+        _95 = call const fn baml.Map.get<copy _97, copy _98>(copy _96, const "content-type") -> [bb17];
     }
 
     bb17: {
-        _115 = call const fn baml.Uint8Array.to_base64(copy _102) -> [bb18];
+        _94 = short_circuit(??) copy _95 -> [eval: bb18, join: bb19];
     }
 
     bb18: {
-        _120 = call const fn baml.String.split(copy _95, const ";") -> [bb19];
+        _94 = copy _4;
+        goto -> bb19;
     }
 
     bb19: {
-        _121 = load_type(string);
-        _119 = call const fn baml.Array.at<copy _121>(copy _120, const 0_i64) -> [bb20];
+        _93 = copy _94;
+        _99 = sys_op const fn baml.http.Response.bytes(copy _65) -> bb20 unwind bb67;
     }
 
     bb20: {
-        _118 = copy _119;
-        _122 = copy _118 == const null;
-        branch copy _122 -> [bb21, bb22];
+        _127 = const null;
+        _112 = call const fn baml.Uint8Array.to_base64(copy _99) -> [bb21];
     }
 
     bb21: {
-        _118 = copy _4;
-        goto -> bb22;
+        _117 = call const fn baml.String.split(copy _93, const ";") -> [bb22];
     }
 
     bb22: {
-        _117 = copy _118;
-        _116 = call const fn baml.String.trim(copy _117) -> [bb23];
+        _118 = load_type(string);
+        _116 = call const fn baml.Array.at<copy _118>(copy _117, const 0_i64) -> [bb23];
     }
 
     bb23: {
-        _0 = ai.wire.ResolvedMedia { const null, copy _115, copy _116 };
-        goto -> bb48;
+        _115 = short_circuit(??) copy _116 -> [eval: bb24, join: bb25];
     }
 
     bb24: {
-        _90 = copy _41;
-        _91 = load_type(string);
-        _89 = call const fn baml.String.from<copy _91>(copy _90) -> [bb25];
+        _115 = copy _4;
+        goto -> bb25;
     }
 
     bb25: {
-        _88 = const "media URL " + copy _89;
-        _87 = copy _88 + const " returned HTTP ";
-        _93 = copy _66.0;
-        _94 = load_type(int);
-        _92 = call const fn baml.String.from<copy _94>(copy _93) -> [bb26];
+        _114 = copy _115;
+        _113 = call const fn baml.String.trim(copy _114) -> [bb26];
     }
 
     bb26: {
-        _86 = copy _87 + copy _92;
-        _85 = ai.errors.NetworkFailure { const "media", copy _86, const null, const null };
-        throw copy _85;
+        _0 = ai.wire.ResolvedMedia { copy _127, copy _112, copy _113 };
+        goto -> bb48;
     }
 
     bb27: {
-        _65 = copy _41;
-        _0 = ai.wire.ResolvedMedia { copy _65, const null, copy _4 };
+        _64 = copy _41;
+        _0 = ai.wire.ResolvedMedia { copy _64, const null, copy _4 };
         goto -> bb48;
     }
 
@@ -5679,11 +5631,12 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     bb36: {
         _61 = copy _52;
         _62 = load_type(string);
+        _123 = const "media carries a data: URL with no ;base64, marker, which has no payload to send: ";
         _60 = call const fn baml.String.from<copy _62>(copy _61) -> [bb37];
     }
 
     bb37: {
-        _59 = const "media carries a data: URL with no ;base64, marker, which has no payload to send: " + copy _60;
+        _59 = copy _123 + copy _60;
         _58 = baml.errors.InvalidArgument { copy _59 };
         throw copy _58;
     }
@@ -5696,6 +5649,7 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     }
 
     bb39: {
+        _122 = const null;
         _46 = call const fn baml.String.slice(copy _41, copy _47, copy _49) -> [bb40];
     }
 
@@ -5705,7 +5659,7 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     }
 
     bb41: {
-        _0 = ai.wire.ResolvedMedia { const null, copy _46, copy _50 };
+        _0 = ai.wire.ResolvedMedia { copy _122, copy _46, copy _50 };
         goto -> bb48;
     }
 
@@ -5749,11 +5703,12 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     bb50: {
         _16 = copy _7;
         _17 = load_type(string);
+        _120 = const "media file ";
         _15 = call const fn baml.String.from<copy _17>(copy _16) -> [bb51];
     }
 
     bb51: {
-        _14 = const "media file " + copy _15;
+        _14 = copy _120 + copy _15;
         _13 = copy _14 + const " could not be opened: ";
         _20 = load_type(baml.errors.InvalidArgument | baml.errors.Io);
         _19 = call const fn baml.String.from<copy _20>(copy _9) -> [bb52];
@@ -5781,11 +5736,12 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     bb56: {
         _31 = copy _7;
         _32 = load_type(string);
+        _121 = const "media file ";
         _30 = call const fn baml.String.from<copy _32>(copy _31) -> [bb57];
     }
 
     bb57: {
-        _29 = const "media file " + copy _30;
+        _29 = copy _121 + copy _30;
         _28 = copy _29 + const " could not be read: ";
         _35 = load_type(baml.errors.Io);
         _34 = call const fn baml.String.from<copy _35>(copy _23) -> [bb58];
@@ -5803,69 +5759,71 @@ fn ai.internal._resolve_media_content(url: string | null, file: string | null, i
     }
 
     bb60: {
-        _70 = copy _67;
-        _70 = narrow_bind copy _70 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Timeout" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb66, bb61];
+        _69 = copy _66;
+        _69 = narrow_bind copy _69 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Timeout" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb66, bb61];
     }
 
     bb61: {
-        throw_if_panic copy _67 -> bb62;
+        throw_if_panic copy _66 -> bb62;
     }
 
     bb62: {
-        _77 = copy _41;
-        _78 = load_type(string);
-        _76 = call const fn baml.String.from<copy _78>(copy _77) -> [bb63];
+        _76 = copy _41;
+        _77 = load_type(string);
+        _124 = const "media URL ";
+        _75 = call const fn baml.String.from<copy _77>(copy _76) -> [bb63];
     }
 
     bb63: {
-        _75 = const "media URL " + copy _76;
-        _74 = copy _75 + const " could not be fetched: ";
-        _81 = load_type(baml.errors.Io);
-        _80 = call const fn baml.String.from<copy _81>(copy _67) -> [bb64];
+        _74 = copy _124 + copy _75;
+        _73 = copy _74 + const " could not be fetched: ";
+        _80 = load_type(baml.errors.Io);
+        _79 = call const fn baml.String.from<copy _80>(copy _66) -> [bb64];
     }
 
     bb64: {
-        _82 = load_type(string);
-        _79 = call const fn baml.String.from<copy _82>(copy _80) -> [bb65];
+        _81 = load_type(string);
+        _78 = call const fn baml.String.from<copy _81>(copy _79) -> [bb65];
     }
 
     bb65: {
-        _73 = copy _74 + copy _79;
-        _72 = ai.errors.NetworkFailure { const "media", copy _73, const null, const null };
-        throw copy _72;
-    }
-
-    bb66: {
-        _71 = copy _70;
+        _72 = copy _73 + copy _78;
+        _71 = ai.errors.NetworkFailure { const "media", copy _72, const null, const null };
         throw copy _71;
     }
 
+    bb66: {
+        _70 = copy _69;
+        throw copy _70;
+    }
+
     bb67: {
-        throw_if_panic copy _103 -> bb68;
+        throw_if_panic copy _100 -> bb68;
     }
 
     bb68: {
-        _109 = copy _41;
-        _110 = load_type(string);
-        _108 = call const fn baml.String.from<copy _110>(copy _109) -> [bb69];
+        _106 = copy _41;
+        _107 = load_type(string);
+        _126 = const "media URL ";
+        _105 = call const fn baml.String.from<copy _107>(copy _106) -> [bb69];
     }
 
     bb69: {
-        _107 = const "media URL " + copy _108;
-        _106 = copy _107 + const " body could not be read: ";
-        _113 = load_type(baml.errors.Io | baml.errors.Timeout);
-        _112 = call const fn baml.String.from<copy _113>(copy _103) -> [bb70];
+        _104 = copy _126 + copy _105;
+        _103 = copy _104 + const " body could not be read: ";
+        _110 = load_type(baml.errors.Io | baml.errors.Timeout);
+        _109 = call const fn baml.String.from<copy _110>(copy _100) -> [bb70];
     }
 
     bb70: {
-        _114 = load_type(string);
-        _111 = call const fn baml.String.from<copy _114>(copy _112) -> [bb71];
+        _111 = load_type(string);
+        _108 = call const fn baml.String.from<copy _111>(copy _109) -> [bb71];
     }
 
     bb71: {
-        _105 = copy _106 + copy _111;
-        _104 = ai.errors.NetworkFailure { const "media", copy _105, const null, const null };
-        throw copy _104;
+        _102 = copy _103 + copy _108;
+        _101 = ai.errors.NetworkFailure { const "media", copy _102, const null, const null };
+        throw copy _101;
     }
 }
 
@@ -5899,6 +5857,8 @@ fn ai.internal._resolve_media_preview_content(url: string | null, file: string |
     let _25: ai.errors.PreviewUnsupported
     let _26: string
     let _27: ai.errors.PreviewUnsupported
+    let _28: string
+    let _29: null
 
     bb0: {
         _5 = copy _2;
@@ -5957,6 +5917,7 @@ fn ai.internal._resolve_media_preview_content(url: string | null, file: string |
     }
 
     bb11: {
+        _29 = const null;
         _19 = call const fn baml.String.slice(copy _14, copy _20, copy _22) -> [bb12];
     }
 
@@ -5966,7 +5927,7 @@ fn ai.internal._resolve_media_preview_content(url: string | null, file: string |
     }
 
     bb13: {
-        _0 = ai.wire.ResolvedMedia { const null, copy _19, copy _23 };
+        _0 = ai.wire.ResolvedMedia { copy _29, copy _19, copy _23 };
         goto -> bb15;
     }
 
@@ -5983,11 +5944,12 @@ fn ai.internal._resolve_media_preview_content(url: string | null, file: string |
         _6 = copy _5;
         _10 = copy _6;
         _11 = load_type(string);
+        _28 = const "request preview cannot read local media file ";
         _9 = call const fn baml.String.from<copy _11>(copy _10) -> [bb17];
     }
 
     bb17: {
-        _8 = const "request preview cannot read local media file " + copy _9;
+        _8 = copy _28 + copy _9;
         _7 = ai.errors.PreviewUnsupported { const "media-preview", copy _8 };
         throw copy _7;
     }
@@ -6012,6 +5974,7 @@ fn ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     let _14: reflect.Diagnostic[]
     let _15: reflect.Diagnostic
     let _16: string
+    let _17: string
 
     bb0: {
         _2 = call const fn reflect.Type._validate_renderable(copy _1) -> [bb1];
@@ -6056,11 +6019,12 @@ fn ai.internal.validate_output_type(return_type: reflect.Type) -> void {
     }
 
     bb9: {
+        _17 = const "empty enum `";
         _11 = virtual_call to_string as baml.ToString(copy _1) -> [bb10];
     }
 
     bb10: {
-        _10 = const "empty enum `" + copy _11;
+        _10 = copy _17 + copy _11;
         _9 = copy _10 + const "` cannot be rendered as an LLM output schema";
         _13 = copy _9;
         _16 = copy _9;
@@ -6156,67 +6120,58 @@ fn ai.internal._redact_after(text: string, marker: string) -> string {
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _5 = call const fn baml.String.index_of(copy _4, copy _2) -> [bb2];
     }
 
     bb2: {
-        _0 = copy _3;
-        goto -> bb6;
+        _6 = copy _5;
+        _6 = narrow_bind copy _6 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb5, bb3];
     }
 
     bb3: {
-        _5 = call const fn baml.String.index_of(copy _4, copy _2) -> [bb4];
-    }
-
-    bb4: {
-        _6 = copy _5;
-        _6 = narrow_bind copy _6 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb7, bb5];
-    }
-
-    bb5: {
         _19 = copy _3;
         _20 = copy _4;
         _0 = copy _19 + copy _20;
-        goto -> bb6;
+        goto -> bb4;
     }
 
-    bb6: {
+    bb4: {
         return;
     }
 
-    bb7: {
+    bb5: {
         _7 = copy _6;
         _9 = copy _7;
-        _10 = call const fn baml.String.length(copy _2) -> [bb8];
+        _10 = call const fn baml.String.length(copy _2) -> [bb6];
     }
 
-    bb8: {
+    bb6: {
         _8 = copy _9 + copy _10;
         _12 = copy _8;
-        _11 = call const fn baml.String.slice(copy _4, const 0_i64, copy _12) -> [bb9];
+        _11 = call const fn baml.String.slice(copy _4, const 0_i64, copy _12) -> [bb7];
     }
 
-    bb9: {
+    bb7: {
         _3 = copy _3 + copy _11;
         _3 = copy _3 + const "REDACTED";
         _14 = copy _8;
-        _15 = call const fn baml.String.length(copy _4) -> [bb10];
+        _15 = call const fn baml.String.length(copy _4) -> [bb8];
+    }
+
+    bb8: {
+        _13 = call const fn baml.String.slice(copy _4, copy _14, copy _15) -> [bb9];
+    }
+
+    bb9: {
+        _17 = copy _13;
+        _16 = call const fn ai.internal._redact_value_end(copy _17) -> [bb10];
     }
 
     bb10: {
-        _13 = call const fn baml.String.slice(copy _4, copy _14, copy _15) -> [bb11];
+        _18 = call const fn baml.String.length(copy _13) -> [bb11];
     }
 
     bb11: {
-        _17 = copy _13;
-        _16 = call const fn ai.internal._redact_value_end(copy _17) -> [bb12];
-    }
-
-    bb12: {
-        _18 = call const fn baml.String.length(copy _13) -> [bb13];
-    }
-
-    bb13: {
         _4 = call const fn baml.String.slice(copy _13, copy _16, copy _18) -> [bb1];
     }
 }
@@ -6773,6 +6728,8 @@ fn ai.mcp.Connection.connect(name: string, command: string, args: string[], time
     let _26: map<string, unknown>
     let _27: void
     let _28: string
+    let _29: string
+    let _30: string
 
     bb0: {
         _5 = copy _4 == const <omitted>;
@@ -6827,22 +6784,24 @@ fn ai.mcp.Connection.connect(name: string, command: string, args: string[], time
 
     bb10: {
         _12 = load_type(string);
+        _29 = const "mcp/";
         _11 = call const fn baml.String.from<copy _12>(copy _1) -> [bb11];
     }
 
     bb11: {
-        _10 = const "mcp/" + copy _11;
+        _10 = copy _29 + copy _11;
         _16 = load_type(baml.errors.Io);
         _15 = call const fn baml.String.from<copy _16>(copy _7) -> [bb12];
     }
 
     bb12: {
         _17 = load_type(string);
+        _30 = const "the MCP server could not start: ";
         _14 = call const fn baml.String.from<copy _17>(copy _15) -> [bb13];
     }
 
     bb13: {
-        _13 = const "the MCP server could not start: " + copy _14;
+        _13 = copy _30 + copy _14;
         _9 = ai.errors.NetworkFailure { copy _10, copy _13, const null, const null };
         throw copy _9;
     }
@@ -6870,6 +6829,8 @@ fn ai.mcp.Connection._send(self: ai.mcp.Connection, line: string) -> void {
     let _17: string
     let _18: reflect.Type
     let _19: reflect.Type
+    let _20: string
+    let _21: string
 
     bb0: {
         _4 = [copy _2, const "\n"]: string[];
@@ -6899,22 +6860,24 @@ fn ai.mcp.Connection._send(self: ai.mcp.Connection, line: string) -> void {
     bb5: {
         _13 = copy _1.0;
         _14 = load_type(string);
+        _20 = const "mcp/";
         _12 = call const fn baml.String.from<copy _14>(copy _13) -> [bb6];
     }
 
     bb6: {
-        _11 = const "mcp/" + copy _12;
+        _11 = copy _20 + copy _12;
         _18 = load_type(baml.errors.Io);
         _17 = call const fn baml.String.from<copy _18>(copy _7) -> [bb7];
     }
 
     bb7: {
         _19 = load_type(string);
+        _21 = const "writing to the MCP server failed: ";
         _16 = call const fn baml.String.from<copy _19>(copy _17) -> [bb8];
     }
 
     bb8: {
-        _15 = const "writing to the MCP server failed: " + copy _16;
+        _15 = copy _21 + copy _16;
         _10 = ai.errors.NetworkFailure { copy _11, copy _15, const null, const null };
         throw copy _10;
     }
@@ -6930,29 +6893,33 @@ fn ai.mcp.Connection._request(self: ai.mcp.Connection, method: string, params: m
     let _5: void
     let _6: string
     let _7: int
-    let _8: unknown // e
-    let _9: baml.time.Duration
-    let _10: int
-    let _11: () -> baml.json.json throws ai.errors.InvalidRequest | ai.errors.NetworkFailure
-    let _12: reflect.Type
+    let _8: string
+    let _9: unknown // e
+    let _10: baml.time.Duration
+    let _11: int
+    let _12: () -> baml.json.json throws ai.errors.InvalidRequest | ai.errors.NetworkFailure
     let _13: reflect.Type
-    let _14: bool
-    let _15: ai.errors.NetworkFailure
-    let _16: string
+    let _14: reflect.Type
+    let _15: bool
+    let _16: ai.errors.NetworkFailure
     let _17: string
     let _18: string
-    let _19: reflect.Type
-    let _20: string
+    let _19: string
+    let _20: reflect.Type
     let _21: string
     let _22: string
-    let _23: int
-    let _24: reflect.Type
+    let _23: string
+    let _24: int
+    let _25: reflect.Type
+    let _26: string
+    let _27: string
 
     bb0: {
         _4 = copy _1.4;
         _1.4 = copy _1.4 + const 1_i64;
         _7 = copy _4;
-        _6 = call const fn ai.mcp.rpc_line(copy _7, copy _2, copy _3) -> [bb1];
+        _8 = copy _2;
+        _6 = call const fn ai.mcp.rpc_line(copy _7, copy _8, copy _3) -> [bb1];
     }
 
     bb1: {
@@ -6960,15 +6927,15 @@ fn ai.mcp.Connection._request(self: ai.mcp.Connection, method: string, params: m
     }
 
     bb2: {
-        _10 = copy _1.3;
-        _9 = call const fn baml.time.Duration.from_milliseconds(copy _10) -> [bb3, unwind: bb5];
+        _11 = copy _1.3;
+        _10 = call const fn baml.time.Duration.from_milliseconds(copy _11) -> [bb3, unwind: bb5];
     }
 
     bb3: {
-        _11 = make_closure lambda[0](copy _1, copy _4, copy _2);
-        _12 = load_type(baml.json.json);
-        _13 = load_type(ai.errors.InvalidRequest | ai.errors.NetworkFailure);
-        _0 = call const fn baml.future.with_timeout<copy _12, copy _13>(copy _9, copy _11) -> [bb4, unwind: bb5];
+        _12 = make_closure lambda[0](copy _1, copy _4, copy _2);
+        _13 = load_type(baml.json.json);
+        _14 = load_type(ai.errors.InvalidRequest | ai.errors.NetworkFailure);
+        _0 = call const fn baml.future.with_timeout<copy _13, copy _14>(copy _10, copy _12) -> [bb4, unwind: bb5];
     }
 
     bb4: {
@@ -6976,32 +6943,34 @@ fn ai.mcp.Connection._request(self: ai.mcp.Connection, method: string, params: m
     }
 
     bb5: {
-        _14 = is_type(copy _8, baml.errors.Timeout);
-        branch copy _14 -> [bb7, bb6];
+        _15 = is_type(copy _9, baml.errors.Timeout);
+        branch copy _15 -> [bb7, bb6];
     }
 
     bb6: {
-        rethrow copy _8;
+        rethrow copy _9;
     }
 
     bb7: {
-        _18 = copy _1.0;
-        _19 = load_type(string);
-        _17 = call const fn baml.String.from<copy _19>(copy _18) -> [bb8];
+        _19 = copy _1.0;
+        _20 = load_type(string);
+        _26 = const "mcp/";
+        _18 = call const fn baml.String.from<copy _20>(copy _19) -> [bb8];
     }
 
     bb8: {
-        _16 = const "mcp/" + copy _17;
-        _23 = copy _1.3;
-        _24 = load_type(int);
-        _22 = call const fn baml.String.from<copy _24>(copy _23) -> [bb9];
+        _17 = copy _26 + copy _18;
+        _24 = copy _1.3;
+        _25 = load_type(int);
+        _27 = const "reading from the MCP server timed out after ";
+        _23 = call const fn baml.String.from<copy _25>(copy _24) -> [bb9];
     }
 
     bb9: {
-        _21 = const "reading from the MCP server timed out after " + copy _22;
-        _20 = copy _21 + const "ms";
-        _15 = ai.errors.NetworkFailure { copy _16, copy _20, const null, const null };
-        throw copy _15;
+        _22 = copy _27 + copy _23;
+        _21 = copy _22 + const "ms";
+        _16 = ai.errors.NetworkFailure { copy _17, copy _21, const null, const null };
+        throw copy _16;
     }
 }
 
@@ -7065,15 +7034,11 @@ fn .<lambda(Connection._request, 0)>() -> int | float | string | bool | null | b
     let _54: string
     let _55: string
     let _56: reflect.Type
-    let _57: ai.errors.NetworkFailure
+    let _57: string
     let _58: string
     let _59: string
     let _60: string
-    let _61: reflect.Type
-    let _62: string
-    let _63: string
-    let _64: string
-    let _65: reflect.Type
+    let _61: string
 
     bb0: {
         goto -> bb5;
@@ -7097,158 +7062,140 @@ fn .<lambda(Connection._request, 0)>() -> int | float | string | bool | null | b
     bb4: {
         _26 = copy capture[1];
         _22 = copy _23 == copy _26;
-        branch copy _22 -> [bb23, bb5];
+        branch copy _22 -> [bb19, bb5];
     }
 
     bb5: {
-        branch const true -> [bb9, bb6];
+        _3 = copy capture[0].2;
+        _1 = call const fn baml.sys.<(baml.sys.ReadPipeLines as baml.iter.Iterator)>.next(copy _3) -> [bb11, unwind: bb6];
     }
 
     bb6: {
-        _60 = copy capture[0].0;
-        _61 = load_type(string);
-        _59 = call const fn baml.String.from<copy _61>(copy _60) -> [bb7];
+        throw_if_panic copy _2 -> bb7;
     }
 
     bb7: {
-        _58 = const "mcp/" + copy _59;
-        _64 = copy capture[2];
-        _65 = load_type(string);
-        _63 = call const fn baml.String.from<copy _65>(copy _64) -> [bb8];
+        _7 = copy capture[0].0;
+        _8 = load_type(string);
+        _57 = const "mcp/";
+        _6 = call const fn baml.String.from<copy _8>(copy _7) -> [bb8];
     }
 
     bb8: {
-        _62 = const "no response for " + copy _63;
-        _57 = ai.errors.NetworkFailure { copy _58, copy _62, const null, const null };
-        throw copy _57;
+        _5 = copy _57 + copy _6;
+        _12 = load_type(baml.errors.Io);
+        _11 = call const fn baml.String.from<copy _12>(copy _2) -> [bb9];
     }
 
     bb9: {
-        _3 = copy capture[0].2;
-        _1 = call const fn baml.sys.<(baml.sys.ReadPipeLines as baml.iter.Iterator)>.next(copy _3) -> [bb15, unwind: bb10];
+        _13 = load_type(string);
+        _58 = const "reading from the MCP server failed: ";
+        _10 = call const fn baml.String.from<copy _13>(copy _11) -> [bb10];
     }
 
     bb10: {
-        throw_if_panic copy _2 -> bb11;
-    }
-
-    bb11: {
-        _7 = copy capture[0].0;
-        _8 = load_type(string);
-        _6 = call const fn baml.String.from<copy _8>(copy _7) -> [bb12];
-    }
-
-    bb12: {
-        _5 = const "mcp/" + copy _6;
-        _12 = load_type(baml.errors.Io);
-        _11 = call const fn baml.String.from<copy _12>(copy _2) -> [bb13];
-    }
-
-    bb13: {
-        _13 = load_type(string);
-        _10 = call const fn baml.String.from<copy _13>(copy _11) -> [bb14];
-    }
-
-    bb14: {
-        _9 = const "reading from the MCP server failed: " + copy _10;
+        _9 = copy _58 + copy _10;
         _4 = ai.errors.NetworkFailure { copy _5, copy _9, const null, const null };
         throw copy _4;
     }
 
-    bb15: {
+    bb11: {
         _14 = copy _1;
-        _14 = narrow_bind copy _14 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb19, bb16];
+        _14 = narrow_bind copy _14 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb12];
     }
 
-    bb16: {
+    bb12: {
         _51 = copy capture[0].0;
         _52 = load_type(string);
-        _50 = call const fn baml.String.from<copy _52>(copy _51) -> [bb17];
+        _60 = const "mcp/";
+        _50 = call const fn baml.String.from<copy _52>(copy _51) -> [bb13];
     }
 
-    bb17: {
-        _49 = const "mcp/" + copy _50;
+    bb13: {
+        _49 = copy _60 + copy _50;
         _55 = copy capture[2];
         _56 = load_type(string);
-        _54 = call const fn baml.String.from<copy _56>(copy _55) -> [bb18];
+        _61 = const "the MCP server stream ended before answering ";
+        _54 = call const fn baml.String.from<copy _56>(copy _55) -> [bb14];
     }
 
-    bb18: {
-        _53 = const "the MCP server stream ended before answering " + copy _54;
+    bb14: {
+        _53 = copy _61 + copy _54;
         _48 = ai.errors.NetworkFailure { copy _49, copy _53, const null, const null };
         throw copy _48;
     }
 
-    bb19: {
+    bb15: {
         _15 = copy _14;
-        _16 = call const fn baml.String.trim(copy _15) -> [bb20];
+        _16 = call const fn baml.String.trim(copy _15) -> [bb16];
     }
 
-    bb20: {
-        _18 = call const fn baml.String.length(copy _16) -> [bb21];
+    bb16: {
+        _18 = call const fn baml.String.length(copy _16) -> [bb17];
     }
 
-    bb21: {
+    bb17: {
         _17 = copy _18 > const 0_i64;
-        branch copy _17 -> [bb22, bb5];
+        branch copy _17 -> [bb18, bb5];
     }
 
-    bb22: {
+    bb18: {
         _21 = copy _16;
         _19 = call const fn baml.json.parse(copy _21) -> [bb3, unwind: bb1];
     }
 
-    bb23: {
+    bb19: {
         _28 = copy _19;
         _29 = load_type(baml.json.json);
-        _27 = call const fn baml.json.path_or<copy _29>(copy _28, const ".error", const null) -> [bb24];
+        _27 = call const fn baml.json.path_or<copy _29>(copy _28, const ".error", const null) -> [bb20];
     }
 
-    bb24: {
+    bb20: {
         _31 = copy _27;
-        _32 = call const fn baml.ops.equals_equals(copy _31, const null) -> [bb25];
+        _32 = call const fn baml.ops.equals_equals(copy _31, const null) -> [bb21];
     }
 
-    bb25: {
+    bb21: {
         _30 = !copy _32;
-        branch copy _30 -> [bb28, bb26];
+        branch copy _30 -> [bb24, bb22];
     }
 
-    bb26: {
+    bb22: {
         _46 = copy _19;
         _47 = load_type(baml.json.json);
-        _0 = call const fn baml.json.path_or<copy _47>(copy _46, const ".result", const null) -> [bb27];
+        _0 = call const fn baml.json.path_or<copy _47>(copy _46, const ".result", const null) -> [bb23];
     }
 
-    bb27: {
+    bb23: {
         return;
     }
 
-    bb28: {
+    bb24: {
         _36 = copy capture[0].0;
         _37 = load_type(string);
-        _35 = call const fn baml.String.from<copy _37>(copy _36) -> [bb29];
+        _59 = const "mcp/";
+        _35 = call const fn baml.String.from<copy _37>(copy _36) -> [bb25];
     }
 
-    bb29: {
-        _34 = const "mcp/" + copy _35;
+    bb25: {
+        _34 = copy _59 + copy _35;
         _39 = copy _27;
         _40 = load_type(int | null);
-        _38 = call const fn baml.json.path_or<copy _40>(copy _39, const ".code", const null) -> [bb30];
+        _38 = call const fn baml.json.path_or<copy _40>(copy _39, const ".code", const null) -> [bb26];
     }
 
-    bb30: {
+    bb26: {
         _42 = copy _27;
         _43 = load_type(string);
-        _41 = call const fn baml.json.path_or<copy _43>(copy _42, const ".message", const "MCP error") -> [bb31];
+        _41 = call const fn baml.json.path_or<copy _43>(copy _42, const ".message", const "MCP error") -> [bb27];
     }
 
-    bb31: {
+    bb27: {
         _45 = copy _27;
-        _44 = call const fn baml.json.stringify(copy _45) -> [bb32];
+        _44 = call const fn baml.json.stringify(copy _45) -> [bb28];
     }
 
-    bb32: {
+    bb28: {
         _33 = ai.errors.InvalidRequest { copy _34, copy _38, copy _41, copy _44 };
         throw copy _33;
     }
@@ -7423,6 +7370,7 @@ fn ai.mcp.Connection.call_tool(self: ai.mcp.Connection, name: string, args: map<
     let _37: string
     let _38: string
     let _39: reflect.Type
+    let _40: string
 
     bb0: {
         _4 = { const "name": copy _2, const "arguments": copy _3 }: map<string, unknown>;
@@ -7502,11 +7450,12 @@ fn ai.mcp.Connection.call_tool(self: ai.mcp.Connection, name: string, args: map<
 
     bb14: {
         _36 = load_type(string);
+        _40 = const "mcp tool ";
         _35 = call const fn baml.String.from<copy _36>(copy _2) -> [bb15];
     }
 
     bb15: {
-        _34 = const "mcp tool " + copy _35;
+        _34 = copy _40 + copy _35;
         _33 = copy _34 + const " failed: ";
         _38 = copy _26;
         _39 = load_type(string);
@@ -7655,11 +7604,10 @@ fn ai.stream.TurnStream._stamp_first_delta(self: ai.stream.TurnStream) -> void {
     let _7: null | baml.time.Instant
     let _8: null | baml.time.Instant
     let _9: null | baml.time.Instant
-    let _10: bool
-    let _11: null | baml.time.Instant
-    let _12: baml.time.Instant // base
-    let _13: baml.time.Duration
-    let _14: bigint
+    let _10: null | baml.time.Instant
+    let _11: baml.time.Instant // base
+    let _12: baml.time.Duration
+    let _13: bigint
 
     bb0: {
         _2 = copy _1.15;
@@ -7689,9 +7637,7 @@ fn ai.stream.TurnStream._stamp_first_delta(self: ai.stream.TurnStream) -> void {
 
     bb5: {
         _9 = copy _1.17;
-        _8 = copy _9;
-        _10 = copy _8 == const null;
-        branch copy _10 -> [bb6, bb7];
+        _8 = short_circuit(??) copy _9 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
@@ -7701,8 +7647,8 @@ fn ai.stream.TurnStream._stamp_first_delta(self: ai.stream.TurnStream) -> void {
 
     bb7: {
         _7 = copy _8;
-        _11 = copy _7;
-        _11 = narrow_bind copy _11 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["time"], name: "Instant" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb8];
+        _10 = copy _7;
+        _10 = narrow_bind copy _10 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["time"], name: "Instant" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb8];
     }
 
     bb8: {
@@ -7711,16 +7657,16 @@ fn ai.stream.TurnStream._stamp_first_delta(self: ai.stream.TurnStream) -> void {
     }
 
     bb9: {
-        _12 = copy _11;
-        _13 = call const fn baml.time.Instant.elapsed(copy _12) -> [bb10];
+        _11 = copy _10;
+        _12 = call const fn baml.time.Instant.elapsed(copy _11) -> [bb10];
     }
 
     bb10: {
-        _14 = call const fn baml.time.Duration.to_milliseconds(copy _13) -> [bb11];
+        _13 = call const fn baml.time.Duration.to_milliseconds(copy _12) -> [bb11];
     }
 
     bb11: {
-        _4.2.2 = copy _14;
+        _4.2.2 = copy _13;
         goto -> bb12;
     }
 
@@ -7740,40 +7686,37 @@ fn ai.stream.TurnStream._capture_batch(self: ai.stream.TurnStream, batch: string
     let _1: ai.stream.TurnStream // self // param
     let _2: string // batch // param
     let _3: bool
-    let _4: bool
+    let _4: null | ai.events.LLMCall
     let _5: null | ai.events.LLMCall
-    let _6: null | ai.events.LLMCall
-    let _7: ai.events.LLMCall // call
-    let _8: ai.stream.SseEvent[] // none
-    let _9: ai.stream.SseEvent[] // decoded
-    let _10: unknown // e
-    let _11: ai.events.SseEventRecord[] // records
-    let _12: ai.events.SseEventRecord[]
-    let _13: null | ai.events.SseEventRecord[]
-    let _14: bool
-    let _15: ai.stream.SseEvent[]
-    let _16: baml.iter.Iterator<Error = never, Item = ai.stream.SseEvent>
-    let _17: unknown
-    let _18: bool
-    let _19: ai.stream.SseEvent
-    let _20: ai.stream.SseEvent // e
-    let _21: int
-    let _22: ai.events.SseEventRecord
+    let _6: ai.events.LLMCall // call
+    let _7: ai.stream.SseEvent[] // none
+    let _8: ai.stream.SseEvent[] // decoded
+    let _9: unknown // e
+    let _10: ai.events.SseEventRecord[] // records
+    let _11: ai.events.SseEventRecord[]
+    let _12: null | ai.events.SseEventRecord[]
+    let _13: ai.stream.SseEvent[]
+    let _14: baml.iter.Iterator<Error = never, Item = ai.stream.SseEvent>
+    let _15: unknown
+    let _16: bool
+    let _17: ai.stream.SseEvent
+    let _18: ai.stream.SseEvent // e
+    let _19: int
+    let _20: ai.events.SseEventRecord
+    let _21: string | null
+    let _22: string | null
     let _23: string | null
-    let _24: string | null
-    let _25: string | null
-    let _26: reflect.Type
+    let _24: reflect.Type
 
     bb0: {
-        _4 = copy _1.18;
-        _3 = !copy _4;
-        branch copy _3 -> [bb13, bb1];
+        _3 = copy _1.18;
+        branch copy _3 -> [bb1, bb13];
     }
 
     bb1: {
-        _5 = copy _1.15;
-        _6 = copy _5;
-        _6 = narrow_bind copy _6 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb3, bb2];
+        _4 = copy _1.15;
+        _5 = copy _4;
+        _5 = narrow_bind copy _5 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb3, bb2];
     }
 
     bb2: {
@@ -7782,61 +7725,59 @@ fn ai.stream.TurnStream._capture_batch(self: ai.stream.TurnStream, batch: string
     }
 
     bb3: {
-        _7 = copy _6;
-        _8 = []: ai.stream.SseEvent[];
-        _9 = call const fn ai.stream.decode_sse_batch(copy _2) -> [bb6, unwind: bb4];
+        _6 = copy _5;
+        _7 = []: ai.stream.SseEvent[];
+        _8 = call const fn ai.stream.decode_sse_batch(copy _2) -> [bb6, unwind: bb4];
     }
 
     bb4: {
-        throw_if_panic copy _10 -> bb5;
+        throw_if_panic copy _9 -> bb5;
     }
 
     bb5: {
-        _9 = copy _8;
+        _8 = copy _7;
         goto -> bb6;
     }
 
     bb6: {
-        _13 = copy _7.7;
-        _12 = copy _13;
-        _14 = copy _12 == const null;
-        branch copy _14 -> [bb7, bb8];
+        _12 = copy _6.7;
+        _11 = short_circuit(??) copy _12 -> [eval: bb7, join: bb8];
     }
 
     bb7: {
-        _12 = []: ai.events.SseEventRecord[];
+        _11 = []: ai.events.SseEventRecord[];
         goto -> bb8;
     }
 
     bb8: {
-        _11 = copy _12;
-        _15 = copy _9;
-        _16 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.stream.SseEvent>(copy _15) -> [bb9];
+        _10 = copy _11;
+        _13 = copy _8;
+        _14 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.stream.SseEvent>(copy _13) -> [bb9];
     }
 
     bb9: {
-        _17 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.stream.SseEvent>(copy _16) -> [bb10];
+        _15 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.stream.SseEvent>(copy _14) -> [bb10];
     }
 
     bb10: {
-        _18 = is_type(copy _17, baml.iter.Done);
-        branch copy _18 -> [bb12, bb11];
+        _16 = is_type(copy _15, baml.iter.Done);
+        branch copy _16 -> [bb12, bb11];
     }
 
     bb11: {
-        _19 = copy _17;
-        fresh_cell(_20);
-        _20 = copy _19;
-        _23 = copy _20.0;
-        _24 = copy _20.1;
-        _25 = copy _20.2;
-        _22 = ai.events.SseEventRecord { copy _23, copy _24, copy _25 };
-        _26 = load_type(ai.events.SseEventRecord);
-        _21 = call const fn baml.Array.push<copy _26>(copy _11, copy _22) -> [bb9];
+        _17 = copy _15;
+        fresh_cell(_18);
+        _18 = copy _17;
+        _21 = copy _18.0;
+        _22 = copy _18.1;
+        _23 = copy _18.2;
+        _20 = ai.events.SseEventRecord { copy _21, copy _22, copy _23 };
+        _24 = load_type(ai.events.SseEventRecord);
+        _19 = call const fn baml.Array.push<copy _24>(copy _10, copy _20) -> [bb9];
     }
 
     bb12: {
-        _7.7 = copy _11;
+        _6.7 = copy _10;
         _0 = const null;
         goto -> bb13;
     }
@@ -7890,19 +7831,19 @@ fn ai.stream.TurnStream._check_terminal(self: ai.stream.TurnStream) -> void {
     let _3: string | null
     let _4: string // provider
     let _5: bool
-    let _6: bool
-    let _7: string | null // partial
-    let _8: bool
-    let _9: string
-    let _10: ai.errors.NetworkFailure
+    let _6: string | null // partial
+    let _7: bool
+    let _8: string
+    let _9: ai.errors.NetworkFailure
+    let _10: string
     let _11: string
     let _12: string
     let _13: string
-    let _14: string
-    let _15: int
-    let _16: (string) -> int throws never
-    let _17: reflect.Type
-    let _18: string | null
+    let _14: int
+    let _15: (string) -> int throws never
+    let _16: reflect.Type
+    let _17: string | null
+    let _18: string
 
     bb0: {
         _2 = copy _1.12;
@@ -7912,58 +7853,58 @@ fn ai.stream.TurnStream._check_terminal(self: ai.stream.TurnStream) -> void {
 
     bb1: {
         _0 = const null;
-        goto -> bb4;
+        goto -> bb10;
     }
 
     bb2: {
         _4 = copy _3;
-        _6 = copy _1.13;
-        _5 = !copy _6;
-        branch copy _5 -> [bb5, bb3];
+        _5 = copy _1.13;
+        branch copy _5 -> [bb9, bb3];
     }
 
     bb3: {
-        _0 = const null;
-        goto -> bb4;
+        _8 = copy _1.7;
+        _7 = copy _8 == const "";
+        branch copy _7 -> [bb5, bb4];
     }
 
     bb4: {
-        return;
+        _6 = copy _1.7;
+        goto -> bb6;
     }
 
     bb5: {
-        _9 = copy _1.7;
-        _8 = copy _9 == const "";
-        branch copy _8 -> [bb7, bb6];
+        _6 = const null;
+        goto -> bb6;
     }
 
     bb6: {
-        _7 = copy _1.7;
-        goto -> bb8;
+        _10 = copy _4;
+        _15 = copy _1.7;
+        _14 = call const fn baml.String.length(copy _15) -> [bb7];
     }
 
     bb7: {
-        _7 = const null;
-        goto -> bb8;
+        _16 = load_type(int);
+        _18 = const "stream ended before the provider's terminal event: the connection closed after ";
+        _13 = call const fn baml.String.from<copy _16>(copy _14) -> [bb8];
     }
 
     bb8: {
-        _11 = copy _4;
-        _16 = copy _1.7;
-        _15 = call const fn baml.String.length(copy _16) -> [bb9];
+        _12 = copy _18 + copy _13;
+        _11 = copy _12 + const " characters of assistant text with no end-of-turn event, so the turn is truncated";
+        _17 = copy _6;
+        _9 = ai.errors.NetworkFailure { copy _10, copy _11, const null, copy _17 };
+        throw copy _9;
     }
 
     bb9: {
-        _17 = load_type(int);
-        _14 = call const fn baml.String.from<copy _17>(copy _15) -> [bb10];
+        _0 = const null;
+        goto -> bb10;
     }
 
     bb10: {
-        _13 = const "stream ended before the provider's terminal event: the connection closed after " + copy _14;
-        _12 = copy _13 + const " characters of assistant text with no end-of-turn event, so the turn is truncated";
-        _18 = copy _7;
-        _10 = ai.errors.NetworkFailure { copy _11, copy _12, const null, copy _18 };
-        throw copy _10;
+        return;
     }
 }
 
@@ -8070,193 +8011,185 @@ fn ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> ai.stream.Done | str
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _3 = copy _1.11;
+        branch copy _3 -> [bb55, bb2];
     }
 
     bb2: {
-        _0 = call const fn baml.sys.panic(const "unreachable") -> [bb58];
-    }
-
-    bb3: {
-        _3 = copy _1.11;
-        branch copy _3 -> [bb57, bb4];
-    }
-
-    bb4: {
         _5 = copy _1.6;
         _7 = copy _1.5;
         _6 = len(_7);
+        goto -> bb3;
+    }
+
+    bb3: {
+        _4 = copy _5 < copy _6;
+        branch copy _4 -> [bb36, bb4];
+    }
+
+    bb4: {
+        _40 = len(_2);
         goto -> bb5;
     }
 
     bb5: {
-        _4 = copy _5 < copy _6;
-        branch copy _4 -> [bb38, bb6];
+        _39 = copy _40 > const 0_i64;
+        branch copy _39 -> [bb35, bb6];
     }
 
     bb6: {
-        _40 = len(_2);
-        goto -> bb7;
+        _41 = copy _1.0;
+        _42 = copy _41;
+        _42 = narrow_bind copy _42 as Function { params: [], ret: Union([Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), throws: Union([Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Timeout" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("reflect"), namespace: ["errors"], name: "CompilationError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb28, bb7];
     }
 
     bb7: {
-        _39 = copy _40 > const 0_i64;
-        branch copy _39 -> [bb37, bb8];
+        _54 = copy _1.1;
+        _55 = copy _54;
+        _55 = narrow_bind copy _55 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["http"], name: "SseStream" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb16, bb8];
     }
 
     bb8: {
-        _41 = copy _1.0;
-        _42 = copy _41;
-        _42 = narrow_bind copy _42 as Function { params: [], ret: Union([Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), throws: Union([Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Timeout" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("reflect"), namespace: ["errors"], name: "CompilationError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb30, bb9];
-    }
-
-    bb9: {
-        _54 = copy _1.1;
-        _55 = copy _54;
-        _55 = narrow_bind copy _55 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["http"], name: "SseStream" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb10];
-    }
-
-    bb10: {
         _80 = copy _1.3;
         _81 = copy _1.4;
         _82 = load_type(string);
-        _79 = call const fn baml.Array.at<copy _82>(copy _80, copy _81) -> [bb11];
+        _79 = call const fn baml.Array.at<copy _82>(copy _80, copy _81) -> [bb9];
+    }
+
+    bb9: {
+        _83 = copy _79;
+        _83 = narrow_bind copy _83 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb12, bb10];
+    }
+
+    bb10: {
+        _93 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb11];
     }
 
     bb11: {
-        _83 = copy _79;
-        _83 = narrow_bind copy _83 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb14, bb12];
+        _0 = ai.stream.Done {  };
+        goto -> bb56;
     }
 
     bb12: {
-        _93 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb13];
+        _84 = copy _83;
+        _85 = call const fn ai.stream.TurnStream._stamp_first_delta(copy _1) -> [bb13];
     }
 
     bb13: {
-        _0 = ai.stream.Done {  };
-        goto -> bb58;
-    }
-
-    bb14: {
-        _84 = copy _83;
-        _85 = call const fn ai.stream.TurnStream._stamp_first_delta(copy _1) -> [bb15];
-    }
-
-    bb15: {
         _1.4 = copy _1.4 + const 1_i64;
         _87 = copy _1.7;
         _88 = load_type(string);
-        _86 = call const fn baml.String.from<copy _88>(copy _87) -> [bb16];
+        _86 = call const fn baml.String.from<copy _88>(copy _87) -> [bb14];
     }
 
-    bb16: {
+    bb14: {
         _90 = copy _84;
         _91 = load_type(string);
-        _89 = call const fn baml.String.from<copy _91>(copy _90) -> [bb17];
+        _89 = call const fn baml.String.from<copy _91>(copy _90) -> [bb15];
     }
 
-    bb17: {
+    bb15: {
         _1.7 = copy _86 + copy _89;
         _92 = copy _84;
         _0 = [copy _92]: string[];
-        goto -> bb58;
+        goto -> bb56;
+    }
+
+    bb16: {
+        _56 = copy _55;
+        _57 = sys_op const fn baml.http.SseStream.next(copy _56) -> bb17;
+    }
+
+    bb17: {
+        _58 = copy _57 == const null;
+        branch copy _58 -> [bb25, bb18];
     }
 
     bb18: {
-        _56 = copy _55;
-        _57 = sys_op const fn baml.http.SseStream.next(copy _56) -> bb19;
+        _61 = copy _57;
+        _63 = copy _61;
+        _62 = call const fn ai.stream.TurnStream._capture_batch(copy _1, copy _63) -> [bb19];
     }
 
     bb19: {
-        _58 = copy _57 == const null;
-        branch copy _58 -> [bb27, bb20];
+        _64 = copy _1.2;
+        _65 = copy _64;
+        _65 = narrow_bind copy _65 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, mode: Required }], ret: List(Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), throws: Union([Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Timeout" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("reflect"), namespace: ["errors"], name: "CompilationError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb20, bb1];
     }
 
     bb20: {
-        _61 = copy _57;
-        _63 = copy _61;
-        _62 = call const fn ai.stream.TurnStream._capture_batch(copy _1, copy _63) -> [bb21];
-    }
-
-    bb21: {
-        _64 = copy _1.2;
-        _65 = copy _64;
-        _65 = narrow_bind copy _65 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, mode: Required }], ret: List(Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), throws: Union([Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "Timeout" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("reflect"), namespace: ["errors"], name: "CompilationError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb22, bb1];
-    }
-
-    bb22: {
         _66 = copy _65;
         _68 = copy _66;
         _69 = copy _61;
-        _67 = call copy _68(copy _69) -> [bb23];
+        _67 = call copy _68(copy _69) -> [bb21];
+    }
+
+    bb21: {
+        _70 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta>(copy _67) -> [bb22];
+    }
+
+    bb22: {
+        _71 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta>(copy _70) -> [bb23];
     }
 
     bb23: {
-        _70 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta>(copy _67) -> [bb24];
+        _72 = is_type(copy _71, baml.iter.Done);
+        branch copy _72 -> [bb1, bb24];
     }
 
     bb24: {
-        _71 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.stream.TextDelta | ai.stream.TurnDone | ai.stream.TurnMeta>(copy _70) -> [bb25];
-    }
-
-    bb25: {
-        _72 = is_type(copy _71, baml.iter.Done);
-        branch copy _72 -> [bb1, bb26];
-    }
-
-    bb26: {
         _73 = copy _71;
         fresh_cell(_74);
         _74 = copy _73;
         _76 = copy _1.5;
         _77 = copy _74;
         _78 = load_type(ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone);
-        _75 = call const fn baml.Array.push<copy _78>(copy _76, copy _77) -> [bb24];
+        _75 = call const fn baml.Array.push<copy _78>(copy _76, copy _77) -> [bb22];
+    }
+
+    bb25: {
+        _59 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb26];
+    }
+
+    bb26: {
+        _60 = call const fn ai.stream.TurnStream._check_terminal(copy _1) -> [bb27];
     }
 
     bb27: {
-        _59 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb28];
+        _0 = ai.stream.Done {  };
+        goto -> bb56;
     }
 
     bb28: {
-        _60 = call const fn ai.stream.TurnStream._check_terminal(copy _1) -> [bb29];
+        _43 = copy _42;
+        _45 = copy _43;
+        _44 = call copy _45() -> [bb29];
     }
 
     bb29: {
-        _0 = ai.stream.Done {  };
-        goto -> bb58;
+        _46 = copy _44;
+        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb30];
     }
 
     bb30: {
-        _43 = copy _42;
-        _45 = copy _43;
-        _44 = call copy _45() -> [bb31];
+        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb31];
     }
 
     bb31: {
-        _46 = copy _44;
-        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb32];
+        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb32];
     }
 
     bb32: {
-        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb33];
+        _52 = copy _44;
+        _53 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb33];
     }
 
     bb33: {
-        _46 = narrow_bind copy _46 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb34];
+        _0 = copy _52;
+        goto -> bb56;
     }
 
     bb34: {
-        _52 = copy _44;
-        _53 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb35];
-    }
-
-    bb35: {
-        _0 = copy _52;
-        goto -> bb58;
-    }
-
-    bb36: {
         _47 = copy _46;
         _49 = copy _1.5;
         _50 = copy _47;
@@ -8264,126 +8197,126 @@ fn ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> ai.stream.Done | str
         _48 = call const fn baml.Array.push<copy _51>(copy _49, copy _50) -> [bb1];
     }
 
-    bb37: {
+    bb35: {
         _0 = copy _2;
-        goto -> bb58;
+        goto -> bb56;
     }
 
-    bb38: {
+    bb36: {
         _9 = copy _1.5;
         _10 = copy _1.6;
         _11 = load_type(ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone);
-        _8 = call const fn baml.Array.at<copy _11>(copy _9, copy _10) -> [bb39];
+        _8 = call const fn baml.Array.at<copy _11>(copy _9, copy _10) -> [bb37];
+    }
+
+    bb37: {
+        _1.6 = copy _1.6 + const 1_i64;
+        _12 = copy _8;
+        _12 = narrow_bind copy _12 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb51, bb38];
+    }
+
+    bb38: {
+        _24 = copy _8;
+        _24 = narrow_bind copy _24 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb45, bb39];
     }
 
     bb39: {
-        _1.6 = copy _1.6 + const 1_i64;
-        _12 = copy _8;
-        _12 = narrow_bind copy _12 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TextDelta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb53, bb40];
+        _35 = copy _8;
+        _35 = narrow_bind copy _35 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb40, bb2];
     }
 
     bb40: {
-        _24 = copy _8;
-        _24 = narrow_bind copy _24 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnMeta" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb47, bb41];
+        _1.13 = const true;
+        _36 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb41];
     }
 
     bb41: {
-        _35 = copy _8;
-        _35 = narrow_bind copy _35 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "TurnDone" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb42, bb4];
+        _38 = len(_2);
+        goto -> bb42;
     }
 
     bb42: {
-        _1.13 = const true;
-        _36 = call const fn ai.stream.TurnStream._finish(copy _1) -> [bb43];
+        _37 = copy _38 > const 0_i64;
+        branch copy _37 -> [bb44, bb43];
     }
 
     bb43: {
-        _38 = len(_2);
-        goto -> bb44;
+        _0 = ai.stream.Done {  };
+        goto -> bb56;
     }
 
     bb44: {
-        _37 = copy _38 > const 0_i64;
-        branch copy _37 -> [bb46, bb45];
+        _0 = copy _2;
+        goto -> bb56;
     }
 
     bb45: {
-        _0 = ai.stream.Done {  };
-        goto -> bb58;
-    }
-
-    bb46: {
-        _0 = copy _2;
-        goto -> bb58;
-    }
-
-    bb47: {
         _25 = copy _24;
         _26 = copy _25.0;
         _27 = copy _26;
-        _27 = narrow_bind copy _27 as Enum(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "StopReason" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb48, bb49];
+        _27 = narrow_bind copy _27 as Enum(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "StopReason" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb46, bb47];
+    }
+
+    bb46: {
+        _28 = copy _27;
+        _1.8 = copy _28;
+        goto -> bb47;
+    }
+
+    bb47: {
+        _29 = copy _25.1;
+        _30 = copy _29;
+        _30 = narrow_bind copy _30 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb48, bb49];
     }
 
     bb48: {
-        _28 = copy _27;
-        _1.8 = copy _28;
+        _31 = copy _30;
+        _1.9 = copy _31;
         goto -> bb49;
     }
 
     bb49: {
-        _29 = copy _25.1;
-        _30 = copy _29;
-        _30 = narrow_bind copy _30 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb50, bb51];
+        _32 = copy _25.2;
+        _33 = copy _32;
+        _33 = narrow_bind copy _33 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb50, bb2];
     }
 
     bb50: {
-        _31 = copy _30;
-        _1.9 = copy _31;
-        goto -> bb51;
+        _34 = copy _33;
+        _1.10 = copy _34;
+        goto -> bb2;
     }
 
     bb51: {
-        _32 = copy _25.2;
-        _33 = copy _32;
-        _33 = narrow_bind copy _33 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb52, bb4];
+        _13 = copy _12;
+        _14 = call const fn ai.stream.TurnStream._stamp_first_delta(copy _1) -> [bb52];
     }
 
     bb52: {
-        _34 = copy _33;
-        _1.10 = copy _34;
-        goto -> bb4;
+        _16 = copy _1.7;
+        _17 = load_type(string);
+        _15 = call const fn baml.String.from<copy _17>(copy _16) -> [bb53];
     }
 
     bb53: {
-        _13 = copy _12;
-        _14 = call const fn ai.stream.TurnStream._stamp_first_delta(copy _1) -> [bb54];
+        _19 = copy _13.0;
+        _20 = load_type(string);
+        _18 = call const fn baml.String.from<copy _20>(copy _19) -> [bb54];
     }
 
     bb54: {
-        _16 = copy _1.7;
-        _17 = load_type(string);
-        _15 = call const fn baml.String.from<copy _17>(copy _16) -> [bb55];
-    }
-
-    bb55: {
-        _19 = copy _13.0;
-        _20 = load_type(string);
-        _18 = call const fn baml.String.from<copy _20>(copy _19) -> [bb56];
-    }
-
-    bb56: {
         _1.7 = copy _15 + copy _18;
         _22 = copy _13.0;
         _23 = load_type(string);
-        _21 = call const fn baml.Array.push<copy _23>(copy _2, copy _22) -> [bb4];
+        _21 = call const fn baml.Array.push<copy _23>(copy _2, copy _22) -> [bb2];
     }
 
-    bb57: {
+    bb55: {
         _0 = ai.stream.Done {  };
-        goto -> bb58;
+        goto -> bb56;
     }
 
-    bb58: {
+    bb56: {
         return;
     }
 }
@@ -8397,180 +8330,163 @@ fn ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.ModelTurn {
     let _4: void
     let _5: null | ai.events.Usage // usage
     let _6: bool
-    let _7: bool
-    let _8: int | null
+    let _7: int | null
+    let _8: bool
     let _9: bool
     let _10: int | null
     let _11: bool
     let _12: int
     let _13: int
     let _14: int | null
-    let _15: bool
+    let _15: int
     let _16: int
-    let _17: int
-    let _18: int | null
-    let _19: bool
-    let _20: null | ai.events.LLMCall
-    let _21: null | ai.events.LLMCall
-    let _22: ai.events.LLMCall // call
-    let _23: bool
-    let _24: bigint | null
-    let _25: null | baml.time.Instant
-    let _26: null | baml.time.Instant
-    let _27: baml.time.Instant // started
-    let _28: baml.time.Duration
-    let _29: bigint
-    let _30: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
-    let _31: ai.content.Text
-    let _32: string
-    let _33: ai.content.StopReason
-    let _34: ai.content.StopReason
-    let _35: null | ai.content.StopReason
-    let _36: bool
-    let _37: null | ai.events.Usage
-    let _38: ai.events.LLMCall[]
+    let _17: int | null
+    let _18: null | ai.events.LLMCall
+    let _19: null | ai.events.LLMCall
+    let _20: ai.events.LLMCall // call
+    let _21: bool
+    let _22: bigint | null
+    let _23: null | baml.time.Instant
+    let _24: null | baml.time.Instant
+    let _25: baml.time.Instant // started
+    let _26: baml.time.Duration
+    let _27: bigint
+    let _28: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
+    let _29: ai.content.Text
+    let _30: string
+    let _31: ai.content.StopReason
+    let _32: ai.content.StopReason
+    let _33: null | ai.content.StopReason
+    let _34: null | ai.events.Usage
+    let _35: ai.events.LLMCall[]
 
     bb0: {
         goto -> bb1;
     }
 
     bb1: {
-        branch const true -> [bb2, bb4];
+        _2 = call const fn ai.stream.TurnStream.next(copy _1) -> [bb2];
     }
 
     bb2: {
-        _2 = call const fn ai.stream.TurnStream.next(copy _1) -> [bb3];
+        _3 = copy _2;
+        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb3, bb1];
     }
 
     bb3: {
-        _3 = copy _2;
-        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb4, bb1];
+        _4 = call const fn ai.stream.TurnStream._check_terminal(copy _1) -> [bb4];
     }
 
     bb4: {
-        _4 = call const fn ai.stream.TurnStream._check_terminal(copy _1) -> [bb5];
+        _7 = copy _1.9;
+        _8 = call const fn baml.ops.equals_equals(copy _7, const null) -> [bb5];
     }
 
     bb5: {
-        _8 = copy _1.9;
-        _9 = call const fn baml.ops.equals_equals(copy _8, const null) -> [bb6];
+        _6 = !copy _8;
+        branch copy _6 -> [bb9, bb6];
     }
 
     bb6: {
-        _7 = !copy _9;
-        _6 = short_circuit(||) copy _7 -> [eval: bb7, join: bb9];
+        _10 = copy _1.10;
+        _11 = call const fn baml.ops.equals_equals(copy _10, const null) -> [bb7];
     }
 
     bb7: {
-        _10 = copy _1.10;
-        _11 = call const fn baml.ops.equals_equals(copy _10, const null) -> [bb8];
+        _9 = !copy _11;
+        branch copy _9 -> [bb9, bb8];
     }
 
     bb8: {
-        _6 = !copy _11;
-        goto -> bb9;
+        _5 = const null;
+        goto -> bb14;
     }
 
     bb9: {
-        branch copy _6 -> [bb11, bb10];
+        _14 = copy _1.9;
+        _13 = short_circuit(??) copy _14 -> [eval: bb10, join: bb11];
     }
 
     bb10: {
-        _5 = const null;
-        goto -> bb16;
+        _13 = const 0_i64;
+        goto -> bb11;
     }
 
     bb11: {
-        _14 = copy _1.9;
-        _13 = copy _14;
-        _15 = copy _13 == const null;
-        branch copy _15 -> [bb12, bb13];
+        _12 = copy _13;
+        _17 = copy _1.10;
+        _16 = short_circuit(??) copy _17 -> [eval: bb12, join: bb13];
     }
 
     bb12: {
-        _13 = const 0_i64;
+        _16 = const 0_i64;
         goto -> bb13;
     }
 
     bb13: {
-        _12 = copy _13;
-        _18 = copy _1.10;
-        _17 = copy _18;
-        _19 = copy _17 == const null;
-        branch copy _19 -> [bb14, bb15];
+        _15 = copy _16;
+        _5 = ai.events.Usage { copy _12, copy _15, const null, const null };
+        goto -> bb14;
     }
 
     bb14: {
-        _17 = const 0_i64;
-        goto -> bb15;
+        _18 = copy _1.15;
+        _19 = copy _18;
+        _19 = narrow_bind copy _19 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb15, bb21];
     }
 
     bb15: {
-        _16 = copy _17;
-        _5 = ai.events.Usage { copy _12, copy _16, const null, const null };
-        goto -> bb16;
+        _20 = copy _19;
+        _22 = copy _20.2.1;
+        _21 = call const fn baml.ops.equals_equals(copy _22, const null) -> [bb16];
     }
 
     bb16: {
-        _20 = copy _1.15;
-        _21 = copy _20;
-        _21 = narrow_bind copy _21 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb17, bb23];
+        branch copy _21 -> [bb17, bb21];
     }
 
     bb17: {
-        _22 = copy _21;
-        _24 = copy _22.2.1;
-        _23 = call const fn baml.ops.equals_equals(copy _24, const null) -> [bb18];
+        _23 = copy _1.16;
+        _24 = copy _23;
+        _24 = narrow_bind copy _24 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["time"], name: "Instant" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb18, bb21];
     }
 
     bb18: {
-        branch copy _23 -> [bb19, bb23];
+        _25 = copy _24;
+        _26 = call const fn baml.time.Instant.elapsed(copy _25) -> [bb19];
     }
 
     bb19: {
-        _25 = copy _1.16;
-        _26 = copy _25;
-        _26 = narrow_bind copy _26 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["time"], name: "Instant" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb23];
+        _27 = call const fn baml.time.Duration.to_milliseconds(copy _26) -> [bb20];
     }
 
     bb20: {
-        _27 = copy _26;
-        _28 = call const fn baml.time.Instant.elapsed(copy _27) -> [bb21];
+        _20.2.1 = copy _27;
+        goto -> bb21;
     }
 
     bb21: {
-        _29 = call const fn baml.time.Duration.to_milliseconds(copy _28) -> [bb22];
+        _30 = copy _1.7;
+        _29 = ai.content.Text { copy _30 };
+        _28 = [copy _29]: ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media[];
+        _33 = copy _1.8;
+        _32 = short_circuit(??) copy _33 -> [eval: bb22, join: bb23];
     }
 
     bb22: {
-        _22.2.1 = copy _29;
+        _32 = const ai.content.StopReason.Complete;
         goto -> bb23;
     }
 
     bb23: {
-        _32 = copy _1.7;
-        _31 = ai.content.Text { copy _32 };
-        _30 = [copy _31]: ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media[];
-        _35 = copy _1.8;
-        _34 = copy _35;
-        _36 = copy _34 == const null;
-        branch copy _36 -> [bb24, bb25];
+        _31 = copy _32;
+        _34 = copy _5;
+        _35 = copy _1.14;
+        _0 = ai.ModelTurn { copy _28, copy _31, copy _34, copy _35 };
+        goto -> bb24;
     }
 
     bb24: {
-        _34 = const ai.content.StopReason.Complete;
-        goto -> bb25;
-    }
-
-    bb25: {
-        _33 = copy _34;
-        _37 = copy _5;
-        _38 = copy _1.14;
-        _0 = ai.ModelTurn { copy _30, copy _33, copy _37, copy _38 };
-        goto -> bb26;
-    }
-
-    bb26: {
         return;
     }
 }
@@ -8599,29 +8515,21 @@ fn ai.stream.Stream.next(self: ai.stream.Stream) -> ai.stream.Done | TStream {
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _2 = copy _1.3;
+        branch copy _2 -> [bb8, bb2];
     }
 
     bb2: {
-        _0 = call const fn baml.sys.panic(const "unreachable") -> [bb11];
+        _4 = copy _1.0;
+        _3 = call copy _4() -> [bb3];
     }
 
     bb3: {
-        _2 = copy _1.3;
-        branch copy _2 -> [bb10, bb4];
+        _5 = copy _3 == const null;
+        branch copy _5 -> [bb7, bb4];
     }
 
     bb4: {
-        _4 = copy _1.0;
-        _3 = call copy _4() -> [bb5];
-    }
-
-    bb5: {
-        _5 = copy _3 == const null;
-        branch copy _5 -> [bb9, bb6];
-    }
-
-    bb6: {
         _6 = copy _3;
         _7 = copy _1.2;
         _8 = copy _6;
@@ -8630,32 +8538,32 @@ fn ai.stream.Stream.next(self: ai.stream.Stream) -> ai.stream.Done | TStream {
         _11 = copy _1.2;
         _12 = load_type(#0);
         _13 = load_type(#1);
-        _9 = sys_op const fn baml.sap._ParseCache._parse_partial(copy _10, copy _11, copy _12, copy _13) -> bb7;
+        _9 = sys_op const fn baml.sap._ParseCache._parse_partial(copy _10, copy _11, copy _12, copy _13) -> bb5;
+    }
+
+    bb5: {
+        _14 = is_type(copy _9, baml.sap._NoYield);
+        branch copy _14 -> [bb1, bb6];
+    }
+
+    bb6: {
+        _15 = copy _9;
+        _0 = copy _15;
+        goto -> bb9;
     }
 
     bb7: {
-        _14 = is_type(copy _9, baml.sap._NoYield);
-        branch copy _14 -> [bb1, bb8];
+        _1.3 = const true;
+        _0 = ai.stream.Done {  };
+        goto -> bb9;
     }
 
     bb8: {
-        _15 = copy _9;
-        _0 = copy _15;
-        goto -> bb11;
+        _0 = ai.stream.Done {  };
+        goto -> bb9;
     }
 
     bb9: {
-        _1.3 = const true;
-        _0 = ai.stream.Done {  };
-        goto -> bb11;
-    }
-
-    bb10: {
-        _0 = ai.stream.Done {  };
-        goto -> bb11;
-    }
-
-    bb11: {
         return;
     }
 }
@@ -8665,61 +8573,59 @@ fn ai.stream.Stream.final(self: ai.stream.Stream) -> TFinal {
     let _0: TFinal // _0 // return
     let _1: ai.stream.Stream // self // param
     let _2: bool
-    let _3: bool
-    let _4: string | null
-    let _5: () -> string | null throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _6: bool
-    let _7: string // s
+    let _3: string | null
+    let _4: () -> string | null throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _5: bool
+    let _6: string // s
+    let _7: string
     let _8: string
-    let _9: string
-    let _10: (baml.sap._ParseCache<TStream, TFinal>, string) -> TFinal throws baml.errors.LlmClient
-    let _11: string
+    let _9: (baml.sap._ParseCache<TStream, TFinal>, string) -> TFinal throws baml.errors.LlmClient
+    let _10: string
+    let _11: reflect.Type
     let _12: reflect.Type
-    let _13: reflect.Type
 
     bb0: {
         goto -> bb1;
     }
 
     bb1: {
-        _3 = copy _1.3;
-        _2 = !copy _3;
-        branch copy _2 -> [bb4, bb2];
+        _2 = copy _1.3;
+        branch copy _2 -> [bb6, bb2];
     }
 
     bb2: {
-        _10 = copy _1.1;
-        _11 = copy _1.2;
-        _12 = load_type(#0);
-        _13 = load_type(#1);
-        _0 = sys_op const fn baml.sap._ParseCache._parse_final(copy _10, copy _11, copy _12, copy _13) -> bb3;
+        _4 = copy _1.0;
+        _3 = call copy _4() -> [bb3];
     }
 
     bb3: {
-        return;
+        _5 = copy _3 == const null;
+        branch copy _5 -> [bb5, bb4];
     }
 
     bb4: {
-        _5 = copy _1.0;
-        _4 = call copy _5() -> [bb5];
+        _6 = copy _3;
+        _7 = copy _1.2;
+        _8 = copy _6;
+        _1.2 = copy _7 + copy _8;
+        goto -> bb1;
     }
 
     bb5: {
-        _6 = copy _4 == const null;
-        branch copy _6 -> [bb7, bb6];
+        _1.3 = const true;
+        goto -> bb1;
     }
 
     bb6: {
-        _7 = copy _4;
-        _8 = copy _1.2;
-        _9 = copy _7;
-        _1.2 = copy _8 + copy _9;
-        goto -> bb1;
+        _9 = copy _1.1;
+        _10 = copy _1.2;
+        _11 = load_type(#0);
+        _12 = load_type(#1);
+        _0 = sys_op const fn baml.sap._ParseCache._parse_final(copy _9, copy _10, copy _11, copy _12) -> bb7;
     }
 
     bb7: {
-        _1.3 = const true;
-        goto -> bb1;
+        return;
     }
 }
 
@@ -8732,52 +8638,52 @@ fn ai.stream.from_spec(spec: ai.FunctionSpec<TFinal>, client: null | ai.stream.S
     let _4: bool
     let _5: bool
     let _6: bool
-    let _7: bool
-    let _8: ai.tools.Toolbox
-    let _9: reflect.Type
-    let _10: baml.errors.InvalidArgument
+    let _7: ai.tools.Toolbox
+    let _8: reflect.Type
+    let _9: baml.errors.InvalidArgument
+    let _10: string
     let _11: string
     let _12: string
     let _13: string
-    let _14: string
+    let _14: reflect.Type
     let _15: reflect.Type
-    let _16: reflect.Type
-    let _17: ai.stream.StreamingClient // selected
-    let _18: null | ai.stream.StreamingClient
-    let _19: ai.stream.StreamingClient // s
+    let _16: ai.stream.StreamingClient // selected
+    let _17: null | ai.stream.StreamingClient
+    let _18: ai.stream.StreamingClient // s
+    let _19: ai.Client
     let _20: ai.Client
-    let _21: ai.Client
-    let _22: ai.stream.StreamingClient // s
-    let _23: ai.errors.StreamingUnsupported
-    let _24: string
-    let _25: ai.Client
-    let _26: string // provider [captured]
-    let _27: ai.Client // c
-    let _28: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // emit [captured]
-    let _29: reflect.Type
-    let _30: bool // settled [captured]
-    let _31: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _32: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
-    let _33: void
-    let _34: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
-    let _35: ai.events.RunStarted
-    let _36: string
-    let _37: reflect.Type
-    let _38: map<string, unknown>
-    let _39: reflect.Type
-    let _40: ai.stream.TurnStream // turns [captured]
-    let _41: ai.ModelTurnInput
-    let _42: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _43: ai.Journal
-    let _44: reflect.Type
-    let _45: ai.tools.Toolbox
+    let _21: ai.stream.StreamingClient // s
+    let _22: ai.errors.StreamingUnsupported
+    let _23: string
+    let _24: ai.Client
+    let _25: string // provider [captured]
+    let _26: ai.Client // c
+    let _27: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never) // emit [captured]
+    let _28: reflect.Type
+    let _29: bool // settled [captured]
+    let _30: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
+    let _31: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
+    let _32: void
+    let _33: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _34: ai.events.RunStarted
+    let _35: string
+    let _36: reflect.Type
+    let _37: map<string, unknown>
+    let _38: reflect.Type
+    let _39: ai.stream.TurnStream // turns [captured]
+    let _40: ai.ModelTurnInput
+    let _41: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _42: ai.Journal
+    let _43: reflect.Type
+    let _44: ai.tools.Toolbox
+    let _45: reflect.Type
     let _46: reflect.Type
     let _47: reflect.Type
-    let _48: reflect.Type
-    let _49: () -> string | null throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _50: baml.sap._ParseCache<TStream, TFinal>
+    let _48: () -> string | null throws baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _49: baml.sap._ParseCache<TStream, TFinal>
+    let _50: reflect.Type
     let _51: reflect.Type
-    let _52: reflect.Type
+    let _52: string
 
     bb0: {
         _4 = copy _2 == const <omitted>;
@@ -8800,137 +8706,137 @@ fn ai.stream.from_spec(spec: ai.FunctionSpec<TFinal>, client: null | ai.stream.S
     }
 
     bb4: {
-        _9 = load_type(#1);
-        _8 = call const fn ai.FunctionSpec.tools<copy _9>(copy _1) -> [bb5];
+        _8 = load_type(#1);
+        _7 = call const fn ai.FunctionSpec.tools<copy _8>(copy _1) -> [bb5];
     }
 
     bb5: {
-        _7 = call const fn ai.tools.Toolbox.is_empty(copy _8) -> [bb6];
+        _6 = call const fn ai.tools.Toolbox.is_empty(copy _7) -> [bb6];
     }
 
     bb6: {
-        _6 = !copy _7;
-        branch copy _6 -> [bb26, bb7];
+        branch copy _6 -> [bb10, bb7];
     }
 
     bb7: {
-        _18 = copy _2;
-        _18 = narrow_bind copy _18 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "StreamingClient" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb12, bb8];
+        _14 = load_type(#1);
+        _13 = call const fn ai.FunctionSpec.name<copy _14>(copy _1) -> [bb8];
     }
 
     bb8: {
-        _20 = copy _1.4;
-        _21 = copy _20;
-        _21 = narrow_bind copy _21 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "StreamingClient" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb11, bb9];
+        _15 = load_type(string);
+        _52 = const "streaming does not run the tool loop yet: ";
+        _12 = call const fn baml.String.from<copy _15>(copy _13) -> [bb9];
     }
 
     bb9: {
-        _25 = copy _1.4;
-        _24 = virtual_call id as ai.Client(copy _25) -> [bb10];
+        _11 = copy _52 + copy _12;
+        _10 = copy _11 + const " has a non-empty toolbox";
+        _9 = baml.errors.InvalidArgument { copy _10 };
+        throw copy _9;
     }
 
     bb10: {
-        _23 = ai.errors.StreamingUnsupported { copy _24 };
-        throw copy _23;
+        _17 = copy _2;
+        _17 = narrow_bind copy _2 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "StreamingClient" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb15, bb11];
     }
 
     bb11: {
-        _22 = copy _21;
-        _17 = copy _22;
-        goto -> bb13;
+        _19 = copy _1.4;
+        _20 = copy _19;
+        _20 = narrow_bind copy _20 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["stream"], name: "StreamingClient" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb12];
     }
 
     bb12: {
-        _19 = copy _18;
-        _17 = copy _19;
-        goto -> bb13;
+        _24 = copy _1.4;
+        _23 = virtual_call id as ai.Client(copy _24) -> [bb13];
     }
 
     bb13: {
-        _27 = copy _17;
-        _26 = virtual_call id as ai.Client(copy _27) -> [bb14];
+        _22 = ai.errors.StreamingUnsupported { copy _23 };
+        throw copy _22;
     }
 
     bb14: {
-        _29 = load_type(unknown);
-        _28 = call const fn ai.events.guard<copy _29>(copy _3) -> [bb15];
+        _21 = copy _20;
+        _16 = copy _21;
+        goto -> bb16;
     }
 
     bb15: {
-        _30 = const false;
-        _31 = copy _28;
-        _31 = narrow_bind copy _31 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb16, bb19];
+        _18 = copy _17;
+        _16 = copy _18;
+        goto -> bb16;
     }
 
     bb16: {
-        _32 = copy _31;
-        _34 = copy _32;
-        _37 = load_type(#1);
-        _36 = call const fn ai.FunctionSpec.name<copy _37>(copy _1) -> [bb17];
+        _26 = copy _16;
+        _25 = virtual_call id as ai.Client(copy _26) -> [bb17];
     }
 
     bb17: {
-        _39 = load_type(#1);
-        _38 = call const fn ai.FunctionSpec.arguments<copy _39>(copy _1) -> [bb18];
+        _28 = load_type(unknown);
+        _27 = call const fn ai.events.guard<copy _28>(copy _3) -> [bb18];
     }
 
     bb18: {
-        _35 = ai.events.RunStarted { copy _36, copy _38 };
-        _33 = call copy _34(copy _35) -> [bb19];
+        _29 = const false;
+        _30 = copy _27;
+        _30 = narrow_bind copy _30 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb19, bb22];
     }
 
     bb19: {
-        _42 = copy _1.2;
-        _44 = load_type(#1);
-        _43 = call const fn ai.Journal.new<copy _44>(copy _1) -> [bb20];
+        _31 = copy _30;
+        _33 = copy _31;
+        _36 = load_type(#1);
+        _35 = call const fn ai.FunctionSpec.name<copy _36>(copy _1) -> [bb20];
     }
 
     bb20: {
-        _46 = load_type(#1);
-        _45 = call const fn ai.FunctionSpec.tools<copy _46>(copy _1) -> [bb21];
+        _38 = load_type(#1);
+        _37 = call const fn ai.FunctionSpec.arguments<copy _38>(copy _1) -> [bb21];
     }
 
     bb21: {
-        _48 = load_type(#1);
-        _47 = call const fn ai.FunctionSpec.output_type<copy _48>(copy _1) -> [bb22];
+        _34 = ai.events.RunStarted { copy _35, copy _37 };
+        _32 = call copy _33(copy _34) -> [bb22];
     }
 
     bb22: {
-        _41 = ai.ModelTurnInput { copy _42, copy _43, copy _45, copy _47 };
-        _40 = virtual_call invoke_stream as ai.stream.StreamingClient(copy _17, copy _41) -> [bb23];
+        _41 = copy _1.2;
+        _43 = load_type(#1);
+        _42 = call const fn ai.Journal.new<copy _43>(copy _1) -> [bb23];
     }
 
     bb23: {
-        _49 = make_closure lambda[0]<2 type_args>(copy _40, copy _30, copy _28, copy _26);
-        _51 = load_type(#0);
-        _52 = load_type(#1);
-        _50 = sys_op const fn baml.sap._new_parse_cache(copy _51, copy _52) -> bb24;
+        _45 = load_type(#1);
+        _44 = call const fn ai.FunctionSpec.tools<copy _45>(copy _1) -> [bb24];
     }
 
     bb24: {
-        _0 = ai.stream.Stream<#0, #1> { copy _49, copy _50, const "", const false };
-        goto -> bb25;
+        _47 = load_type(#1);
+        _46 = call const fn ai.FunctionSpec.output_type<copy _47>(copy _1) -> [bb25];
     }
 
     bb25: {
-        return;
+        _40 = ai.ModelTurnInput { copy _41, copy _42, copy _44, copy _46 };
+        _39 = virtual_call invoke_stream as ai.stream.StreamingClient(copy _16, copy _40) -> [bb26];
     }
 
     bb26: {
-        _15 = load_type(#1);
-        _14 = call const fn ai.FunctionSpec.name<copy _15>(copy _1) -> [bb27];
+        _48 = make_closure lambda[0]<2 type_args>(copy _39, copy _29, copy _27, copy _25);
+        _50 = load_type(#0);
+        _51 = load_type(#1);
+        _49 = sys_op const fn baml.sap._new_parse_cache(copy _50, copy _51) -> bb27;
     }
 
     bb27: {
-        _16 = load_type(string);
-        _13 = call const fn baml.String.from<copy _16>(copy _14) -> [bb28];
+        _0 = ai.stream.Stream<#0, #1> { copy _48, copy _49, const "", const false };
+        goto -> bb28;
     }
 
     bb28: {
-        _12 = const "streaming does not run the tool loop yet: " + copy _13;
-        _11 = copy _12 + const " has a non-empty toolbox";
-        _10 = baml.errors.InvalidArgument { copy _11 };
-        throw copy _10;
+        return;
     }
 }
 
@@ -8942,35 +8848,34 @@ fn .<lambda(from_spec, 0)>() -> string | null {
     let _2: ai.stream.Done | string[]
     let _3: ai.stream.Done | string[]
     let _4: bool
-    let _5: bool
+    let _5: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
     let _6: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _7: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _8: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
-    let _9: ai.ModelTurn // turn
-    let _10: void
-    let _11: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
-    let _12: ai.events.AssistantMessage
-    let _13: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
-    let _14: string
+    let _7: (ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced) -> void throws never // cb
+    let _8: ai.ModelTurn // turn
+    let _9: void
+    let _10: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _11: ai.events.AssistantMessage
+    let _12: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
+    let _13: string
+    let _14: null | ai.events.Usage
     let _15: null | ai.events.Usage
-    let _16: null | ai.events.Usage
-    let _17: ai.events.Usage // u
-    let _18: void
-    let _19: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
-    let _20: ai.events.Usage
-    let _21: ai.events.LLMCall[]
-    let _22: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
-    let _23: unknown
-    let _24: bool
-    let _25: ai.events.LLMCall
-    let _26: ai.events.LLMCall // call
-    let _27: void
-    let _28: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
-    let _29: ai.events.LLMCall
-    let _30: string[] // batch
-    let _31: reflect.Type
-    let _32: baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
-    let _33: baml.errors.Io | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _16: ai.events.Usage // u
+    let _17: void
+    let _18: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _19: ai.events.Usage
+    let _20: ai.events.LLMCall[]
+    let _21: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
+    let _22: unknown
+    let _23: bool
+    let _24: ai.events.LLMCall
+    let _25: ai.events.LLMCall // call
+    let _26: void
+    let _27: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never
+    let _28: ai.events.LLMCall
+    let _29: string[] // batch
+    let _30: reflect.Type
+    let _31: baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
+    let _32: baml.errors.Io | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | ai.errors.Failure
 
     bb0: {
         _2 = call const fn ai.stream.TurnStream.next(copy capture[0]) -> [bb1, unwind: bb15];
@@ -8982,71 +8887,70 @@ fn .<lambda(from_spec, 0)>() -> string | null {
     }
 
     bb2: {
-        _30 = copy _2;
-        _31 = load_type(string);
-        _0 = call const fn baml.Array.join<copy _31>(copy _30, const "") -> [bb14, unwind: bb15];
+        _29 = copy _2;
+        _30 = load_type(string);
+        _0 = call const fn baml.Array.join<copy _30>(copy _29, const "") -> [bb14, unwind: bb15];
     }
 
     bb3: {
-        _5 = copy capture[1];
-        _4 = !copy _5;
-        branch copy _4 -> [bb4, bb13];
+        _4 = copy capture[1];
+        branch copy _4 -> [bb13, bb4];
     }
 
     bb4: {
         capture[1] = const true;
-        _6 = copy capture[2];
-        _7 = copy _6;
-        _7 = narrow_bind copy _7 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb5, bb13];
+        _5 = copy capture[2];
+        _6 = copy _5;
+        _6 = narrow_bind copy _6 as Function { params: [TyTemplateFunctionParamTy { name: None, ty: Union([Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "RunStarted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "UserMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolRequested" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "LLMCall" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "FinalProduced" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset })], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), mode: Required }], ret: Void { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, throws: Never { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb5, bb13];
     }
 
     bb5: {
-        _8 = copy _7;
-        _9 = call const fn ai.stream.TurnStream.final_turn(copy capture[0]) -> [bb6, unwind: bb15];
+        _7 = copy _6;
+        _8 = call const fn ai.stream.TurnStream.final_turn(copy capture[0]) -> [bb6, unwind: bb15];
     }
 
     bb6: {
-        _11 = copy _8;
-        _13 = copy _9.0;
-        _14 = copy capture[3];
-        _12 = ai.events.AssistantMessage { copy _13, copy _14 };
-        _10 = call copy _11(copy _12) -> [bb7, unwind: bb15];
+        _10 = copy _7;
+        _12 = copy _8.0;
+        _13 = copy capture[3];
+        _11 = ai.events.AssistantMessage { copy _12, copy _13 };
+        _9 = call copy _10(copy _11) -> [bb7, unwind: bb15];
     }
 
     bb7: {
-        _15 = copy _9.2;
-        _16 = copy _15;
-        _16 = narrow_bind copy _16 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb9];
+        _14 = copy _8.2;
+        _15 = copy _14;
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb9];
     }
 
     bb8: {
-        _17 = copy _16;
-        _19 = copy _8;
-        _20 = copy _17;
-        _18 = call copy _19(copy _20) -> [bb9, unwind: bb15];
+        _16 = copy _15;
+        _18 = copy _7;
+        _19 = copy _16;
+        _17 = call copy _18(copy _19) -> [bb9, unwind: bb15];
     }
 
     bb9: {
-        _21 = copy _9.3;
-        _22 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _21) -> [bb10, unwind: bb15];
+        _20 = copy _8.3;
+        _21 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _20) -> [bb10, unwind: bb15];
     }
 
     bb10: {
-        _23 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>(copy _22) -> [bb11, unwind: bb15];
+        _22 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>(copy _21) -> [bb11, unwind: bb15];
     }
 
     bb11: {
-        _24 = is_type(copy _23, baml.iter.Done);
-        branch copy _24 -> [bb13, bb12];
+        _23 = is_type(copy _22, baml.iter.Done);
+        branch copy _23 -> [bb13, bb12];
     }
 
     bb12: {
-        _25 = copy _23;
-        fresh_cell(_26);
-        _26 = copy _25;
-        _28 = copy _8;
-        _29 = copy _26;
-        _27 = call copy _28(copy _29) -> [bb10, unwind: bb15];
+        _24 = copy _22;
+        fresh_cell(_25);
+        _25 = copy _24;
+        _27 = copy _7;
+        _28 = copy _25;
+        _26 = call copy _27(copy _28) -> [bb10, unwind: bb15];
     }
 
     bb13: {
@@ -9063,12 +8967,12 @@ fn .<lambda(from_spec, 0)>() -> string | null {
     }
 
     bb16: {
-        _33 = copy _1;
-        _32 = call const fn ai.errors.normalize(copy _33) -> [bb17];
+        _32 = copy _1;
+        _31 = call const fn ai.errors.normalize(copy _32) -> [bb17];
     }
 
     bb17: {
-        throw copy _32;
+        throw copy _31;
     }
 }
 
@@ -9110,6 +9014,8 @@ fn ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> string
     let _33: string
     let _34: string
     let _35: reflect.Type
+    let _36: string
+    let _37: string
 
     bb0: {
         _3 = copy _1.4;
@@ -9126,11 +9032,12 @@ fn ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> string
     bb2: {
         _34 = copy _1.0;
         _35 = load_type(string);
+        _37 = const "tool ";
         _33 = call const fn baml.String.from<copy _35>(copy _34) -> [bb3];
     }
 
     bb3: {
-        _32 = const "tool " + copy _33;
+        _32 = copy _37 + copy _33;
         _31 = copy _32 + const " has no handler";
         _30 = baml.errors.InvalidArgument { copy _31 };
         throw copy _30;
@@ -9176,11 +9083,12 @@ fn ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> string
         _16 = copy _15;
         _22 = copy _1.0;
         _23 = load_type(string);
+        _36 = const "invalid arguments for ";
         _21 = call const fn baml.String.from<copy _23>(copy _22) -> [bb12];
     }
 
     bb12: {
-        _20 = const "invalid arguments for " + copy _21;
+        _20 = copy _36 + copy _21;
         _19 = copy _20 + const ": ";
         _26 = load_type(reflect.InvalidArgumentError);
         _25 = call const fn baml.String.from<copy _26>(copy _16) -> [bb13];
@@ -9211,21 +9119,18 @@ fn ai.tools.tool(handler: reflect.AnyFunction<Returns = unknown, Throws = unknow
     let _8: reflect.Signature // sig
     let _9: string | null // resolved_name
     let _10: string | null
-    let _11: bool
-    let _12: string | null
-    let _13: string // n
-    let _14: bool
-    let _15: string
-    let _16: baml.errors.InvalidArgument
+    let _11: string | null
+    let _12: string // n
+    let _13: bool
+    let _14: string
+    let _15: baml.errors.InvalidArgument
+    let _16: string
     let _17: string
     let _18: string
-    let _19: string
+    let _19: string | null
     let _20: string | null
-    let _21: string | null
-    let _22: bool
-    let _23: bool
-    let _24: map<string, unknown>
-    let _25: baml.errors.InvalidArgument
+    let _21: map<string, unknown>
+    let _22: baml.errors.InvalidArgument
 
     bb0: {
         _5 = copy _2 == const <omitted>;
@@ -9262,9 +9167,7 @@ fn ai.tools.tool(handler: reflect.AnyFunction<Returns = unknown, Throws = unknow
     }
 
     bb7: {
-        _10 = copy _2;
-        _11 = copy _10 == const null;
-        branch copy _11 -> [bb8, bb9];
+        _10 = short_circuit(??) copy _2 -> [eval: bb8, join: bb9];
     }
 
     bb8: {
@@ -9274,53 +9177,49 @@ fn ai.tools.tool(handler: reflect.AnyFunction<Returns = unknown, Throws = unknow
 
     bb9: {
         _9 = copy _10;
-        _12 = copy _9;
-        _12 = narrow_bind copy _12 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb10];
+        _11 = copy _9;
+        _11 = narrow_bind copy _11 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb10];
     }
 
     bb10: {
-        _25 = baml.errors.InvalidArgument { const "anonymous tool needs a name" };
-        throw copy _25;
+        _22 = baml.errors.InvalidArgument { const "anonymous tool needs a name" };
+        throw copy _22;
     }
 
     bb11: {
-        _13 = copy _12;
-        _15 = copy _13;
-        _14 = copy _15 == const "__baml_return_output";
-        branch copy _14 -> [bb19, bb12];
+        _12 = copy _11;
+        _14 = copy _12;
+        _13 = copy _14 == const "__baml_return_output";
+        branch copy _13 -> [bb19, bb12];
     }
 
     bb12: {
-        _17 = copy _13;
-        _21 = copy _3;
-        _22 = copy _21 == const null;
-        branch copy _22 -> [bb13, bb14];
+        _16 = copy _12;
+        _20 = short_circuit(??) copy _3 -> [eval: bb13, join: bb14];
     }
 
     bb13: {
-        _21 = copy _8.5;
+        _20 = copy _8.5;
         goto -> bb14;
     }
 
     bb14: {
-        _20 = copy _21;
         _19 = copy _20;
-        _23 = copy _19 == const null;
-        branch copy _23 -> [bb15, bb16];
+        _18 = short_circuit(??) copy _19 -> [eval: bb15, join: bb16];
     }
 
     bb15: {
-        _19 = const "";
+        _18 = const "";
         goto -> bb16;
     }
 
     bb16: {
-        _18 = copy _19;
-        _24 = call const fn ai.internal._schema_for_signature(copy _1) -> [bb17];
+        _17 = copy _18;
+        _21 = call const fn ai.internal._schema_for_signature(copy _1) -> [bb17];
     }
 
     bb17: {
-        _0 = ai.tools.Tool { copy _17, copy _18, copy _24, copy _1, const null, copy _4 };
+        _0 = ai.tools.Tool { copy _16, copy _17, copy _21, copy _1, const null, copy _4 };
         goto -> bb18;
     }
 
@@ -9329,8 +9228,8 @@ fn ai.tools.tool(handler: reflect.AnyFunction<Returns = unknown, Throws = unknow
     }
 
     bb19: {
-        _16 = baml.errors.InvalidArgument { const "the tool name __baml_return_output is reserved" };
-        throw copy _16;
+        _15 = baml.errors.InvalidArgument { const "the tool name __baml_return_output is reserved" };
+        throw copy _15;
     }
 }
 
@@ -9397,6 +9296,7 @@ fn ai.tools.Toolbox.new(tools: ai.tools.Tool[]) -> ai.tools.Toolbox {
     let _16: int
     let _17: string
     let _18: reflect.Type
+    let _19: string
 
     bb0: {
         _2 = []: string[];
@@ -9434,11 +9334,12 @@ fn ai.tools.Toolbox.new(tools: ai.tools.Tool[]) -> ai.tools.Toolbox {
     bb6: {
         _14 = copy _7.0;
         _15 = load_type(string);
+        _19 = const "duplicate tool name: ";
         _13 = call const fn baml.String.from<copy _15>(copy _14) -> [bb7];
     }
 
     bb7: {
-        _12 = const "duplicate tool name: " + copy _13;
+        _12 = copy _19 + copy _13;
         _11 = baml.errors.InvalidArgument { copy _12 };
         throw copy _11;
     }
@@ -9548,16 +9449,14 @@ fn ai.wire.resolve_credential(cred: string | null | baml.env.Ref, env_fallback: 
     let _9: string
     let _10: string
     let _11: string | null
-    let _12: bool
-    let _13: string | null
-    let _14: string // value
-    let _15: string | null
-    let _16: string // fallback
+    let _12: string | null
+    let _13: string // value
+    let _14: string | null
+    let _15: string // fallback
+    let _16: string
     let _17: string
-    let _18: string
-    let _19: string | null
-    let _20: string
-    let _21: bool
+    let _18: string | null
+    let _19: string
 
     bb0: {
         _4 = copy _1;
@@ -9580,9 +9479,7 @@ fn ai.wire.resolve_credential(cred: string | null | baml.env.Ref, env_fallback: 
     }
 
     bb4: {
-        _10 = copy _11;
-        _12 = copy _10 == const null;
-        branch copy _12 -> [bb5, bb6];
+        _10 = short_circuit(??) copy _11 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
@@ -9602,13 +9499,13 @@ fn ai.wire.resolve_credential(cred: string | null | baml.env.Ref, env_fallback: 
     }
 
     bb8: {
-        _13 = copy _3;
-        _13 = narrow_bind copy _13 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb9];
+        _12 = copy _3;
+        _12 = narrow_bind copy _12 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb9];
     }
 
     bb9: {
-        _15 = copy _2;
-        _15 = narrow_bind copy _15 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb10];
+        _14 = copy _2;
+        _14 = narrow_bind copy _14 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb10];
     }
 
     bb10: {
@@ -9617,30 +9514,28 @@ fn ai.wire.resolve_credential(cred: string | null | baml.env.Ref, env_fallback: 
     }
 
     bb11: {
-        _16 = copy _15;
-        _20 = copy _16;
-        _19 = sys_op const fn baml.env.get(copy _20) -> bb12;
+        _15 = copy _14;
+        _19 = copy _15;
+        _18 = sys_op const fn baml.env.get(copy _19) -> bb12;
     }
 
     bb12: {
-        _18 = copy _19;
-        _21 = copy _18 == const null;
-        branch copy _21 -> [bb13, bb14];
+        _17 = short_circuit(??) copy _18 -> [eval: bb13, join: bb14];
     }
 
     bb13: {
-        _18 = const "";
+        _17 = const "";
         goto -> bb14;
     }
 
     bb14: {
-        _17 = copy _18;
-        _0 = call const fn ai.internal._configured(copy _17) -> [bb16];
+        _16 = copy _17;
+        _0 = call const fn ai.internal._configured(copy _16) -> [bb16];
     }
 
     bb15: {
-        _14 = copy _13;
-        _0 = copy _14;
+        _13 = copy _12;
+        _0 = copy _13;
         goto -> bb16;
     }
 
@@ -9698,29 +9593,35 @@ fn ai.wire.redact_request_headers(headers: map<string, string>) -> map<string, s
     let _16: bool
     let _17: bool
     let _18: bool
-    let _19: string
-    let _20: string
-    let _21: string
-    let _22: string
-    let _23: string
-    let _24: string
+    let _19: bool
+    let _20: bool
+    let _21: bool
+    let _22: bool
+    let _23: bool
+    let _24: bool
     let _25: string
-    let _26: bool
-    let _27: string | null
+    let _26: string
+    let _27: string
     let _28: string
-    let _29: reflect.Type
-    let _30: reflect.Type
-    let _31: string | null
-    let _32: string
-    let _33: reflect.Type
-    let _34: reflect.Type
-    let _35: string | null
-    let _36: string // value
+    let _29: string
+    let _30: string
+    let _31: string
+    let _32: bool
+    let _33: string | null
+    let _34: string
+    let _35: reflect.Type
+    let _36: reflect.Type
     let _37: string | null
     let _38: string
-    let _39: string
+    let _39: reflect.Type
     let _40: reflect.Type
-    let _41: reflect.Type
+    let _41: string | null
+    let _42: string // value
+    let _43: string | null
+    let _44: string
+    let _45: string
+    let _46: reflect.Type
+    let _47: reflect.Type
 
     bb0: {
         _2 = {  }: map<string, string>;
@@ -9750,98 +9651,104 @@ fn ai.wire.redact_request_headers(headers: map<string, string>) -> map<string, s
     }
 
     bb5: {
-        _19 = copy _11;
-        _18 = copy _19 == const "authorization";
-        _17 = short_circuit(||) copy _18 -> [eval: bb6, join: bb7];
+        _25 = copy _11;
+        _24 = copy _25 == const "authorization";
+        _23 = short_circuit(||) copy _24 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
-        _20 = copy _11;
-        _17 = copy _20 == const "proxy-authorization";
+        _26 = copy _11;
+        _23 = copy _26 == const "proxy-authorization";
         goto -> bb7;
     }
 
     bb7: {
-        _16 = short_circuit(||) copy _17 -> [eval: bb8, join: bb9];
+        _22 = copy _23;
+        _21 = short_circuit(||) copy _22 -> [eval: bb8, join: bb9];
     }
 
     bb8: {
-        _21 = copy _11;
-        _16 = copy _21 == const "x-api-key";
+        _27 = copy _11;
+        _21 = copy _27 == const "x-api-key";
         goto -> bb9;
     }
 
     bb9: {
-        _15 = short_circuit(||) copy _16 -> [eval: bb10, join: bb11];
+        _20 = copy _21;
+        _19 = short_circuit(||) copy _20 -> [eval: bb10, join: bb11];
     }
 
     bb10: {
-        _22 = copy _11;
-        _15 = copy _22 == const "api-key";
+        _28 = copy _11;
+        _19 = copy _28 == const "api-key";
         goto -> bb11;
     }
 
     bb11: {
-        _14 = short_circuit(||) copy _15 -> [eval: bb12, join: bb13];
+        _18 = copy _19;
+        _17 = short_circuit(||) copy _18 -> [eval: bb12, join: bb13];
     }
 
     bb12: {
-        _23 = copy _11;
-        _14 = copy _23 == const "x-goog-api-key";
+        _29 = copy _11;
+        _17 = copy _29 == const "x-goog-api-key";
         goto -> bb13;
     }
 
     bb13: {
-        _13 = short_circuit(||) copy _14 -> [eval: bb14, join: bb15];
+        _16 = copy _17;
+        _15 = short_circuit(||) copy _16 -> [eval: bb14, join: bb15];
     }
 
     bb14: {
-        _24 = copy _11;
-        _13 = copy _24 == const "x-amz-security-token";
+        _30 = copy _11;
+        _15 = copy _30 == const "x-amz-security-token";
         goto -> bb15;
     }
 
     bb15: {
-        _12 = short_circuit(||) copy _13 -> [eval: bb16, join: bb17];
+        _14 = copy _15;
+        _13 = short_circuit(||) copy _14 -> [eval: bb16, join: bb17];
     }
 
     bb16: {
-        _25 = copy _11;
-        _12 = copy _25 == const "cookie";
+        _31 = copy _11;
+        _13 = copy _31 == const "cookie";
         goto -> bb17;
     }
 
     bb17: {
-        _26 = copy _12;
-        branch copy _26 -> [bb21, bb18];
+        _12 = copy _13;
+        _32 = copy _12;
+        branch copy _32 -> [bb21, bb18];
     }
 
     bb18: {
-        _32 = copy _10;
-        _33 = load_type(string);
-        _34 = load_type(string);
-        _31 = call const fn baml.Map.get<copy _33, copy _34>(copy _1, copy _32) -> [bb19];
+        _38 = copy _10;
+        _39 = load_type(string);
+        _40 = load_type(string);
+        _37 = call const fn baml.Map.get<copy _39, copy _40>(copy _1, copy _38) -> [bb19];
     }
 
     bb19: {
-        _35 = copy _31;
-        _35 = narrow_bind copy _35 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb20, bb2];
+        _41 = copy _37;
+        _41 = narrow_bind copy _41 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb20, bb2];
     }
 
     bb20: {
-        _36 = copy _35;
-        _38 = copy _10;
-        _39 = copy _36;
-        _40 = load_type(string);
-        _41 = load_type(string);
-        _37 = call const fn baml.Map.set<copy _40, copy _41>(copy _2, copy _38, copy _39) -> [bb2];
+        _42 = copy _41;
+        _44 = copy _10;
+        _45 = copy _42;
+        _46 = load_type(string);
+        _47 = load_type(string);
+        _43 = call const fn baml.Map.set<copy _46, copy _47>(copy _2, copy _44, copy _45) -> [bb2];
     }
 
     bb21: {
-        _28 = copy _10;
-        _29 = load_type(string);
-        _30 = load_type(string);
-        _27 = call const fn baml.Map.set<copy _29, copy _30>(copy _2, copy _28, const "REDACTED") -> [bb2];
+        _34 = copy _10;
+        _35 = load_type(string);
+        _36 = load_type(string);
+        _33 = call const fn baml.Map.set<copy _35, copy _36>(copy _2, copy _34, const "REDACTED") -> [bb2];
     }
 
     bb22: {
@@ -9953,15 +9860,15 @@ fn ai.wire.send_as(req: baml.http.Request, provider: string, request_timeout_ms:
     let _24: baml.errors.Timeout // timeout
     let _25: ai.errors.NetworkFailure
     let _26: bool
-    let _27: bool
-    let _28: ai.errors.Failure
-    let _29: int
-    let _30: string
-    let _31: map<string, string>
-    let _32: unknown // e
-    let _33: string
-    let _34: reflect.Type
-    let _35: ai.errors.ParseFailed
+    let _27: ai.errors.Failure
+    let _28: int
+    let _29: string
+    let _30: map<string, string>
+    let _31: unknown // e
+    let _32: string
+    let _33: reflect.Type
+    let _34: ai.errors.ParseFailed
+    let _35: string
     let _36: string
 
     bb0: {
@@ -9976,7 +9883,7 @@ fn ai.wire.send_as(req: baml.http.Request, provider: string, request_timeout_ms:
 
     bb2: {
         _6 = copy _3;
-        _6 = narrow_bind copy _6 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb4, bb3];
+        _6 = narrow_bind copy _3 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb4, bb3];
     }
 
     bb3: {
@@ -10000,33 +9907,32 @@ fn ai.wire.send_as(req: baml.http.Request, provider: string, request_timeout_ms:
     }
 
     bb7: {
-        _27 = call const fn baml.http.Response.ok(copy _9) -> [bb8];
+        _26 = call const fn baml.http.Response.ok(copy _9) -> [bb8];
     }
 
     bb8: {
-        _26 = !copy _27;
         branch copy _26 -> [bb11, bb9];
     }
 
     bb9: {
-        _33 = copy _21;
-        _34 = load_type(#0);
-        _0 = call const fn baml.json.from_string<copy _34>(copy _33) -> [bb10, unwind: bb24];
+        _28 = copy _9.0;
+        _29 = copy _21;
+        _30 = copy _9.1;
+        _27 = call const fn ai.errors.classify_http(copy _2, copy _28, copy _29, copy _30) -> [bb10];
     }
 
     bb10: {
-        return;
+        throw copy _27;
     }
 
     bb11: {
-        _29 = copy _9.0;
-        _30 = copy _21;
-        _31 = copy _9.1;
-        _28 = call const fn ai.errors.classify_http(copy _2, copy _29, copy _30, copy _31) -> [bb12];
+        _32 = copy _21;
+        _33 = load_type(#0);
+        _0 = call const fn baml.json.from_string<copy _33>(copy _32) -> [bb12, unwind: bb24];
     }
 
     bb12: {
-        throw copy _28;
+        return;
     }
 
     bb13: {
@@ -10049,11 +9955,12 @@ fn ai.wire.send_as(req: baml.http.Request, provider: string, request_timeout_ms:
 
     bb17: {
         _20 = load_type(string);
+        _36 = const "transport failed before a response arrived: ";
         _16 = call const fn baml.String.from<copy _20>(copy _17) -> [bb18];
     }
 
     bb18: {
-        _15 = const "transport failed before a response arrived: " + copy _16;
+        _15 = copy _36 + copy _16;
         _14 = ai.errors.NetworkFailure { copy _2, copy _15, const null, const null };
         throw copy _14;
     }
@@ -10083,13 +9990,13 @@ fn ai.wire.send_as(req: baml.http.Request, provider: string, request_timeout_ms:
     }
 
     bb24: {
-        throw_if_panic copy _32 -> bb25;
+        throw_if_panic copy _31 -> bb25;
     }
 
     bb25: {
-        _36 = copy _21;
-        _35 = ai.errors.ParseFailed { copy _2, copy _36 };
-        throw copy _35;
+        _35 = copy _21;
+        _34 = ai.errors.ParseFailed { copy _2, copy _35 };
+        throw copy _34;
     }
 }
 
@@ -10126,36 +10033,36 @@ fn ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_na
     let _28: baml.errors.Timeout // timeout
     let _29: ai.errors.NetworkFailure
     let _30: bool
-    let _31: bool
-    let _32: ai.errors.Failure
-    let _33: int
-    let _34: string
-    let _35: map<string, string>
-    let _36: T // value
-    let _37: unknown // e
-    let _38: string
-    let _39: reflect.Type
-    let _40: ai.errors.ParseFailed
-    let _41: string
-    let _42: ai.events.LLMCall // call
-    let _43: ai.events.Timing
+    let _31: ai.errors.Failure
+    let _32: int
+    let _33: string
+    let _34: map<string, string>
+    let _35: T // value
+    let _36: unknown // e
+    let _37: string
+    let _38: reflect.Type
+    let _39: ai.errors.ParseFailed
+    let _40: string
+    let _41: ai.events.LLMCall // call
+    let _42: ai.events.Timing
+    let _43: bigint
     let _44: bigint
-    let _45: bigint
-    let _46: baml.time.Duration
-    let _47: null | baml.http.Request
+    let _45: baml.time.Duration
+    let _46: null | baml.http.Request
+    let _47: string
     let _48: string
     let _49: string
-    let _50: string
+    let _50: map<string, string>
     let _51: map<string, string>
-    let _52: map<string, string>
-    let _53: string
-    let _54: ai.events.HttpResponse
-    let _55: int
-    let _56: map<string, string>
-    let _57: string | null
-    let _58: string
-    let _59: T
-    let _60: ai.events.LLMCall
+    let _52: string
+    let _53: ai.events.HttpResponse
+    let _54: int
+    let _55: map<string, string>
+    let _56: string | null
+    let _57: string
+    let _58: T
+    let _59: ai.events.LLMCall
+    let _60: string
 
     bb0: {
         _6 = copy _4 == const <omitted>;
@@ -10183,7 +10090,7 @@ fn ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_na
 
     bb5: {
         _10 = copy _5;
-        _10 = narrow_bind copy _10 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb7, bb6];
+        _10 = narrow_bind copy _5 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb7, bb6];
     }
 
     bb6: {
@@ -10207,97 +10114,96 @@ fn ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_na
     }
 
     bb10: {
-        _31 = call const fn baml.http.Response.ok(copy _13) -> [bb11];
+        _30 = call const fn baml.http.Response.ok(copy _13) -> [bb11];
     }
 
     bb11: {
-        _30 = !copy _31;
-        branch copy _30 -> [bb26, bb12];
+        branch copy _30 -> [bb14, bb12];
     }
 
     bb12: {
-        _38 = copy _25;
-        _39 = load_type(#0);
-        _36 = call const fn baml.json.from_string<copy _39>(copy _38) -> [bb13, unwind: bb39];
+        _32 = copy _13.0;
+        _33 = copy _25;
+        _34 = copy _13.1;
+        _31 = call const fn ai.errors.classify_http(copy _2, copy _32, copy _33, copy _34) -> [bb13];
     }
 
     bb13: {
-        _44 = call const fn baml.time.Instant.to_timestamp_milliseconds(copy _8) -> [bb14];
+        throw copy _31;
     }
 
     bb14: {
-        _46 = call const fn baml.time.Instant.elapsed(copy _8) -> [bb15];
+        _37 = copy _25;
+        _38 = load_type(#0);
+        _35 = call const fn baml.json.from_string<copy _38>(copy _37) -> [bb15, unwind: bb39];
     }
 
     bb15: {
-        _45 = call const fn baml.time.Duration.to_milliseconds(copy _46) -> [bb16];
+        _43 = call const fn baml.time.Instant.to_timestamp_milliseconds(copy _8) -> [bb16];
     }
 
     bb16: {
-        _43 = ai.events.Timing { copy _44, copy _45, const null };
-        branch copy _4 -> [bb18, bb17];
+        _45 = call const fn baml.time.Instant.elapsed(copy _8) -> [bb17];
     }
 
     bb17: {
-        _47 = const null;
-        goto -> bb21;
+        _44 = call const fn baml.time.Duration.to_milliseconds(copy _45) -> [bb18];
     }
 
     bb18: {
-        _48 = copy _1.0;
-        _50 = copy _1.1;
-        _49 = call const fn ai.wire.redact_url_secrets(copy _50) -> [bb19];
+        _42 = ai.events.Timing { copy _43, copy _44, const null };
+        branch copy _4 -> [bb20, bb19];
     }
 
     bb19: {
-        _52 = copy _1.2;
-        _51 = call const fn ai.wire.redact_request_headers(copy _52) -> [bb20];
+        _46 = const null;
+        goto -> bb23;
     }
 
     bb20: {
-        _53 = copy _1.3;
-        _47 = baml.http.Request { copy _48, copy _49, copy _51, copy _53 };
-        goto -> bb21;
+        _47 = copy _1.0;
+        _49 = copy _1.1;
+        _48 = call const fn ai.wire.redact_url_secrets(copy _49) -> [bb21];
     }
 
     bb21: {
-        _55 = copy _13.0;
-        _56 = copy _13.1;
-        branch copy _4 -> [bb23, bb22];
+        _51 = copy _1.2;
+        _50 = call const fn ai.wire.redact_request_headers(copy _51) -> [bb22];
     }
 
     bb22: {
-        _57 = const null;
-        goto -> bb24;
+        _52 = copy _1.3;
+        _46 = baml.http.Request { copy _47, copy _48, copy _50, copy _52 };
+        goto -> bb23;
     }
 
     bb23: {
-        _58 = copy _25;
-        _57 = call const fn ai.wire.redact_url_secrets(copy _58) -> [bb24];
+        _54 = copy _13.0;
+        _55 = copy _13.1;
+        branch copy _4 -> [bb25, bb24];
     }
 
     bb24: {
-        _54 = ai.events.HttpResponse { copy _55, copy _56, copy _57 };
-        _42 = ai.events.LLMCall { copy _3, copy _2, copy _43, copy _47, copy _54, const null, const true, const null };
-        _59 = copy _36;
-        _60 = copy _42;
-        _0 = ai.wire.SentAs<#0> { copy _59, copy _60 };
-        goto -> bb25;
+        _56 = const null;
+        goto -> bb26;
     }
 
     bb25: {
-        return;
+        _57 = copy _25;
+        _56 = call const fn ai.wire.redact_url_secrets(copy _57) -> [bb26];
     }
 
     bb26: {
-        _33 = copy _13.0;
-        _34 = copy _25;
-        _35 = copy _13.1;
-        _32 = call const fn ai.errors.classify_http(copy _2, copy _33, copy _34, copy _35) -> [bb27];
+        _53 = ai.events.HttpResponse { copy _54, copy _55, copy _56 };
+        _41 = ai.events.LLMCall { copy _3, copy _2, copy _42, copy _46, copy _53, const null, const true, const null };
+        _58 = copy _35;
+        _59 = copy _41;
+        _0 = ai.wire.SentAs<#0> { copy _58, copy _59 };
+        goto -> bb27;
     }
 
     bb27: {
-        throw copy _32;
+        return;
     }
 
     bb28: {
@@ -10320,11 +10226,12 @@ fn ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_na
 
     bb32: {
         _24 = load_type(string);
+        _60 = const "transport failed before a response arrived: ";
         _20 = call const fn baml.String.from<copy _24>(copy _21) -> [bb33];
     }
 
     bb33: {
-        _19 = const "transport failed before a response arrived: " + copy _20;
+        _19 = copy _60 + copy _20;
         _18 = ai.errors.NetworkFailure { copy _2, copy _19, const null, const null };
         throw copy _18;
     }
@@ -10354,13 +10261,13 @@ fn ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_na
     }
 
     bb39: {
-        throw_if_panic copy _37 -> bb40;
+        throw_if_panic copy _36 -> bb40;
     }
 
     bb40: {
-        _41 = copy _25;
-        _40 = ai.errors.ParseFailed { copy _2, copy _41 };
-        throw copy _40;
+        _40 = copy _25;
+        _39 = ai.errors.ParseFailed { copy _2, copy _40 };
+        throw copy _39;
     }
 }
 
@@ -10395,58 +10302,50 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     let _7: string | null
     let _8: string | null
     let _9: string | null
-    let _10: bool
-    let _11: bool
-    let _12: string | null
-    let _13: string | null
-    let _14: string
+    let _10: string | null
+    let _11: string | null
+    let _12: string
+    let _13: string
+    let _14: string | null
     let _15: string
-    let _16: string | null
-    let _17: string
-    let _18: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _19: baml.media.Audio // audio
-    let _20: string // source
-    let _21: string
+    let _16: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _17: baml.media.Audio // audio
+    let _18: string // source
+    let _19: string
+    let _20: string | null
+    let _21: string | null
     let _22: string | null
     let _23: string | null
     let _24: string | null
-    let _25: bool
-    let _26: bool
+    let _25: string
+    let _26: string
     let _27: string | null
-    let _28: string | null
-    let _29: string
-    let _30: string
-    let _31: string | null
+    let _28: string
+    let _29: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _30: baml.media.Video // video
+    let _31: string // source
     let _32: string
-    let _33: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _34: baml.media.Video // video
-    let _35: string // source
-    let _36: string
+    let _33: string | null
+    let _34: string | null
+    let _35: string | null
+    let _36: string | null
     let _37: string | null
-    let _38: string | null
-    let _39: string | null
-    let _40: bool
-    let _41: bool
-    let _42: string | null
-    let _43: string | null
+    let _38: string
+    let _39: string
+    let _40: string | null
+    let _41: string
+    let _42: baml.media.Pdf // pdf
+    let _43: string // source
     let _44: string
-    let _45: string
+    let _45: string | null
     let _46: string | null
-    let _47: string
-    let _48: baml.media.Pdf // pdf
-    let _49: string // source
+    let _47: string | null
+    let _48: string | null
+    let _49: string | null
     let _50: string
-    let _51: string | null
+    let _51: string
     let _52: string | null
-    let _53: string | null
-    let _54: bool
-    let _55: bool
-    let _56: string | null
-    let _57: string | null
-    let _58: string
-    let _59: string
-    let _60: string | null
-    let _61: string
+    let _53: string
 
     bb0: {
         _3 = copy _1;
@@ -10454,172 +10353,160 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     }
 
     bb1: {
-        _18 = copy _1;
-        _18 = narrow_bind copy _18 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
+        _16 = copy _1;
+        _16 = narrow_bind copy _16 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
     }
 
     bb2: {
-        _33 = copy _1;
-        _33 = narrow_bind copy _33 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
+        _29 = copy _1;
+        _29 = narrow_bind copy _29 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
     }
 
     bb3: {
-        _48 = copy _1;
-        _53 = call const fn baml.media.Pdf.file(copy _48) -> [bb4];
+        _42 = copy _1;
+        _47 = call const fn baml.media.Pdf.file(copy _42) -> [bb4];
     }
 
     bb4: {
-        _52 = copy _53;
-        _54 = copy _52 == const null;
-        branch copy _54 -> [bb5, bb6];
+        _46 = short_circuit(??) copy _47 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
-        _52 = call const fn baml.media.Pdf.url(copy _48) -> [bb6];
+        _46 = call const fn baml.media.Pdf.url(copy _42) -> [bb6];
     }
 
     bb6: {
-        _51 = copy _52;
-        _50 = copy _51;
-        _55 = copy _50 == const null;
-        branch copy _55 -> [bb7, bb8];
+        _45 = copy _46;
+        _44 = short_circuit(??) copy _45 -> [eval: bb7, join: bb8];
     }
 
     bb7: {
-        _50 = const "";
+        _44 = const "";
         goto -> bb8;
     }
 
     bb8: {
-        _49 = copy _50;
-        _56 = call const fn baml.media.Pdf.url(copy _48) -> [bb9];
+        _43 = copy _44;
+        _48 = call const fn baml.media.Pdf.url(copy _42) -> [bb9];
     }
 
     bb9: {
-        _57 = call const fn baml.media.Pdf.file(copy _48) -> [bb10];
+        _49 = call const fn baml.media.Pdf.file(copy _42) -> [bb10];
     }
 
     bb10: {
-        _58 = call const fn baml.media.Pdf.base64(copy _48) -> [bb11];
+        _50 = call const fn baml.media.Pdf.base64(copy _42) -> [bb11];
     }
 
     bb11: {
-        _60 = call const fn baml.media.Pdf.mime_type(copy _48) -> [bb12];
+        _52 = call const fn baml.media.Pdf.mime_type(copy _42) -> [bb12];
     }
 
     bb12: {
-        _61 = copy _49;
-        _59 = call const fn ai.internal._media_mime_type(copy _60, copy _61, const "pdf") -> [bb13];
+        _53 = copy _43;
+        _51 = call const fn ai.internal._media_mime_type(copy _52, copy _53, const "pdf") -> [bb13];
     }
 
     bb13: {
-        _0 = call const fn ai.internal._resolve_media_content(copy _56, copy _57, copy _58, copy _59, copy _2) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_content(copy _48, copy _49, copy _50, copy _51, copy _2) -> [bb47];
     }
 
     bb14: {
-        _34 = copy _33;
-        _39 = call const fn baml.media.Video.file(copy _34) -> [bb15];
+        _30 = copy _29;
+        _35 = call const fn baml.media.Video.file(copy _30) -> [bb15];
     }
 
     bb15: {
-        _38 = copy _39;
-        _40 = copy _38 == const null;
-        branch copy _40 -> [bb16, bb17];
+        _34 = short_circuit(??) copy _35 -> [eval: bb16, join: bb17];
     }
 
     bb16: {
-        _38 = call const fn baml.media.Video.url(copy _34) -> [bb17];
+        _34 = call const fn baml.media.Video.url(copy _30) -> [bb17];
     }
 
     bb17: {
-        _37 = copy _38;
-        _36 = copy _37;
-        _41 = copy _36 == const null;
-        branch copy _41 -> [bb18, bb19];
+        _33 = copy _34;
+        _32 = short_circuit(??) copy _33 -> [eval: bb18, join: bb19];
     }
 
     bb18: {
-        _36 = const "";
+        _32 = const "";
         goto -> bb19;
     }
 
     bb19: {
-        _35 = copy _36;
-        _42 = call const fn baml.media.Video.url(copy _34) -> [bb20];
+        _31 = copy _32;
+        _36 = call const fn baml.media.Video.url(copy _30) -> [bb20];
     }
 
     bb20: {
-        _43 = call const fn baml.media.Video.file(copy _34) -> [bb21];
+        _37 = call const fn baml.media.Video.file(copy _30) -> [bb21];
     }
 
     bb21: {
-        _44 = call const fn baml.media.Video.base64(copy _34) -> [bb22];
+        _38 = call const fn baml.media.Video.base64(copy _30) -> [bb22];
     }
 
     bb22: {
-        _46 = call const fn baml.media.Video.mime_type(copy _34) -> [bb23];
+        _40 = call const fn baml.media.Video.mime_type(copy _30) -> [bb23];
     }
 
     bb23: {
-        _47 = copy _35;
-        _45 = call const fn ai.internal._media_mime_type(copy _46, copy _47, const "video") -> [bb24];
+        _41 = copy _31;
+        _39 = call const fn ai.internal._media_mime_type(copy _40, copy _41, const "video") -> [bb24];
     }
 
     bb24: {
-        _0 = call const fn ai.internal._resolve_media_content(copy _42, copy _43, copy _44, copy _45, copy _2) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_content(copy _36, copy _37, copy _38, copy _39, copy _2) -> [bb47];
     }
 
     bb25: {
-        _19 = copy _18;
-        _24 = call const fn baml.media.Audio.file(copy _19) -> [bb26];
+        _17 = copy _16;
+        _22 = call const fn baml.media.Audio.file(copy _17) -> [bb26];
     }
 
     bb26: {
-        _23 = copy _24;
-        _25 = copy _23 == const null;
-        branch copy _25 -> [bb27, bb28];
+        _21 = short_circuit(??) copy _22 -> [eval: bb27, join: bb28];
     }
 
     bb27: {
-        _23 = call const fn baml.media.Audio.url(copy _19) -> [bb28];
+        _21 = call const fn baml.media.Audio.url(copy _17) -> [bb28];
     }
 
     bb28: {
-        _22 = copy _23;
-        _21 = copy _22;
-        _26 = copy _21 == const null;
-        branch copy _26 -> [bb29, bb30];
+        _20 = copy _21;
+        _19 = short_circuit(??) copy _20 -> [eval: bb29, join: bb30];
     }
 
     bb29: {
-        _21 = const "";
+        _19 = const "";
         goto -> bb30;
     }
 
     bb30: {
-        _20 = copy _21;
-        _27 = call const fn baml.media.Audio.url(copy _19) -> [bb31];
+        _18 = copy _19;
+        _23 = call const fn baml.media.Audio.url(copy _17) -> [bb31];
     }
 
     bb31: {
-        _28 = call const fn baml.media.Audio.file(copy _19) -> [bb32];
+        _24 = call const fn baml.media.Audio.file(copy _17) -> [bb32];
     }
 
     bb32: {
-        _29 = call const fn baml.media.Audio.base64(copy _19) -> [bb33];
+        _25 = call const fn baml.media.Audio.base64(copy _17) -> [bb33];
     }
 
     bb33: {
-        _31 = call const fn baml.media.Audio.mime_type(copy _19) -> [bb34];
+        _27 = call const fn baml.media.Audio.mime_type(copy _17) -> [bb34];
     }
 
     bb34: {
-        _32 = copy _20;
-        _30 = call const fn ai.internal._media_mime_type(copy _31, copy _32, const "audio") -> [bb35];
+        _28 = copy _18;
+        _26 = call const fn ai.internal._media_mime_type(copy _27, copy _28, const "audio") -> [bb35];
     }
 
     bb35: {
-        _0 = call const fn ai.internal._resolve_media_content(copy _27, copy _28, copy _29, copy _30, copy _2) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_content(copy _23, copy _24, copy _25, copy _26, copy _2) -> [bb47];
     }
 
     bb36: {
@@ -10628,9 +10515,7 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     }
 
     bb37: {
-        _8 = copy _9;
-        _10 = copy _8 == const null;
-        branch copy _10 -> [bb38, bb39];
+        _8 = short_circuit(??) copy _9 -> [eval: bb38, join: bb39];
     }
 
     bb38: {
@@ -10639,9 +10524,7 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
 
     bb39: {
         _7 = copy _8;
-        _6 = copy _7;
-        _11 = copy _6 == const null;
-        branch copy _11 -> [bb40, bb41];
+        _6 = short_circuit(??) copy _7 -> [eval: bb40, join: bb41];
     }
 
     bb40: {
@@ -10651,28 +10534,28 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
 
     bb41: {
         _5 = copy _6;
-        _12 = call const fn baml.media.Image.url(copy _4) -> [bb42];
+        _10 = call const fn baml.media.Image.url(copy _4) -> [bb42];
     }
 
     bb42: {
-        _13 = call const fn baml.media.Image.file(copy _4) -> [bb43];
+        _11 = call const fn baml.media.Image.file(copy _4) -> [bb43];
     }
 
     bb43: {
-        _14 = call const fn baml.media.Image.base64(copy _4) -> [bb44];
+        _12 = call const fn baml.media.Image.base64(copy _4) -> [bb44];
     }
 
     bb44: {
-        _16 = call const fn baml.media.Image.mime_type(copy _4) -> [bb45];
+        _14 = call const fn baml.media.Image.mime_type(copy _4) -> [bb45];
     }
 
     bb45: {
-        _17 = copy _5;
-        _15 = call const fn ai.internal._media_mime_type(copy _16, copy _17, const "image") -> [bb46];
+        _15 = copy _5;
+        _13 = call const fn ai.internal._media_mime_type(copy _14, copy _15, const "image") -> [bb46];
     }
 
     bb46: {
-        _0 = call const fn ai.internal._resolve_media_content(copy _12, copy _13, copy _14, copy _15, copy _2) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_content(copy _10, copy _11, copy _12, copy _13, copy _2) -> [bb47];
     }
 
     bb47: {
@@ -10691,58 +10574,50 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
     let _6: string | null
     let _7: string | null
     let _8: string | null
-    let _9: bool
-    let _10: bool
-    let _11: string | null
-    let _12: string | null
-    let _13: string
+    let _9: string | null
+    let _10: string | null
+    let _11: string
+    let _12: string
+    let _13: string | null
     let _14: string
-    let _15: string | null
-    let _16: string
-    let _17: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _18: baml.media.Audio // audio
-    let _19: string // source
-    let _20: string
+    let _15: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _16: baml.media.Audio // audio
+    let _17: string // source
+    let _18: string
+    let _19: string | null
+    let _20: string | null
     let _21: string | null
     let _22: string | null
     let _23: string | null
-    let _24: bool
-    let _25: bool
+    let _24: string
+    let _25: string
     let _26: string | null
-    let _27: string | null
-    let _28: string
-    let _29: string
-    let _30: string | null
+    let _27: string
+    let _28: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _29: baml.media.Video // video
+    let _30: string // source
     let _31: string
-    let _32: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _33: baml.media.Video // video
-    let _34: string // source
-    let _35: string
+    let _32: string | null
+    let _33: string | null
+    let _34: string | null
+    let _35: string | null
     let _36: string | null
-    let _37: string | null
-    let _38: string | null
-    let _39: bool
-    let _40: bool
-    let _41: string | null
-    let _42: string | null
+    let _37: string
+    let _38: string
+    let _39: string | null
+    let _40: string
+    let _41: baml.media.Pdf // pdf
+    let _42: string // source
     let _43: string
-    let _44: string
+    let _44: string | null
     let _45: string | null
-    let _46: string
-    let _47: baml.media.Pdf // pdf
-    let _48: string // source
+    let _46: string | null
+    let _47: string | null
+    let _48: string | null
     let _49: string
-    let _50: string | null
+    let _50: string
     let _51: string | null
-    let _52: string | null
-    let _53: bool
-    let _54: bool
-    let _55: string | null
-    let _56: string | null
-    let _57: string
-    let _58: string
-    let _59: string | null
-    let _60: string
+    let _52: string
 
     bb0: {
         _2 = copy _1;
@@ -10750,172 +10625,160 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
     }
 
     bb1: {
-        _17 = copy _1;
-        _17 = narrow_bind copy _17 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
+        _15 = copy _1;
+        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
     }
 
     bb2: {
-        _32 = copy _1;
-        _32 = narrow_bind copy _32 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
+        _28 = copy _1;
+        _28 = narrow_bind copy _28 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
     }
 
     bb3: {
-        _47 = copy _1;
-        _52 = call const fn baml.media.Pdf.file(copy _47) -> [bb4];
+        _41 = copy _1;
+        _46 = call const fn baml.media.Pdf.file(copy _41) -> [bb4];
     }
 
     bb4: {
-        _51 = copy _52;
-        _53 = copy _51 == const null;
-        branch copy _53 -> [bb5, bb6];
+        _45 = short_circuit(??) copy _46 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
-        _51 = call const fn baml.media.Pdf.url(copy _47) -> [bb6];
+        _45 = call const fn baml.media.Pdf.url(copy _41) -> [bb6];
     }
 
     bb6: {
-        _50 = copy _51;
-        _49 = copy _50;
-        _54 = copy _49 == const null;
-        branch copy _54 -> [bb7, bb8];
+        _44 = copy _45;
+        _43 = short_circuit(??) copy _44 -> [eval: bb7, join: bb8];
     }
 
     bb7: {
-        _49 = const "";
+        _43 = const "";
         goto -> bb8;
     }
 
     bb8: {
-        _48 = copy _49;
-        _55 = call const fn baml.media.Pdf.url(copy _47) -> [bb9];
+        _42 = copy _43;
+        _47 = call const fn baml.media.Pdf.url(copy _41) -> [bb9];
     }
 
     bb9: {
-        _56 = call const fn baml.media.Pdf.file(copy _47) -> [bb10];
+        _48 = call const fn baml.media.Pdf.file(copy _41) -> [bb10];
     }
 
     bb10: {
-        _57 = call const fn baml.media.Pdf.base64(copy _47) -> [bb11];
+        _49 = call const fn baml.media.Pdf.base64(copy _41) -> [bb11];
     }
 
     bb11: {
-        _59 = call const fn baml.media.Pdf.mime_type(copy _47) -> [bb12];
+        _51 = call const fn baml.media.Pdf.mime_type(copy _41) -> [bb12];
     }
 
     bb12: {
-        _60 = copy _48;
-        _58 = call const fn ai.internal._media_mime_type(copy _59, copy _60, const "pdf") -> [bb13];
+        _52 = copy _42;
+        _50 = call const fn ai.internal._media_mime_type(copy _51, copy _52, const "pdf") -> [bb13];
     }
 
     bb13: {
-        _0 = call const fn ai.internal._resolve_media_preview_content(copy _55, copy _56, copy _57, copy _58) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_preview_content(copy _47, copy _48, copy _49, copy _50) -> [bb47];
     }
 
     bb14: {
-        _33 = copy _32;
-        _38 = call const fn baml.media.Video.file(copy _33) -> [bb15];
+        _29 = copy _28;
+        _34 = call const fn baml.media.Video.file(copy _29) -> [bb15];
     }
 
     bb15: {
-        _37 = copy _38;
-        _39 = copy _37 == const null;
-        branch copy _39 -> [bb16, bb17];
+        _33 = short_circuit(??) copy _34 -> [eval: bb16, join: bb17];
     }
 
     bb16: {
-        _37 = call const fn baml.media.Video.url(copy _33) -> [bb17];
+        _33 = call const fn baml.media.Video.url(copy _29) -> [bb17];
     }
 
     bb17: {
-        _36 = copy _37;
-        _35 = copy _36;
-        _40 = copy _35 == const null;
-        branch copy _40 -> [bb18, bb19];
+        _32 = copy _33;
+        _31 = short_circuit(??) copy _32 -> [eval: bb18, join: bb19];
     }
 
     bb18: {
-        _35 = const "";
+        _31 = const "";
         goto -> bb19;
     }
 
     bb19: {
-        _34 = copy _35;
-        _41 = call const fn baml.media.Video.url(copy _33) -> [bb20];
+        _30 = copy _31;
+        _35 = call const fn baml.media.Video.url(copy _29) -> [bb20];
     }
 
     bb20: {
-        _42 = call const fn baml.media.Video.file(copy _33) -> [bb21];
+        _36 = call const fn baml.media.Video.file(copy _29) -> [bb21];
     }
 
     bb21: {
-        _43 = call const fn baml.media.Video.base64(copy _33) -> [bb22];
+        _37 = call const fn baml.media.Video.base64(copy _29) -> [bb22];
     }
 
     bb22: {
-        _45 = call const fn baml.media.Video.mime_type(copy _33) -> [bb23];
+        _39 = call const fn baml.media.Video.mime_type(copy _29) -> [bb23];
     }
 
     bb23: {
-        _46 = copy _34;
-        _44 = call const fn ai.internal._media_mime_type(copy _45, copy _46, const "video") -> [bb24];
+        _40 = copy _30;
+        _38 = call const fn ai.internal._media_mime_type(copy _39, copy _40, const "video") -> [bb24];
     }
 
     bb24: {
-        _0 = call const fn ai.internal._resolve_media_preview_content(copy _41, copy _42, copy _43, copy _44) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_preview_content(copy _35, copy _36, copy _37, copy _38) -> [bb47];
     }
 
     bb25: {
-        _18 = copy _17;
-        _23 = call const fn baml.media.Audio.file(copy _18) -> [bb26];
+        _16 = copy _15;
+        _21 = call const fn baml.media.Audio.file(copy _16) -> [bb26];
     }
 
     bb26: {
-        _22 = copy _23;
-        _24 = copy _22 == const null;
-        branch copy _24 -> [bb27, bb28];
+        _20 = short_circuit(??) copy _21 -> [eval: bb27, join: bb28];
     }
 
     bb27: {
-        _22 = call const fn baml.media.Audio.url(copy _18) -> [bb28];
+        _20 = call const fn baml.media.Audio.url(copy _16) -> [bb28];
     }
 
     bb28: {
-        _21 = copy _22;
-        _20 = copy _21;
-        _25 = copy _20 == const null;
-        branch copy _25 -> [bb29, bb30];
+        _19 = copy _20;
+        _18 = short_circuit(??) copy _19 -> [eval: bb29, join: bb30];
     }
 
     bb29: {
-        _20 = const "";
+        _18 = const "";
         goto -> bb30;
     }
 
     bb30: {
-        _19 = copy _20;
-        _26 = call const fn baml.media.Audio.url(copy _18) -> [bb31];
+        _17 = copy _18;
+        _22 = call const fn baml.media.Audio.url(copy _16) -> [bb31];
     }
 
     bb31: {
-        _27 = call const fn baml.media.Audio.file(copy _18) -> [bb32];
+        _23 = call const fn baml.media.Audio.file(copy _16) -> [bb32];
     }
 
     bb32: {
-        _28 = call const fn baml.media.Audio.base64(copy _18) -> [bb33];
+        _24 = call const fn baml.media.Audio.base64(copy _16) -> [bb33];
     }
 
     bb33: {
-        _30 = call const fn baml.media.Audio.mime_type(copy _18) -> [bb34];
+        _26 = call const fn baml.media.Audio.mime_type(copy _16) -> [bb34];
     }
 
     bb34: {
-        _31 = copy _19;
-        _29 = call const fn ai.internal._media_mime_type(copy _30, copy _31, const "audio") -> [bb35];
+        _27 = copy _17;
+        _25 = call const fn ai.internal._media_mime_type(copy _26, copy _27, const "audio") -> [bb35];
     }
 
     bb35: {
-        _0 = call const fn ai.internal._resolve_media_preview_content(copy _26, copy _27, copy _28, copy _29) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_preview_content(copy _22, copy _23, copy _24, copy _25) -> [bb47];
     }
 
     bb36: {
@@ -10924,9 +10787,7 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
     }
 
     bb37: {
-        _7 = copy _8;
-        _9 = copy _7 == const null;
-        branch copy _9 -> [bb38, bb39];
+        _7 = short_circuit(??) copy _8 -> [eval: bb38, join: bb39];
     }
 
     bb38: {
@@ -10935,9 +10796,7 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
 
     bb39: {
         _6 = copy _7;
-        _5 = copy _6;
-        _10 = copy _5 == const null;
-        branch copy _10 -> [bb40, bb41];
+        _5 = short_circuit(??) copy _6 -> [eval: bb40, join: bb41];
     }
 
     bb40: {
@@ -10947,28 +10806,28 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
 
     bb41: {
         _4 = copy _5;
-        _11 = call const fn baml.media.Image.url(copy _3) -> [bb42];
+        _9 = call const fn baml.media.Image.url(copy _3) -> [bb42];
     }
 
     bb42: {
-        _12 = call const fn baml.media.Image.file(copy _3) -> [bb43];
+        _10 = call const fn baml.media.Image.file(copy _3) -> [bb43];
     }
 
     bb43: {
-        _13 = call const fn baml.media.Image.base64(copy _3) -> [bb44];
+        _11 = call const fn baml.media.Image.base64(copy _3) -> [bb44];
     }
 
     bb44: {
-        _15 = call const fn baml.media.Image.mime_type(copy _3) -> [bb45];
+        _13 = call const fn baml.media.Image.mime_type(copy _3) -> [bb45];
     }
 
     bb45: {
-        _16 = copy _4;
-        _14 = call const fn ai.internal._media_mime_type(copy _15, copy _16, const "image") -> [bb46];
+        _14 = copy _4;
+        _12 = call const fn ai.internal._media_mime_type(copy _13, copy _14, const "image") -> [bb46];
     }
 
     bb46: {
-        _0 = call const fn ai.internal._resolve_media_preview_content(copy _11, copy _12, copy _13, copy _14) -> [bb47];
+        _0 = call const fn ai.internal._resolve_media_preview_content(copy _9, copy _10, copy _11, copy _12) -> [bb47];
     }
 
     bb47: {
@@ -11265,8 +11124,12 @@ fn ai.Agent.new(max_steps: int, schema_attempts: int, client: null | ai.Client, 
     let _10: bool
     let _11: bool
     let _12: baml.errors.InvalidArgument
-    let _13: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
-    let _14: reflect.Type
+    let _13: int
+    let _14: int
+    let _15: null | ai.Client
+    let _16: ai.tools.ErrorMode
+    let _17: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> void throws never)
+    let _18: reflect.Type
 
     bb0: {
         _6 = copy _1 == const <omitted>;
@@ -11324,12 +11187,16 @@ fn ai.Agent.new(max_steps: int, schema_attempts: int, client: null | ai.Client, 
     }
 
     bb11: {
-        _14 = load_type(unknown);
-        _13 = call const fn ai.events.guard<copy _14>(copy _5) -> [bb12];
+        _13 = copy _1;
+        _14 = copy _2;
+        _15 = copy _3;
+        _16 = copy _4;
+        _18 = load_type(unknown);
+        _17 = call const fn ai.events.guard<copy _18>(copy _5) -> [bb12];
     }
 
     bb12: {
-        _0 = ai.Agent { copy _1, copy _2, copy _3, copy _4, copy _13 };
+        _0 = ai.Agent { copy _13, copy _14, copy _15, copy _16, copy _17 };
         goto -> bb13;
     }
 
@@ -11396,31 +11263,31 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     let _19: ai.tools.ErrorMode
     let _20: ai.tools.ErrorMode
     let _21: null | ai.tools.ErrorMode
-    let _22: bool
-    let _23: null | ai.errors.Failure // classified
-    let _24: unknown
-    let _25: ai.errors.Failure // f
-    let _26: ai.errors.ToolFailedError
+    let _22: null | ai.errors.Failure // classified
+    let _23: unknown
+    let _24: ai.errors.Failure // f
+    let _25: ai.errors.ToolFailedError
+    let _26: string
     let _27: string
     let _28: string
-    let _29: string
-    let _30: reflect.Type
-    let _31: null | ai.errors.Failure
-    let _32: string | null
-    let _33: string // output
-    let _34: void
-    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _36: ai.events.ToolCompleted
+    let _29: reflect.Type
+    let _30: null | ai.errors.Failure
+    let _31: string | null
+    let _32: string // output
+    let _33: void
+    let _34: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _35: ai.events.ToolCompleted
+    let _36: string
     let _37: string
-    let _38: string
-    let _39: void
-    let _40: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _41: ai.events.ToolFailed
+    let _38: void
+    let _39: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _40: ai.events.ToolFailed
+    let _41: string
     let _42: string
     let _43: string
     let _44: string
-    let _45: string
-    let _46: reflect.Type
+    let _45: reflect.Type
+    let _46: string
 
     bb0: {
         _6 = copy _3.1;
@@ -11433,17 +11300,18 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb2: {
-        _42 = copy _3.0;
-        _45 = copy _3.1;
-        _46 = load_type(string);
-        _44 = call const fn baml.String.from<copy _46>(copy _45) -> [bb3];
+        _41 = copy _3.0;
+        _44 = copy _3.1;
+        _45 = load_type(string);
+        _46 = const "tool is not in the active toolbox: ";
+        _43 = call const fn baml.String.from<copy _45>(copy _44) -> [bb3];
     }
 
     bb3: {
-        _43 = const "tool is not in the active toolbox: " + copy _44;
-        _41 = ai.events.ToolFailed { copy _42, copy _43 };
-        _40 = [copy _41]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
-        _39 = call const fn ai.Journal.append_all(copy _4, copy _40) -> [bb4];
+        _42 = copy _46 + copy _43;
+        _40 = ai.events.ToolFailed { copy _41, copy _42 };
+        _39 = [copy _40]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _38 = call const fn ai.Journal.append_all(copy _4, copy _39) -> [bb4];
     }
 
     bb4: {
@@ -11475,9 +11343,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
 
     bb9: {
         _21 = copy _8.5;
-        _20 = copy _21;
-        _22 = copy _20 == const null;
-        branch copy _22 -> [bb10, bb11];
+        _20 = short_circuit(??) copy _21 -> [eval: bb10, join: bb11];
     }
 
     bb10: {
@@ -11500,17 +11366,17 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb14: {
-        _32 = copy _9;
-        _32 = narrow_bind copy _32 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb16];
+        _31 = copy _9;
+        _31 = narrow_bind copy _31 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb16];
     }
 
     bb15: {
-        _33 = copy _32;
-        _37 = copy _3.0;
-        _38 = copy _33;
-        _36 = ai.events.ToolCompleted { copy _37, copy _38 };
-        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
-        _34 = call const fn ai.Journal.append_all(copy _4, copy _35) -> [bb16];
+        _32 = copy _31;
+        _36 = copy _3.0;
+        _37 = copy _32;
+        _35 = ai.events.ToolCompleted { copy _36, copy _37 };
+        _34 = [copy _35]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _33 = call const fn ai.Journal.append_all(copy _4, copy _34) -> [bb16];
     }
 
     bb16: {
@@ -11523,32 +11389,32 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb18: {
-        _24 = copy _10;
-        _24 = narrow_bind copy _24 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb19];
+        _23 = copy _10;
+        _23 = narrow_bind copy _23 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb19];
     }
 
     bb19: {
-        _23 = const null;
+        _22 = const null;
         goto -> bb21;
     }
 
     bb20: {
-        _25 = copy _24;
-        _23 = copy _25;
+        _24 = copy _23;
+        _22 = copy _24;
         goto -> bb21;
     }
 
     bb21: {
-        _27 = copy _3.0;
-        _28 = copy _3.1;
-        _30 = load_type(unknown);
-        _29 = call const fn baml.String.from<copy _30>(copy _10) -> [bb22];
+        _26 = copy _3.0;
+        _27 = copy _3.1;
+        _29 = load_type(unknown);
+        _28 = call const fn baml.String.from<copy _29>(copy _10) -> [bb22];
     }
 
     bb22: {
-        _31 = copy _23;
-        _26 = ai.errors.ToolFailedError { copy _27, copy _28, copy _29, copy _31 };
-        throw copy _26;
+        _30 = copy _22;
+        _25 = ai.errors.ToolFailedError { copy _26, copy _27, copy _28, copy _30 };
+        throw copy _25;
     }
 }
 
@@ -11565,22 +11431,20 @@ fn ai.Agent._has_media_output(self: ai.Agent, turn: ai.ModelTurn) -> bool {
     let _8: string[]
     let _9: reflect.Type
     let _10: bool
-    let _11: bool
-    let _12: string
-    let _13: bool
+    let _11: string
+    let _12: bool
+    let _13: string
     let _14: bool
     let _15: string
-    let _16: string
-    let _17: int
-    let _18: baml.json.json[]
-    let _19: int
-    let _20: baml.json.json[]
+    let _16: int
+    let _17: baml.json.json[]
+    let _18: int
+    let _19: baml.json.json[]
+    let _20: string
     let _21: string
-    let _22: string
-    let _23: string | null
-    let _24: string[]
-    let _25: reflect.Type
-    let _26: bool
+    let _22: string | null
+    let _23: string[]
+    let _24: reflect.Type
 
     bb0: {
         _4 = load_type(#0);
@@ -11601,9 +11465,7 @@ fn ai.Agent._has_media_output(self: ai.Agent, turn: ai.ModelTurn) -> bool {
     }
 
     bb4: {
-        _6 = copy _7;
-        _10 = copy _6 == const null;
-        branch copy _10 -> [bb5, bb6];
+        _6 = short_circuit(??) copy _7 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
@@ -11613,82 +11475,76 @@ fn ai.Agent._has_media_output(self: ai.Agent, turn: ai.ModelTurn) -> bool {
 
     bb6: {
         _5 = copy _6;
-        _12 = copy _5;
-        _11 = copy _12 == const "";
-        branch copy _11 -> [bb20, bb7];
+        _11 = copy _5;
+        _10 = copy _11 == const "";
+        branch copy _10 -> [bb19, bb7];
     }
 
     bb7: {
-        _15 = copy _5;
-        _14 = copy _15 == const "mixed";
-        _13 = short_circuit(||) copy _14 -> [eval: bb8, join: bb9];
+        _13 = copy _5;
+        _12 = copy _13 == const "mixed";
+        branch copy _12 -> [bb16, bb8];
     }
 
     bb8: {
-        _16 = copy _5;
-        _13 = copy _16 == const "mixedlist";
-        goto -> bb9;
+        _15 = copy _5;
+        _14 = copy _15 == const "mixedlist";
+        branch copy _14 -> [bb16, bb9];
     }
 
     bb9: {
-        branch copy _13 -> [bb17, bb10];
+        _23 = call const fn baml.String.split(copy _3, const ":") -> [bb10];
     }
 
     bb10: {
-        _24 = call const fn baml.String.split(copy _3, const ":") -> [bb11];
+        _24 = load_type(string);
+        _22 = call const fn baml.Array.at<copy _24>(copy _23, const 1_i64) -> [bb11];
     }
 
     bb11: {
-        _25 = load_type(string);
-        _23 = call const fn baml.Array.at<copy _25>(copy _24, const 1_i64) -> [bb12];
+        _21 = short_circuit(??) copy _22 -> [eval: bb12, join: bb13];
     }
 
     bb12: {
-        _22 = copy _23;
-        _26 = copy _22 == const null;
-        branch copy _26 -> [bb13, bb14];
+        _21 = const "";
+        goto -> bb13;
     }
 
     bb13: {
-        _22 = const "";
-        goto -> bb14;
+        _20 = copy _21;
+        _19 = call const fn ai.internal._media_of_kind(copy _2, copy _20) -> [bb14];
     }
 
     bb14: {
-        _21 = copy _22;
-        _20 = call const fn ai.internal._media_of_kind(copy _2, copy _21) -> [bb15];
+        _18 = len(_19);
+        goto -> bb15;
     }
 
     bb15: {
-        _19 = len(_20);
-        goto -> bb16;
+        _0 = copy _18 > const 0_i64;
+        goto -> bb20;
     }
 
     bb16: {
-        _0 = copy _19 > const 0_i64;
-        goto -> bb21;
+        _17 = call const fn ai.internal._media_mixed_parts(copy _2) -> [bb17];
     }
 
     bb17: {
-        _18 = call const fn ai.internal._media_mixed_parts(copy _2) -> [bb18];
+        _16 = len(_17);
+        goto -> bb18;
     }
 
     bb18: {
-        _17 = len(_18);
-        goto -> bb19;
+        _0 = copy _16 > const 0_i64;
+        goto -> bb20;
     }
 
     bb19: {
-        _0 = copy _17 > const 0_i64;
-        goto -> bb21;
+        _0 = const false;
+        goto -> bb20;
     }
 
     bb20: {
-        _0 = const false;
-        goto -> bb21;
-    }
-
-    bb21: {
         return;
     }
 }
@@ -11707,70 +11563,70 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     let _9: string | null
     let _10: string[]
     let _11: reflect.Type
-    let _12: bool
-    let _13: string // kind
-    let _14: string
-    let _15: string | null
-    let _16: string[]
-    let _17: reflect.Type
+    let _12: string // kind
+    let _13: string
+    let _14: string | null
+    let _15: string[]
+    let _16: reflect.Type
+    let _17: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // payload
     let _18: bool
-    let _19: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // payload
+    let _19: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // items
     let _20: bool
-    let _21: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // items
+    let _21: baml.json.json[] // items
     let _22: bool
-    let _23: baml.json.json[] // items
-    let _24: bool
-    let _25: int
-    let _26: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // only
-    let _27: baml.json.json[]
-    let _28: baml.iter.Iterator<Error = never, Item = baml.json.json>
-    let _29: unknown
-    let _30: bool
-    let _31: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _32: baml.json.json // i
-    let _33: bool
-    let _34: baml.json.json[]
-    let _35: baml.json.json[]
-    let _36: ai.errors.ParseFailed
+    let _23: int
+    let _24: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // only
+    let _25: baml.json.json[]
+    let _26: baml.iter.Iterator<Error = never, Item = baml.json.json>
+    let _27: unknown
+    let _28: bool
+    let _29: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _30: baml.json.json // i
+    let _31: bool
+    let _32: baml.json.json[]
+    let _33: baml.json.json[]
+    let _34: ai.errors.ParseFailed
+    let _35: string
+    let _36: string
     let _37: string
     let _38: string
     let _39: string
     let _40: string
-    let _41: string
+    let _41: reflect.Type
     let _42: string
-    let _43: reflect.Type
-    let _44: string
-    let _45: int
-    let _46: reflect.Type
-    let _47: bool
-    let _48: void
+    let _43: int
+    let _44: reflect.Type
+    let _45: bool
+    let _46: void
+    let _47: string
+    let _48: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // items
     let _49: string
-    let _50: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // items
+    let _50: baml.json.json[] // parts
     let _51: string
-    let _52: baml.json.json[] // parts
+    let _52: void
     let _53: string
-    let _54: void
-    let _55: string
-    let _56: bool
-    let _57: int
-    let _58: ai.errors.ParseFailed
+    let _54: bool
+    let _55: int
+    let _56: ai.errors.ParseFailed
+    let _57: string
+    let _58: bool
     let _59: string
-    let _60: bool
+    let _60: string
     let _61: string
     let _62: string
     let _63: string
     let _64: string
     let _65: string
     let _66: string
-    let _67: string
+    let _67: reflect.Type
     let _68: string
-    let _69: reflect.Type
-    let _70: string
-    let _71: int
-    let _72: reflect.Type
-    let _73: string
+    let _69: int
+    let _70: reflect.Type
+    let _71: string
+    let _72: string
+    let _73: reflect.Type
     let _74: string
-    let _75: reflect.Type
+    let _75: string
     let _76: string
     let _77: string
     let _78: string
@@ -11778,44 +11634,46 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     let _80: string
     let _81: string
     let _82: string
-    let _83: string
+    let _83: reflect.Type
     let _84: string
-    let _85: reflect.Type
-    let _86: string
+    let _85: string
+    let _86: reflect.Type
     let _87: string
-    let _88: reflect.Type
-    let _89: string
-    let _90: int
-    let _91: reflect.Type
-    let _92: string
-    let _93: string
-    let _94: reflect.Type
-    let _95: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // only
-    let _96: baml.json.json[]
-    let _97: baml.iter.Iterator<Error = never, Item = baml.json.json>
-    let _98: unknown
-    let _99: bool
-    let _100: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _101: baml.json.json // p
-    let _102: unknown // e
-    let _103: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _104: reflect.Type
-    let _105: ai.errors.ParseFailed
+    let _88: int
+    let _89: reflect.Type
+    let _90: string
+    let _91: string
+    let _92: reflect.Type
+    let _93: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // only
+    let _94: baml.json.json[]
+    let _95: baml.iter.Iterator<Error = never, Item = baml.json.json>
+    let _96: unknown
+    let _97: bool
+    let _98: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _99: baml.json.json // p
+    let _100: unknown // e
+    let _101: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _102: reflect.Type
+    let _103: ai.errors.ParseFailed
+    let _104: string
+    let _105: string
     let _106: string
     let _107: string
     let _108: string
     let _109: string
     let _110: string
-    let _111: string
+    let _111: reflect.Type
     let _112: string
-    let _113: reflect.Type
-    let _114: string
+    let _113: string
+    let _114: reflect.Type
     let _115: string
-    let _116: reflect.Type
-    let _117: string
-    let _118: string
-    let _119: reflect.Type
-    let _120: reflect.Type
+    let _116: string
+    let _117: reflect.Type
+    let _118: reflect.Type
+    let _119: string
+    let _120: string
+    let _121: string
+    let _122: string
 
     bb0: {
         _4 = load_type(#0);
@@ -11837,9 +11695,7 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     }
 
     bb4: {
-        _8 = copy _9;
-        _12 = copy _8 == const null;
-        branch copy _12 -> [bb5, bb6];
+        _8 = short_circuit(??) copy _9 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
@@ -11849,287 +11705,288 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
 
     bb6: {
         _7 = copy _8;
-        _16 = call const fn baml.String.split(copy _5, const ":") -> [bb7];
+        _15 = call const fn baml.String.split(copy _5, const ":") -> [bb7];
     }
 
     bb7: {
-        _17 = load_type(string);
-        _15 = call const fn baml.Array.at<copy _17>(copy _16, const 1_i64) -> [bb8];
+        _16 = load_type(string);
+        _14 = call const fn baml.Array.at<copy _16>(copy _15, const 1_i64) -> [bb8];
     }
 
     bb8: {
-        _14 = copy _15;
-        _18 = copy _14 == const null;
-        branch copy _18 -> [bb9, bb10];
+        _13 = short_circuit(??) copy _14 -> [eval: bb9, join: bb10];
     }
 
     bb9: {
-        _14 = const "";
+        _13 = const "";
         goto -> bb10;
     }
 
     bb10: {
-        _13 = copy _14;
-        _20 = is_type(copy _7, "mixedlist");
-        branch copy _20 -> [bb55, bb11];
+        _12 = copy _13;
+        _18 = is_type(copy _7, "mixedlist");
+        branch copy _18 -> [bb55, bb11];
     }
 
     bb11: {
-        _22 = is_type(copy _7, "mixed");
-        branch copy _22 -> [bb39, bb12];
+        _20 = is_type(copy _7, "mixed");
+        branch copy _20 -> [bb39, bb12];
     }
 
     bb12: {
-        _47 = is_type(copy _7, "list");
-        branch copy _47 -> [bb36, bb13];
+        _45 = is_type(copy _7, "list");
+        branch copy _45 -> [bb36, bb13];
     }
 
     bb13: {
-        _53 = copy _13;
-        _52 = call const fn ai.internal._media_of_kind(copy _2, copy _53) -> [bb14];
+        _51 = copy _12;
+        _50 = call const fn ai.internal._media_of_kind(copy _2, copy _51) -> [bb14];
     }
 
     bb14: {
-        _55 = copy _13;
-        _54 = call const fn ai.internal._media_reject_mixed(copy _2, copy _55, copy _3) -> [bb15];
+        _53 = copy _12;
+        _52 = call const fn ai.internal._media_reject_mixed(copy _2, copy _53, copy _3) -> [bb15];
     }
 
     bb15: {
-        _57 = len(_52);
+        _55 = len(_50);
         goto -> bb16;
     }
 
     bb16: {
-        _56 = copy _57 != const 1_i64;
-        branch copy _56 -> [bb22, bb17];
+        _54 = copy _55 != const 1_i64;
+        branch copy _54 -> [bb22, bb17];
     }
 
     bb17: {
-        _95 = const null;
-        _96 = copy _52;
-        _97 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _96) -> [bb18];
+        _93 = const null;
+        _94 = copy _50;
+        _95 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _94) -> [bb18];
     }
 
     bb18: {
-        _98 = virtual_call next as baml.iter.Iterator<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _97) -> [bb19];
+        _96 = virtual_call next as baml.iter.Iterator<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _95) -> [bb19];
     }
 
     bb19: {
-        _99 = is_type(copy _98, baml.iter.Done);
-        branch copy _99 -> [bb21, bb20];
+        _97 = is_type(copy _96, baml.iter.Done);
+        branch copy _97 -> [bb21, bb20];
     }
 
     bb20: {
-        _100 = copy _98;
-        fresh_cell(_101);
-        _101 = copy _100;
-        _95 = copy _101;
+        _98 = copy _96;
+        fresh_cell(_99);
+        _99 = copy _98;
+        _93 = copy _99;
         goto -> bb18;
     }
 
     bb21: {
-        _19 = copy _95;
+        _17 = copy _93;
         goto -> bb57;
     }
 
     bb22: {
-        _61 = copy _7;
-        _60 = copy _61 == const "one";
-        branch copy _60 -> [bb30, bb23];
+        _59 = copy _7;
+        _58 = copy _59 == const "one";
+        branch copy _58 -> [bb30, bb23];
     }
 
     bb23: {
-        _84 = copy _13;
-        _85 = load_type(string);
-        _83 = call const fn baml.String.from<copy _85>(copy _84) -> [bb24];
+        _82 = copy _12;
+        _83 = load_type(string);
+        _121 = const "Expected zero or one ";
+        _81 = call const fn baml.String.from<copy _83>(copy _82) -> [bb24];
     }
 
     bb24: {
-        _82 = const "Expected zero or one " + copy _83;
-        _81 = copy _82 + const " output for ";
-        _87 = virtual_call to_string as baml.ToString(copy _4) -> [bb25];
+        _80 = copy _121 + copy _81;
+        _79 = copy _80 + const " output for ";
+        _85 = virtual_call to_string as baml.ToString(copy _4) -> [bb25];
     }
 
     bb25: {
-        _88 = load_type(string);
-        _86 = call const fn baml.String.from<copy _88>(copy _87) -> [bb26];
+        _86 = load_type(string);
+        _84 = call const fn baml.String.from<copy _86>(copy _85) -> [bb26];
     }
 
     bb26: {
-        _80 = copy _81 + copy _86;
-        _79 = copy _80 + const ", got ";
-        _90 = len(_52);
+        _78 = copy _79 + copy _84;
+        _77 = copy _78 + const ", got ";
+        _88 = len(_50);
         goto -> bb27;
     }
 
     bb27: {
-        _91 = load_type(int);
-        _89 = call const fn baml.String.from<copy _91>(copy _90) -> [bb28];
+        _89 = load_type(int);
+        _87 = call const fn baml.String.from<copy _89>(copy _88) -> [bb28];
     }
 
     bb28: {
-        _78 = copy _79 + copy _89;
-        _77 = copy _78 + const ". Use ";
-        _93 = copy _13;
-        _94 = load_type(string);
-        _92 = call const fn baml.String.from<copy _94>(copy _93) -> [bb29];
+        _76 = copy _77 + copy _87;
+        _75 = copy _76 + const ". Use ";
+        _91 = copy _12;
+        _92 = load_type(string);
+        _90 = call const fn baml.String.from<copy _92>(copy _91) -> [bb29];
     }
 
     bb29: {
-        _76 = copy _77 + copy _92;
-        _59 = copy _76 + const "[] for multiple outputs.";
+        _74 = copy _75 + copy _90;
+        _57 = copy _74 + const "[] for multiple outputs.";
         goto -> bb35;
     }
 
     bb30: {
-        _68 = copy _13;
-        _69 = load_type(string);
-        _67 = call const fn baml.String.from<copy _69>(copy _68) -> [bb31];
+        _66 = copy _12;
+        _67 = load_type(string);
+        _120 = const "Expected exactly one ";
+        _65 = call const fn baml.String.from<copy _67>(copy _66) -> [bb31];
     }
 
     bb31: {
-        _66 = const "Expected exactly one " + copy _67;
-        _65 = copy _66 + const " output, got ";
-        _71 = len(_52);
+        _64 = copy _120 + copy _65;
+        _63 = copy _64 + const " output, got ";
+        _69 = len(_50);
         goto -> bb32;
     }
 
     bb32: {
-        _72 = load_type(int);
-        _70 = call const fn baml.String.from<copy _72>(copy _71) -> [bb33];
+        _70 = load_type(int);
+        _68 = call const fn baml.String.from<copy _70>(copy _69) -> [bb33];
     }
 
     bb33: {
-        _64 = copy _65 + copy _70;
-        _63 = copy _64 + const ". Use ";
-        _74 = copy _13;
-        _75 = load_type(string);
-        _73 = call const fn baml.String.from<copy _75>(copy _74) -> [bb34];
+        _62 = copy _63 + copy _68;
+        _61 = copy _62 + const ". Use ";
+        _72 = copy _12;
+        _73 = load_type(string);
+        _71 = call const fn baml.String.from<copy _73>(copy _72) -> [bb34];
     }
 
     bb34: {
-        _62 = copy _63 + copy _73;
-        _59 = copy _62 + const "[] for multiple outputs.";
+        _60 = copy _61 + copy _71;
+        _57 = copy _60 + const "[] for multiple outputs.";
         goto -> bb35;
     }
 
     bb35: {
-        _58 = ai.errors.ParseFailed { copy _3, copy _59 };
-        throw copy _58;
+        _56 = ai.errors.ParseFailed { copy _3, copy _57 };
+        throw copy _56;
     }
 
     bb36: {
-        _49 = copy _13;
-        _48 = call const fn ai.internal._media_reject_mixed(copy _2, copy _49, copy _3) -> [bb37];
+        _47 = copy _12;
+        _46 = call const fn ai.internal._media_reject_mixed(copy _2, copy _47, copy _3) -> [bb37];
     }
 
     bb37: {
-        _51 = copy _13;
-        _50 = call const fn ai.internal._media_of_kind(copy _2, copy _51) -> [bb38];
+        _49 = copy _12;
+        _48 = call const fn ai.internal._media_of_kind(copy _2, copy _49) -> [bb38];
     }
 
     bb38: {
-        _19 = copy _50;
+        _17 = copy _48;
         goto -> bb57;
     }
 
     bb39: {
-        _23 = call const fn ai.internal._media_mixed_parts(copy _2) -> [bb40];
+        _21 = call const fn ai.internal._media_mixed_parts(copy _2) -> [bb40];
     }
 
     bb40: {
-        _25 = len(_23);
+        _23 = len(_21);
         goto -> bb41;
     }
 
     bb41: {
-        _24 = copy _25 == const 1_i64;
-        branch copy _24 -> [bb50, bb42];
+        _22 = copy _23 == const 1_i64;
+        branch copy _22 -> [bb50, bb42];
     }
 
     bb42: {
-        _34 = copy _23;
-        _33 = call const fn ai.internal._media_all_text(copy _34) -> [bb43];
+        _32 = copy _21;
+        _31 = call const fn ai.internal._media_all_text(copy _32) -> [bb43];
     }
 
     bb43: {
-        branch copy _33 -> [bb49, bb44];
+        branch copy _31 -> [bb49, bb44];
     }
 
     bb44: {
-        _42 = virtual_call to_string as baml.ToString(copy _4) -> [bb45];
+        _40 = virtual_call to_string as baml.ToString(copy _4) -> [bb45];
     }
 
     bb45: {
-        _43 = load_type(string);
-        _41 = call const fn baml.String.from<copy _43>(copy _42) -> [bb46];
+        _41 = load_type(string);
+        _119 = const "Expected one text or image output for ";
+        _39 = call const fn baml.String.from<copy _41>(copy _40) -> [bb46];
     }
 
     bb46: {
-        _40 = const "Expected one text or image output for " + copy _41;
-        _39 = copy _40 + const ", got ";
-        _45 = len(_23);
+        _38 = copy _119 + copy _39;
+        _37 = copy _38 + const ", got ";
+        _43 = len(_21);
         goto -> bb47;
     }
 
     bb47: {
-        _46 = load_type(int);
-        _44 = call const fn baml.String.from<copy _46>(copy _45) -> [bb48];
+        _44 = load_type(int);
+        _42 = call const fn baml.String.from<copy _44>(copy _43) -> [bb48];
     }
 
     bb48: {
-        _38 = copy _39 + copy _44;
-        _37 = copy _38 + const " parts. Use (image | string)[] to preserve mixed outputs.";
-        _36 = ai.errors.ParseFailed { copy _3, copy _37 };
-        throw copy _36;
+        _36 = copy _37 + copy _42;
+        _35 = copy _36 + const " parts. Use (image | string)[] to preserve mixed outputs.";
+        _34 = ai.errors.ParseFailed { copy _3, copy _35 };
+        throw copy _34;
     }
 
     bb49: {
-        _35 = copy _23;
-        _19 = call const fn ai.internal._media_join_text(copy _35) -> [bb57];
+        _33 = copy _21;
+        _17 = call const fn ai.internal._media_join_text(copy _33) -> [bb57];
     }
 
     bb50: {
-        _26 = const null;
-        _27 = copy _23;
-        _28 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _27) -> [bb51];
+        _24 = const null;
+        _25 = copy _21;
+        _26 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _25) -> [bb51];
     }
 
     bb51: {
-        _29 = virtual_call next as baml.iter.Iterator<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _28) -> [bb52];
+        _27 = virtual_call next as baml.iter.Iterator<Error = never, Item = int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>(copy _26) -> [bb52];
     }
 
     bb52: {
-        _30 = is_type(copy _29, baml.iter.Done);
-        branch copy _30 -> [bb54, bb53];
+        _28 = is_type(copy _27, baml.iter.Done);
+        branch copy _28 -> [bb54, bb53];
     }
 
     bb53: {
-        _31 = copy _29;
-        fresh_cell(_32);
-        _32 = copy _31;
-        _26 = copy _32;
+        _29 = copy _27;
+        fresh_cell(_30);
+        _30 = copy _29;
+        _24 = copy _30;
         goto -> bb51;
     }
 
     bb54: {
-        _19 = copy _26;
+        _17 = copy _24;
         goto -> bb57;
     }
 
     bb55: {
-        _21 = call const fn ai.internal._media_mixed_parts(copy _2) -> [bb56];
+        _19 = call const fn ai.internal._media_mixed_parts(copy _2) -> [bb56];
     }
 
     bb56: {
-        _19 = copy _21;
+        _17 = copy _19;
         goto -> bb57;
     }
 
     bb57: {
-        _103 = copy _19;
-        _104 = load_type(#0);
-        _0 = call const fn baml.json.from_json<copy _104>(copy _103) -> [bb58, unwind: bb59];
+        _101 = copy _17;
+        _102 = load_type(#0);
+        _0 = call const fn baml.json.from_json<copy _102>(copy _101) -> [bb58, unwind: bb59];
     }
 
     bb58: {
@@ -12137,42 +11994,43 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
     }
 
     bb59: {
-        throw_if_panic copy _102 -> bb60;
+        throw_if_panic copy _100 -> bb60;
     }
 
     bb60: {
-        _112 = copy _13;
-        _113 = load_type(string);
-        _111 = call const fn baml.String.from<copy _113>(copy _112) -> [bb61];
+        _110 = copy _12;
+        _111 = load_type(string);
+        _122 = const "the ";
+        _109 = call const fn baml.String.from<copy _111>(copy _110) -> [bb61];
     }
 
     bb61: {
-        _110 = const "the " + copy _111;
-        _109 = copy _110 + const " output did not fit ";
-        _115 = virtual_call to_string as baml.ToString(copy _4) -> [bb62];
+        _108 = copy _122 + copy _109;
+        _107 = copy _108 + const " output did not fit ";
+        _113 = virtual_call to_string as baml.ToString(copy _4) -> [bb62];
     }
 
     bb62: {
-        _116 = load_type(string);
-        _114 = call const fn baml.String.from<copy _116>(copy _115) -> [bb63];
+        _114 = load_type(string);
+        _112 = call const fn baml.String.from<copy _114>(copy _113) -> [bb63];
     }
 
     bb63: {
-        _108 = copy _109 + copy _114;
-        _107 = copy _108 + const ": ";
-        _119 = load_type(baml.json.DecodeError);
-        _118 = call const fn baml.String.from<copy _119>(copy _102) -> [bb64];
+        _106 = copy _107 + copy _112;
+        _105 = copy _106 + const ": ";
+        _117 = load_type(baml.json.DecodeError);
+        _116 = call const fn baml.String.from<copy _117>(copy _100) -> [bb64];
     }
 
     bb64: {
-        _120 = load_type(string);
-        _117 = call const fn baml.String.from<copy _120>(copy _118) -> [bb65];
+        _118 = load_type(string);
+        _115 = call const fn baml.String.from<copy _118>(copy _116) -> [bb65];
     }
 
     bb65: {
-        _106 = copy _107 + copy _117;
-        _105 = ai.errors.ParseFailed { copy _3, copy _106 };
-        throw copy _105;
+        _104 = copy _105 + copy _115;
+        _103 = ai.errors.ParseFailed { copy _3, copy _104 };
+        throw copy _103;
     }
 }
 
@@ -12253,52 +12111,52 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     let _22: int
     let _23: int
     let _24: int | null
-    let _25: bool
-    let _26: int
+    let _25: int
+    let _26: int | null
     let _27: int | null
-    let _28: int | null
-    let _29: int // rt
+    let _28: int // rt
+    let _29: int
     let _30: int
-    let _31: int
-    let _32: int | null
-    let _33: bool
-    let _34: int
-    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // batch
-    let _36: ai.events.AssistantMessage
-    let _37: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
-    let _38: string
-    let _39: ai.events.LLMCall[]
-    let _40: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
-    let _41: unknown
-    let _42: bool
-    let _43: ai.events.LLMCall
-    let _44: ai.events.LLMCall // call
-    let _45: int
-    let _46: ai.events.LLMCall
-    let _47: reflect.Type
-    let _48: ai.content.ToolUse[]
-    let _49: baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
-    let _50: unknown
-    let _51: bool
-    let _52: ai.content.ToolUse
-    let _53: ai.content.ToolUse // u
-    let _54: int
-    let _55: ai.events.ToolRequested
-    let _56: string
-    let _57: string
-    let _58: map<string, unknown>
-    let _59: reflect.Type
-    let _60: null | ai.events.Usage
-    let _61: null | ai.events.Usage
-    let _62: ai.events.Usage // u
-    let _63: int
-    let _64: ai.events.Usage
-    let _65: reflect.Type
-    let _66: string // candidate
-    let _67: string
-    let _68: string | null
+    let _31: int | null
+    let _32: int
+    let _33: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // batch
+    let _34: ai.events.AssistantMessage
+    let _35: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
+    let _36: string
+    let _37: ai.events.LLMCall[]
+    let _38: baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>
+    let _39: unknown
+    let _40: bool
+    let _41: ai.events.LLMCall
+    let _42: ai.events.LLMCall // call
+    let _43: int
+    let _44: ai.events.LLMCall
+    let _45: reflect.Type
+    let _46: ai.content.ToolUse[]
+    let _47: baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
+    let _48: unknown
+    let _49: bool
+    let _50: ai.content.ToolUse
+    let _51: ai.content.ToolUse // u
+    let _52: int
+    let _53: ai.events.ToolRequested
+    let _54: string
+    let _55: string
+    let _56: map<string, unknown>
+    let _57: reflect.Type
+    let _58: null | ai.events.Usage
+    let _59: null | ai.events.Usage
+    let _60: ai.events.Usage // u
+    let _61: int
+    let _62: ai.events.Usage
+    let _63: reflect.Type
+    let _64: string // candidate
+    let _65: string
+    let _66: string | null
+    let _67: bool // accepted
+    let _68: bool
     let _69: bool
-    let _70: bool // accepted
+    let _70: bool
     let _71: bool
     let _72: bool
     let _73: bool
@@ -12370,9 +12228,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     bb5: {
         _21 = copy _20;
         _24 = copy _5.2;
-        _23 = copy _24;
-        _25 = copy _23 == const null;
-        branch copy _25 -> [bb6, bb7];
+        _23 = short_circuit(??) copy _24 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
@@ -12382,126 +12238,122 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
 
     bb7: {
         _22 = copy _23;
-        _26 = copy _21;
-        _5.2 = copy _22 + copy _26;
+        _25 = copy _21;
+        _5.2 = copy _22 + copy _25;
         goto -> bb8;
     }
 
     bb8: {
-        _27 = copy _16.3;
-        _28 = copy _27;
-        _28 = narrow_bind copy _28 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb9, bb12];
+        _26 = copy _16.3;
+        _27 = copy _26;
+        _27 = narrow_bind copy _27 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb9, bb12];
     }
 
     bb9: {
-        _29 = copy _28;
-        _32 = copy _5.3;
-        _31 = copy _32;
-        _33 = copy _31 == const null;
-        branch copy _33 -> [bb10, bb11];
+        _28 = copy _27;
+        _31 = copy _5.3;
+        _30 = short_circuit(??) copy _31 -> [eval: bb10, join: bb11];
     }
 
     bb10: {
-        _31 = const 0_i64;
+        _30 = const 0_i64;
         goto -> bb11;
     }
 
     bb11: {
-        _30 = copy _31;
-        _34 = copy _29;
-        _5.3 = copy _30 + copy _34;
+        _29 = copy _30;
+        _32 = copy _28;
+        _5.3 = copy _29 + copy _32;
         goto -> bb12;
     }
 
     bb12: {
-        _37 = copy _7.0;
-        _38 = virtual_call id as ai.Client(copy _2) -> [bb13];
+        _35 = copy _7.0;
+        _36 = virtual_call id as ai.Client(copy _2) -> [bb13];
     }
 
     bb13: {
-        _36 = ai.events.AssistantMessage { copy _37, copy _38 };
-        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
-        _39 = copy _7.3;
-        _40 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _39) -> [bb14];
+        _34 = ai.events.AssistantMessage { copy _35, copy _36 };
+        _33 = [copy _34]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _37 = copy _7.3;
+        _38 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.LLMCall>(copy _37) -> [bb14];
     }
 
     bb14: {
-        _41 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>(copy _40) -> [bb15];
+        _39 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.LLMCall>(copy _38) -> [bb15];
     }
 
     bb15: {
-        _42 = is_type(copy _41, baml.iter.Done);
-        branch copy _42 -> [bb17, bb16];
+        _40 = is_type(copy _39, baml.iter.Done);
+        branch copy _40 -> [bb17, bb16];
     }
 
     bb16: {
-        _43 = copy _41;
-        fresh_cell(_44);
-        _44 = copy _43;
-        _46 = copy _44;
-        _47 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _45 = call const fn baml.Array.push<copy _47>(copy _35, copy _46) -> [bb14];
+        _41 = copy _39;
+        fresh_cell(_42);
+        _42 = copy _41;
+        _44 = copy _42;
+        _45 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _43 = call const fn baml.Array.push<copy _45>(copy _33, copy _44) -> [bb14];
     }
 
     bb17: {
-        _48 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb18];
+        _46 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb18];
     }
 
     bb18: {
-        _49 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>(copy _48) -> [bb19];
+        _47 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>(copy _46) -> [bb19];
     }
 
     bb19: {
-        _50 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>(copy _49) -> [bb20];
+        _48 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>(copy _47) -> [bb20];
     }
 
     bb20: {
-        _51 = is_type(copy _50, baml.iter.Done);
-        branch copy _51 -> [bb22, bb21];
+        _49 = is_type(copy _48, baml.iter.Done);
+        branch copy _49 -> [bb22, bb21];
     }
 
     bb21: {
-        _52 = copy _50;
-        fresh_cell(_53);
-        _53 = copy _52;
-        _56 = copy _53.0;
-        _57 = copy _53.1;
-        _58 = copy _53.2;
-        _55 = ai.events.ToolRequested { copy _56, copy _57, copy _58 };
-        _59 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _54 = call const fn baml.Array.push<copy _59>(copy _35, copy _55) -> [bb19];
+        _50 = copy _48;
+        fresh_cell(_51);
+        _51 = copy _50;
+        _54 = copy _51.0;
+        _55 = copy _51.1;
+        _56 = copy _51.2;
+        _53 = ai.events.ToolRequested { copy _54, copy _55, copy _56 };
+        _57 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _52 = call const fn baml.Array.push<copy _57>(copy _33, copy _53) -> [bb19];
     }
 
     bb22: {
-        _60 = copy _7.2;
-        _61 = copy _60;
-        _61 = narrow_bind copy _61 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb23, bb24];
+        _58 = copy _7.2;
+        _59 = copy _58;
+        _59 = narrow_bind copy _59 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb23, bb24];
     }
 
     bb23: {
-        _62 = copy _61;
-        _64 = copy _62;
-        _65 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _63 = call const fn baml.Array.push<copy _65>(copy _35, copy _64) -> [bb24];
+        _60 = copy _59;
+        _62 = copy _60;
+        _63 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _61 = call const fn baml.Array.push<copy _63>(copy _33, copy _62) -> [bb24];
     }
 
     bb24: {
-        _68 = call const fn ai.ModelTurn.terminal_text(copy _7) -> [bb25];
+        _66 = call const fn ai.ModelTurn.terminal_text(copy _7) -> [bb25];
     }
 
     bb25: {
-        _67 = copy _68;
-        _69 = copy _67 == const null;
-        branch copy _69 -> [bb26, bb27];
+        _65 = short_circuit(??) copy _66 -> [eval: bb26, join: bb27];
     }
 
     bb26: {
-        _67 = const "";
+        _65 = const "";
         goto -> bb27;
     }
 
     bb27: {
-        _66 = copy _67;
+        _64 = copy _65;
         _75 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb28];
     }
 
@@ -12521,27 +12373,30 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     }
 
     bb31: {
-        _71 = short_circuit(||) copy _72 -> [eval: bb32, join: bb33];
+        _71 = copy _72;
+        _70 = short_circuit(||) copy _71 -> [eval: bb32, join: bb33];
     }
 
     bb32: {
         _77 = copy _7.1;
-        _71 = call const fn baml.ops.equals_equals(copy _77, const ai.content.StopReason.Refused) -> [bb33];
+        _70 = call const fn baml.ops.equals_equals(copy _77, const ai.content.StopReason.Refused) -> [bb33];
     }
 
     bb33: {
-        _70 = short_circuit(||) copy _71 -> [eval: bb34, join: bb35];
+        _69 = copy _70;
+        _68 = short_circuit(||) copy _69 -> [eval: bb34, join: bb35];
     }
 
     bb34: {
         _78 = copy _7;
-        _79 = copy _66;
+        _79 = copy _64;
         _80 = load_type(#0);
-        _70 = call const fn ai.Agent._parses<copy _80>(copy _1, copy _78, copy _79) -> [bb35];
+        _68 = call const fn ai.Agent._parses<copy _80>(copy _1, copy _78, copy _79) -> [bb35];
     }
 
     bb35: {
-        _81 = copy _70;
+        _67 = copy _68;
+        _81 = copy _67;
         branch copy _81 -> [bb43, bb36];
     }
 
@@ -12551,7 +12406,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     }
 
     bb37: {
-        _101 = copy _35;
+        _101 = copy _33;
         _100 = call const fn ai.Journal.append_all(copy _4, copy _101) -> [bb38];
     }
 
@@ -12560,7 +12415,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     }
 
     bb39: {
-        _104 = copy _66;
+        _104 = copy _64;
         _102 = ai.errors.ParseFailed { copy _103, copy _104 };
         throw copy _102;
     }
@@ -12568,11 +12423,11 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     bb40: {
         _94 = ai.events.UserMessage { const "The reply did not match the required schema. Answer again with only the corrected value." };
         _95 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _93 = call const fn baml.Array.push<copy _95>(copy _35, copy _94) -> [bb41];
+        _93 = call const fn baml.Array.push<copy _95>(copy _33, copy _94) -> [bb41];
     }
 
     bb41: {
-        _97 = copy _35;
+        _97 = copy _33;
         _96 = call const fn ai.Journal.append_all(copy _4, copy _97) -> [bb42];
     }
 
@@ -12583,7 +12438,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     }
 
     bb43: {
-        _83 = copy _35;
+        _83 = copy _33;
         _82 = call const fn ai.Journal.append_all(copy _4, copy _83) -> [bb44];
     }
 
@@ -12617,7 +12472,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
 
     bb50: {
         _88 = copy _7.1;
-        _89 = copy _66;
+        _89 = copy _64;
         _86 = ai.errors.FinishReasonError { copy _87, copy _88, copy _89 };
         throw copy _86;
     }
@@ -12749,8 +12604,8 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     let _4: ai.Client // selected
     let _5: ai.Client
     let _6: null | ai.Client
-    let _7: bool
-    let _8: ai.Journal // j [captured]
+    let _7: ai.Journal // j [captured]
+    let _8: ai.FunctionSpec<Out>
     let _9: reflect.Type
     let _10: int // seen
     let _11: ai.Journal
@@ -12762,65 +12617,65 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     let _17: int
     let _18: ai.ModelTurn // turn
     let _19: ai.Client
-    let _20: ai.Journal
-    let _21: ai.events.Usage
-    let _22: int
-    let _23: reflect.Type
-    let _24: int
-    let _25: ai.Journal
-    let _26: int
-    let _27: ai.content.ToolUse[] // calls
-    let _28: bool
-    let _29: int
-    let _30: int // before
-    let _31: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _32: baml.future.Future<void, ai.errors.ToolFailedError>[] // futures
-    let _33: (ai.content.ToolUse) -> baml.future.Future<void, ai.errors.ToolFailedError> throws never
-    let _34: reflect.Type
+    let _20: ai.FunctionSpec<Out>
+    let _21: ai.Journal
+    let _22: ai.events.Usage
+    let _23: int
+    let _24: reflect.Type
+    let _25: int
+    let _26: ai.Journal
+    let _27: int
+    let _28: ai.content.ToolUse[] // calls
+    let _29: bool
+    let _30: int
+    let _31: int // before
+    let _32: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _33: baml.future.Future<void, ai.errors.ToolFailedError>[] // futures
+    let _34: (ai.content.ToolUse) -> baml.future.Future<void, ai.errors.ToolFailedError> throws never
     let _35: reflect.Type
     let _36: reflect.Type
-    let _37: void[]
-    let _38: unknown // e
-    let _39: null
-    let _40: baml.future.Future<void, ai.errors.ToolFailedError>[]
-    let _41: reflect.Type
+    let _37: reflect.Type
+    let _38: void[]
+    let _39: unknown // e
+    let _40: null
+    let _41: baml.future.Future<void, ai.errors.ToolFailedError>[]
     let _42: reflect.Type
-    let _43: ai.Journal
-    let _44: int
-    let _45: ai.Journal
-    let _46: int
-    let _47: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // entries
-    let _48: int // i
-    let _49: bool
-    let _50: int
+    let _43: reflect.Type
+    let _44: ai.Journal
+    let _45: int
+    let _46: ai.Journal
+    let _47: int
+    let _48: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // entries
+    let _49: int // i
+    let _50: bool
     let _51: int
-    let _52: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _53: int
-    let _54: reflect.Type
-    let _55: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _56: ai.events.ToolFailed // f [captured]
-    let _57: null | ai.content.ToolUse // failed_call
-    let _58: (ai.content.ToolUse) -> bool throws never
-    let _59: reflect.Type
+    let _52: int
+    let _53: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _54: int
+    let _55: reflect.Type
+    let _56: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _57: ai.events.ToolFailed // f [captured]
+    let _58: null | ai.content.ToolUse // failed_call
+    let _59: (ai.content.ToolUse) -> bool throws never
     let _60: reflect.Type
-    let _61: null | ai.content.ToolUse
-    let _62: ai.content.ToolUse // known
-    let _63: string // key
-    let _64: string
+    let _61: reflect.Type
+    let _62: null | ai.content.ToolUse
+    let _63: ai.content.ToolUse // known
+    let _64: string // key
     let _65: string
     let _66: string
-    let _67: reflect.Type
-    let _68: string
+    let _67: string
+    let _68: reflect.Type
     let _69: string
-    let _70: reflect.Type
-    let _71: int // n
-    let _72: int
+    let _70: string
+    let _71: reflect.Type
+    let _72: int // n
     let _73: int
-    let _74: int | null
-    let _75: string
-    let _76: reflect.Type
+    let _74: int
+    let _75: int | null
+    let _76: string
     let _77: reflect.Type
-    let _78: bool
+    let _78: reflect.Type
     let _79: int | null
     let _80: string
     let _81: int
@@ -12844,38 +12699,38 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     let _99: string // candidate
     let _100: string
     let _101: string | null
-    let _102: bool
-    let _103: Out // value
-    let _104: bool
-    let _105: ai.ModelTurn
-    let _106: reflect.Type
-    let _107: ai.ModelTurn
-    let _108: string
-    let _109: reflect.Type
-    let _110: unknown // e
-    let _111: string
-    let _112: reflect.Type
-    let _113: ai.errors.ParseFailed
+    let _102: Out // value
+    let _103: bool
+    let _104: ai.ModelTurn
+    let _105: reflect.Type
+    let _106: ai.ModelTurn
+    let _107: string
+    let _108: reflect.Type
+    let _109: unknown // e
+    let _110: string
+    let _111: reflect.Type
+    let _112: ai.errors.ParseFailed
+    let _113: string
     let _114: string
-    let _115: string
-    let _116: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // value_json
-    let _117: unknown // e
-    let _118: Out
-    let _119: baml.errors.UnknownError
-    let _120: baml.json.SerializationError
-    let _121: reflect.Type
-    let _122: void
-    let _123: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _124: ai.events.FinalProduced
-    let _125: string
-    let _126: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _127: ai.Journal
-    let _128: int
-    let _129: Out
-    let _130: ai.Journal
-    let _131: ai.events.Usage
-    let _132: ai.errors.StepBudgetExceeded
-    let _133: int
+    let _115: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // value_json
+    let _116: unknown // e
+    let _117: Out
+    let _118: baml.errors.UnknownError
+    let _119: baml.json.SerializationError
+    let _120: reflect.Type
+    let _121: void
+    let _122: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _123: ai.events.FinalProduced
+    let _124: string
+    let _125: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _126: ai.Journal
+    let _127: int
+    let _128: Out
+    let _129: ai.Journal
+    let _130: ai.events.Usage
+    let _131: ai.errors.StepBudgetExceeded
+    let _132: int
+    let _133: string
 
     bb0: {
         _3 = call const fn ai.Agent._validated_schema_attempts(copy _1) -> [bb1];
@@ -12883,9 +12738,7 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
 
     bb1: {
         _6 = copy _1.2;
-        _5 = copy _6;
-        _7 = copy _5 == const null;
-        branch copy _7 -> [bb2, bb3];
+        _5 = short_circuit(??) copy _6 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
@@ -12895,12 +12748,13 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
 
     bb3: {
         _4 = copy _5;
+        _8 = copy _2;
         _9 = load_type(#0);
-        _8 = call const fn ai.Journal.new<copy _9>(copy _2) -> [bb4];
+        _7 = call const fn ai.Journal.new<copy _9>(copy _8) -> [bb4];
     }
 
     bb4: {
-        _11 = copy _8;
+        _11 = copy _7;
         _10 = call const fn ai.Agent._emit_from(copy _1, copy _11, const 0_i64) -> [bb5];
     }
 
@@ -12919,40 +12773,41 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     }
 
     bb7: {
-        _133 = copy _12;
-        _132 = ai.errors.StepBudgetExceeded { copy _133 };
-        throw copy _132;
+        _132 = copy _12;
+        _131 = ai.errors.StepBudgetExceeded { copy _132 };
+        throw copy _131;
     }
 
     bb8: {
         _19 = copy _4;
-        _20 = copy _8;
-        _21 = copy _13;
-        _22 = copy _3;
-        _23 = load_type(#0);
-        _18 = call const fn ai.Agent._attempt_turn<copy _23>(copy _1, copy _19, copy _2, copy _20, copy _21, copy _22) -> [bb9];
+        _20 = copy _2;
+        _21 = copy _7;
+        _22 = copy _13;
+        _23 = copy _3;
+        _24 = load_type(#0);
+        _18 = call const fn ai.Agent._attempt_turn<copy _24>(copy _1, copy _19, copy _20, copy _21, copy _22, copy _23) -> [bb9];
     }
 
     bb9: {
-        _24 = copy _12;
-        _12 = copy _24 + const 1_i64;
-        _25 = copy _8;
-        _26 = copy _10;
-        _10 = call const fn ai.Agent._emit_from(copy _1, copy _25, copy _26) -> [bb10];
+        _25 = copy _12;
+        _12 = copy _25 + const 1_i64;
+        _26 = copy _7;
+        _27 = copy _10;
+        _10 = call const fn ai.Agent._emit_from(copy _1, copy _26, copy _27) -> [bb10];
     }
 
     bb10: {
-        _27 = call const fn ai.ModelTurn.tool_uses(copy _18) -> [bb11];
+        _28 = call const fn ai.ModelTurn.tool_uses(copy _18) -> [bb11];
     }
 
     bb11: {
-        _29 = len(_27);
+        _30 = len(_28);
         goto -> bb12;
     }
 
     bb12: {
-        _28 = copy _29 > const 0_i64;
-        branch copy _28 -> [bb27, bb13];
+        _29 = copy _30 > const 0_i64;
+        branch copy _29 -> [bb27, bb13];
     }
 
     bb13: {
@@ -12960,9 +12815,7 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     }
 
     bb14: {
-        _100 = copy _101;
-        _102 = copy _100 == const null;
-        branch copy _102 -> [bb15, bb16];
+        _100 = short_circuit(??) copy _101 -> [eval: bb15, join: bb16];
     }
 
     bb15: {
@@ -12972,58 +12825,58 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
 
     bb16: {
         _99 = copy _100;
-        _105 = copy _18;
-        _106 = load_type(#0);
-        _104 = call const fn ai.Agent._has_media_output<copy _106>(copy _1, copy _105) -> [bb17];
+        _104 = copy _18;
+        _105 = load_type(#0);
+        _103 = call const fn ai.Agent._has_media_output<copy _105>(copy _1, copy _104) -> [bb17];
     }
 
     bb17: {
-        branch copy _104 -> [bb19, bb18];
+        branch copy _103 -> [bb19, bb18];
     }
 
     bb18: {
-        _111 = copy _99;
-        _112 = load_type(#0);
-        _103 = call const fn baml.sap.parse<copy _112>(copy _111) -> [bb21, unwind: bb55];
+        _110 = copy _99;
+        _111 = load_type(#0);
+        _102 = call const fn baml.sap.parse<copy _111>(copy _110) -> [bb21, unwind: bb55];
     }
 
     bb19: {
-        _107 = copy _18;
-        _108 = virtual_call id as ai.Client(copy _4) -> [bb20];
+        _106 = copy _18;
+        _107 = virtual_call id as ai.Client(copy _4) -> [bb20];
     }
 
     bb20: {
-        _109 = load_type(#0);
-        _103 = call const fn ai.Agent._media_value<copy _109>(copy _1, copy _107, copy _108) -> [bb21];
+        _108 = load_type(#0);
+        _102 = call const fn ai.Agent._media_value<copy _108>(copy _1, copy _106, copy _107) -> [bb21];
     }
 
     bb21: {
-        _118 = copy _103;
-        _116 = call const fn baml.json.to_json(copy _118) -> [bb22, unwind: bb58];
+        _117 = copy _102;
+        _115 = call const fn baml.json.to_json(copy _117) -> [bb22, unwind: bb58];
     }
 
     bb22: {
-        _126 = copy _116;
-        _125 = call const fn baml.json.stringify(copy _126) -> [bb23];
+        _125 = copy _115;
+        _124 = call const fn baml.json.stringify(copy _125) -> [bb23];
     }
 
     bb23: {
-        _124 = ai.events.FinalProduced { copy _125 };
-        _123 = [copy _124]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
-        _122 = call const fn ai.Journal.append_all(copy _8, copy _123) -> [bb24];
+        _123 = ai.events.FinalProduced { copy _124 };
+        _122 = [copy _123]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _121 = call const fn ai.Journal.append_all(copy _7, copy _122) -> [bb24];
     }
 
     bb24: {
-        _127 = copy _8;
-        _128 = copy _10;
-        _10 = call const fn ai.Agent._emit_from(copy _1, copy _127, copy _128) -> [bb25];
+        _126 = copy _7;
+        _127 = copy _10;
+        _10 = call const fn ai.Agent._emit_from(copy _1, copy _126, copy _127) -> [bb25];
     }
 
     bb25: {
-        _129 = copy _103;
-        _130 = copy _8;
-        _131 = copy _13;
-        _0 = ai.RunResult<#0> { copy _129, copy _130, copy _131 };
+        _128 = copy _102;
+        _129 = copy _7;
+        _130 = copy _13;
+        _0 = ai.RunResult<#0> { copy _128, copy _129, copy _130 };
         goto -> bb26;
     }
 
@@ -13032,150 +12885,149 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     }
 
     bb27: {
-        _31 = call const fn ai.Journal.entries(copy _8) -> [bb28];
+        _32 = call const fn ai.Journal.entries(copy _7) -> [bb28];
     }
 
     bb28: {
-        _30 = len(_31);
+        _31 = len(_32);
         goto -> bb29;
     }
 
     bb29: {
-        _33 = make_closure lambda[0]<1 type_args>(copy _1, copy _2, copy _8);
-        _34 = load_type(baml.future.Future<void, ai.errors.ToolFailedError>);
-        _35 = load_type(never);
-        _36 = load_type(ai.content.ToolUse);
-        _32 = call const fn baml.Array.map<copy _36, copy _34, copy _35>(copy _27, copy _33) -> [bb30];
+        _34 = make_closure lambda[0]<1 type_args>(copy _1, copy _2, copy _7);
+        _35 = load_type(baml.future.Future<void, ai.errors.ToolFailedError>);
+        _36 = load_type(never);
+        _37 = load_type(ai.content.ToolUse);
+        _33 = call const fn baml.Array.map<copy _37, copy _35, copy _36>(copy _28, copy _34) -> [bb30];
     }
 
     bb30: {
-        _40 = copy _32;
-        _41 = load_type(void);
-        _42 = load_type(ai.errors.ToolFailedError);
-        _39 = call const fn baml.future.all<copy _41, copy _42>(copy _40) -> [bb31, unwind: bb52];
+        _41 = copy _33;
+        _42 = load_type(void);
+        _43 = load_type(ai.errors.ToolFailedError);
+        _40 = call const fn baml.future.all<copy _42, copy _43>(copy _41) -> [bb31, unwind: bb52];
     }
 
     bb31: {
-        _37 = await _39 -> [bb32, unwind: bb52];
+        _38 = await _40 -> [bb32, unwind: bb52];
     }
 
     bb32: {
-        _45 = copy _8;
-        _46 = copy _10;
-        _10 = call const fn ai.Agent._emit_from(copy _1, copy _45, copy _46) -> [bb33];
+        _46 = copy _7;
+        _47 = copy _10;
+        _10 = call const fn ai.Agent._emit_from(copy _1, copy _46, copy _47) -> [bb33];
     }
 
     bb33: {
-        _47 = call const fn ai.Journal.entries(copy _8) -> [bb34];
+        _48 = call const fn ai.Journal.entries(copy _7) -> [bb34];
     }
 
     bb34: {
-        _48 = copy _30;
+        _49 = copy _31;
         goto -> bb35;
     }
 
     bb35: {
-        _50 = copy _48;
-        _51 = len(_47);
+        _51 = copy _49;
+        _52 = len(_48);
         goto -> bb36;
     }
 
     bb36: {
-        _49 = copy _50 < copy _51;
-        branch copy _49 -> [bb37, bb6];
+        _50 = copy _51 < copy _52;
+        branch copy _50 -> [bb37, bb6];
     }
 
     bb37: {
-        _53 = copy _48;
-        _54 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _52 = call const fn baml.Array.at<copy _54>(copy _47, copy _53) -> [bb38];
+        _54 = copy _49;
+        _55 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _53 = call const fn baml.Array.at<copy _55>(copy _48, copy _54) -> [bb38];
     }
 
     bb38: {
-        _55 = copy _52;
-        _55 = narrow_bind copy _55 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb39, bb48];
+        _56 = copy _53;
+        _56 = narrow_bind copy _56 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb39, bb48];
     }
 
     bb39: {
-        _56 = copy _55;
-        _58 = make_closure lambda[1]<1 type_args>(copy _56);
-        _59 = load_type(never);
-        _60 = load_type(ai.content.ToolUse);
-        _57 = call const fn baml.Array.find<copy _60, copy _59>(copy _27, copy _58) -> [bb40];
+        _57 = copy _56;
+        _59 = make_closure lambda[1]<1 type_args>(copy _57);
+        _60 = load_type(never);
+        _61 = load_type(ai.content.ToolUse);
+        _58 = call const fn baml.Array.find<copy _61, copy _60>(copy _28, copy _59) -> [bb40];
     }
 
     bb40: {
-        _61 = copy _57;
-        _61 = narrow_bind copy _61 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb41, bb48];
+        _62 = copy _58;
+        _62 = narrow_bind copy _62 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb41, bb48];
     }
 
     bb41: {
-        _62 = copy _61;
-        _66 = copy _62.1;
-        _67 = load_type(string);
-        _65 = call const fn baml.String.from<copy _67>(copy _66) -> [bb42];
+        _63 = copy _62;
+        _67 = copy _63.1;
+        _68 = load_type(string);
+        _66 = call const fn baml.String.from<copy _68>(copy _67) -> [bb42];
     }
 
     bb42: {
-        _64 = copy _65 + const "|";
-        _69 = copy _56.1;
-        _70 = load_type(string);
-        _68 = call const fn baml.String.from<copy _70>(copy _69) -> [bb43];
+        _65 = copy _66 + const "|";
+        _70 = copy _57.1;
+        _71 = load_type(string);
+        _69 = call const fn baml.String.from<copy _71>(copy _70) -> [bb43];
     }
 
     bb43: {
-        _63 = copy _64 + copy _68;
-        _75 = copy _63;
-        _76 = load_type(string);
-        _77 = load_type(int);
-        _74 = call const fn baml.Map.get<copy _76, copy _77>(copy _14, copy _75) -> [bb44];
+        _64 = copy _65 + copy _69;
+        _76 = copy _64;
+        _77 = load_type(string);
+        _78 = load_type(int);
+        _75 = call const fn baml.Map.get<copy _77, copy _78>(copy _14, copy _76) -> [bb44];
     }
 
     bb44: {
-        _73 = copy _74;
-        _78 = copy _73 == const null;
-        branch copy _78 -> [bb45, bb46];
+        _74 = short_circuit(??) copy _75 -> [eval: bb45, join: bb46];
     }
 
     bb45: {
-        _73 = const 0_i64;
+        _74 = const 0_i64;
         goto -> bb46;
     }
 
     bb46: {
-        _72 = copy _73;
-        _71 = copy _72 + const 1_i64;
-        _80 = copy _63;
-        _81 = copy _71;
+        _73 = copy _74;
+        _72 = copy _73 + const 1_i64;
+        _80 = copy _64;
+        _81 = copy _72;
         _82 = load_type(string);
         _83 = load_type(int);
         _79 = call const fn baml.Map.set<copy _82, copy _83>(copy _14, copy _80, copy _81) -> [bb47];
     }
 
     bb47: {
-        _85 = copy _71;
+        _85 = copy _72;
         _84 = copy _85 >= const 3_i64;
         branch copy _84 -> [bb49, bb48];
     }
 
     bb48: {
-        _98 = copy _48;
-        _48 = copy _98 + const 1_i64;
+        _98 = copy _49;
+        _49 = copy _98 + const 1_i64;
         goto -> bb35;
     }
 
     bb49: {
-        _87 = copy _62.0;
-        _88 = copy _62.1;
-        _93 = copy _71;
+        _87 = copy _63.0;
+        _88 = copy _63.1;
+        _93 = copy _72;
         _94 = load_type(int);
+        _133 = const "the same tool call failed ";
         _92 = call const fn baml.String.from<copy _94>(copy _93) -> [bb50];
     }
 
     bb50: {
-        _91 = const "the same tool call failed " + copy _92;
+        _91 = copy _133 + copy _92;
         _90 = copy _91 + const " times; stopping the run: ";
-        _96 = copy _56.1;
+        _96 = copy _57.1;
         _97 = load_type(string);
         _95 = call const fn baml.String.from<copy _97>(copy _96) -> [bb51];
     }
@@ -13187,45 +13039,45 @@ fn ai.<(ai.Agent as ai.Runner)>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) 
     }
 
     bb52: {
-        throw_if_panic copy _38 -> bb53;
+        throw_if_panic copy _39 -> bb53;
     }
 
     bb53: {
-        _43 = copy _8;
-        _44 = copy _10;
-        _10 = call const fn ai.Agent._emit_from(copy _1, copy _43, copy _44) -> [bb54];
+        _44 = copy _7;
+        _45 = copy _10;
+        _10 = call const fn ai.Agent._emit_from(copy _1, copy _44, copy _45) -> [bb54];
     }
 
     bb54: {
-        rethrow copy _38;
+        rethrow copy _39;
     }
 
     bb55: {
-        throw_if_panic copy _110 -> bb56;
+        throw_if_panic copy _109 -> bb56;
     }
 
     bb56: {
-        _114 = virtual_call id as ai.Client(copy _4) -> [bb57];
+        _113 = virtual_call id as ai.Client(copy _4) -> [bb57];
     }
 
     bb57: {
-        _115 = copy _99;
-        _113 = ai.errors.ParseFailed { copy _114, copy _115 };
-        throw copy _113;
+        _114 = copy _99;
+        _112 = ai.errors.ParseFailed { copy _113, copy _114 };
+        throw copy _112;
     }
 
     bb58: {
-        throw_if_panic copy _117 -> bb59;
+        throw_if_panic copy _116 -> bb59;
     }
 
     bb59: {
-        _120 = copy _117;
-        _121 = load_type(never);
-        _119 = call const fn baml.errors.UnknownError.with_message<copy _121>(copy _120, const "final value serialization failed") -> [bb60];
+        _119 = copy _116;
+        _120 = load_type(never);
+        _118 = call const fn baml.errors.UnknownError.with_message<copy _120>(copy _119, const "final value serialization failed") -> [bb60];
     }
 
     bb60: {
-        throw copy _119;
+        throw copy _118;
     }
 }
 
@@ -13449,15 +13301,14 @@ fn ai.FunctionSpec.build_request(self: ai.FunctionSpec, client: null | ai.Client
     let _3: bool
     let _4: ai.Client // selected
     let _5: ai.Client
-    let _6: bool
-    let _7: ai.ModelTurnInput
-    let _8: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
-    let _9: ai.Journal
-    let _10: reflect.Type
-    let _11: ai.tools.Toolbox
+    let _6: ai.ModelTurnInput
+    let _7: (ai.OutputFormat) -> ai.Prompt throws ai.errors.PromptRenderError
+    let _8: ai.Journal
+    let _9: reflect.Type
+    let _10: ai.tools.Toolbox
+    let _11: reflect.Type
     let _12: reflect.Type
     let _13: reflect.Type
-    let _14: reflect.Type
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -13470,9 +13321,7 @@ fn ai.FunctionSpec.build_request(self: ai.FunctionSpec, client: null | ai.Client
     }
 
     bb2: {
-        _5 = copy _2;
-        _6 = copy _5 == const null;
-        branch copy _6 -> [bb3, bb4];
+        _5 = short_circuit(??) copy _2 -> [eval: bb3, join: bb4];
     }
 
     bb3: {
@@ -13482,24 +13331,24 @@ fn ai.FunctionSpec.build_request(self: ai.FunctionSpec, client: null | ai.Client
 
     bb4: {
         _4 = copy _5;
-        _8 = copy _1.2;
-        _10 = load_type(#0);
-        _9 = call const fn ai.Journal.new<copy _10>(copy _1) -> [bb5];
+        _7 = copy _1.2;
+        _9 = load_type(#0);
+        _8 = call const fn ai.Journal.new<copy _9>(copy _1) -> [bb5];
     }
 
     bb5: {
-        _12 = load_type(#0);
-        _11 = call const fn ai.FunctionSpec.tools<copy _12>(copy _1) -> [bb6];
+        _11 = load_type(#0);
+        _10 = call const fn ai.FunctionSpec.tools<copy _11>(copy _1) -> [bb6];
     }
 
     bb6: {
-        _14 = load_type(#0);
-        _13 = call const fn ai.FunctionSpec.output_type<copy _14>(copy _1) -> [bb7];
+        _13 = load_type(#0);
+        _12 = call const fn ai.FunctionSpec.output_type<copy _13>(copy _1) -> [bb7];
     }
 
     bb7: {
-        _7 = ai.ModelTurnInput { copy _8, copy _9, copy _11, copy _13 };
-        _0 = virtual_call render as ai.Client(copy _4, copy _7) -> [bb8];
+        _6 = ai.ModelTurnInput { copy _7, copy _8, copy _10, copy _12 };
+        _0 = virtual_call render as ai.Client(copy _4, copy _6) -> [bb8];
     }
 
     bb8: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/assert/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/assert/bytecode.snap
@@ -101,8 +101,6 @@ function assert.equal(actual: unknown, expected: unknown) -> void {
     load_type string
     load_var actual
     call baml.String.from
-    store_var _8
-    load_var _8
     bin_op +
     load_const "\""
     bin_op +
@@ -123,8 +121,6 @@ function assert.equal(actual: unknown, expected: unknown) -> void {
     load_type string
     load_var expected
     call baml.String.from
-    store_var _14
-    load_var _14
     bin_op +
     load_const "\""
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/assert/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/assert/bytecode.snap
@@ -5,42 +5,24 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> void
     load_var eps
     load_const 0.0
     cmp_float_op <
-    jump_if_false L0
-    jump L1
-
-  L0:
-    pop 1
+    pop_jump_if_true L1
     load_var eps
     call baml.Float.is_nan
-
-  L1:
-    pop_jump_if_false L2
-    jump L7
-
-  L2:
+    pop_jump_if_true L1
     load_var2 1 2
     sub_float
     call baml.Float.abs
     store_var delta
     load_var delta
     call baml.Float.is_nan
-    jump_if_false L3
-    jump L4
-
-  L3:
-    pop 1
+    pop_jump_if_true L0
     load_var2 4 3
     cmp_float_op >
-
-  L4:
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L0
     load_const null
     return
 
-  L6:
+  L0:
     load_type float
     load_var delta
     call baml.String.from
@@ -77,7 +59,7 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> void
     init_instance baml.panics.AssertionFailed .message
     throw
 
-  L7:
+  L1:
     load_const "assertion failed: epsilon must be a non-negative number"
     init_instance baml.panics.AssertionFailed .message
     throw
@@ -86,82 +68,69 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> void
 function assert.contains(haystack: string, needle: string) -> void {
     load_var2 1 2
     call baml.String.includes
-    unary_op !
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const "assertion failed: string does not contain expected substring"
+    init_instance baml.panics.AssertionFailed .message
+    throw
 
   L0:
     load_const null
     return
-
-  L1:
-    load_const "assertion failed: string does not contain expected substring"
-    init_instance baml.panics.AssertionFailed .message
-    throw
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> void {
     load_var2 1 2
     call baml.ops.equals_equals
     unary_op !
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const null
     return
 
-  L1:
+  L0:
     load_var actual
     is_type string
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type unknown
     load_var actual
     call baml.String.from
     store_var actual_str
-    jump L4
+    jump L2
 
-  L3:
+  L1:
+    load_const "\""
     load_type string
     load_var actual
     call baml.String.from
     store_var _8
-    load_const "\""
     load_var _8
     bin_op +
     load_const "\""
     bin_op +
     store_var actual_str
 
-  L4:
+  L2:
     load_var expected
     is_type string
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_type unknown
     load_var expected
     call baml.String.from
     store_var expected_str
-    jump L7
+    jump L4
 
-  L6:
+  L3:
+    load_const "\""
     load_type string
     load_var expected
     call baml.String.from
     store_var _14
-    load_const "\""
     load_var _14
     bin_op +
     load_const "\""
     bin_op +
     store_var expected_str
 
-  L7:
+  L4:
     load_type string
     load_var actual_str
     call baml.String.from
@@ -183,27 +152,20 @@ function assert.equal(actual: unknown, expected: unknown) -> void {
 
 function assert.is_true(condition: bool) -> void {
     load_var condition
-    unary_op !
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const "assertion failed: expected true"
+    init_instance baml.panics.AssertionFailed .message
+    throw
 
   L0:
     load_const null
     return
-
-  L1:
-    load_const "assertion failed: expected true"
-    init_instance baml.panics.AssertionFailed .message
-    throw
 }
 
 function assert.is_type(actual: unknown) -> #0 {
     load_var actual
     is_type #0
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type reflect.Type
     load_type #0
     call baml.String.from
@@ -224,7 +186,7 @@ function assert.is_type(actual: unknown) -> #0 {
     init_instance baml.panics.AssertionFailed .message
     throw
 
-  L1:
+  L0:
     load_var actual
     return
 }
@@ -233,14 +195,11 @@ function assert.not_null(value: unknown | null) -> void {
     load_var value
     load_const null
     call baml.ops.equals_equals
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const null
     return
 
-  L1:
+  L0:
     load_const "assertion failed: expected non-null value"
     init_instance baml.panics.AssertionFailed .message
     throw

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/assert/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/assert/mir.snap
@@ -6,26 +6,24 @@ fn assert.is_true(condition: bool) -> void {
     // Locals:
     let _0: void // _0 // return
     let _1: bool // condition // param
-    let _2: bool
-    let _3: baml.panics.AssertionFailed
+    let _2: baml.panics.AssertionFailed
 
     bb0: {
-        _2 = !copy _1;
-        branch copy _2 -> [bb3, bb1];
+        branch copy _1 -> [bb2, bb1];
     }
 
     bb1: {
-        _0 = const null;
-        goto -> bb2;
+        _2 = baml.panics.AssertionFailed { const "assertion failed: expected true" };
+        throw copy _2;
     }
 
     bb2: {
-        return;
+        _0 = const null;
+        goto -> bb3;
     }
 
     bb3: {
-        _3 = baml.panics.AssertionFailed { const "assertion failed: expected true" };
-        throw copy _3;
+        return;
     }
 }
 
@@ -88,6 +86,9 @@ fn assert.equal(actual: unknown, expected: unknown) -> void {
     let _24: string
     let _25: string
     let _26: reflect.Type
+    let _27: string
+    let _28: string
+    let _29: string
 
     bb0: {
         _4 = call const fn baml.ops.equals_equals(copy _1, copy _2) -> [bb1];
@@ -119,11 +120,12 @@ fn assert.equal(actual: unknown, expected: unknown) -> void {
 
     bb6: {
         _9 = load_type(string);
+        _27 = const "\"";
         _8 = call const fn baml.String.from<copy _9>(copy _1) -> [bb7];
     }
 
     bb7: {
-        _7 = const "\"" + copy _8;
+        _7 = copy _27 + copy _8;
         _5 = copy _7 + const "\"";
         goto -> bb8;
     }
@@ -140,11 +142,12 @@ fn assert.equal(actual: unknown, expected: unknown) -> void {
 
     bb10: {
         _15 = load_type(string);
+        _28 = const "\"";
         _14 = call const fn baml.String.from<copy _15>(copy _2) -> [bb11];
     }
 
     bb11: {
-        _13 = const "\"" + copy _14;
+        _13 = copy _28 + copy _14;
         _11 = copy _13 + const "\"";
         goto -> bb12;
     }
@@ -152,11 +155,12 @@ fn assert.equal(actual: unknown, expected: unknown) -> void {
     bb12: {
         _22 = copy _5;
         _23 = load_type(string);
+        _29 = const "assertion failed: left = ";
         _21 = call const fn baml.String.from<copy _23>(copy _22) -> [bb13];
     }
 
     bb13: {
-        _20 = const "assertion failed: left = " + copy _21;
+        _20 = copy _29 + copy _21;
         _19 = copy _20 + const ", right = ";
         _25 = copy _11;
         _26 = load_type(string);
@@ -202,18 +206,19 @@ fn assert.approx_equal(actual: float, expected: float, eps: float) -> void {
     let _27: reflect.Type
     let _28: string
     let _29: reflect.Type
+    let _30: string
 
     bb0: {
-        _5 = copy _3 < const 0_f64;
-        _4 = short_circuit(||) copy _5 -> [eval: bb1, join: bb2];
+        _4 = copy _3 < const 0_f64;
+        branch copy _4 -> [bb14, bb1];
     }
 
     bb1: {
-        _4 = call const fn baml.Float.is_nan(copy _3) -> [bb2];
+        _5 = call const fn baml.Float.is_nan(copy _3) -> [bb2];
     }
 
     bb2: {
-        branch copy _4 -> [bb15, bb3];
+        branch copy _5 -> [bb14, bb3];
     }
 
     bb3: {
@@ -222,67 +227,64 @@ fn assert.approx_equal(actual: float, expected: float, eps: float) -> void {
     }
 
     bb4: {
-        _10 = call const fn baml.Float.is_nan(copy _7) -> [bb5];
+        _9 = call const fn baml.Float.is_nan(copy _7) -> [bb5];
     }
 
     bb5: {
-        _9 = short_circuit(||) copy _10 -> [eval: bb6, join: bb7];
+        branch copy _9 -> [bb9, bb6];
     }
 
     bb6: {
         _11 = copy _7;
-        _9 = copy _11 > copy _3;
-        goto -> bb7;
+        _10 = copy _11 > copy _3;
+        branch copy _10 -> [bb9, bb7];
     }
 
     bb7: {
-        branch copy _9 -> [bb10, bb8];
+        _0 = const null;
+        goto -> bb8;
     }
 
     bb8: {
-        _0 = const null;
-        goto -> bb9;
-    }
-
-    bb9: {
         return;
     }
 
-    bb10: {
+    bb9: {
         _22 = copy _7;
         _23 = load_type(float);
-        _21 = call const fn baml.String.from<copy _23>(copy _22) -> [bb11];
+        _30 = const "assertion failed: |left - right| = \"";
+        _21 = call const fn baml.String.from<copy _23>(copy _22) -> [bb10];
+    }
+
+    bb10: {
+        _20 = copy _30 + copy _21;
+        _19 = copy _20 + const "\", eps = \"";
+        _25 = load_type(float);
+        _24 = call const fn baml.String.from<copy _25>(copy _3) -> [bb11];
     }
 
     bb11: {
-        _20 = const "assertion failed: |left - right| = \"" + copy _21;
-        _19 = copy _20 + const "\", eps = \"";
-        _25 = load_type(float);
-        _24 = call const fn baml.String.from<copy _25>(copy _3) -> [bb12];
-    }
-
-    bb12: {
         _18 = copy _19 + copy _24;
         _17 = copy _18 + const "\", left = \"";
         _27 = load_type(float);
-        _26 = call const fn baml.String.from<copy _27>(copy _1) -> [bb13];
+        _26 = call const fn baml.String.from<copy _27>(copy _1) -> [bb12];
     }
 
-    bb13: {
+    bb12: {
         _16 = copy _17 + copy _26;
         _15 = copy _16 + const "\", right = \"";
         _29 = load_type(float);
-        _28 = call const fn baml.String.from<copy _29>(copy _2) -> [bb14];
+        _28 = call const fn baml.String.from<copy _29>(copy _2) -> [bb13];
     }
 
-    bb14: {
+    bb13: {
         _14 = copy _15 + copy _28;
         _13 = copy _14 + const "\"";
         _12 = baml.panics.AssertionFailed { copy _13 };
         throw copy _12;
     }
 
-    bb15: {
+    bb14: {
         _6 = baml.panics.AssertionFailed { const "assertion failed: epsilon must be a non-negative number" };
         throw copy _6;
     }
@@ -294,30 +296,28 @@ fn assert.contains(haystack: string, needle: string) -> void {
     let _1: string // haystack // param
     let _2: string // needle // param
     let _3: bool
-    let _4: bool
-    let _5: baml.panics.AssertionFailed
+    let _4: baml.panics.AssertionFailed
 
     bb0: {
-        _4 = call const fn baml.String.includes(copy _1, copy _2) -> [bb1];
+        _3 = call const fn baml.String.includes(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
-        _3 = !copy _4;
-        branch copy _3 -> [bb4, bb2];
+        branch copy _3 -> [bb3, bb2];
     }
 
     bb2: {
-        _0 = const null;
-        goto -> bb3;
+        _4 = baml.panics.AssertionFailed { const "assertion failed: string does not contain expected substring" };
+        throw copy _4;
     }
 
     bb3: {
-        return;
+        _0 = const null;
+        goto -> bb4;
     }
 
     bb4: {
-        _5 = baml.panics.AssertionFailed { const "assertion failed: string does not contain expected substring" };
-        throw copy _5;
+        return;
     }
 }
 
@@ -337,6 +337,7 @@ fn assert.is_type(actual: unknown) -> T {
     let _11: reflect.Type
     let _12: string
     let _13: reflect.Type
+    let _14: string
 
     bb0: {
         _2 = is_type(copy _1, #0);
@@ -351,11 +352,12 @@ fn assert.is_type(actual: unknown) -> T {
     bb2: {
         _10 = copy _3;
         _11 = load_type(reflect.Type);
+        _14 = const "assertion failed: expected type \"";
         _9 = call const fn baml.String.from<copy _11>(copy _10) -> [bb3];
     }
 
     bb3: {
-        _8 = const "assertion failed: expected type \"" + copy _9;
+        _8 = copy _14 + copy _9;
         _7 = copy _8 + const "\", got \"";
         _13 = load_type(unknown);
         _12 = call const fn baml.String.from<copy _13>(copy _1) -> [bb4];

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -79,8 +79,6 @@ function baml.<(string as baml.ops.Add<string>)>.add(self: string, rhs: string) 
     load_type string
     load_var rhs
     call baml.String.from
-    store_var _5
-    load_var _5
     bin_op +
     return
 }
@@ -2287,12 +2285,10 @@ function baml.errors.<(baml.errors.UnknownError as baml.ToString)>.to_string(sel
     load_type string
     load_var _14
     call baml.String.from
-    store_var _13
     load_type string
     load_var detail
     call baml.String.from
     store_var _18
-    load_var _13
     bin_op +
     load_const ": "
     bin_op +

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -5,24 +5,21 @@ function baml.<(#0[] as baml.Sortable)>.sort(self: #0[]) -> #0[] {
     load_type #0
     load_var self
     call baml._is_primitive_array
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type #0
     load_type never
     load_var self
     load_type #0
     make_closure .<lambda(sort, 0)>, captures=0, ntypeargs=1
     call baml.Array.sort_by
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_type #0[]
     load_var self
     call baml._rust_sort
 
-  L2:
+  L1:
     return
 }
 
@@ -33,23 +30,19 @@ function baml.<(float[] as baml.FloatStats)>.mean(self: float[]) -> float {
     load_var _3
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_type baml.Summable
     load_const "sum"
     virtual_call nargs=1 ntypeargs=0
-    store_var _5
     load_var self
     container_len
     store_var _6
-    load_var2 3 4
+    load_var _6
     bin_op /
     return
 
-  L1:
+  L0:
     load_const "float[].mean: cannot take the mean of an empty array"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -83,12 +76,11 @@ function baml.<(string as baml.ops.Add<string>)>.add(self: string, rhs: string) 
     load_type string
     load_var self
     call baml.String.from
-    store_var _3
     load_type string
     load_var rhs
     call baml.String.from
     store_var _5
-    load_var2 3 4
+    load_var _5
     bin_op +
     return
 }
@@ -142,27 +134,21 @@ function baml.Array.filter_map(self: #0[], fn: (#0) -> #1 | null throws #2) -> #
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L3
-
-  L1:
+    pop_jump_if_true L1
     load_var2 6 2
     call_indirect
     store_var _12
     load_var _12
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L0
-
-  L2:
+    pop_jump_if_true L0
     load_type #1
     load_var2 3 7
     call baml.Array.push
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_var out
     return
 }
@@ -204,16 +190,13 @@ function baml.Array.for_each(self: #0[], fn: (#0) -> void throws #1) -> void {
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 5 2
     call_indirect
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_const null
     return
 }
@@ -228,14 +211,11 @@ function baml.Array.generate(length: int, f: (int) -> #0 throws #1) -> #0[] {
   L0:
     load_var2 4 1
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var out
     return
 
-  L2:
+  L1:
     load_var2 4 2
     call_indirect
     store_var _8
@@ -268,78 +248,70 @@ function baml.Array.join(self: #0[], separator: string) -> string {
     store_var_load_var _4
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L4
+    pop_jump_if_true L3
 
   L0:
     load_var self
     is_type _[]
-    pop_jump_if_false L6
+    pop_jump_if_false L5
     load_var self
     container_len
     store_var_load_var _7
     load_const 1
     cmp_int_op >=
-    pop_jump_if_false L6
-    load_var self
-    load_const 0
-    load_array_element
-    pop 1
+    pop_jump_if_false L5
     load_var self
     container_len
-    store_var _15
+    store_var _13
     load_var self
     load_const 1
-    load_var _15
+    load_var _13
     call baml.Array.slice
-    store_var _14
+    store_var _12
     load_type #0
     load_var self
     load_const 0
     load_array_element
     call baml.String.from
     store_var joined
-    load_var _14
+    load_var _12
     load_type baml.iter.Iterable<Error = never, Item = #0>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _21
+    store_var _19
 
   L1:
-    load_var _21
+    load_var _19
     load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _22
-    load_var _22
+    store_var _20
+    load_var _20
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L2
     load_var2 7 2
     bin_op +
-    store_var _26
+    store_var _24
     load_type #0
-    load_var _22
+    load_var _20
     call baml.String.from
-    store_var _28
+    store_var _26
     load_var2 10 11
     bin_op +
     store_var joined
     jump L1
 
-  L3:
+  L2:
     load_var joined
-    jump L5
+    jump L4
 
-  L4:
+  L3:
     load_const ""
 
-  L5:
+  L4:
     return
 
-  L6:
+  L5:
     unreachable
 }
 
@@ -389,10 +361,7 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     load_var n
     load_const 1
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L14
-
-  L0:
+    pop_jump_if_true L8
     load_type #0
     load_var self
     load_const 0
@@ -408,7 +377,7 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
-  L1:
+  L0:
     load_var _11
     load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
@@ -416,10 +385,7 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 7 2
     call_indirect
     store_var _17
@@ -428,22 +394,19 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     load_var _17
     call baml.Array.push
     pop 1
-    jump L1
+    jump L0
 
-  L3:
+  L1:
     load_type int
     alloc_array 0
     store_var order
     load_const 0
     store_var p
 
-  L4:
+  L2:
     load_var2 10 3
     cmp_int_op <
-    pop_jump_if_false L5
-    jump L13
-
-  L5:
+    pop_jump_if_true L7
     load_type int
     load_type never
     load_var order
@@ -463,7 +426,7 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _34
 
-  L6:
+  L3:
     load_var _34
     load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
@@ -471,10 +434,7 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     store_var _35
     load_var _35
     is_type baml.iter.Done
-    pop_jump_if_false L7
-    jump L9
-
-  L7:
+    pop_jump_if_true L4
     load_type #0
     load_var2 4 13
     call baml.Array.at
@@ -482,17 +442,14 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     load_var _39
     load_const null
     cmp_op ==
-    pop_jump_if_false L8
-    jump L6
-
-  L8:
+    pop_jump_if_true L3
     load_type #0
     load_var2 11 14
     call baml.Array.push
     pop 1
-    jump L6
+    jump L3
 
-  L9:
+  L4:
     load_type #0
     load_var self
     call baml.Array.clear
@@ -503,7 +460,7 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _50
 
-  L10:
+  L5:
     load_var _50
     load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
@@ -511,21 +468,18 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     store_var _51
     load_var _51
     is_type baml.iter.Done
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
+    pop_jump_if_true L6
     load_type #0
     load_var2 1 16
     call baml.Array.push
     pop 1
-    jump L10
+    jump L5
 
-  L12:
+  L6:
     load_var self
-    jump L15
+    jump L9
 
-  L13:
+  L7:
     load_type int
     load_var2 9 10
     call baml.Array.push
@@ -534,12 +488,12 @@ function baml.Array.sort_by_key(self: #0[], key: (#0) -> #1 throws #2) -> #0[] {
     load_const 1
     add_int
     store_var p
-    jump L4
+    jump L2
 
-  L14:
+  L8:
     load_var self
 
-  L15:
+  L9:
     return
 }
 
@@ -581,10 +535,7 @@ function baml.Bigint.random(lower: bigint, upper: bigint, rng: baml.random.Rng) 
   L0:
     load_var2 1 2
     cmp_bigint_op >=
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var2 1 2
     call baml.Bigint._random_byte_count
     store_var width
@@ -592,35 +543,28 @@ function baml.Bigint.random(lower: bigint, upper: bigint, rng: baml.random.Rng) 
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _17
-    load_var2 8 1
-    load_var upper
+    load_var2 1 2
     call baml.Bigint._random_in_range
     store_var r
 
-  L2:
+  L1:
     load_var2 7 2
     cmp_bigint_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var r
     return
 
-  L4:
+  L2:
     load_var2 3 6
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _21
-    load_var2 9 1
-    load_var upper
+    load_var2 1 2
     call baml.Bigint._random_in_range
     store_var r
-    jump L2
+    jump L1
 
-  L5:
+  L3:
     load_type bigint
     load_var lower
     call baml.String.from
@@ -659,8 +603,6 @@ function baml.Bool.random(rng: baml.random.Rng) -> bool {
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _5
-    load_var _5
     load_const 0
     load_array_element
     load_const 128
@@ -737,8 +679,7 @@ function baml.Float.is_finite(self: float) -> bool {
     load_var self
     call baml.Float.is_nan
     unary_op !
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var self
     call baml.Float.is_infinite
     unary_op !
@@ -784,8 +725,6 @@ function baml.Float.random(rng: baml.random.Rng) -> float {
     load_type baml.random.Rng
     load_const "random_int"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     call baml.Float._unit_from_draw
     return
 }
@@ -883,43 +822,33 @@ function baml.Int.random(lower: int, upper: int, rng: baml.random.Rng) -> int {
   L0:
     load_var2 1 2
     cmp_int_op >=
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L3
     load_var rng
     load_type baml.random.Rng
     load_const "random_int"
     virtual_call nargs=1 ntypeargs=0
-    store_var _16
-    load_var2 7 1
-    load_var upper
+    load_var2 1 2
     call baml.Int._random_in_range
     store_var r
 
-  L2:
+  L1:
     load_var2 6 2
     cmp_int_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var r
     return
 
-  L4:
+  L2:
     load_var rng
     load_type baml.random.Rng
     load_const "random_int"
     virtual_call nargs=1 ntypeargs=0
-    store_var _19
-    load_var2 8 1
-    load_var upper
+    load_var2 1 2
     call baml.Int._random_in_range
     store_var r
-    jump L2
+    jump L1
 
-  L5:
+  L3:
     load_type int
     load_var lower
     call baml.String.from
@@ -995,22 +924,19 @@ function baml.String.ends_with(self: string, suffix: string) -> bool {
 function baml.String.from(value: #0) -> string {
     load_var value
     is_type baml.ToString
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type #0
     load_var value
     call baml._to_string_default
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var value
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
 
-  L2:
+  L1:
     return
 }
 
@@ -1252,8 +1178,6 @@ function baml.crypto.<(baml.crypto.Aes128GcmSiv as baml.crypto.GenerateKey)>.ran
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1269,8 +1193,6 @@ function baml.crypto.<(baml.crypto.Aes256GcmSiv as baml.crypto.GenerateKey)>.ran
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1286,8 +1208,6 @@ function baml.crypto.<(baml.crypto.ChaCha20Poly1305 as baml.crypto.GenerateKey)>
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1309,8 +1229,6 @@ function baml.crypto.<(baml.crypto.XChaCha20Poly1305 as baml.crypto.GenerateKey)
     load_type baml.random.Rng
     load_const "random"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -1336,16 +1254,6 @@ function baml.csv.<(baml.csv.Reader as baml.iter.Iterable)>.iter(self: baml.csv.
 
 function baml.csv.<(baml.csv.Reader as baml.iter.Iterator)>.next(self: baml.csv.Reader) -> baml.csv.Record | baml.iter.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const "unreachable: Reader.next loop ended"
-    call baml.sys.panic
-    jump L10
-
-  L2:
     load_var self
     call baml.csv.Reader._poll
     store_var _2
@@ -1353,32 +1261,23 @@ function baml.csv.<(baml.csv.Reader as baml.iter.Iterator)>.next(self: baml.csv.
     store_var _3
     load_var _3
     narrow_bind baml.csv.Record, slot=3
-    pop_jump_if_false L3
-    jump L9
-
-  L3:
+    pop_jump_if_true L3
     load_var _2
     store_var _5
     load_var _5
     narrow_bind baml.iter.Done, slot=4
-    pop_jump_if_false L4
-    jump L8
-
-  L4:
+    pop_jump_if_true L2
     load_var _2
     store_var _7
     load_var _7
     narrow_bind baml.csv._Skip, slot=5
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L1
     load_var self
     call baml.csv.Reader._read_chunk
     pop 1
     jump L0
 
-  L6:
+  L1:
     load_var _7
     store_var s
     load_var self
@@ -1386,10 +1285,7 @@ function baml.csv.<(baml.csv.Reader as baml.iter.Iterator)>.next(self: baml.csv.
     store_var_load_var _10
     load_const null
     cmp_op ==
-    pop_jump_if_false L7
-    jump L0
-
-  L7:
+    pop_jump_if_true L0
     load_var s
     load_field .error
     load_var _10
@@ -1397,14 +1293,14 @@ function baml.csv.<(baml.csv.Reader as baml.iter.Iterator)>.next(self: baml.csv.
     pop 1
     jump L0
 
-  L8:
+  L2:
     load_var _5
-    jump L10
+    jump L4
 
-  L9:
+  L3:
     load_var _3
 
-  L10:
+  L4:
     return
 }
 
@@ -1415,16 +1311,6 @@ function baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterable)>.iter(self: baml.cs
 
 function baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterator)>.next(self: baml.csv.Rows<#0>) -> #0 | baml.iter.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const "unreachable: Rows.next loop ended"
-    call baml.sys.panic
-    jump L8
-
-  L2:
     load_var self
     load_field .reader
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
@@ -1435,10 +1321,7 @@ function baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterator)>.next(self: baml.cs
     store_var _4
     load_var _4
     narrow_bind baml.iter.Done, slot=3
-    pop_jump_if_false L3
-    jump L7
-
-  L3:
+    pop_jump_if_true L2
     load_type #0
     load_var2 2 1
     load_field .reader
@@ -1448,14 +1331,11 @@ function baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterator)>.next(self: baml.cs
     store_var _11
     load_var _11
     narrow_bind baml.csv._Skip, slot=5
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_var _7
-    jump L8
+    jump L3
 
-  L5:
+  L1:
     load_var _11
     store_var s
     load_var self
@@ -1464,10 +1344,7 @@ function baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterator)>.next(self: baml.cs
     store_var_load_var _14
     load_const null
     cmp_op ==
-    pop_jump_if_false L6
-    jump L0
-
-  L6:
+    pop_jump_if_true L0
     load_var s
     load_field .error
     load_var _14
@@ -1475,10 +1352,10 @@ function baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterator)>.next(self: baml.cs
     pop 1
     jump L0
 
-  L7:
+  L2:
     load_var _4
 
-  L8:
+  L3:
     return
 }
 
@@ -1505,10 +1382,7 @@ function baml.csv.Reader._read_chunk(self: baml.csv.Reader) -> void {
     load_field ._file
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field ._file
     load_const 65536
@@ -1516,48 +1390,42 @@ function baml.csv.Reader._read_chunk(self: baml.csv.Reader) -> void {
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
     store_var chunk
-    jump L4
+    jump L2
     load_var e
     is_type baml.errors.Io
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L2:
+  L0:
     load_var self
     call baml.csv.Reader._mark_exhausted
     pop 1
     load_var e
     rethrow
 
-  L3:
+  L1:
     load_const null
     store_var chunk
 
-  L4:
+  L2:
     load_var chunk
     load_const null
     cmp_op ==
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_var2 1 2
     call baml.csv.Reader._feed
     pop 1
     load_const null
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_var self
     call baml.csv.Reader._feed_eof
     pop 1
     load_const null
 
-  L7:
+  L4:
     return
 }
 
@@ -1570,59 +1438,41 @@ function baml.csv.Reader.close(self: baml.csv.Reader) -> null {
     store_var_load_var _3
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field ._owns_file
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var _3
     sys_op baml.fs.File.close
     pop 1
 
+  L0:
+    load_const null
+    jump L2
+
   L1:
     load_const null
-    jump L3
 
   L2:
-    load_const null
-
-  L3:
     return
 }
 
 function baml.csv.Reader.headers(self: baml.csv.Reader) -> string[] | null {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const "unreachable: Reader.headers loop ended"
-    call baml.sys.panic
-    jump L5
-
-  L2:
     load_var self
     call baml.csv.Reader._poll_headers
     store_var _3
     load_var _3
     narrow_bind baml.csv._Headers, slot=2
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var self
     call baml.csv.Reader._read_chunk
     pop 1
     jump L0
 
-  L4:
+  L1:
     load_var _3
     load_field .names
-
-  L5:
     return
 }
 
@@ -1691,29 +1541,26 @@ function baml.csv.Writer._emit(self: baml.csv.Writer, out: string) -> null {
     store_var_load_var _3
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var out
     call baml.String.length
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var2 3 2
     load_type baml.io.Write
     load_const "write"
     virtual_call nargs=2 ntypeargs=0
     pop 1
 
+  L0:
+    load_const null
+    jump L2
+
   L1:
     load_const null
-    jump L3
 
   L2:
-    load_const null
-
-  L3:
     return
 }
 
@@ -1735,25 +1582,22 @@ function baml.csv.Writer.close(self: baml.csv.Writer) -> null {
     store_var_load_var _3
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field ._owns_file
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var _3
     sys_op baml.fs.File.close
     pop 1
 
+  L0:
+    load_const null
+    jump L2
+
   L1:
     load_const null
-    jump L3
 
   L2:
-    load_const null
-
-  L3:
     return
 }
 
@@ -1880,26 +1724,20 @@ function baml.csv.create(path: string, options: baml.csv.WriterOptions | null) -
     load_var path
     load_const "w"
     sys_op baml.fs.open
-    jump L3
+    jump L2
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L2:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     init_instance baml.errors.Io .message
     throw
 
-  L3:
+  L2:
     load_var options
     load_const true
     call baml.csv._writer
@@ -1924,27 +1762,21 @@ function baml.csv.decode(source: string | uint8array, options: baml.csv.ReaderOp
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = #0>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
-    jump L3
+    jump L2
     load_var _
     is_type baml.errors.Io
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L2:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_const "unreachable: in-memory CSV source raised Io: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
 
-  L3:
+  L2:
     return
 }
 
@@ -1967,20 +1799,14 @@ function baml.csv.decode_one(source: string | uint8array, options: baml.csv.Read
     load_var _7
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L7
-
-  L1:
+    pop_jump_if_true L4
     load_var all
     container_len
     store_var _10
     load_var _10
     load_const 1
     cmp_int_op >
-    pop_jump_if_false L2
-    jump L6
-
-  L2:
+    pop_jump_if_true L3
     load_type #0
     load_var all
     load_const 0
@@ -1989,21 +1815,18 @@ function baml.csv.decode_one(source: string | uint8array, options: baml.csv.Read
     load_var _15
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var _15
-    jump L5
+    jump L2
 
-  L4:
+  L1:
     load_const "unreachable: decode_one lost its record"
     call baml.sys.panic
 
-  L5:
+  L2:
     return
 
-  L6:
+  L3:
     load_var all
     container_len
     store_var _14
@@ -2018,7 +1841,7 @@ function baml.csv.decode_one(source: string | uint8array, options: baml.csv.Read
     call baml.csv._error
     throw
 
-  L7:
+  L4:
     load_const baml.csv.ErrorKind.NotFound
     alloc_variant baml.csv.ErrorKind
     load_const "expected exactly one data record, found none"
@@ -2045,17 +1868,14 @@ function baml.csv.decode_optional(source: string | uint8array, options: baml.csv
     load_var _7
     load_const 1
     cmp_int_op >
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type #0
     load_var all
     load_const 0
     call baml.Array.at
     return
 
-  L2:
+  L1:
     load_var all
     container_len
     store_var _11
@@ -2083,26 +1903,20 @@ function baml.csv.open(path: string, options: baml.csv.ReaderOptions | null) -> 
     load_var path
     load_const "r"
     sys_op baml.fs.open
-    jump L3
+    jump L2
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L2:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     init_instance baml.errors.Io .message
     throw
 
-  L3:
+  L2:
     load_var options
     load_const true
     call baml.csv._reader
@@ -2126,8 +1940,6 @@ function baml.csv.parse(source: string | uint8array, options: baml.csv.ReaderOpt
     store_var out
 
   L1:
-    load_const true
-    pop_jump_if_false L5
     load_var r
     load_type baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>
     load_const "next"
@@ -2135,10 +1947,7 @@ function baml.csv.parse(source: string | uint8array, options: baml.csv.ReaderOpt
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L5
-
-  L2:
+    pop_jump_if_true L3
     load_var _7
     call baml.csv.Record.fields
     store_var _11
@@ -2149,28 +1958,22 @@ function baml.csv.parse(source: string | uint8array, options: baml.csv.ReaderOpt
     jump L1
     load_var _
     is_type baml.errors.Io
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _
     rethrow
 
-  L4:
-    load_var _
-    load_field .0
-    pop 1
+  L2:
     load_const "unreachable: in-memory CSV source raised Io: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
-    jump L6
+    jump L4
 
-  L5:
+  L3:
     load_var out
 
-  L6:
+  L4:
     return
 }
 
@@ -2233,27 +2036,21 @@ function baml.csv.stringify(rows: #0[], options: baml.csv.WriterOptions | null) 
     pop 1
     load_var w
     call baml.csv.Writer.text
-    jump L3
+    jump L2
     load_var _
     is_type baml.errors.Io
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L2:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_const "unreachable: buffer writer raised Io: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
 
-  L3:
+  L2:
     return
 }
 
@@ -2283,39 +2080,30 @@ function baml.csv.stringify_records(records: (null | bool | int | bigint | float
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L2
     load_var2 4 6
     call baml.csv.Writer.write_record
     pop 1
     jump L1
 
-  L3:
+  L2:
     load_var w
     call baml.csv.Writer.text
-    jump L6
+    jump L4
     load_var _
     is_type baml.errors.Io
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var _
     rethrow
 
-  L5:
-    load_var _
-    load_field .0
-    pop 1
+  L3:
     load_const "unreachable: buffer writer raised Io: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
 
-  L6:
+  L4:
     return
 }
 
@@ -2417,15 +2205,10 @@ function baml.env.Ref.or(self: baml.env.Ref, fallback: string) -> string {
     load_var self
     load_field .name
     sys_op baml.env.get
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_var fallback
-    store_var _3
 
   L0:
-    load_var _3
     return
 }
 
@@ -2435,45 +2218,30 @@ function baml.env.get(key: string) -> string | null {
 function baml.env.get_or_panic(key: string) -> string {
     load_var key
     sys_op baml.env.get
-    store_var_load_var _2
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L0
+    jump_if_not_null_or_pop L0
     load_const "env var not found: "
     load_var key
     bin_op +
     call baml.sys.panic
-    store_var _2
 
   L0:
-    load_var _2
     return
 }
 
 function baml.env.get_or_panic_lenient(key: string, lenient: bool) -> string {
     load_var lenient
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var key
+    call baml.env.get_or_panic
     jump L1
 
   L0:
     load_var key
-    call baml.env.get_or_panic
-    jump L3
+    sys_op baml.env.get
+    jump_if_not_null_or_pop L1
+    load_const ""
 
   L1:
-    load_var key
-    sys_op baml.env.get
-    store_var_load_var _3
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
-    load_const ""
-    store_var _3
-
-  L2:
-    load_var _3
-
-  L3:
     return
 }
 
@@ -2508,16 +2276,14 @@ function baml.errors.<(baml.errors.UnknownError as baml.ToString)>.to_string(sel
     load_var _6
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type string
     load_var self
     load_field .message
     load_const ": "
     call baml.Array.join
     store_var _14
+    load_const "UnknownError: "
     load_type string
     load_var _14
     call baml.String.from
@@ -2526,25 +2292,22 @@ function baml.errors.<(baml.errors.UnknownError as baml.ToString)>.to_string(sel
     load_var detail
     call baml.String.from
     store_var _18
-    load_const "UnknownError: "
     load_var _13
     bin_op +
     load_const ": "
     bin_op +
     load_var _18
     bin_op +
-    jump L2
+    jump L1
 
-  L1:
+  L0:
+    load_const "UnknownError: "
     load_type string
     load_var detail
     call baml.String.from
-    store_var _8
-    load_const "UnknownError: "
-    load_var _8
     bin_op +
 
-  L2:
+  L1:
     return
 }
 
@@ -2557,18 +2320,15 @@ function baml.errors.Context.root_cause(self: baml.errors.Context) -> baml.error
     store_var_load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var _2
+    call baml.errors.Context.root_cause
     jump L1
 
   L0:
-    load_var _2
-    call baml.errors.Context.root_cause
-    jump L2
-
-  L1:
     load_var self
 
-  L2:
+  L1:
     return
 }
 
@@ -2583,30 +2343,23 @@ function baml.errors.UnknownError.from(data: unknown) -> #0 | baml.errors.Unknow
     store_var _2
     load_var _2
     narrow_bind #0, slot=2
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L3
     load_var data
     is_type baml.errors.UnknownError
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var data
     load_field .0
     store_var _8
     load_var _8
     narrow_bind #0, slot=4
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L2
 
-  L1:
+  L0:
     load_var data
-    store_var _13
-    load_var _13
+    store_var _12
+    load_var _12
     narrow_bind baml.errors.UnknownError, slot=6
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var data
     load_type string
     alloc_array 0
@@ -2616,30 +2369,27 @@ function baml.errors.UnknownError.from(data: unknown) -> #0 | baml.errors.Unknow
     call baml.errors.UnknownError._preserve_context
     pop 1
     load_var error
-    jump L6
+    jump L4
 
-  L3:
-    load_var _13
+  L1:
+    load_var _12
     store_var error
     load_var2 1 7
     call baml.errors.UnknownError._preserve_context
     pop 1
     load_var error
-    jump L6
+    jump L4
 
-  L4:
-    load_var data
-    load_field .0
-    pop 1
+  L2:
     load_var _8
     store_var inner
     load_var2 1 5
     call baml.errors.UnknownError._preserve_context
     pop 1
     load_var inner
-    jump L6
+    jump L4
 
-  L5:
+  L3:
     load_var _2
     store_var value
     load_var2 1 3
@@ -2647,7 +2397,7 @@ function baml.errors.UnknownError.from(data: unknown) -> #0 | baml.errors.Unknow
     pop 1
     load_var value
 
-  L6:
+  L4:
     return
 }
 
@@ -2656,30 +2406,23 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     store_var _3
     load_var _3
     narrow_bind #0, slot=3
-    pop_jump_if_false L0
-    jump L5
-
-  L0:
+    pop_jump_if_true L3
     load_var data
     is_type baml.errors.UnknownError
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_var data
     load_field .0
     store_var _9
     load_var _9
     narrow_bind #0, slot=5
-    pop_jump_if_false L1
-    jump L4
+    pop_jump_if_true L2
 
-  L1:
+  L0:
     load_var data
-    store_var _14
-    load_var _14
+    store_var _13
+    load_var _13
     narrow_bind baml.errors.UnknownError, slot=7
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 1 2
     load_type string
     alloc_array 1
@@ -2689,10 +2432,10 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     call baml.errors.UnknownError._preserve_context
     pop 1
     load_var error
-    jump L6
+    jump L4
 
-  L3:
-    load_var _14
+  L1:
+    load_var _13
     store_var error
     load_type string
     load_var error
@@ -2701,28 +2444,25 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     load_type string
     alloc_array 1
     call baml.Array.concat
-    store_var _19
+    store_var _18
     load_var2 8 9
     store_field .message
     load_var2 1 8
     call baml.errors.UnknownError._preserve_context
     pop 1
     load_var error
-    jump L6
+    jump L4
 
-  L4:
-    load_var data
-    load_field .0
-    pop 1
+  L2:
     load_var _9
     store_var inner
     load_var2 1 6
     call baml.errors.UnknownError._preserve_context
     pop 1
     load_var inner
-    jump L6
+    jump L4
 
-  L5:
+  L3:
     load_var _3
     store_var value
     load_var2 1 4
@@ -2730,7 +2470,7 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     pop 1
     load_var value
 
-  L6:
+  L4:
     return
 }
 
@@ -2748,8 +2488,6 @@ function baml.fs.File.bytes(self: baml.fs.File) -> uint8array {
     load_type baml.io.Read
     load_const "bytes"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2764,8 +2502,6 @@ function baml.fs.File.text(self: baml.fs.File) -> string {
     load_type baml.io.Read
     load_const "text"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2774,8 +2510,6 @@ function baml.fs.File.write(self: baml.fs.File, data: string | uint8array) -> in
     load_type baml.io.Write
     load_const "write"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -2963,59 +2697,53 @@ function baml.future.with_timeout(limit: baml.time.Duration, body: () -> #0 thro
     load_var _12
     await
     store_var _0
-    jump L8
+    jump L5
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_var e
+    rethrow
 
   L0:
+    load_deref ?4
+    call baml.spawn.CancelToken.is_cancelled
+    pop_jump_if_true L1
     load_var e
     rethrow
 
   L1:
-    load_deref ?4
-    call baml.spawn.CancelToken.is_cancelled
-    unary_op !
-    pop_jump_if_false L2
-    jump L7
-
-  L2:
     load_deref ?1
     call baml.time.Duration.to_milliseconds
     store_var limit_ms
     load_var limit_ms
     call baml.Bigint.to_int
     store_var reported
-    jump L5
+    jump L3
     load_var conversion
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var conversion
     rethrow
 
-  L4:
+  L2:
     load_const null
     store_var reported
 
-  L5:
+  L3:
     load_type bigint
     load_var limit_ms
     call baml.String.from
-    store_var _30
-    jump L6
+    store_var _29
+    jump L4
     load_var deadline
     call baml.future.Future.cancel
     pop 1
     load_var _16
     rethrow
 
-  L6:
+  L4:
     load_const "operation timed out after "
-    load_var _30
+    load_var _29
     bin_op +
     load_const "ms"
     bin_op +
@@ -3023,11 +2751,7 @@ function baml.future.with_timeout(limit: baml.time.Duration, body: () -> #0 thro
     init_instance baml.errors.Timeout .message, .duration_ms
     throw
 
-  L7:
-    load_var e
-    rethrow
-
-  L8:
+  L5:
     load_var deadline
     call baml.future.Future.cancel
     pop 1
@@ -3064,8 +2788,7 @@ function baml.http.Response.ok(self: baml.http.Response) -> bool {
     load_field .status_code
     load_const 200
     cmp_int_op >=
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var self
     load_field .status_code
     load_const 300
@@ -3137,13 +2860,23 @@ function baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Requ
     store_var header_read_timeout
 
   L5:
+    load_var tls_config
+    store_var _15
+    load_var allow_http1
+    store_var _16
+    load_var allow_http2
+    store_var _17
+    load_var max_body_size
+    store_var _18
+    load_var max_connections
+    store_var _19
     load_var header_read_timeout
     call baml.time.Duration.to_nanoseconds
-    store_var _15
+    store_var _20
     load_var2 1 2
-    load_var2 3 4
-    load_var2 5 6
-    load_var2 7 9
+    load_var2 9 10
+    load_var2 11 12
+    load_var2 13 14
     sys_op baml.http.Server._serve
     return
 }
@@ -3175,11 +2908,13 @@ function baml.http.TlsConfig.new(cert_pem: uint8array, key_pem: uint8array, allo
     store_var handshake_timeout
 
   L1:
+    load_var allow_tls1_2
+    store_var _7
     load_var handshake_timeout
     call baml.time.Duration.to_nanoseconds
-    store_var _7
+    store_var _8
     load_var2 1 2
-    load_var2 3 5
+    load_var2 5 6
     sys_op baml.http.TlsConfig._new
     return
 }
@@ -3197,18 +2932,15 @@ function baml.http._timeout_nanos(timeout: baml.time.Duration | null) -> bigint 
     load_var timeout
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var timeout
+    call baml.time.Duration.to_nanoseconds
     jump L1
 
   L0:
-    load_var timeout
-    call baml.time.Duration.to_nanoseconds
-    jump L2
-
-  L1:
     load_const 0n
 
-  L2:
+  L1:
     return
 }
 
@@ -3295,20 +3027,15 @@ function baml.io.Read.bytes(self: baml.io.Read) -> uint8array {
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     store_var _4
     load_var _4
-    narrow_bind uint8array, slot=4
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    narrow_bind uint8array, slot=3
+    pop_jump_if_true L1
     load_var result
     return
 
-  L2:
-    load_var2 2 4
+  L1:
+    load_var2 2 3
     call baml.Uint8Array.concat
     store_var result
     jump L0
@@ -3319,25 +3046,20 @@ function baml.io.Read.text(self: baml.io.Read) -> string {
     load_type baml.io.Read
     load_const "bytes"
     virtual_call nargs=1 ntypeargs=0
-    store_var data
-    load_var data
     call baml.String.from_utf8
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "invalid utf-8"
     init_instance baml.errors.ParseError .message
     throw
 
-  L2:
+  L1:
     return
 }
 
@@ -3346,39 +3068,33 @@ function baml.io.Write.write(self: baml.io.Write, data: string | uint8array) -> 
     store_var _4
     load_var _4
     narrow_bind string, slot=4
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var data
+    store_var remaining
     jump L1
 
   L0:
-    load_var data
-    store_var remaining
-    jump L2
-
-  L1:
     load_var _4
     call baml.String.to_utf8
     store_var remaining
 
-  L2:
+  L1:
     load_var remaining
     container_len
     store_var total
 
-  L3:
+  L2:
     load_var remaining
     container_len
     store_var _9
     load_var _9
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var total
     return
 
-  L5:
+  L3:
     load_var2 1 3
     load_type baml.io.Write
     load_const "write_some"
@@ -3387,22 +3103,13 @@ function baml.io.Write.write(self: baml.io.Write, data: string | uint8array) -> 
     load_var written
     load_const 0
     cmp_int_op <=
-    jump_if_false L6
-    jump L7
-
-  L6:
-    pop 1
+    pop_jump_if_true L4
     load_var remaining
     container_len
     store_var _16
     load_var2 7 8
     cmp_int_op >
-
-  L7:
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    pop_jump_if_true L4
     load_var remaining
     container_len
     store_var _19
@@ -3410,9 +3117,9 @@ function baml.io.Write.write(self: baml.io.Write, data: string | uint8array) -> 
     load_var _19
     call baml.Uint8Array.slice
     store_var remaining
-    jump L3
+    jump L2
 
-  L9:
+  L4:
     load_const "writer made invalid progress"
     init_instance baml.errors.Io .message
     throw
@@ -3455,10 +3162,7 @@ function baml.iter.<(baml.iter.ArrayIterator<#0> as baml.iter.Iterator)>.next(se
     store_var _4
     load_var2 2 3
     cmp_int_op >=
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .arr
     load_var self
@@ -3472,12 +3176,12 @@ function baml.iter.<(baml.iter.ArrayIterator<#0> as baml.iter.Iterator)>.next(se
     bin_op +
     store_field .idx
     load_var item
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     alloc_instance baml.iter.Done
 
-  L2:
+  L1:
     return
 }
 
@@ -3489,36 +3193,32 @@ function baml.iter.<(baml.iter.Chain<#0, #1, #2> as baml.iter.Iterable)>.iter(se
 function baml.iter.<(baml.iter.Chain<#0, #1, #2> as baml.iter.Iterator)>.next(self: baml.iter.Chain<#0, #1, #2>) -> #0 | baml.iter.Done {
     load_var self
     load_field .first_done
-    unary_op !
-    pop_jump_if_false L2
+    pop_jump_if_true L1
     load_var self
     load_field .first
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
+    store_var _3
+    load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_var _3
+    jump L2
 
   L0:
-    load_var _4
-    jump L3
-
-  L1:
     load_var self
     load_const true
     store_field .first_done
 
-  L2:
+  L1:
     load_var self
     load_field .other
     load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
 
-  L3:
+  L2:
     return
 }
 
@@ -3529,15 +3229,6 @@ function baml.iter.<(baml.iter.Filter<#0, #1, #2> as baml.iter.Iterable)>.iter(s
 
 function baml.iter.<(baml.iter.Filter<#0, #1, #2> as baml.iter.Iterator)>.next(self: baml.iter.Filter<#0, #1, #2>) -> #0 | baml.iter.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance baml.iter.Done
-    jump L5
-
-  L2:
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
@@ -3546,10 +3237,7 @@ function baml.iter.<(baml.iter.Filter<#0, #1, #2> as baml.iter.Iterator)>.next(s
     store_var _2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_var _2
     store_var_load_var x
     load_var self
@@ -3557,12 +3245,12 @@ function baml.iter.<(baml.iter.Filter<#0, #1, #2> as baml.iter.Iterator)>.next(s
     call_indirect
     pop_jump_if_false L0
     load_var x
-    jump L5
+    jump L2
 
-  L4:
+  L1:
     alloc_instance baml.iter.Done
 
-  L5:
+  L2:
     return
 }
 
@@ -3573,15 +3261,6 @@ function baml.iter.<(baml.iter.FilterMap<#0, #1, #2, #3> as baml.iter.Iterable)>
 
 function baml.iter.<(baml.iter.FilterMap<#0, #1, #2, #3> as baml.iter.Iterator)>.next(self: baml.iter.FilterMap<#0, #1, #2, #3>) -> #1 | baml.iter.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance baml.iter.Done
-    jump L6
-
-  L2:
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #2, Item = #0>
@@ -3590,10 +3269,7 @@ function baml.iter.<(baml.iter.FilterMap<#0, #1, #2, #3> as baml.iter.Iterator)>
     store_var _2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L5
-
-  L3:
+    pop_jump_if_true L1
     load_var2 2 1
     load_field .func
     call_indirect
@@ -3601,17 +3277,14 @@ function baml.iter.<(baml.iter.FilterMap<#0, #1, #2, #3> as baml.iter.Iterator)>
     load_var _6
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L0
-
-  L4:
+    pop_jump_if_true L0
     load_var _6
-    jump L6
+    jump L2
 
-  L5:
+  L1:
     alloc_instance baml.iter.Done
 
-  L6:
+  L2:
     return
 }
 
@@ -3622,15 +3295,6 @@ function baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterable
 
 function baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterator)>.next(self: baml.iter.FlatMap<#0, #1, #2, #3, #4>) -> #1 | baml.iter.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance baml.iter.Done
-    jump L8
-
-  L2:
     load_var self
     load_field .inner
     store_var _2
@@ -3638,13 +3302,10 @@ function baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterator
     store_var _3
     load_var _3
     narrow_bind baml.iter.Iterator<Error = #4, Item = #1>, slot=3
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L10
+    pop_jump_if_false L5
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #2, Item = #0>
@@ -3653,10 +3314,7 @@ function baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterator
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_var2 5 1
     load_field .func
     call_indirect
@@ -3668,11 +3326,11 @@ function baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterator
     store_field .inner
     jump L0
 
-  L5:
+  L1:
     alloc_instance baml.iter.Done
-    jump L8
+    jump L3
 
-  L6:
+  L2:
     load_var _3
     load_type baml.iter.Iterator<Error = #4, Item = #1>
     load_const "next"
@@ -3680,22 +3338,19 @@ function baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterator
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L7
-    jump L9
-
-  L7:
+    pop_jump_if_true L4
     load_var _5
 
-  L8:
+  L3:
     return
 
-  L9:
+  L4:
     load_var self
     alloc_instance baml.iter.Done
     store_field .inner
     jump L0
 
-  L10:
+  L5:
     unreachable
 }
 
@@ -3706,15 +3361,6 @@ function baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterable)>.i
 
 function baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterator)>.next(self: baml.iter.Flatten<#0, #1, #2, #3>) -> #1 | baml.iter.Done {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    alloc_instance baml.iter.Done
-    jump L8
-
-  L2:
     load_var self
     load_field .inner
     store_var _2
@@ -3722,13 +3368,10 @@ function baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterator)>.n
     store_var _3
     load_var _3
     narrow_bind baml.iter.Iterator<Error = #3, Item = #1>, slot=3
-    pop_jump_if_false L3
-    jump L6
-
-  L3:
+    pop_jump_if_true L2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L10
+    pop_jump_if_false L5
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #2, Item = #0>
@@ -3737,10 +3380,7 @@ function baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterator)>.n
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_var _9
     load_type baml.iter.Iterable<Error = #3, Item = #1>
     load_const "iter"
@@ -3750,11 +3390,11 @@ function baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterator)>.n
     store_field .inner
     jump L0
 
-  L5:
+  L1:
     alloc_instance baml.iter.Done
-    jump L8
+    jump L3
 
-  L6:
+  L2:
     load_var _3
     load_type baml.iter.Iterator<Error = #3, Item = #1>
     load_const "next"
@@ -3762,22 +3402,19 @@ function baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterator)>.n
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L7
-    jump L9
-
-  L7:
+    pop_jump_if_true L4
     load_var _5
 
-  L8:
+  L3:
     return
 
-  L9:
+  L4:
     load_var self
     alloc_instance baml.iter.Done
     store_field .inner
     jump L0
 
-  L10:
+  L5:
     unreachable
 }
 
@@ -3795,19 +3432,16 @@ function baml.iter.<(baml.iter.Map<#0, #1, #2, #3> as baml.iter.Iterator)>.next(
     store_var _2
     load_var _2
     is_type baml.iter.Done
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var2 2 1
     load_field .func
     call_indirect
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     alloc_instance baml.iter.Done
 
-  L2:
+  L1:
     return
 }
 
@@ -3819,18 +3453,15 @@ function baml.iter.<(baml.iter.Peekable<#0, #1> as baml.iter.Iterable)>.iter(sel
 function baml.iter.<(baml.iter.Peekable<#0, #1> as baml.iter.Iterator)>.next(self: baml.iter.Peekable<#0, #1>) -> #0 | baml.iter.Done {
     load_var self
     load_field .has_buffer
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var self
     load_field .buffer
     store_var v
@@ -3842,7 +3473,7 @@ function baml.iter.<(baml.iter.Peekable<#0, #1> as baml.iter.Iterator)>.next(sel
     store_field .has_buffer
     load_var v
 
-  L2:
+  L1:
     return
 }
 
@@ -3857,14 +3488,11 @@ function baml.iter.<(baml.iter.Range as baml.iter.Iterator)>.next(self: baml.ite
     load_var self
     load_field .max
     cmp_int_op <
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    alloc_instance baml.iter.Done
     jump L1
 
   L0:
-    alloc_instance baml.iter.Done
-    jump L2
-
-  L1:
     load_var self
     load_field .i
     store_var cur
@@ -3877,7 +3505,7 @@ function baml.iter.<(baml.iter.Range as baml.iter.Iterator)>.next(self: baml.ite
     store_field .i
     load_var cur
 
-  L2:
+  L1:
     return
 }
 
@@ -3891,22 +3519,16 @@ function baml.iter.<(baml.iter.Repeat<#0> as baml.iter.Iterator)>.next(self: bam
     load_field .count
     load_const 0
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    alloc_instance baml.iter.Done
     jump L2
 
-  L1:
-    alloc_instance baml.iter.Done
-    jump L4
-
-  L2:
+  L0:
     load_var self
     copy 0
     load_field .count
@@ -3915,13 +3537,13 @@ function baml.iter.<(baml.iter.Repeat<#0> as baml.iter.Iterator)>.next(self: bam
     store_field .count
     load_var self
     load_field .value
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var self
     load_field .value
 
-  L4:
+  L2:
     return
 }
 
@@ -3936,8 +3558,13 @@ function baml.iter.<(baml.iter.Skip<#0, #1> as baml.iter.Iterator)>.next(self: b
     load_field .remaining
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L1
-    jump L2
+    pop_jump_if_true L1
+    load_var self
+    load_field .source
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    jump L3
 
   L1:
     load_var self
@@ -3945,21 +3572,8 @@ function baml.iter.<(baml.iter.Skip<#0, #1> as baml.iter.Iterator)>.next(self: b
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    jump L5
-
-  L2:
-    load_var self
-    load_field .source
-    load_type baml.iter.Iterator<Error = #1, Item = #0>
-    load_const "next"
-    virtual_call nargs=1 ntypeargs=0
-    store_var _4
-    load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var self
     copy 0
     load_field .remaining
@@ -3968,13 +3582,13 @@ function baml.iter.<(baml.iter.Skip<#0, #1> as baml.iter.Iterator)>.next(self: b
     store_field .remaining
     jump L0
 
-  L4:
+  L2:
     load_var self
     load_const 0
     store_field .remaining
     alloc_instance baml.iter.Done
 
-  L5:
+  L3:
     return
 }
 
@@ -3987,18 +3601,15 @@ function baml.iter.<(baml.iter.SkipWhile<#0, #1, #2> as baml.iter.Iterator)>.nex
   L0:
     load_var self
     load_field .skipping
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    jump L5
+    jump L3
 
-  L2:
+  L1:
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
@@ -4007,30 +3618,26 @@ function baml.iter.<(baml.iter.SkipWhile<#0, #1, #2> as baml.iter.Iterator)>.nex
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _3
     store_var_load_var x
     load_var self
     load_field .predicate
     call_indirect
-    unary_op !
-    pop_jump_if_false L0
+    pop_jump_if_true L0
     load_var self
     load_const false
     store_field .skipping
     load_var x
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_var self
     load_const false
     store_field .skipping
     alloc_instance baml.iter.Done
 
-  L5:
+  L3:
     return
 }
 
@@ -4042,54 +3649,43 @@ function baml.iter.<(baml.iter.StepBy<#0, #1> as baml.iter.Iterable)>.iter(self:
 function baml.iter.<(baml.iter.StepBy<#0, #1> as baml.iter.Iterator)>.next(self: baml.iter.StepBy<#0, #1>) -> #0 | baml.iter.Done {
     load_var self
     load_field .first
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_const 0
     store_var i
 
-  L1:
+  L0:
     load_var2 2 1
     load_field .n
     load_const 1
     sub_int
     cmp_int_op <
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    jump L7
+    jump L4
 
-  L3:
+  L1:
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _9
-    load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L1
+    jump L0
 
-  L5:
+  L2:
     alloc_instance baml.iter.Done
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_var self
     load_const false
     store_field .first
@@ -4099,7 +3695,7 @@ function baml.iter.<(baml.iter.StepBy<#0, #1> as baml.iter.Iterator)>.next(self:
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
 
-  L7:
+  L4:
     return
 }
 
@@ -4113,10 +3709,7 @@ function baml.iter.<(baml.iter.Take<#0, #1> as baml.iter.Iterator)>.next(self: b
     load_field .remaining
     load_const 0
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
@@ -4125,10 +3718,7 @@ function baml.iter.<(baml.iter.Take<#0, #1> as baml.iter.Iterator)>.next(self: b
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var self
     copy 0
     load_field .remaining
@@ -4136,19 +3726,19 @@ function baml.iter.<(baml.iter.Take<#0, #1> as baml.iter.Iterator)>.next(self: b
     bin_op -
     store_field .remaining
     load_var _4
-    jump L4
+    jump L2
 
-  L2:
+  L0:
     load_var self
     load_const 0
     store_field .remaining
     alloc_instance baml.iter.Done
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     alloc_instance baml.iter.Done
 
-  L4:
+  L2:
     return
 }
 
@@ -4160,10 +3750,7 @@ function baml.iter.<(baml.iter.TakeWhile<#0, #1, #2> as baml.iter.Iterable)>.ite
 function baml.iter.<(baml.iter.TakeWhile<#0, #1, #2> as baml.iter.Iterator)>.next(self: baml.iter.TakeWhile<#0, #1, #2>) -> #0 | baml.iter.Done {
     load_var self
     load_field .done
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
@@ -4172,41 +3759,35 @@ function baml.iter.<(baml.iter.TakeWhile<#0, #1, #2> as baml.iter.Iterator)>.nex
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
     store_var_load_var x
     load_var self
     load_field .predicate
     call_indirect
-    pop_jump_if_false L2
-    jump L3
+    pop_jump_if_true L0
+    load_var self
+    load_const true
+    store_field .done
+    jump L2
+
+  L0:
+    load_var x
+    jump L4
+
+  L1:
+    load_var self
+    load_const true
+    store_field .done
 
   L2:
-    load_var self
-    load_const true
-    store_field .done
-    jump L5
+    alloc_instance baml.iter.Done
+    jump L4
 
   L3:
-    load_var x
-    jump L7
+    alloc_instance baml.iter.Done
 
   L4:
-    load_var self
-    load_const true
-    store_field .done
-
-  L5:
-    alloc_instance baml.iter.Done
-    jump L7
-
-  L6:
-    alloc_instance baml.iter.Done
-
-  L7:
     return
 }
 
@@ -4216,8 +3797,6 @@ function baml.iter.<(string as baml.iter.Iterable)>.iter(self: string) -> baml.i
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -4250,8 +3829,6 @@ function baml.iter.Iterator.collect(self: baml.iter.Iterator) -> (#0 as baml.ite
     store_var r
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
@@ -4259,17 +3836,14 @@ function baml.iter.Iterator.collect(self: baml.iter.Iterator) -> (#0 as baml.ite
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type (#0 as baml.iter.Iterator).Item
     load_var2 2 3
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var r
     return
 }
@@ -4279,34 +3853,25 @@ function baml.iter.Iterator.count(self: baml.iter.Iterator) -> int {
     store_var n
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
-    load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var n
     load_const 1
     add_int
     store_var n
     jump L0
 
-  L2:
+  L1:
     load_var n
     return
 }
 
 function baml.iter.Iterator.every(self: baml.iter.Iterator, predicate: ((#0 as baml.iter.Iterator).Item) -> bool throws #1) -> bool {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
@@ -4314,21 +3879,17 @@ function baml.iter.Iterator.every(self: baml.iter.Iterator, predicate: ((#0 as b
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_var2 3 2
+    call_indirect
+    pop_jump_if_true L0
+    load_const false
     jump L2
 
   L1:
-    load_var2 3 2
-    call_indirect
-    unary_op !
-    pop_jump_if_false L0
-    load_const false
-    jump L3
-
-  L2:
     load_const true
 
-  L3:
+  L2:
     return
 }
 
@@ -4353,8 +3914,6 @@ function baml.iter.Iterator.filter_map(self: baml.iter.Iterator, fn: ((#0 as bam
 
 function baml.iter.Iterator.find(self: baml.iter.Iterator, predicate: ((#0 as baml.iter.Iterator).Item) -> bool throws #1) -> (#0 as baml.iter.Iterator).Item | null {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
@@ -4362,22 +3921,19 @@ function baml.iter.Iterator.find(self: baml.iter.Iterator, predicate: ((#0 as ba
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _3
     store_var_load_var x
     load_var predicate
     call_indirect
     pop_jump_if_false L0
     load_var x
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const null
 
-  L3:
+  L2:
     return
 }
 
@@ -4395,8 +3951,6 @@ function baml.iter.Iterator.flat_map(self: baml.iter.Iterator, fn: ((#0 as baml.
 
 function baml.iter.Iterator.for_each(self: baml.iter.Iterator, fn: ((#0 as baml.iter.Iterator).Item) -> void throws #1) -> void {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
@@ -4404,16 +3958,13 @@ function baml.iter.Iterator.for_each(self: baml.iter.Iterator, fn: ((#0 as baml.
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 3 2
     call_indirect
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_const null
     return
 }
@@ -4443,8 +3994,6 @@ function baml.iter.Iterator.reduce(self: baml.iter.Iterator, fn: (#1, (#0 as bam
     store_var acc
 
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
@@ -4452,17 +4001,14 @@ function baml.iter.Iterator.reduce(self: baml.iter.Iterator, fn: (#1, (#0 as bam
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 4 5
     load_var fn
     call_indirect
     store_var acc
     jump L0
 
-  L2:
+  L1:
     load_var acc
     return
 }
@@ -4487,8 +4033,6 @@ function baml.iter.Iterator.skip_while(self: baml.iter.Iterator, predicate: ((#0
 
 function baml.iter.Iterator.some(self: baml.iter.Iterator, predicate: ((#0 as baml.iter.Iterator).Item) -> bool throws #1) -> bool {
   L0:
-    load_const true
-    pop_jump_if_false L2
     load_var self
     load_type baml.iter.Iterator
     load_const "next"
@@ -4496,20 +4040,17 @@ function baml.iter.Iterator.some(self: baml.iter.Iterator, predicate: ((#0 as ba
     store_var _3
     load_var _3
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 3 2
     call_indirect
     pop_jump_if_false L0
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -4543,10 +4084,7 @@ function baml.iter.Iterator.take_while(self: baml.iter.Iterator, predicate: ((#0
 function baml.iter.Peekable.peek(self: baml.iter.Peekable<#0, #1>) -> #0 | baml.iter.Done {
     load_var self
     load_field .has_buffer
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var self
     load_field .source
     load_type baml.iter.Iterator<Error = #1, Item = #0>
@@ -4559,13 +4097,13 @@ function baml.iter.Peekable.peek(self: baml.iter.Peekable<#0, #1>) -> #0 | baml.
     load_const true
     store_field .has_buffer
     load_var v
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var self
     load_field .buffer
 
-  L2:
+  L1:
     return
 }
 
@@ -4615,10 +4153,7 @@ function baml.json._path_field(current: baml.json.json, key: string, selector: s
     store_var _4
     load_var _4
     narrow_bind map<string, baml.json.json>, slot=4
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "field access '."
     load_var key
     bin_op +
@@ -4628,25 +4163,14 @@ function baml.json._path_field(current: baml.json.json, key: string, selector: s
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L1:
+  L0:
     load_var _4
     store_var m
     load_type string
     load_type baml.json.json
     load_var2 5 2
     call baml.Map.has
-    unary_op !
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
-    load_type string
-    load_type baml.json.json
-    load_var2 5 2
-    call baml.Map.get
-    return
-
-  L3:
+    pop_jump_if_true L1
     load_const "missing field '"
     load_var key
     bin_op +
@@ -4655,6 +4179,13 @@ function baml.json._path_field(current: baml.json.json, key: string, selector: s
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
+
+  L1:
+    load_type string
+    load_type baml.json.json
+    load_var2 5 2
+    call baml.Map.get
+    return
 }
 
 function baml.json._path_index(current: baml.json.json, idx: int, selector: string) -> baml.json.json {
@@ -4662,10 +4193,7 @@ function baml.json._path_index(current: baml.json.json, idx: int, selector: stri
     store_var _4
     load_var _4
     narrow_bind baml.json.json[], slot=4
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type int
     load_var idx
     call baml.String.from
@@ -4679,34 +4207,25 @@ function baml.json._path_index(current: baml.json.json, idx: int, selector: stri
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L1:
+  L0:
     load_var _4
     store_var arr
     load_var idx
     load_const 0
     cmp_int_op <
-    jump_if_false L2
-    jump L3
-
-  L2:
-    pop 1
+    pop_jump_if_true L1
     load_var arr
     container_len
     store_var _8
     load_var2 2 6
     cmp_int_op >=
-
-  L3:
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L1
     load_type baml.json.json
     load_var2 5 2
     call baml.Array.at
     return
 
-  L5:
+  L1:
     load_type int
     load_var idx
     call baml.String.from
@@ -4765,61 +4284,55 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var selector
     load_const "."
     call baml.String.starts_with
-    jump_if_false L0
-    jump L1
-
-  L0:
-    pop 1
+    pop_jump_if_true L0
     load_var selector
     load_const "["
     call baml.String.starts_with
+    pop_jump_if_true L0
+    load_const "selector must start with '.' or '[' (jq style), got '"
+    load_var selector
+    bin_op +
+    load_const "'"
+    bin_op +
+    load_var selector
+    init_instance baml.json.PathError .message, .selector
+    throw
 
-  L1:
-    unary_op !
-    pop_jump_if_false L2
-    jump L47
-
-  L2:
+  L0:
     load_var j
     store_var current
     load_const 0
     store_var i
 
-  L3:
+  L1:
     load_var i
-    store_var _12
+    store_var _11
     load_var selector
     call baml.String.length
-    store_var _13
+    store_var _12
     load_var2 5 6
     cmp_int_op <
-    pop_jump_if_false L4
-    jump L8
-
-  L4:
+    pop_jump_if_true L4
     load_type #0
     load_var current
     call baml.json.to
-    jump L7
+    jump L3
     load_var _
     is_type baml.json.DecodeError
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L2
     load_var _
     rethrow
 
-  L6:
+  L2:
     load_const "leaf does not coerce to the requested type"
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L7:
+  L3:
     return
 
-  L8:
+  L4:
     load_var2 2 4
     load_var i
     load_const 1
@@ -4829,32 +4342,23 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var marker
     load_const "."
     cmp_op ==
-    pop_jump_if_false L9
-    jump L41
-
-  L9:
+    pop_jump_if_true L20
     load_var marker
     load_const "["
     cmp_op !=
-    pop_jump_if_false L10
-    jump L40
-
-  L10:
+    pop_jump_if_true L19
     load_var i
     load_const 1
     add_int
     store_var i
     load_var i
-    store_var _48
+    store_var _47
     load_var selector
     call baml.String.length
-    store_var _49
+    store_var _48
     load_var2 14 15
     cmp_int_op >=
-    pop_jump_if_false L11
-    jump L39
-
-  L11:
+    pop_jump_if_true L18
     load_var2 2 4
     load_var i
     load_const 1
@@ -4864,33 +4368,23 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var first
     load_const "\""
     cmp_op ==
-    jump_if_false L12
-    jump L13
-
-  L12:
-    pop 1
+    pop_jump_if_true L11
     load_var first
     load_const "'"
     cmp_op ==
-
-  L13:
-    pop_jump_if_false L14
-    jump L24
-
-  L14:
+    pop_jump_if_true L11
     load_var i
     store_var start
 
-  L15:
+  L5:
     load_var i
-    store_var _103
+    store_var _100
     load_var selector
     call baml.String.length
-    store_var _104
+    store_var _101
     load_var2 29 30
     cmp_int_op <
-    jump_if_false L16
-    pop 1
+    pop_jump_if_false L6
     load_var2 2 4
     load_var i
     load_const 1
@@ -4898,23 +4392,17 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     call baml.String.slice
     load_const "]"
     cmp_op !=
+    pop_jump_if_true L10
 
-  L16:
-    pop_jump_if_false L17
-    jump L23
-
-  L17:
+  L6:
     load_var i
-    store_var _110
+    store_var _108
     load_var selector
     call baml.String.length
-    store_var _111
+    store_var _109
     load_var2 31 32
     cmp_int_op >=
-    pop_jump_if_false L18
-    jump L22
-
-  L18:
+    pop_jump_if_true L9
     load_var2 2 28
     load_var i
     call baml.String.slice
@@ -4926,17 +4414,14 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var token
     call baml.Int.parse
     store_var idx
-    jump L21
+    jump L8
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L19
-    jump L20
-
-  L19:
+    pop_jump_if_true L7
     load_var _
     rethrow
 
-  L20:
+  L7:
     load_const "bad bracket token '["
     load_var token
     bin_op +
@@ -4946,27 +4431,27 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L21:
+  L8:
     load_var2 3 34
     load_var selector
     call baml.json._path_index
     store_var current
-    jump L3
+    jump L1
 
-  L22:
+  L9:
     load_const "unterminated '[' segment"
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L23:
+  L10:
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L15
+    jump L5
 
-  L24:
+  L11:
     load_var i
     load_const 1
     add_int
@@ -4976,15 +4461,15 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_const false
     store_var closed
 
-  L25:
+  L12:
     load_var i
-    store_var _63
+    store_var _62
     load_var selector
     call baml.String.length
-    store_var _64
+    store_var _63
     load_var2 19 20
     cmp_int_op <
-    pop_jump_if_false L29
+    pop_jump_if_false L14
     load_var2 2 4
     load_var i
     load_const 1
@@ -4994,16 +4479,10 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var ch
     load_const "\\"
     cmp_op ==
-    pop_jump_if_false L26
-    jump L36
-
-  L26:
+    pop_jump_if_true L16
     load_var2 21 16
     cmp_op ==
-    pop_jump_if_false L27
-    jump L28
-
-  L27:
+    pop_jump_if_true L13
     load_var2 17 21
     bin_op +
     store_var key
@@ -5011,9 +4490,9 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_const 1
     add_int
     store_var i
-    jump L25
+    jump L12
 
-  L28:
+  L13:
     load_const true
     store_var closed
     load_var i
@@ -5021,28 +4500,17 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     add_int
     store_var i
 
-  L29:
+  L14:
     load_var closed
-    unary_op !
-    jump_if_false L30
-    jump L31
-
-  L30:
-    pop 1
+    pop_jump_if_false L15
     load_var i
-    store_var _91
+    store_var _88
     load_var selector
     call baml.String.length
-    store_var _92
+    store_var _89
     load_var2 26 27
     cmp_int_op >=
-
-  L31:
-    jump_if_false L32
-    jump L33
-
-  L32:
-    pop 1
+    pop_jump_if_true L15
     load_var2 2 4
     load_var i
     load_const 1
@@ -5050,12 +4518,7 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     call baml.String.slice
     load_const "]"
     cmp_op !=
-
-  L33:
-    pop_jump_if_false L34
-    jump L35
-
-  L34:
+    pop_jump_if_true L15
     load_var i
     load_const 1
     add_int
@@ -5064,30 +4527,27 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var selector
     call baml.json._path_field
     store_var current
-    jump L3
+    jump L1
 
-  L35:
+  L15:
     load_const "unterminated quoted bracket key"
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L36:
+  L16:
     load_var i
     load_const 1
     add_int
-    store_var _72
+    store_var _71
     load_var selector
     call baml.String.length
-    store_var _74
+    store_var _73
     load_var2 22 23
     cmp_int_op >=
-    pop_jump_if_false L37
-    jump L38
-
-  L37:
+    pop_jump_if_true L17
     load_var key
-    store_var _76
+    store_var _75
     load_var2 2 4
     load_const 1
     add_int
@@ -5095,7 +4555,7 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_const 2
     add_int
     call baml.String.slice
-    store_var _77
+    store_var _76
     load_var2 24 25
     bin_op +
     store_var key
@@ -5103,33 +4563,33 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_const 2
     add_int
     store_var i
-    jump L25
+    jump L12
 
-  L38:
+  L17:
     load_const "unterminated escape in quoted bracket key"
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L39:
+  L18:
     load_const "unterminated '[' segment"
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L40:
+  L19:
     load_type int
     load_var i
     call baml.String.from
-    store_var _45
+    store_var _44
     load_const "expected '.' or '[' at offset "
-    load_var _45
+    load_var _44
     bin_op +
     load_var selector
     init_instance baml.json.PathError .message, .selector
     throw
 
-  L41:
+  L20:
     load_var i
     load_const 1
     add_int
@@ -5137,16 +4597,15 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     load_var i
     store_var start
 
-  L42:
+  L21:
     load_var i
-    store_var _24
+    store_var _21
     load_var selector
     call baml.String.length
-    store_var _25
+    store_var _22
     load_var2 9 10
     cmp_int_op <
-    jump_if_false L43
-    pop 1
+    pop_jump_if_false L22
     load_var2 2 4
     load_var i
     load_const 1
@@ -5154,10 +4613,7 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     call baml.String.slice
     load_const "."
     cmp_op !=
-
-  L43:
-    jump_if_false L44
-    pop 1
+    pop_jump_if_false L22
     load_var2 2 4
     load_var i
     load_const 1
@@ -5165,63 +4621,47 @@ function baml.json.path(j: baml.json.json, selector: string) -> #0 {
     call baml.String.slice
     load_const "["
     cmp_op !=
+    pop_jump_if_true L23
 
-  L44:
-    pop_jump_if_false L45
-    jump L46
-
-  L45:
+  L22:
     load_var2 4 8
     cmp_int_op >
-    pop_jump_if_false L3
+    pop_jump_if_false L1
     load_var current
-    store_var _37
+    store_var _36
     load_var2 2 8
     load_var i
     call baml.String.slice
-    store_var _38
+    store_var _37
     load_var2 11 12
     load_var selector
     call baml.json._path_field
     store_var current
-    jump L3
+    jump L1
 
-  L46:
+  L23:
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L42
-
-  L47:
-    load_const "selector must start with '.' or '[' (jq style), got '"
-    load_var selector
-    bin_op +
-    load_const "'"
-    bin_op +
-    load_var selector
-    init_instance baml.json.PathError .message, .selector
-    throw
+    jump L21
 }
 
 function baml.json.path_or(j: baml.json.json, selector: string, default: #0) -> #0 {
     load_type #0
     load_var2 1 2
     call baml.json.path
-    jump L2
+    jump L1
     load_var _
     is_type baml.json.PathError
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
+  L0:
     load_var default
 
-  L2:
+  L1:
     return
 }
 
@@ -5379,26 +4819,27 @@ function baml.net.TcpStream.connect(addr: string, timeout: baml.time.Duration | 
     load_var timeout
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_var timeout
+    call baml.time.Duration.to_nanoseconds
     jump L2
 
   L1:
-    load_var timeout
-    call baml.time.Duration.to_nanoseconds
-    jump L3
+    load_const null
 
   L2:
-    load_const null
+    jump_if_not_null_or_pop L3
+    jump L4
 
   L3:
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    store_var _5
+    jump L5
+
+  L4:
     load_const 0n
     store_var _5
 
-  L4:
+  L5:
     load_var2 1 3
     sys_op baml.net.TcpStream._connect
     return
@@ -5428,26 +4869,27 @@ function baml.net.UdpSocket.recv_from(self: baml.net.UdpSocket, timeout: baml.ti
     load_var timeout
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_var timeout
+    call baml.time.Duration.to_nanoseconds
     jump L2
 
   L1:
-    load_var timeout
-    call baml.time.Duration.to_nanoseconds
-    jump L3
+    load_const null
 
   L2:
-    load_const null
+    jump_if_not_null_or_pop L3
+    jump L4
 
   L3:
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    store_var _5
+    jump L5
+
+  L4:
     load_const 0n
     store_var _5
 
-  L4:
+  L5:
     load_var2 1 3
     sys_op baml.net.UdpSocket._recv_from
     return
@@ -5465,26 +4907,27 @@ function baml.net.UdpSocket.send_to(self: baml.net.UdpSocket, data: uint8array, 
     load_var timeout
     load_const null
     cmp_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L1
+    load_var timeout
+    call baml.time.Duration.to_nanoseconds
     jump L2
 
   L1:
-    load_var timeout
-    call baml.time.Duration.to_nanoseconds
-    jump L3
+    load_const null
 
   L2:
-    load_const null
+    jump_if_not_null_or_pop L3
+    jump L4
 
   L3:
-    store_var_load_var _7
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
+    store_var _7
+    jump L5
+
+  L4:
     load_const 0n
     store_var _7
 
-  L4:
+  L5:
     load_var2 1 2
     load_var2 3 5
     sys_op baml.net.UdpSocket._send_to
@@ -5530,30 +4973,24 @@ function baml.ops.<(bigint as baml.ops.BitXor<int>)>.bit_xor(self: bigint, rhs: 
 function baml.ops.<(bigint as baml.ops.Compare)>.cmp(self: bigint, other: bigint) -> baml.ops.Ordering {
     load_var2 1 2
     cmp_bigint_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var2 1 2
     cmp_bigint_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -5602,41 +5039,32 @@ function baml.ops.<(bigint as baml.ops.Subtract<int>)>.sub(self: bigint, rhs: in
 function baml.ops.<(bool as baml.ops.Compare)>.cmp(self: bool, other: bool) -> baml.ops.Ordering {
     load_var self
     is_type true
-    pop_jump_if_false L0
+    pop_jump_if_true L1
+    load_var other
+    is_type true
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
     jump L3
 
   L0:
-    load_var other
-    is_type true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L6
-
-  L2:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
-    jump L6
+    jump L3
 
-  L3:
+  L1:
     load_var other
     is_type true
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_const baml.ops.Ordering.Greater
     alloc_variant baml.ops.Ordering
-    jump L6
+    jump L3
 
-  L5:
+  L2:
     load_const baml.ops.Ordering.Equal
     alloc_variant baml.ops.Ordering
 
-  L6:
+  L3:
     return
 }
 
@@ -5652,30 +5080,24 @@ function baml.ops.<(float as baml.ops.Add<int>)>.add(self: float, rhs: int) -> f
 function baml.ops.<(float as baml.ops.Compare)>.cmp(self: float, other: float) -> baml.ops.Ordering {
     load_var2 1 2
     cmp_float_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var2 1 2
     cmp_float_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -5739,30 +5161,24 @@ function baml.ops.<(int as baml.ops.BitXor<int>)>.bit_xor(self: int, rhs: int) -
 function baml.ops.<(int as baml.ops.Compare)>.cmp(self: int, other: int) -> baml.ops.Ordering {
     load_var2 1 2
     cmp_int_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var2 1 2
     cmp_int_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -5845,30 +5261,24 @@ function baml.ops.<(null as baml.ops.Equals)>.neq(self: null, other: null) -> bo
 function baml.ops.<(string as baml.ops.Compare)>.cmp(self: string, other: string) -> baml.ops.Ordering {
     load_var2 1 2
     cmp_op <
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var2 1 2
     cmp_op >
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_const baml.ops.Ordering.Equal
+    alloc_variant baml.ops.Ordering
+    jump L2
+
+  L0:
+    load_const baml.ops.Ordering.Greater
+    alloc_variant baml.ops.Ordering
     jump L2
 
   L1:
-    load_const baml.ops.Ordering.Equal
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L2:
-    load_const baml.ops.Ordering.Greater
-    alloc_variant baml.ops.Ordering
-    jump L4
-
-  L3:
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
 
-  L4:
+  L2:
     return
 }
 
@@ -5889,13 +5299,10 @@ function baml.ops.Compare.clamp(self: baml.ops.Compare, min: #0, max: #0) -> #0 
     load_type baml.ops.Compare
     load_const "min"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var2 5 2
+    load_var min
     load_type baml.ops.Compare
     load_const "max"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
-    load_var _0
     return
 }
 
@@ -5904,8 +5311,6 @@ function baml.ops.Compare.ge(self: baml.ops.Compare, other: #0) -> bool {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
     call baml.ops.equals_equals
@@ -5918,8 +5323,6 @@ function baml.ops.Compare.gt(self: baml.ops.Compare, other: #0) -> bool {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     load_const baml.ops.Ordering.Greater
     alloc_variant baml.ops.Ordering
     call baml.ops.equals_equals
@@ -5931,8 +5334,6 @@ function baml.ops.Compare.le(self: baml.ops.Compare, other: #0) -> bool {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     load_const baml.ops.Ordering.Greater
     alloc_variant baml.ops.Ordering
     call baml.ops.equals_equals
@@ -5945,8 +5346,6 @@ function baml.ops.Compare.lt(self: baml.ops.Compare, other: #0) -> bool {
     load_type baml.ops.Compare
     load_const "cmp"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     load_const baml.ops.Ordering.Less
     alloc_variant baml.ops.Ordering
     call baml.ops.equals_equals
@@ -6030,8 +5429,6 @@ function baml.ops.Equals.neq(self: baml.ops.Equals, other: #0) -> bool {
     load_type baml.ops.Equals
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _3
-    load_var _3
     unary_op !
     return
 }
@@ -6194,26 +5591,20 @@ function baml.sap.parse(text: string) -> #0 {
     load_type #0
     load_type #0
     sys_op baml.sap._ParseCache._parse_final
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.LlmClient
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_var _
     load_field .0
     init_instance baml.errors.ParseError .message
     throw
 
-  L2:
+  L1:
     return
 }
 
@@ -6317,14 +5708,11 @@ function baml.sys.<(baml.sys.ReadPipeLines as baml.iter.Iterator)>.next(self: ba
 
   L0:
     load_var framing
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var line
     return
 
-  L2:
+  L1:
     load_var self
     load_field ._pending
     load_const 10
@@ -6332,25 +5720,17 @@ function baml.sys.<(baml.sys.ReadPipeLines as baml.iter.Iterator)>.next(self: ba
     store_var _7
     load_var _7
     narrow_bind int, slot=4
-    pop_jump_if_false L3
-    jump L7
-
-  L3:
+    pop_jump_if_true L4
     load_var self
     load_field .pipe
     load_const 65536
     load_type baml.io.Read
     load_const "read"
     virtual_call nargs=2 ntypeargs=0
-    store_var _20
-    load_var _20
     store_var _22
     load_var _22
-    narrow_bind uint8array, slot=12
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    narrow_bind uint8array, slot=11
+    pop_jump_if_true L3
     load_var self
     load_field ._pending
     container_len
@@ -6358,7 +5738,7 @@ function baml.sys.<(baml.sys.ReadPipeLines as baml.iter.Iterator)>.next(self: ba
     load_var _28
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L5
+    pop_jump_if_false L2
     load_var self
     load_field ._pending
     call baml.sys._strip_carriage_return
@@ -6371,22 +5751,22 @@ function baml.sys.<(baml.sys.ReadPipeLines as baml.iter.Iterator)>.next(self: ba
     call baml.deep_copy
     store_field ._pending
 
-  L5:
+  L2:
     load_const false
     store_var framing
     jump L0
 
-  L6:
+  L3:
     load_var self
     load_field ._pending
     load_var _22
     call baml.Uint8Array.concat
     store_var _26
-    load_var2 1 13
+    load_var2 1 12
     store_field ._pending
     jump L0
 
-  L7:
+  L4:
     load_var _7
     store_var index
     load_var self
@@ -6615,59 +5995,44 @@ function baml.time.<(baml.time.Duration as baml.ops.Subtract<baml.time.Duration>
 function baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: baml.json.json) -> baml.time.Instant {
     load_var j
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "Expected timestamp string"
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L1:
+  L0:
     load_var j
     call baml.time.Instant.parse
-    jump L4
+    jump L2
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L3:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L4:
+  L2:
     return
 }
 
 function baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.Instant) -> baml.json.json {
     load_var self
     call baml.time.Instant._to_string_impl
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_var _
     load_field .0
     load_const ""
@@ -6675,34 +6040,28 @@ function baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.
     init_instance baml.json.SerializationError .message, .path, .reason
     throw
 
-  L2:
+  L1:
     return
 }
 
 function baml.time.<(baml.time.Instant as baml.ToString)>.to_string(self: baml.time.Instant) -> string {
     load_var self
     call baml.time.Instant._to_string_impl
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_const "Instant.to_string: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
 
-  L2:
+  L1:
     return
 }
 
@@ -6739,59 +6098,44 @@ function baml.time.<(baml.time.Instant as baml.ops.Subtract<baml.time.Instant>)>
 function baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: baml.json.json) -> baml.time.PlainDate {
     load_var j
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "Expected ISO 8601 date string"
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L1:
+  L0:
     load_var j
     call baml.time.PlainDate.parse
-    jump L4
+    jump L2
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L3:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L4:
+  L2:
     return
 }
 
 function baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.time.PlainDate) -> baml.json.json {
     load_var self
     call baml.time.PlainDate._to_string_impl
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_var _
     load_field .0
     load_const ""
@@ -6799,93 +6143,72 @@ function baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.tim
     init_instance baml.json.SerializationError .message, .path, .reason
     throw
 
-  L2:
+  L1:
     return
 }
 
 function baml.time.<(baml.time.PlainDate as baml.ToString)>.to_string(self: baml.time.PlainDate) -> string {
     load_var self
     call baml.time.PlainDate._to_string_impl
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_const "PlainDate.to_string: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
 
-  L2:
+  L1:
     return
 }
 
 function baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: baml.json.json) -> baml.time.PlainDateTime {
     load_var j
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "Expected zoneless ISO 8601 string"
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L1:
+  L0:
     load_var j
     call baml.time.PlainDateTime.parse
-    jump L4
+    jump L2
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L3:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L4:
+  L2:
     return
 }
 
 function baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml.time.PlainDateTime) -> baml.json.json {
     load_var self
     call baml.time.PlainDateTime._to_string_impl
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_var _
     load_field .0
     load_const ""
@@ -6893,34 +6216,28 @@ function baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml
     init_instance baml.json.SerializationError .message, .path, .reason
     throw
 
-  L2:
+  L1:
     return
 }
 
 function baml.time.<(baml.time.PlainDateTime as baml.ToString)>.to_string(self: baml.time.PlainDateTime) -> string {
     load_var self
     call baml.time.PlainDateTime._to_string_impl
-    jump L2
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L1:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_const "PlainDateTime.to_string: "
     load_var _
     load_field .0
     bin_op +
     call baml.sys.panic
 
-  L2:
+  L1:
     return
 }
 
@@ -6957,39 +6274,30 @@ function baml.time.<(baml.time.PlainDateTime as baml.ops.Subtract<baml.time.Plai
 function baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: baml.json.json) -> baml.time.PlainTime {
     load_var j
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "Expected ISO 8601 time string"
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L1:
+  L0:
     load_var j
     call baml.time.PlainTime.parse
-    jump L4
+    jump L2
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L3:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L4:
+  L2:
     return
 }
 
@@ -7048,39 +6356,30 @@ function baml.time.<(baml.time.PlainTime as baml.ops.Subtract<baml.time.PlainTim
 function baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: baml.json.json) -> baml.time.ZonedDateTime {
     load_var j
     is_type string
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "Expected RFC 3339 / RFC 9557 timestamp string"
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L1:
+  L0:
     load_var j
     call baml.time.ZonedDateTime.parse
-    jump L4
+    jump L2
     load_var _
     is_type baml.errors.ParseError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var _
     rethrow
 
-  L3:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L4:
+  L2:
     return
 }
 
@@ -7096,26 +6395,17 @@ function baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml
     load_var self
     load_field ._iana
     call baml.time._format_zoned
-    jump L4
+    jump L2
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var _
     is_type baml.time.UnknownTimezoneError
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L2:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_const "unknown timezone: "
     load_var _
     load_field .0
@@ -7125,10 +6415,7 @@ function baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml
     init_instance baml.json.SerializationError .message, .path, .reason
     throw
 
-  L3:
-    load_var _
-    load_field .0
-    pop 1
+  L1:
     load_var _
     load_field .0
     load_const ""
@@ -7136,7 +6423,7 @@ function baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml
     init_instance baml.json.SerializationError .message, .path, .reason
     throw
 
-  L4:
+  L2:
     return
 }
 
@@ -7213,21 +6500,18 @@ function baml.time.Duration.from_hours(h: int | bigint) -> baml.time.Duration {
     store_var _4
     load_var _4
     narrow_bind bigint, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0n
     load_var h
     add_bigint
     store_var _3
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _4
     store_var _3
 
-  L2:
+  L1:
     load_var _3
     load_const 3600000000000n
     mul_bigint
@@ -7240,21 +6524,18 @@ function baml.time.Duration.from_microseconds(us: int | bigint) -> baml.time.Dur
     store_var _4
     load_var _4
     narrow_bind bigint, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0n
     load_var us
     add_bigint
     store_var _3
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _4
     store_var _3
 
-  L2:
+  L1:
     load_var _3
     load_const 1000n
     mul_bigint
@@ -7267,21 +6548,18 @@ function baml.time.Duration.from_milliseconds(ms: int | bigint) -> baml.time.Dur
     store_var _4
     load_var _4
     narrow_bind bigint, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0n
     load_var ms
     add_bigint
     store_var _3
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _4
     store_var _3
 
-  L2:
+  L1:
     load_var _3
     load_const 1000000n
     mul_bigint
@@ -7294,21 +6572,18 @@ function baml.time.Duration.from_minutes(m: int | bigint) -> baml.time.Duration 
     store_var _4
     load_var _4
     narrow_bind bigint, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0n
     load_var m
     add_bigint
     store_var _3
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _4
     store_var _3
 
-  L2:
+  L1:
     load_var _3
     load_const 60000000000n
     mul_bigint
@@ -7321,19 +6596,16 @@ function baml.time.Duration.from_nanoseconds(ns: int | bigint) -> baml.time.Dura
     store_var _3
     load_var _3
     narrow_bind bigint, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0n
     load_var ns
     add_bigint
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _3
 
-  L2:
+  L1:
     init_instance baml.time.Duration ._nanoseconds
     return
 }
@@ -7343,21 +6615,18 @@ function baml.time.Duration.from_seconds(s: int | bigint) -> baml.time.Duration 
     store_var _4
     load_var _4
     narrow_bind bigint, slot=3
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const 0n
     load_var s
     add_bigint
     store_var _3
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _4
     store_var _3
 
-  L2:
+  L1:
     load_var _3
     load_const 1000000000n
     mul_bigint
@@ -7479,17 +6748,14 @@ function baml.time.Instant.max(self: baml.time.Instant, other: baml.time.Instant
     load_var self
     load_field ._nanoseconds
     cmp_bigint_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var self
     jump L1
 
   L0:
-    load_var self
-    jump L2
-
-  L1:
     load_var other
 
-  L2:
+  L1:
     return
 }
 
@@ -7499,17 +6765,14 @@ function baml.time.Instant.min(self: baml.time.Instant, other: baml.time.Instant
     load_var self
     load_field ._nanoseconds
     cmp_bigint_op <
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var self
     jump L1
 
   L0:
-    load_var self
-    jump L2
-
-  L1:
     load_var other
 
-  L2:
+  L1:
     return
 }
 
@@ -7662,17 +6925,14 @@ function baml.time.PlainDateTime.max(self: baml.time.PlainDateTime, other: baml.
     load_var self
     load_field ._nanoseconds
     cmp_bigint_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var self
     jump L1
 
   L0:
-    load_var self
-    jump L2
-
-  L1:
     load_var other
 
-  L2:
+  L1:
     return
 }
 
@@ -7685,17 +6945,14 @@ function baml.time.PlainDateTime.min(self: baml.time.PlainDateTime, other: baml.
     load_var self
     load_field ._nanoseconds
     cmp_bigint_op <
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var self
     jump L1
 
   L0:
-    load_var self
-    jump L2
-
-  L1:
     load_var other
 
-  L2:
+  L1:
     return
 }
 
@@ -7728,50 +6985,45 @@ function baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezon
   L0:
     load_var timezone
     is_type baml.time.TimeZoneOffset
-    pop_jump_if_false L1
-    jump L14
-
-  L1:
+    pop_jump_if_true L12
     load_var disambiguation
     load_const "reject"
     call baml.ops.equals_equals
-    pop_jump_if_false L2
-    jump L6
-
-  L2:
+    pop_jump_if_true L5
     load_var2 2 1
     load_field ._nanoseconds
     load_var disambiguation
     sys_op baml.time._tz_to_instant
-    store_var _30
-    load_var _30
+    store_var _29
+    load_var _29
     load_const null
     cmp_op ==
-    pop_jump_if_false L3
-    jump L5
+    pop_jump_if_true L4
+    load_var _29
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _35
+    jump L3
+
+  L2:
+    load_const 0n
+    store_var _35
 
   L3:
-    load_var _30
-    store_var_load_var _36
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L4
-    load_const 0n
-    store_var _36
-
-  L4:
-    load_var _36
+    load_var _35
     load_const null
     load_var timezone
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
-    jump L15
+    jump L13
 
-  L5:
+  L4:
     load_var timezone
     init_instance baml.time.UnknownTimezoneError .timezone
     throw
 
-  L6:
+  L5:
     load_var2 2 1
     load_field ._nanoseconds
     load_const "earlier"
@@ -7780,10 +7032,7 @@ function baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezon
     load_var _11
     load_const null
     cmp_op ==
-    pop_jump_if_false L7
-    jump L13
-
-  L7:
+    pop_jump_if_true L11
     load_var _11
     store_var earlier
     load_var2 2 1
@@ -7794,49 +7043,47 @@ function baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezon
     load_var _16
     load_const null
     cmp_op ==
-    pop_jump_if_false L8
-    jump L12
-
-  L8:
+    pop_jump_if_true L10
     load_var2 5 6
     call baml.ops.equals_equals
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
+    pop_jump_if_true L6
     load_const "wall-clock time is ambiguous or skipped in timezone "
     load_var timezone
     bin_op +
     init_instance baml.time.AmbiguousTimeError .message
     throw
 
-  L10:
+  L6:
     load_var earlier
-    store_var_load_var _25
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L11
+    jump_if_not_null_or_pop L7
+    jump L8
+
+  L7:
+    store_var _25
+    jump L9
+
+  L8:
     load_const 0n
     store_var _25
 
-  L11:
+  L9:
     load_var _25
     load_const null
     load_var timezone
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
-    jump L15
+    jump L13
+
+  L10:
+    load_var timezone
+    init_instance baml.time.UnknownTimezoneError .timezone
+    throw
+
+  L11:
+    load_var timezone
+    init_instance baml.time.UnknownTimezoneError .timezone
+    throw
 
   L12:
-    load_var timezone
-    init_instance baml.time.UnknownTimezoneError .timezone
-    throw
-
-  L13:
-    load_var timezone
-    init_instance baml.time.UnknownTimezoneError .timezone
-    throw
-
-  L14:
     load_var self
     load_field ._nanoseconds
     load_var timezone
@@ -7847,7 +7094,7 @@ function baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezon
     load_const null
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
 
-  L15:
+  L13:
     return
 }
 
@@ -7966,24 +7213,25 @@ function baml.time.TimeZoneOffset.from_timezone(timezone: string, at: baml.time.
     load_var _3
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
+    pop_jump_if_true L3
+    load_var _3
+    jump_if_not_null_or_pop L0
+    jump L1
 
   L0:
-    load_var _3
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    store_var _9
+    jump L2
+
+  L1:
     load_const 0
     store_var _9
 
-  L1:
+  L2:
     load_var _9
     init_instance baml.time.TimeZoneOffset ._nanoseconds
     return
 
-  L2:
+  L3:
     load_var timezone
     init_instance baml.time.UnknownTimezoneError .timezone
     throw
@@ -7999,10 +7247,7 @@ function baml.time.TimeZoneOffset.hours(self: baml.time.TimeZoneOffset) -> int {
 
 function baml.time.TimeZoneOffset.local() -> baml.time.TimeZoneOffset {
     sys_op baml.time.system_timezone
-    store_var _1
     sys_op baml.time.Instant.now
-    store_var _2
-    load_var2 1 2
     call baml.time.TimeZoneOffset.from_timezone
     return
 }
@@ -8021,32 +7266,23 @@ function baml.time.TimeZoneOffset.new(hours: int, minutes: int) -> baml.time.Tim
     load_var hours
     load_const 0
     cmp_int_op >
-    jump_if_false L0
-    pop 1
+    pop_jump_if_false L0
     load_var minutes
     load_const 0
     cmp_int_op <
+    pop_jump_if_true L3
 
   L0:
-    jump_if_false L1
-    jump L2
-
-  L1:
-    pop 1
     load_var hours
     load_const 0
     cmp_int_op <
-    jump_if_false L2
-    pop 1
+    pop_jump_if_false L1
     load_var minutes
     load_const 0
     cmp_int_op >
+    pop_jump_if_true L3
 
-  L2:
-    pop_jump_if_false L3
-    jump L8
-
-  L3:
+  L1:
     load_var hours
     load_const 60
     mul_int
@@ -8059,30 +7295,21 @@ function baml.time.TimeZoneOffset.new(hours: int, minutes: int) -> baml.time.Tim
     store_var_load_var nanoseconds
     load_const 86400000000000
     cmp_int_op >
-    jump_if_false L4
-    jump L5
-
-  L4:
-    pop 1
+    pop_jump_if_true L2
     load_var nanoseconds
     load_const -86400000000000
     cmp_int_op <
-
-  L5:
-    pop_jump_if_false L6
-    jump L7
-
-  L6:
+    pop_jump_if_true L2
     load_var nanoseconds
     init_instance baml.time.TimeZoneOffset ._nanoseconds
     return
 
-  L7:
+  L2:
     load_const "TimeZoneOffset out of range: must be within ±24 hours"
     init_instance baml.errors.InvalidArgument .message
     throw
 
-  L8:
+  L3:
     load_const "TimeZoneOffset.new: hours and minutes must carry the same sign"
     init_instance baml.errors.InvalidArgument .message
     throw
@@ -8181,18 +7408,15 @@ function baml.time.ZonedDateTime.from_components(timezone: baml.time.TimeZoneOff
 function baml.time.ZonedDateTime.from_instant(instant: baml.time.Instant, timezone: baml.time.TimeZoneOffset | string) -> baml.time.ZonedDateTime {
     load_var timezone
     is_type baml.time.TimeZoneOffset
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var instant
     load_field ._nanoseconds
     load_const null
     load_var timezone
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var instant
     load_field ._nanoseconds
     load_var timezone
@@ -8200,7 +7424,7 @@ function baml.time.ZonedDateTime.from_instant(instant: baml.time.Instant, timezo
     load_const null
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
 
-  L2:
+  L1:
     return
 }
 
@@ -8217,17 +7441,14 @@ function baml.time.ZonedDateTime.max(self: baml.time.ZonedDateTime, other: baml.
     load_var self
     load_field ._nanoseconds
     cmp_bigint_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var self
     jump L1
 
   L0:
-    load_var self
-    jump L2
-
-  L1:
     load_var other
 
-  L2:
+  L1:
     return
 }
 
@@ -8244,17 +7465,14 @@ function baml.time.ZonedDateTime.min(self: baml.time.ZonedDateTime, other: baml.
     load_var self
     load_field ._nanoseconds
     cmp_bigint_op <
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var self
     jump L1
 
   L0:
-    load_var self
-    jump L2
-
-  L1:
     load_var other
 
-  L2:
+  L1:
     return
 }
 
@@ -8274,10 +7492,7 @@ function baml.time.ZonedDateTime.month(self: baml.time.ZonedDateTime) -> int {
 
 function baml.time.ZonedDateTime.now() -> baml.time.ZonedDateTime {
     sys_op baml.time.Instant.now
-    store_var _1
     sys_op baml.time.system_timezone
-    store_var _2
-    load_var2 1 2
     call baml.time.ZonedDateTime.from_instant
     return
 }
@@ -8305,37 +7520,33 @@ function baml.time.ZonedDateTime.timezone(self: baml.time.ZonedDateTime) -> baml
     store_var_load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
+    pop_jump_if_true L1
+    load_var _2
+    jump_if_not_null_or_pop L0
+    load_const ""
 
   L0:
-    load_var _2
-    store_var_load_var _9
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
-    load_const ""
-    store_var _9
+    jump L5
 
   L1:
-    load_var _9
-    jump L4
-
-  L2:
     load_var self
     load_field ._offset_ns
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
+    jump_if_not_null_or_pop L2
+    jump L3
+
+  L2:
+    store_var _5
+    jump L4
+
+  L3:
     load_const 0
     store_var _5
 
-  L3:
+  L4:
     load_var _5
     init_instance baml.time.TimeZoneOffset ._nanoseconds
 
-  L4:
+  L5:
     return
 }
 
@@ -8345,73 +7556,75 @@ function baml.time.ZonedDateTime.timezone_offset(self: baml.time.ZonedDateTime) 
     store_var_load_var _2
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L8
     load_var _2
     store_var_load_var iana
-    store_var_load_var _11
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L1
+    jump_if_not_null_or_pop L0
     load_const ""
-    store_var _11
 
-  L1:
-    load_var2 6 1
+  L0:
+    load_var self
     load_field ._nanoseconds
     sys_op baml.time._tz_offset_at
-    store_var _9
-    load_var _9
+    store_var _8
+    load_var _8
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
-    jump L4
+    pop_jump_if_true L4
+    load_var _8
+    jump_if_not_null_or_pop L1
+    jump L2
+
+  L1:
+    store_var _20
+    jump L3
 
   L2:
-    load_var _9
-    store_var_load_var _23
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L3
     load_const 0
-    store_var _23
+    store_var _20
 
   L3:
-    load_var _23
+    load_var _20
     init_instance baml.time.TimeZoneOffset ._nanoseconds
-    jump L8
+    jump L12
 
   L4:
     load_var iana
-    store_var_load_var _18
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L5
-    load_const ""
-    store_var _18
+    jump_if_not_null_or_pop L5
+    jump L6
 
   L5:
-    load_var _18
+    store_var _16
+    jump L7
+
+  L6:
+    load_const ""
+    store_var _16
+
+  L7:
+    load_var _16
     init_instance baml.time.UnknownTimezoneError .timezone
     throw
 
-  L6:
+  L8:
     load_var self
     load_field ._offset_ns
-    store_var_load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L7
+    jump_if_not_null_or_pop L9
+    jump L10
+
+  L9:
+    store_var _5
+    jump L11
+
+  L10:
     load_const 0
     store_var _5
 
-  L7:
+  L11:
     load_var _5
     init_instance baml.time.TimeZoneOffset ._nanoseconds
 
-  L8:
+  L12:
     return
 }
 
@@ -8469,21 +7682,18 @@ function baml.time._wrap_into_day(total_ns: bigint) -> int {
     load_const 86400000000000n
     mod_bigint
     call baml.Bigint.to_int
-    jump L2
+    jump L1
     load_var e
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var e
     rethrow
 
-  L1:
+  L0:
     load_const "unreachable: nanoseconds wrapped into [0, 24h) exceed int range"
     call baml.sys.panic
 
-  L2:
+  L1:
     return
 }
 
@@ -8609,16 +7819,13 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
 function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     load_var j
     is_type map<_, _>
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const "expected map"
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
 
-  L1:
+  L0:
     load_const null /* unknown class: map */
     store_var items
     load_type string
@@ -8630,7 +7837,7 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
-  L2:
+  L1:
     load_var _7
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -8638,10 +7845,7 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L5
-
-  L3:
+    pop_jump_if_true L2
     load_var _8
     store_var key
     load_var2 1 5
@@ -8649,19 +7853,16 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     store_var_load_var _13
     load_const null
     cmp_op ==
-    pop_jump_if_false L4
-    jump L2
-
-  L4:
+    pop_jump_if_true L1
     load_var _13
     call baml.toml.item_from_json
     store_var _19
     load_var2 2 5
     load_var _19
     store_map_element
-    jump L2
+    jump L1
 
-  L5:
+  L2:
     load_var items
     init_instance baml.toml.Table .items
     return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -282,32 +282,36 @@ function baml.Array.join(self: #0[], separator: string) -> string {
     cmp_int_op >=
     pop_jump_if_false L6
     load_var self
+    load_const 0
+    load_array_element
+    pop 1
+    load_var self
     container_len
-    store_var _14
+    store_var _15
     load_var self
     load_const 1
-    load_var _14
+    load_var _15
     call baml.Array.slice
-    store_var _13
+    store_var _14
     load_type #0
     load_var self
     load_const 0
     load_array_element
     call baml.String.from
     store_var joined
-    load_var _13
+    load_var _14
     load_type baml.iter.Iterable<Error = never, Item = #0>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _20
+    store_var _21
 
   L1:
-    load_var _20
+    load_var _21
     load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _21
-    load_var _21
+    store_var _22
+    load_var _22
     is_type baml.iter.Done
     pop_jump_if_false L2
     jump L3
@@ -315,11 +319,11 @@ function baml.Array.join(self: #0[], separator: string) -> string {
   L2:
     load_var2 7 2
     bin_op +
-    store_var _25
+    store_var _26
     load_type #0
-    load_var _21
+    load_var _22
     call baml.String.from
-    store_var _27
+    store_var _28
     load_var2 10 11
     bin_op +
     store_var joined
@@ -1889,6 +1893,9 @@ function baml.csv.create(path: string, options: baml.csv.WriterOptions | null) -
   L2:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     init_instance baml.errors.Io .message
     throw
 
@@ -1928,6 +1935,9 @@ function baml.csv.decode(source: string | uint8array, options: baml.csv.ReaderOp
     rethrow
 
   L2:
+    load_var _
+    load_field .0
+    pop 1
     load_const "unreachable: in-memory CSV source raised Io: "
     load_var _
     load_field .0
@@ -2086,6 +2096,9 @@ function baml.csv.open(path: string, options: baml.csv.ReaderOptions | null) -> 
   L2:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     init_instance baml.errors.Io .message
     throw
 
@@ -2144,6 +2157,9 @@ function baml.csv.parse(source: string | uint8array, options: baml.csv.ReaderOpt
     rethrow
 
   L4:
+    load_var _
+    load_field .0
+    pop 1
     load_const "unreachable: in-memory CSV source raised Io: "
     load_var _
     load_field .0
@@ -2228,6 +2244,9 @@ function baml.csv.stringify(rows: #0[], options: baml.csv.WriterOptions | null) 
     rethrow
 
   L2:
+    load_var _
+    load_field .0
+    pop 1
     load_const "unreachable: buffer writer raised Io: "
     load_var _
     load_field .0
@@ -2287,6 +2306,9 @@ function baml.csv.stringify_records(records: (null | bool | int | bigint | float
     rethrow
 
   L5:
+    load_var _
+    load_field .0
+    pop 1
     load_const "unreachable: buffer writer raised Io: "
     load_var _
     load_field .0
@@ -2578,8 +2600,8 @@ function baml.errors.UnknownError.from(data: unknown) -> #0 | baml.errors.Unknow
 
   L1:
     load_var data
-    store_var _12
-    load_var _12
+    store_var _13
+    load_var _13
     narrow_bind baml.errors.UnknownError, slot=6
     pop_jump_if_false L2
     jump L3
@@ -2597,7 +2619,7 @@ function baml.errors.UnknownError.from(data: unknown) -> #0 | baml.errors.Unknow
     jump L6
 
   L3:
-    load_var _12
+    load_var _13
     store_var error
     load_var2 1 7
     call baml.errors.UnknownError._preserve_context
@@ -2606,6 +2628,9 @@ function baml.errors.UnknownError.from(data: unknown) -> #0 | baml.errors.Unknow
     jump L6
 
   L4:
+    load_var data
+    load_field .0
+    pop 1
     load_var _8
     store_var inner
     load_var2 1 5
@@ -2648,8 +2673,8 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
 
   L1:
     load_var data
-    store_var _13
-    load_var _13
+    store_var _14
+    load_var _14
     narrow_bind baml.errors.UnknownError, slot=7
     pop_jump_if_false L2
     jump L3
@@ -2667,7 +2692,7 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     jump L6
 
   L3:
-    load_var _13
+    load_var _14
     store_var error
     load_type string
     load_var error
@@ -2676,7 +2701,7 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     load_type string
     alloc_array 1
     call baml.Array.concat
-    store_var _18
+    store_var _19
     load_var2 8 9
     store_field .message
     load_var2 1 8
@@ -2686,6 +2711,9 @@ function baml.errors.UnknownError.with_message(data: unknown, message: string) -
     jump L6
 
   L4:
+    load_var data
+    load_field .0
+    pop 1
     load_var _9
     store_var inner
     load_var2 1 6
@@ -6179,6 +6207,9 @@ function baml.sap.parse(text: string) -> #0 {
   L1:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     init_instance baml.errors.ParseError .message
     throw
 
@@ -6609,6 +6640,9 @@ function baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: baml.json
   L3:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
@@ -6631,6 +6665,9 @@ function baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_var _
     load_field .0
     load_const ""
@@ -6656,6 +6693,9 @@ function baml.time.<(baml.time.Instant as baml.ToString)>.to_string(self: baml.t
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_const "Instant.to_string: "
     load_var _
     load_field .0
@@ -6724,6 +6764,9 @@ function baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: baml.js
   L3:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
@@ -6746,6 +6789,9 @@ function baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.tim
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_var _
     load_field .0
     load_const ""
@@ -6771,6 +6817,9 @@ function baml.time.<(baml.time.PlainDate as baml.ToString)>.to_string(self: baml
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_const "PlainDate.to_string: "
     load_var _
     load_field .0
@@ -6809,6 +6858,9 @@ function baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: bam
   L3:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
@@ -6831,6 +6883,9 @@ function baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_var _
     load_field .0
     load_const ""
@@ -6856,6 +6911,9 @@ function baml.time.<(baml.time.PlainDateTime as baml.ToString)>.to_string(self: 
     rethrow
 
   L1:
+    load_var _
+    load_field .0
+    pop 1
     load_const "PlainDateTime.to_string: "
     load_var _
     load_field .0
@@ -6922,6 +6980,9 @@ function baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: baml.js
     rethrow
 
   L3:
+    load_var _
+    load_field .0
+    pop 1
     load_var _
     load_field .0
     load_const ""
@@ -7012,6 +7073,9 @@ function baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: bam
   L3:
     load_var _
     load_field .0
+    pop 1
+    load_var _
+    load_field .0
     load_const ""
     init_instance baml.json.DecodeError .message, .path
     throw
@@ -7049,6 +7113,9 @@ function baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml
     rethrow
 
   L2:
+    load_var _
+    load_field .0
+    pop 1
     load_const "unknown timezone: "
     load_var _
     load_field .0
@@ -7059,6 +7126,9 @@ function baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml
     throw
 
   L3:
+    load_var _
+    load_field .0
+    pop 1
     load_var _
     load_field .0
     load_const ""

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -39,6 +39,7 @@ fn baml.Bigint.random(lower: bigint, upper: bigint, rng: baml.random.Rng) -> big
     let _20: bigint
     let _21: uint8array
     let _22: int
+    let _23: string
 
     bb0: {
         _4 = copy _3 == const <omitted>;
@@ -93,11 +94,12 @@ fn baml.Bigint.random(lower: bigint, upper: bigint, rng: baml.random.Rng) -> big
 
     bb11: {
         _12 = load_type(bigint);
+        _23 = const "bigint.random: lower (";
         _11 = call const fn baml.String.from<copy _12>(copy _1) -> [bb12];
     }
 
     bb12: {
-        _10 = const "bigint.random: lower (" + copy _11;
+        _10 = copy _23 + copy _11;
         _9 = copy _10 + const ") must be less than upper (";
         _14 = load_type(bigint);
         _13 = call const fn baml.String.from<copy _14>(copy _2) -> [bb13];
@@ -644,26 +646,24 @@ fn baml.Array.join(self: baml.Array, separator: string) -> string {
     let _8: bool
     let _9: int
     let _10: T
-    let _11: int
-    let _12: T
-    let _13: T // first
-    let _14: T[]
-    let _15: int
-    let _16: T[] // rest
-    let _17: string // joined
-    let _18: T
-    let _19: reflect.Type
-    let _20: T[]
-    let _21: baml.iter.Iterator<Error = never, Item = T>
-    let _22: unknown
-    let _23: bool
-    let _24: T
-    let _25: T // item
+    let _11: T // first
+    let _12: T[]
+    let _13: int
+    let _14: T[] // rest
+    let _15: string // joined
+    let _16: T
+    let _17: reflect.Type
+    let _18: T[]
+    let _19: baml.iter.Iterator<Error = never, Item = T>
+    let _20: unknown
+    let _21: bool
+    let _22: T
+    let _23: T // item
+    let _24: string
+    let _25: string
     let _26: string
-    let _27: string
-    let _28: string
-    let _29: T
-    let _30: reflect.Type
+    let _27: T
+    let _28: reflect.Type
 
     bb0: {
         _3 = is_type_tag(copy _1, LIST);
@@ -673,7 +673,7 @@ fn baml.Array.join(self: baml.Array, separator: string) -> string {
     bb1: {
         _4 = len(_1);
         _5 = copy _4 == const 0_i64;
-        branch copy _5 -> [bb14, bb2];
+        branch copy _5 -> [bb13, bb2];
     }
 
     bb2: {
@@ -694,66 +694,59 @@ fn baml.Array.join(self: baml.Array, separator: string) -> string {
     bb5: {
         _9 = const 0_i64;
         _10 = copy _1[_9];
-        drop(_10);
-        goto -> bb6;
+        _11 = copy _10;
+        _13 = len(_1);
+        _12 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _13) -> [bb6];
     }
 
     bb6: {
-        _11 = const 0_i64;
-        _12 = copy _1[_11];
-        _13 = copy _12;
-        _15 = len(_1);
-        _14 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _15) -> [bb7];
+        _14 = copy _12;
+        _16 = copy _11;
+        _17 = load_type(#0);
+        _15 = call const fn baml.String.from<copy _17>(copy _16) -> [bb7];
     }
 
     bb7: {
-        _16 = copy _14;
-        _18 = copy _13;
-        _19 = load_type(#0);
-        _17 = call const fn baml.String.from<copy _19>(copy _18) -> [bb8];
+        _18 = copy _14;
+        _19 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _18) -> [bb8];
     }
 
     bb8: {
-        _20 = copy _16;
-        _21 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _20) -> [bb9];
+        _20 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _19) -> [bb9];
     }
 
     bb9: {
-        _22 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _21) -> [bb10];
+        _21 = is_type(copy _20, baml.iter.Done);
+        branch copy _21 -> [bb12, bb10];
     }
 
     bb10: {
-        _23 = is_type(copy _22, baml.iter.Done);
-        branch copy _23 -> [bb13, bb11];
+        _22 = copy _20;
+        fresh_cell(_23);
+        _23 = copy _22;
+        _25 = copy _15;
+        _24 = copy _25 + copy _2;
+        _27 = copy _23;
+        _28 = load_type(#0);
+        _26 = call const fn baml.String.from<copy _28>(copy _27) -> [bb11];
     }
 
     bb11: {
-        _24 = copy _22;
-        fresh_cell(_25);
-        _25 = copy _24;
-        _27 = copy _17;
-        _26 = copy _27 + copy _2;
-        _29 = copy _25;
-        _30 = load_type(#0);
-        _28 = call const fn baml.String.from<copy _30>(copy _29) -> [bb12];
+        _15 = copy _24 + copy _26;
+        goto -> bb8;
     }
 
     bb12: {
-        _17 = copy _26 + copy _28;
-        goto -> bb9;
+        _0 = copy _15;
+        goto -> bb14;
     }
 
     bb13: {
-        _0 = copy _17;
-        goto -> bb15;
+        _0 = const "";
+        goto -> bb14;
     }
 
     bb14: {
-        _0 = const "";
-        goto -> bb15;
-    }
-
-    bb15: {
         return;
     }
 }
@@ -1011,26 +1004,32 @@ fn baml.Float.is_finite(self: baml.Float) -> bool {
     let _2: bool
     let _3: bool
     let _4: bool
+    let _5: bool
 
     bb0: {
-        _3 = call const fn baml.Float.is_nan(copy _1) -> [bb1];
+        _4 = call const fn baml.Float.is_nan(copy _1) -> [bb1];
     }
 
     bb1: {
-        _2 = !copy _3;
-        _0 = short_circuit(&&) copy _2 -> [eval: bb2, join: bb4];
+        _3 = !copy _4;
+        _2 = short_circuit(&&) copy _3 -> [eval: bb2, join: bb4];
     }
 
     bb2: {
-        _4 = call const fn baml.Float.is_infinite(copy _1) -> [bb3];
+        _5 = call const fn baml.Float.is_infinite(copy _1) -> [bb3];
     }
 
     bb3: {
-        _0 = !copy _4;
+        _2 = !copy _5;
         goto -> bb4;
     }
 
     bb4: {
+        _0 = copy _2;
+        goto -> bb5;
+    }
+
+    bb5: {
         return;
     }
 }
@@ -1222,6 +1221,7 @@ fn baml.Int.random(lower: int, upper: int, rng: baml.random.Rng) -> int {
     let _17: bool
     let _18: int
     let _19: int
+    let _20: string
 
     bb0: {
         _4 = copy _3 == const <omitted>;
@@ -1270,11 +1270,12 @@ fn baml.Int.random(lower: int, upper: int, rng: baml.random.Rng) -> int {
 
     bb10: {
         _12 = load_type(int);
+        _20 = const "int.random: lower (";
         _11 = call const fn baml.String.from<copy _12>(copy _1) -> [bb11];
     }
 
     bb11: {
-        _10 = const "int.random: lower (" + copy _11;
+        _10 = copy _20 + copy _11;
         _9 = copy _10 + const ") must be less than upper (";
         _14 = load_type(int);
         _13 = call const fn baml.String.from<copy _14>(copy _2) -> [bb12];
@@ -1558,68 +1559,55 @@ fn baml.csv.<(baml.csv.Reader as baml.iter.Iterator)>.next(self: baml.csv.Reader
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _2 = call const fn baml.csv.Reader._poll(copy _1) -> [bb2];
     }
 
     bb2: {
-        _0 = call const fn baml.sys.panic(const "unreachable: Reader.next loop ended") -> [bb13];
+        _3 = copy _2;
+        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "Record" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb3];
     }
 
     bb3: {
-        _2 = call const fn baml.csv.Reader._poll(copy _1) -> [bb4];
+        _5 = copy _2;
+        _5 = narrow_bind copy _5 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb4];
     }
 
     bb4: {
-        _3 = copy _2;
-        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "Record" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb12, bb5];
+        _7 = copy _2;
+        _7 = narrow_bind copy _7 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "_Skip" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb5];
     }
 
     bb5: {
-        _5 = copy _2;
-        _5 = narrow_bind copy _5 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb11, bb6];
-    }
-
-    bb6: {
-        _7 = copy _2;
-        _7 = narrow_bind copy _7 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "_Skip" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb7];
-    }
-
-    bb7: {
         _15 = call const fn baml.csv.Reader._read_chunk(copy _1) -> [bb1];
     }
 
-    bb8: {
+    bb6: {
         _8 = copy _7;
         _10 = copy _1.2;
         _11 = copy _10 == const null;
-        branch copy _11 -> [bb10, bb9];
+        branch copy _11 -> [bb1, bb7];
     }
 
-    bb9: {
+    bb7: {
         _12 = copy _10;
         _13 = copy _12;
         _14 = copy _8.0;
         _9 = call copy _13(copy _14) -> [bb1];
     }
 
-    bb10: {
-        _9 = const null;
-        goto -> bb1;
-    }
-
-    bb11: {
+    bb8: {
         _6 = copy _5;
         _0 = copy _6;
-        goto -> bb13;
+        goto -> bb10;
     }
 
-    bb12: {
+    bb9: {
         _4 = copy _3;
         _0 = copy _4;
-        goto -> bb13;
+        goto -> bb10;
     }
 
-    bb13: {
+    bb10: {
         return;
     }
 }
@@ -1638,33 +1626,25 @@ fn baml.csv.Reader.headers(self: baml.csv.Reader) -> null | string[] {
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _2 = call const fn baml.csv.Reader._poll_headers(copy _1) -> [bb2];
     }
 
     bb2: {
-        _0 = call const fn baml.sys.panic(const "unreachable: Reader.headers loop ended") -> [bb7];
+        _3 = copy _2;
+        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "_Headers" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb4, bb3];
     }
 
     bb3: {
-        _2 = call const fn baml.csv.Reader._poll_headers(copy _1) -> [bb4];
-    }
-
-    bb4: {
-        _3 = copy _2;
-        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "_Headers" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb5];
-    }
-
-    bb5: {
         _5 = call const fn baml.csv.Reader._read_chunk(copy _1) -> [bb1];
     }
 
-    bb6: {
+    bb4: {
         _4 = copy _3;
         _0 = copy _4.0;
-        goto -> bb7;
+        goto -> bb5;
     }
 
-    bb7: {
+    bb5: {
         return;
     }
 }
@@ -1883,68 +1863,55 @@ fn baml.csv.<(baml.csv.Rows<#0> as baml.iter.Iterator)>.next(self: baml.csv.Rows
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _3 = copy _1.0;
+        _2 = virtual_call next as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _0 = call const fn baml.sys.panic(const "unreachable: Rows.next loop ended") -> [bb12];
+        _4 = copy _2;
+        _4 = narrow_bind copy _4 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb3];
     }
 
     bb3: {
-        _3 = copy _1.0;
-        _2 = virtual_call next as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>(copy _3) -> [bb4];
-    }
-
-    bb4: {
-        _4 = copy _2;
-        _4 = narrow_bind copy _4 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Done" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb11, bb5];
-    }
-
-    bb5: {
         _6 = copy _2;
         _8 = copy _6;
         _9 = copy _1.0;
         _10 = load_type(#0);
-        _7 = call const fn baml.csv._try_decode<copy _10>(copy _8, copy _9) -> [bb6];
+        _7 = call const fn baml.csv._try_decode<copy _10>(copy _8, copy _9) -> [bb4];
+    }
+
+    bb4: {
+        _11 = copy _7;
+        _11 = narrow_bind copy _11 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "_Skip" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb5];
+    }
+
+    bb5: {
+        _19 = copy _7;
+        _0 = copy _19;
+        goto -> bb9;
     }
 
     bb6: {
-        _11 = copy _7;
-        _11 = narrow_bind copy _11 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["csv"], name: "_Skip" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb7];
-    }
-
-    bb7: {
-        _19 = copy _7;
-        _0 = copy _19;
-        goto -> bb12;
-    }
-
-    bb8: {
         _12 = copy _11;
         _14 = copy _1.0.2;
         _15 = copy _14 == const null;
-        branch copy _15 -> [bb10, bb9];
+        branch copy _15 -> [bb1, bb7];
     }
 
-    bb9: {
+    bb7: {
         _16 = copy _14;
         _17 = copy _16;
         _18 = copy _12.0;
         _13 = call copy _17(copy _18) -> [bb1];
     }
 
-    bb10: {
-        _13 = const null;
-        goto -> bb1;
-    }
-
-    bb11: {
+    bb8: {
         _5 = copy _4;
         _0 = copy _5;
-        goto -> bb12;
+        goto -> bb9;
     }
 
-    bb12: {
+    bb9: {
         return;
     }
 }
@@ -2189,11 +2156,10 @@ fn baml.csv.open(path: string, options: null | baml.csv.ReaderOptions) -> baml.c
     let _5: unknown // _
     let _6: bool
     let _7: string
-    let _8: string
-    let _9: string // message
-    let _10: baml.errors.Io
-    let _11: string
-    let _12: baml.fs.File
+    let _8: string // message
+    let _9: baml.errors.Io
+    let _10: string
+    let _11: baml.fs.File
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2210,8 +2176,8 @@ fn baml.csv.open(path: string, options: null | baml.csv.ReaderOptions) -> baml.c
     }
 
     bb3: {
-        _12 = copy _4;
-        _0 = call const fn baml.csv._reader(copy _12, copy _2, const true) -> [bb4];
+        _11 = copy _4;
+        _0 = call const fn baml.csv._reader(copy _11, copy _2, const true) -> [bb4];
     }
 
     bb4: {
@@ -2229,16 +2195,10 @@ fn baml.csv.open(path: string, options: null | baml.csv.ReaderOptions) -> baml.c
 
     bb7: {
         _7 = copy _5.0;
-        drop(_7);
-        goto -> bb8;
-    }
-
-    bb8: {
-        _8 = copy _5.0;
-        _9 = copy _8;
-        _11 = copy _9;
-        _10 = baml.errors.Io { copy _11 };
-        throw copy _10;
+        _8 = copy _7;
+        _10 = copy _8;
+        _9 = baml.errors.Io { copy _10 };
+        throw copy _9;
     }
 }
 
@@ -2308,10 +2268,9 @@ fn baml.csv.parse(source: string | uint8array, options: null | baml.csv.ReaderOp
     let _12: reflect.Type
     let _13: bool
     let _14: string
-    let _15: string
-    let _16: string // message
+    let _15: string // message
+    let _16: string
     let _17: string
-    let _18: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2324,7 +2283,7 @@ fn baml.csv.parse(source: string | uint8array, options: null | baml.csv.ReaderOp
     }
 
     bb2: {
-        _5 = call const fn baml.csv.reader(copy _1, copy _2) -> [bb3, unwind: bb10];
+        _5 = call const fn baml.csv.reader(copy _1, copy _2) -> [bb3, unwind: bb9];
     }
 
     bb3: {
@@ -2333,57 +2292,47 @@ fn baml.csv.parse(source: string | uint8array, options: null | baml.csv.ReaderOp
     }
 
     bb4: {
-        branch const true -> [bb5, bb9];
+        _7 = virtual_call next as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>(copy _5) -> [bb5, unwind: bb9];
     }
 
     bb5: {
-        _7 = virtual_call next as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = baml.csv.Record>(copy _5) -> [bb6, unwind: bb10];
+        _8 = is_type(copy _7, baml.iter.Done);
+        branch copy _8 -> [bb8, bb6];
     }
 
     bb6: {
-        _8 = is_type(copy _7, baml.iter.Done);
-        branch copy _8 -> [bb9, bb7];
+        _9 = copy _7;
+        _11 = call const fn baml.csv.Record.fields(copy _9) -> [bb7, unwind: bb9];
     }
 
     bb7: {
-        _9 = copy _7;
-        _11 = call const fn baml.csv.Record.fields(copy _9) -> [bb8, unwind: bb10];
+        _12 = load_type(string[]);
+        _10 = call const fn baml.Array.push<copy _12>(copy _6, copy _11) -> [bb4, unwind: bb9];
     }
 
     bb8: {
-        _12 = load_type(string[]);
-        _10 = call const fn baml.Array.push<copy _12>(copy _6, copy _11) -> [bb4, unwind: bb10];
+        _0 = copy _6;
+        goto -> bb12;
     }
 
     bb9: {
-        _0 = copy _6;
-        goto -> bb14;
+        _13 = is_type(copy _4, baml.errors.Io);
+        branch copy _13 -> [bb11, bb10];
     }
 
     bb10: {
-        _13 = is_type(copy _4, baml.errors.Io);
-        branch copy _13 -> [bb12, bb11];
-    }
-
-    bb11: {
         rethrow copy _4;
     }
 
-    bb12: {
+    bb11: {
         _14 = copy _4.0;
-        drop(_14);
-        goto -> bb13;
+        _15 = copy _14;
+        _17 = copy _15;
+        _16 = const "unreachable: in-memory CSV source raised Io: " + copy _17;
+        _0 = call const fn baml.sys.panic(copy _16) -> [bb12];
     }
 
-    bb13: {
-        _15 = copy _4.0;
-        _16 = copy _15;
-        _18 = copy _16;
-        _17 = const "unreachable: in-memory CSV source raised Io: " + copy _18;
-        _0 = call const fn baml.sys.panic(copy _17) -> [bb14];
-    }
-
-    bb14: {
+    bb12: {
         return;
     }
 }
@@ -2400,10 +2349,9 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
     let _7: reflect.Type
     let _8: bool
     let _9: string
-    let _10: string
-    let _11: string // message
+    let _10: string // message
+    let _11: string
     let _12: string
-    let _13: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2425,7 +2373,7 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
     }
 
     bb4: {
-        _0 = virtual_call collect as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = #0>(copy _5) -> [bb9, unwind: bb5];
+        _0 = virtual_call collect as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = #0>(copy _5) -> [bb8, unwind: bb5];
     }
 
     bb5: {
@@ -2439,19 +2387,13 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
 
     bb7: {
         _9 = copy _4.0;
-        drop(_9);
-        goto -> bb8;
+        _10 = copy _9;
+        _12 = copy _10;
+        _11 = const "unreachable: in-memory CSV source raised Io: " + copy _12;
+        _0 = call const fn baml.sys.panic(copy _11) -> [bb8];
     }
 
     bb8: {
-        _10 = copy _4.0;
-        _11 = copy _10;
-        _13 = copy _11;
-        _12 = const "unreachable: in-memory CSV source raised Io: " + copy _13;
-        _0 = call const fn baml.sys.panic(copy _12) -> [bb9];
-    }
-
-    bb9: {
         return;
     }
 }
@@ -2471,6 +2413,7 @@ fn baml.csv.decode_optional(source: string | uint8array, options: null | baml.cs
     let _10: string
     let _11: int
     let _12: reflect.Type
+    let _13: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2512,11 +2455,12 @@ fn baml.csv.decode_optional(source: string | uint8array, options: null | baml.cs
     }
 
     bb8: {
+        _13 = const "expected at most one data record, found ";
         _10 = call const fn baml.json.stringify(copy _11) -> [bb9];
     }
 
     bb9: {
-        _9 = const "expected at most one data record, found " + copy _10;
+        _9 = copy _13 + copy _10;
         _8 = call const fn baml.csv._error(const baml.csv.ErrorKind.TooManyRows, copy _9) -> [bb10];
     }
 
@@ -2546,6 +2490,7 @@ fn baml.csv.decode_one(source: string | uint8array, options: null | baml.csv.Rea
     let _16: reflect.Type
     let _17: bool
     let _18: T // v
+    let _19: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2612,11 +2557,12 @@ fn baml.csv.decode_one(source: string | uint8array, options: null | baml.csv.Rea
     }
 
     bb13: {
+        _19 = const "expected exactly one data record, found ";
         _13 = call const fn baml.json.stringify(copy _14) -> [bb14];
     }
 
     bb14: {
-        _12 = const "expected exactly one data record, found " + copy _13;
+        _12 = copy _19 + copy _13;
         _11 = call const fn baml.csv._error(const baml.csv.ErrorKind.TooManyRows, copy _12) -> [bb15];
     }
 
@@ -2669,11 +2615,10 @@ fn baml.csv.create(path: string, options: null | baml.csv.WriterOptions) -> baml
     let _5: unknown // _
     let _6: bool
     let _7: string
-    let _8: string
-    let _9: string // message
-    let _10: baml.errors.Io
-    let _11: string
-    let _12: baml.fs.File
+    let _8: string // message
+    let _9: baml.errors.Io
+    let _10: string
+    let _11: baml.fs.File
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2690,8 +2635,8 @@ fn baml.csv.create(path: string, options: null | baml.csv.WriterOptions) -> baml
     }
 
     bb3: {
-        _12 = copy _4;
-        _0 = call const fn baml.csv._writer(copy _12, copy _2, const true) -> [bb4];
+        _11 = copy _4;
+        _0 = call const fn baml.csv._writer(copy _11, copy _2, const true) -> [bb4];
     }
 
     bb4: {
@@ -2709,16 +2654,10 @@ fn baml.csv.create(path: string, options: null | baml.csv.WriterOptions) -> baml
 
     bb7: {
         _7 = copy _5.0;
-        drop(_7);
-        goto -> bb8;
-    }
-
-    bb8: {
-        _8 = copy _5.0;
-        _9 = copy _8;
-        _11 = copy _9;
-        _10 = baml.errors.Io { copy _11 };
-        throw copy _10;
+        _8 = copy _7;
+        _10 = copy _8;
+        _9 = baml.errors.Io { copy _10 };
+        throw copy _9;
     }
 }
 
@@ -2803,10 +2742,9 @@ fn baml.csv.stringify(rows: T[], options: null | baml.csv.WriterOptions) -> stri
     let _7: reflect.Type
     let _8: bool
     let _9: string
-    let _10: string
-    let _11: string // message
+    let _10: string // message
+    let _11: string
     let _12: string
-    let _13: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2828,7 +2766,7 @@ fn baml.csv.stringify(rows: T[], options: null | baml.csv.WriterOptions) -> stri
     }
 
     bb4: {
-        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb9, unwind: bb5];
+        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb8, unwind: bb5];
     }
 
     bb5: {
@@ -2842,19 +2780,13 @@ fn baml.csv.stringify(rows: T[], options: null | baml.csv.WriterOptions) -> stri
 
     bb7: {
         _9 = copy _4.0;
-        drop(_9);
-        goto -> bb8;
+        _10 = copy _9;
+        _12 = copy _10;
+        _11 = const "unreachable: buffer writer raised Io: " + copy _12;
+        _0 = call const fn baml.sys.panic(copy _11) -> [bb8];
     }
 
     bb8: {
-        _10 = copy _4.0;
-        _11 = copy _10;
-        _13 = copy _11;
-        _12 = const "unreachable: buffer writer raised Io: " + copy _13;
-        _0 = call const fn baml.sys.panic(copy _12) -> [bb9];
-    }
-
-    bb9: {
         return;
     }
 }
@@ -2876,10 +2808,9 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
     let _12: (int | bigint | float | string | bool | null)[]
     let _13: bool
     let _14: string
-    let _15: string
-    let _16: string // message
+    let _15: string // message
+    let _16: string
     let _17: string
-    let _18: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2917,7 +2848,7 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
     }
 
     bb7: {
-        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb12, unwind: bb8];
+        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb11, unwind: bb8];
     }
 
     bb8: {
@@ -2931,19 +2862,13 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
 
     bb10: {
         _14 = copy _4.0;
-        drop(_14);
-        goto -> bb11;
+        _15 = copy _14;
+        _17 = copy _15;
+        _16 = const "unreachable: buffer writer raised Io: " + copy _17;
+        _0 = call const fn baml.sys.panic(copy _16) -> [bb11];
     }
 
     bb11: {
-        _15 = copy _4.0;
-        _16 = copy _15;
-        _18 = copy _16;
-        _17 = const "unreachable: buffer writer raised Io: " + copy _18;
-        _0 = call const fn baml.sys.panic(copy _17) -> [bb12];
-    }
-
-    bb12: {
         return;
     }
 }
@@ -3062,22 +2987,19 @@ fn baml.env.get_or_panic(key: string) -> string {
     let _1: string // key // param
     let _2: string
     let _3: string | null
-    let _4: bool
-    let _5: string
+    let _4: string
 
     bb0: {
         _3 = sys_op const fn baml.env.get(copy _1) -> bb1;
     }
 
     bb1: {
-        _2 = copy _3;
-        _4 = copy _2 == const null;
-        branch copy _4 -> [bb2, bb3];
+        _2 = short_circuit(??) copy _3 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _5 = const "env var not found: " + copy _1;
-        _2 = call const fn baml.sys.panic(copy _5) -> [bb3];
+        _4 = const "env var not found: " + copy _1;
+        _2 = call const fn baml.sys.panic(copy _4) -> [bb3];
     }
 
     bb3: {
@@ -3130,7 +3052,6 @@ fn baml.env.Ref.or(self: baml.env.Ref, fallback: string) -> string {
     let _3: string
     let _4: string | null
     let _5: string
-    let _6: bool
 
     bb0: {
         _5 = copy _1.0;
@@ -3138,9 +3059,7 @@ fn baml.env.Ref.or(self: baml.env.Ref, fallback: string) -> string {
     }
 
     bb1: {
-        _3 = copy _4;
-        _6 = copy _3 == const null;
-        branch copy _6 -> [bb2, bb3];
+        _3 = short_circuit(??) copy _4 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
@@ -3180,7 +3099,6 @@ fn baml.env.get_or_panic_lenient(key: string, lenient: bool) -> string {
     let _2: bool // lenient // param
     let _3: string
     let _4: string | null
-    let _5: bool
 
     bb0: {
         branch copy _2 -> [bb2, bb1];
@@ -3195,9 +3113,7 @@ fn baml.env.get_or_panic_lenient(key: string, lenient: bool) -> string {
     }
 
     bb3: {
-        _3 = copy _4;
-        _5 = copy _3 == const null;
-        branch copy _5 -> [bb4, bb5];
+        _3 = short_circuit(??) copy _4 -> [eval: bb4, join: bb5];
     }
 
     bb4: {
@@ -3287,18 +3203,17 @@ fn baml.errors.UnknownError.from(data: unknown) -> baml.errors.UnknownError | T 
     let _6: bool
     let _7: unknown
     let _8: unknown
-    let _9: unknown
-    let _10: T // inner
-    let _11: null
-    let _12: T
-    let _13: unknown
-    let _14: baml.errors.UnknownError // error
-    let _15: null
-    let _16: baml.errors.UnknownError
-    let _17: baml.errors.UnknownError // error
-    let _18: string[]
-    let _19: null
-    let _20: baml.errors.UnknownError
+    let _9: T // inner
+    let _10: null
+    let _11: T
+    let _12: unknown
+    let _13: baml.errors.UnknownError // error
+    let _14: null
+    let _15: baml.errors.UnknownError
+    let _16: baml.errors.UnknownError // error
+    let _17: string[]
+    let _18: null
+    let _19: baml.errors.UnknownError
 
     bb0: {
         _2 = copy _1;
@@ -3317,43 +3232,41 @@ fn baml.errors.UnknownError.from(data: unknown) -> baml.errors.UnknownError | T 
     }
 
     bb3: {
-        _13 = copy _1;
-        _13 = narrow_bind copy _13 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
+        _12 = copy _1;
+        _12 = narrow_bind copy _12 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
     }
 
     bb4: {
-        _18 = []: string[];
-        _17 = baml.errors.UnknownError { copy _1, copy _18 };
-        _20 = copy _17;
-        _19 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _20) -> [bb5];
+        _17 = []: string[];
+        _16 = baml.errors.UnknownError { copy _1, copy _17 };
+        _19 = copy _16;
+        _18 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _19) -> [bb5];
     }
 
     bb5: {
-        _0 = copy _17;
+        _0 = copy _16;
         goto -> bb12;
     }
 
     bb6: {
-        _14 = copy _13;
-        _16 = copy _14;
-        _15 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _16) -> [bb7];
+        _13 = copy _12;
+        _15 = copy _13;
+        _14 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _15) -> [bb7];
     }
 
     bb7: {
-        _0 = copy _14;
+        _0 = copy _13;
         goto -> bb12;
     }
 
     bb8: {
-        _9 = copy _1.0;
-        drop(_9);
-        _10 = copy _8;
-        _12 = copy _10;
-        _11 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _12) -> [bb9];
+        _9 = copy _8;
+        _11 = copy _9;
+        _10 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _11) -> [bb9];
     }
 
     bb9: {
-        _0 = copy _10;
+        _0 = copy _9;
         goto -> bb12;
     }
 
@@ -3385,22 +3298,21 @@ fn baml.errors.UnknownError.with_message(data: unknown, message: string) -> baml
     let _7: bool
     let _8: unknown
     let _9: unknown
-    let _10: unknown
-    let _11: T // inner
-    let _12: null
-    let _13: T
-    let _14: unknown
-    let _15: baml.errors.UnknownError // error
-    let _16: (string[], string[]) -> string[] throws never
-    let _17: string[]
-    let _18: reflect.Type
-    let _19: string[]
-    let _20: null
-    let _21: baml.errors.UnknownError
-    let _22: baml.errors.UnknownError // error
-    let _23: string[]
-    let _24: null
-    let _25: baml.errors.UnknownError
+    let _10: T // inner
+    let _11: null
+    let _12: T
+    let _13: unknown
+    let _14: baml.errors.UnknownError // error
+    let _15: (string[], string[]) -> string[] throws never
+    let _16: string[]
+    let _17: reflect.Type
+    let _18: string[]
+    let _19: null
+    let _20: baml.errors.UnknownError
+    let _21: baml.errors.UnknownError // error
+    let _22: string[]
+    let _23: null
+    let _24: baml.errors.UnknownError
 
     bb0: {
         _3 = copy _1;
@@ -3419,55 +3331,53 @@ fn baml.errors.UnknownError.with_message(data: unknown, message: string) -> baml
     }
 
     bb3: {
-        _14 = copy _1;
-        _14 = narrow_bind copy _14 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
+        _13 = copy _1;
+        _13 = narrow_bind copy _13 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
     }
 
     bb4: {
-        _23 = [copy _2]: string[];
-        _22 = baml.errors.UnknownError { copy _1, copy _23 };
-        _25 = copy _22;
-        _24 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _25) -> [bb5];
+        _22 = [copy _2]: string[];
+        _21 = baml.errors.UnknownError { copy _1, copy _22 };
+        _24 = copy _21;
+        _23 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _24) -> [bb5];
     }
 
     bb5: {
-        _0 = copy _22;
+        _0 = copy _21;
         goto -> bb14;
     }
 
     bb6: {
-        _15 = copy _14;
-        _16 = copy _15.1;
-        _17 = [copy _2]: string[];
-        _18 = load_type(string);
-        _19 = call const fn baml.Array.concat<copy _18>(copy _16, copy _17) -> [bb7];
+        _14 = copy _13;
+        _15 = copy _14.1;
+        _16 = [copy _2]: string[];
+        _17 = load_type(string);
+        _18 = call const fn baml.Array.concat<copy _17>(copy _15, copy _16) -> [bb7];
     }
 
     bb7: {
-        _15.1 = copy _19;
+        _14.1 = copy _18;
         goto -> bb8;
     }
 
     bb8: {
-        _21 = copy _15;
-        _20 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _21) -> [bb9];
+        _20 = copy _14;
+        _19 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _20) -> [bb9];
     }
 
     bb9: {
-        _0 = copy _15;
+        _0 = copy _14;
         goto -> bb14;
     }
 
     bb10: {
-        _10 = copy _1.0;
-        drop(_10);
-        _11 = copy _9;
-        _13 = copy _11;
-        _12 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _13) -> [bb11];
+        _10 = copy _9;
+        _12 = copy _10;
+        _11 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _12) -> [bb11];
     }
 
     bb11: {
-        _0 = copy _11;
+        _0 = copy _10;
         goto -> bb14;
     }
 
@@ -3512,6 +3422,8 @@ fn baml.errors.<(baml.errors.UnknownError as baml.ToString)>.to_string(self: bam
     let _18: string
     let _19: string
     let _20: reflect.Type
+    let _21: string
+    let _22: string
 
     bb0: {
         _3 = copy _1.0;
@@ -3538,11 +3450,12 @@ fn baml.errors.<(baml.errors.UnknownError as baml.ToString)>.to_string(self: bam
 
     bb4: {
         _17 = load_type(string);
+        _22 = const "UnknownError: ";
         _13 = call const fn baml.String.from<copy _17>(copy _14) -> [bb5];
     }
 
     bb5: {
-        _12 = const "UnknownError: " + copy _13;
+        _12 = copy _22 + copy _13;
         _11 = copy _12 + const ": ";
         _19 = copy _2;
         _20 = load_type(string);
@@ -3557,11 +3470,12 @@ fn baml.errors.<(baml.errors.UnknownError as baml.ToString)>.to_string(self: bam
     bb7: {
         _9 = copy _2;
         _10 = load_type(string);
+        _21 = const "UnknownError: ";
         _8 = call const fn baml.String.from<copy _10>(copy _9) -> [bb8];
     }
 
     bb8: {
-        _0 = const "UnknownError: " + copy _8;
+        _0 = copy _21 + copy _8;
         goto -> bb9;
     }
 
@@ -3710,9 +3624,11 @@ fn .<lambda(<lambda(all_complete, 0)>, 1)>(f: baml.future.Future<T, E>) -> T {
     // Locals:
     let _0: T // _0 // return
     let _1: baml.future.Future<T, E> // f // param
+    let _2: null
 
     bb0: {
-        _0 = await _1 -> [bb1];
+        _2 = copy _1;
+        _0 = await _2 -> [bb1];
     }
 
     bb1: {
@@ -3770,27 +3686,29 @@ fn .<lambda(<lambda(all, 0)>, 1)>(f: baml.future.Future<T, E>) -> T {
     let _0: T // _0 // return
     let _1: baml.future.Future<T, E> // f // param
     let _2: unknown // e
-    let _3: E // e
-    let _4: bool[]
-    let _5: (baml.future.Future<T, E>) -> bool throws never
-    let _6: reflect.Type
+    let _3: null
+    let _4: E // e
+    let _5: bool[]
+    let _6: (baml.future.Future<T, E>) -> bool throws never
     let _7: reflect.Type
     let _8: reflect.Type
-    let _9: int // j
-    let _10: bool
-    let _11: int
+    let _9: reflect.Type
+    let _10: int // j
+    let _11: bool
     let _12: int
-    let _13: baml.future.Future<T, E> // g
-    let _14: baml.future.Future<T, E>[]
-    let _15: int
-    let _16: bool
-    let _17: null | T
-    let _18: unknown // drained
-    let _19: null
-    let _20: int
+    let _13: int
+    let _14: baml.future.Future<T, E> // g
+    let _15: baml.future.Future<T, E>[]
+    let _16: int
+    let _17: bool
+    let _18: null | T
+    let _19: unknown // drained
+    let _20: null
+    let _21: int
 
     bb0: {
-        _0 = await _1 -> [bb1, unwind: bb2];
+        _3 = copy _1;
+        _0 = await _3 -> [bb1, unwind: bb2];
     }
 
     bb1: {
@@ -3802,63 +3720,58 @@ fn .<lambda(<lambda(all, 0)>, 1)>(f: baml.future.Future<T, E>) -> T {
     }
 
     bb3: {
-        _3 = copy _2;
-        _5 = make_closure lambda[0]<2 type_args>();
-        _6 = load_type(bool);
-        _7 = load_type(never);
-        _8 = load_type(baml.future.Future<#0, #1>);
-        _4 = call const fn baml.Array.map<copy _8, copy _6, copy _7>(copy capture[0], copy _5) -> [bb4];
+        _4 = copy _2;
+        _6 = make_closure lambda[0]<2 type_args>();
+        _7 = load_type(bool);
+        _8 = load_type(never);
+        _9 = load_type(baml.future.Future<#0, #1>);
+        _5 = call const fn baml.Array.map<copy _9, copy _7, copy _8>(copy capture[0], copy _6) -> [bb4];
     }
 
     bb4: {
-        _9 = const 0_i64;
-        goto -> bb8;
+        _10 = const 0_i64;
+        goto -> bb7;
     }
 
     bb5: {
-        throw_if_panic copy _18 -> bb6;
+        throw_if_panic copy _19 -> bb6;
     }
 
     bb6: {
-        _17 = const null;
+        _21 = copy _10;
+        _10 = copy _21 + const 1_i64;
         goto -> bb7;
     }
 
     bb7: {
-        _20 = copy _9;
-        _9 = copy _20 + const 1_i64;
+        _12 = copy _10;
+        _13 = len(capture[0]);
         goto -> bb8;
     }
 
     bb8: {
-        _11 = copy _9;
-        _12 = len(capture[0]);
-        goto -> bb9;
+        _11 = copy _12 < copy _13;
+        branch copy _11 -> [bb10, bb9];
     }
 
     bb9: {
-        _10 = copy _11 < copy _12;
-        branch copy _10 -> [bb11, bb10];
+        throw copy _4;
     }
 
     bb10: {
-        throw copy _3;
+        _15 = copy capture[0];
+        _16 = copy _10;
+        _14 = copy _15[_16];
+        _17 = call const fn baml.future.Future.is_error(copy _14) -> [bb11];
     }
 
     bb11: {
-        _14 = copy capture[0];
-        _15 = copy _9;
-        _13 = copy _14[_15];
-        _16 = call const fn baml.future.Future.is_error(copy _13) -> [bb12];
+        branch copy _17 -> [bb12, bb6];
     }
 
     bb12: {
-        branch copy _16 -> [bb13, bb7];
-    }
-
-    bb13: {
-        _19 = copy _13;
-        _17 = await _19 -> [bb7, unwind: bb5];
+        _20 = copy _14;
+        _18 = await _20 -> [bb6, unwind: bb5];
     }
 }
 
@@ -4046,7 +3959,7 @@ fn .<lambda(any, 0)>() -> T {
     bb0: {
         _1 = []: #0[];
         _2 = copy capture[0];
-        goto -> bb7;
+        goto -> bb6;
     }
 
     bb1: {
@@ -4054,82 +3967,77 @@ fn .<lambda(any, 0)>() -> T {
     }
 
     bb2: {
-        _21 = const null;
-        goto -> bb3;
+        _25 = copy _5;
+        _26 = load_type(baml.future.Future<#0, #1>);
+        _24 = call const fn baml.Array.slice<copy _26>(copy _2, const 0_i64, copy _25) -> [bb3];
     }
 
     bb3: {
-        _25 = copy _5;
-        _26 = load_type(baml.future.Future<#0, #1>);
-        _24 = call const fn baml.Array.slice<copy _26>(copy _2, const 0_i64, copy _25) -> [bb4];
-    }
-
-    bb4: {
         _29 = copy _5;
         _28 = copy _29 + const 1_i64;
         _30 = len(_2);
-        goto -> bb5;
+        goto -> bb4;
+    }
+
+    bb4: {
+        _31 = load_type(baml.future.Future<#0, #1>);
+        _27 = call const fn baml.Array.slice<copy _31>(copy _2, copy _28, copy _30) -> [bb5];
     }
 
     bb5: {
-        _31 = load_type(baml.future.Future<#0, #1>);
-        _27 = call const fn baml.Array.slice<copy _31>(copy _2, copy _28, copy _30) -> [bb6];
+        _32 = load_type(baml.future.Future<#0, #1>);
+        _2 = call const fn baml.Array.concat<copy _32>(copy _24, copy _27) -> [bb6];
     }
 
     bb6: {
-        _32 = load_type(baml.future.Future<#0, #1>);
-        _2 = call const fn baml.Array.concat<copy _32>(copy _24, copy _27) -> [bb7];
+        _4 = len(_2);
+        goto -> bb7;
     }
 
     bb7: {
-        _4 = len(_2);
-        goto -> bb8;
+        _3 = copy _4 > const 0_i64;
+        branch copy _3 -> [bb8, bb18];
     }
 
     bb8: {
-        _3 = copy _4 > const 0_i64;
-        branch copy _3 -> [bb9, bb19];
+        _6 = copy _2;
+        _5 = await_any copy _6 -> [bb9];
     }
 
     bb9: {
-        _6 = copy _2;
-        _5 = await_any copy _6 -> [bb10];
-    }
-
-    bb10: {
         _8 = copy _2;
         _9 = copy _5;
         _7 = copy _8[_9];
-        _10 = call const fn baml.future.Future.is_result(copy _7) -> [bb11];
+        _10 = call const fn baml.future.Future.is_result(copy _7) -> [bb10];
+    }
+
+    bb10: {
+        branch copy _10 -> [bb14, bb11];
     }
 
     bb11: {
-        branch copy _10 -> [bb15, bb12];
+        _20 = call const fn baml.future.Future.is_error(copy _7) -> [bb12];
     }
 
     bb12: {
-        _20 = call const fn baml.future.Future.is_error(copy _7) -> [bb13];
+        branch copy _20 -> [bb13, bb2];
     }
 
     bb13: {
-        branch copy _20 -> [bb14, bb3];
+        _23 = copy _7;
+        _21 = await _23 -> [bb2, unwind: bb1];
     }
 
     bb14: {
-        _23 = copy _7;
-        _21 = await _23 -> [bb3, unwind: bb1];
+        _14 = copy _7;
+        _12 = await _14 -> [bb17, unwind: bb15];
     }
 
     bb15: {
-        _14 = copy _7;
-        _12 = await _14 -> [bb18, unwind: bb16];
+        throw_if_panic copy _13 -> bb16;
     }
 
     bb16: {
-        throw_if_panic copy _13 -> bb17;
-    }
-
-    bb17: {
         _15 = copy _13;
         _18 = copy _15;
         _17 = [copy _18]: #1[];
@@ -4137,99 +4045,94 @@ fn .<lambda(any, 0)>() -> T {
         throw copy _16;
     }
 
-    bb18: {
+    bb17: {
         _19 = load_type(#0);
-        _11 = call const fn baml.Array.push<copy _19>(copy _1, copy _12) -> [bb19];
+        _11 = call const fn baml.Array.push<copy _19>(copy _1, copy _12) -> [bb18];
+    }
+
+    bb18: {
+        _34 = len(_1);
+        goto -> bb19;
     }
 
     bb19: {
-        _34 = len(_1);
-        goto -> bb20;
+        _33 = copy _34 == const 0_i64;
+        branch copy _33 -> [bb23, bb20];
     }
 
     bb20: {
-        _33 = copy _34 == const 0_i64;
-        branch copy _33 -> [bb24, bb21];
-    }
-
-    bb21: {
         _55 = make_closure lambda[0]<2 type_args>();
         _56 = load_type(bool);
         _57 = load_type(never);
         _58 = load_type(baml.future.Future<#0, #1>);
-        _54 = call const fn baml.Array.map<copy _58, copy _56, copy _57>(copy capture[0], copy _55) -> [bb22];
+        _54 = call const fn baml.Array.map<copy _58, copy _56, copy _57>(copy capture[0], copy _55) -> [bb21];
     }
 
-    bb22: {
+    bb21: {
         _59 = copy _1;
         _60 = const 0_i64;
         _0 = copy _59[_60];
-        goto -> bb23;
+        goto -> bb22;
     }
 
-    bb23: {
+    bb22: {
         return;
     }
 
-    bb24: {
+    bb23: {
         _35 = []: #1[];
         _36 = const 0_i64;
-        goto -> bb29;
+        goto -> bb27;
+    }
+
+    bb24: {
+        throw_if_panic copy _45 -> bb25;
     }
 
     bb25: {
-        throw_if_panic copy _45 -> bb26;
-    }
-
-    bb26: {
         _47 = copy _45;
         _49 = copy _47;
         _50 = load_type(#1);
-        _48 = call const fn baml.Array.push<copy _50>(copy _35, copy _49) -> [bb27];
+        _48 = call const fn baml.Array.push<copy _50>(copy _35, copy _49) -> [bb26];
+    }
+
+    bb26: {
+        _51 = copy _36;
+        _36 = copy _51 + const 1_i64;
+        goto -> bb27;
     }
 
     bb27: {
-        _44 = const null;
+        _38 = copy _36;
+        _39 = len(capture[0]);
         goto -> bb28;
     }
 
     bb28: {
-        _51 = copy _36;
-        _36 = copy _51 + const 1_i64;
-        goto -> bb29;
+        _37 = copy _38 < copy _39;
+        branch copy _37 -> [bb30, bb29];
     }
 
     bb29: {
-        _38 = copy _36;
-        _39 = len(capture[0]);
-        goto -> bb30;
-    }
-
-    bb30: {
-        _37 = copy _38 < copy _39;
-        branch copy _37 -> [bb32, bb31];
-    }
-
-    bb31: {
         _53 = copy _35;
         _52 = baml.future.AllFailed<#1> { copy _53 };
         throw copy _52;
     }
 
-    bb32: {
+    bb30: {
         _41 = copy capture[0];
         _42 = copy _36;
         _40 = copy _41[_42];
-        _43 = call const fn baml.future.Future.is_error(copy _40) -> [bb33];
+        _43 = call const fn baml.future.Future.is_error(copy _40) -> [bb31];
     }
 
-    bb33: {
-        branch copy _43 -> [bb34, bb28];
+    bb31: {
+        branch copy _43 -> [bb32, bb26];
     }
 
-    bb34: {
+    bb32: {
         _46 = copy _40;
-        _44 = await _46 -> [bb28, unwind: bb25];
+        _44 = await _46 -> [bb26, unwind: bb24];
     }
 }
 
@@ -4272,20 +4175,20 @@ fn baml.future.with_timeout(limit: baml.time.Duration, body: () -> T throws E) -
     let _19: null
     let _20: bool
     let _21: bool
-    let _22: bool
-    let _23: bigint // limit_ms
-    let _24: int | null // reported
-    let _25: unknown // conversion
-    let _26: bool
-    let _27: baml.errors.Timeout
+    let _22: bigint // limit_ms
+    let _23: int | null // reported
+    let _24: unknown // conversion
+    let _25: bool
+    let _26: baml.errors.Timeout
+    let _27: string
     let _28: string
     let _29: string
-    let _30: string
-    let _31: bigint
-    let _32: reflect.Type
-    let _33: int | null
+    let _30: bigint
+    let _31: reflect.Type
+    let _32: int | null
+    let _33: void
     let _34: void
-    let _35: void
+    let _35: string
 
     bb0: {
         _3 = call const fn baml.spawn.CancelToken.new() -> [bb1];
@@ -4325,7 +4228,7 @@ fn baml.future.with_timeout(limit: baml.time.Duration, body: () -> T throws E) -
     }
 
     bb7: {
-        _34 = call const fn baml.future.Future.cancel(copy _13) -> [bb8];
+        _33 = call const fn baml.future.Future.cancel(copy _13) -> [bb8];
     }
 
     bb8: {
@@ -4342,48 +4245,48 @@ fn baml.future.with_timeout(limit: baml.time.Duration, body: () -> T throws E) -
     }
 
     bb11: {
-        _22 = call const fn baml.spawn.CancelToken.is_cancelled(copy _3) -> [bb12, unwind: bb20];
+        _21 = call const fn baml.spawn.CancelToken.is_cancelled(copy _3) -> [bb12, unwind: bb20];
     }
 
     bb12: {
-        _21 = !copy _22;
-        branch copy _21 -> [bb15, bb13];
+        branch copy _21 -> [bb14, bb13];
     }
 
     bb13: {
-        _23 = call const fn baml.time.Duration.to_milliseconds(copy _1) -> [bb14, unwind: bb20];
-    }
-
-    bb14: {
-        _24 = call const fn baml.Bigint.to_int(copy _23) -> [bb19, unwind: bb16];
-    }
-
-    bb15: {
         rethrow copy _18;
     }
 
+    bb14: {
+        _22 = call const fn baml.time.Duration.to_milliseconds(copy _1) -> [bb15, unwind: bb20];
+    }
+
+    bb15: {
+        _23 = call const fn baml.Bigint.to_int(copy _22) -> [bb19, unwind: bb16];
+    }
+
     bb16: {
-        _26 = is_type(copy _25, baml.errors.InvalidArgument);
-        branch copy _26 -> [bb18, bb17];
+        _25 = is_type(copy _24, baml.errors.InvalidArgument);
+        branch copy _25 -> [bb18, bb17];
     }
 
     bb17: {
-        rethrow copy _25;
+        rethrow copy _24;
     }
 
     bb18: {
-        _24 = const null;
+        _23 = const null;
         goto -> bb19;
     }
 
     bb19: {
-        _31 = copy _23;
-        _32 = load_type(bigint);
-        _30 = call const fn baml.String.from<copy _32>(copy _31) -> [bb22, unwind: bb20];
+        _30 = copy _22;
+        _31 = load_type(bigint);
+        _35 = const "operation timed out after ";
+        _29 = call const fn baml.String.from<copy _31>(copy _30) -> [bb22, unwind: bb20];
     }
 
     bb20: {
-        _35 = call const fn baml.future.Future.cancel(copy _13) -> [bb21];
+        _34 = call const fn baml.future.Future.cancel(copy _13) -> [bb21];
     }
 
     bb21: {
@@ -4391,11 +4294,11 @@ fn baml.future.with_timeout(limit: baml.time.Duration, body: () -> T throws E) -
     }
 
     bb22: {
-        _29 = const "operation timed out after " + copy _30;
-        _28 = copy _29 + const "ms";
-        _33 = copy _24;
-        _27 = baml.errors.Timeout { copy _28, copy _33 };
-        throw copy _27;
+        _28 = copy _35 + copy _29;
+        _27 = copy _28 + const "ms";
+        _32 = copy _23;
+        _26 = baml.errors.Timeout { copy _27, copy _32 };
+        throw copy _26;
     }
 }
 
@@ -4453,22 +4356,28 @@ fn baml.http.Response.ok(self: baml.http.Response) -> bool {
     let _0: bool // _0 // return
     let _1: baml.http.Response // self // param
     let _2: bool
-    let _3: int
+    let _3: bool
     let _4: int
+    let _5: int
 
     bb0: {
-        _3 = copy _1.0;
-        _2 = copy _3 >= const 200_i64;
-        _0 = short_circuit(&&) copy _2 -> [eval: bb1, join: bb2];
+        _4 = copy _1.0;
+        _3 = copy _4 >= const 200_i64;
+        _2 = short_circuit(&&) copy _3 -> [eval: bb1, join: bb2];
     }
 
     bb1: {
-        _4 = copy _1.0;
-        _0 = copy _4 < const 300_i64;
+        _5 = copy _1.0;
+        _2 = copy _5 < const 300_i64;
         goto -> bb2;
     }
 
     bb2: {
+        _0 = copy _2;
+        goto -> bb3;
+    }
+
+    bb3: {
         return;
     }
 }
@@ -4647,7 +4556,12 @@ fn baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -
     let _12: bool
     let _13: bool
     let _14: bool
-    let _15: bigint
+    let _15: null | baml.http.TlsConfig
+    let _16: bool
+    let _17: bool
+    let _18: int
+    let _19: int
+    let _20: bigint
 
     bb0: {
         _9 = copy _3 == const <omitted>;
@@ -4709,11 +4623,16 @@ fn baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -
     }
 
     bb12: {
-        _15 = call const fn baml.time.Duration.to_nanoseconds(copy _8) -> [bb13];
+        _15 = copy _3;
+        _16 = copy _4;
+        _17 = copy _5;
+        _18 = copy _6;
+        _19 = copy _7;
+        _20 = call const fn baml.time.Duration.to_nanoseconds(copy _8) -> [bb13];
     }
 
     bb13: {
-        _0 = sys_op const fn baml.http.Server._serve(copy _1, copy _2, copy _3, copy _4, copy _5, copy _6, copy _7, copy _15) -> bb14;
+        _0 = sys_op const fn baml.http.Server._serve(copy _1, copy _2, copy _15, copy _16, copy _17, copy _18, copy _19, copy _20) -> bb14;
     }
 
     bb14: {
@@ -4732,7 +4651,8 @@ fn baml.http.TlsConfig.new(cert_pem: uint8array, key_pem: uint8array, allow_tls1
     let _4: baml.time.Duration // handshake_timeout // param
     let _5: bool
     let _6: bool
-    let _7: bigint
+    let _7: bool
+    let _8: bigint
 
     bb0: {
         _5 = copy _3 == const <omitted>;
@@ -4754,11 +4674,12 @@ fn baml.http.TlsConfig.new(cert_pem: uint8array, key_pem: uint8array, allow_tls1
     }
 
     bb4: {
-        _7 = call const fn baml.time.Duration.to_nanoseconds(copy _4) -> [bb5];
+        _7 = copy _3;
+        _8 = call const fn baml.time.Duration.to_nanoseconds(copy _4) -> [bb5];
     }
 
     bb5: {
-        _0 = sys_op const fn baml.http.TlsConfig._new(copy _1, copy _2, copy _3, copy _7) -> bb6;
+        _0 = sys_op const fn baml.http.TlsConfig._new(copy _1, copy _2, copy _7, copy _8) -> bb6;
     }
 
     bb6: {
@@ -4900,8 +4821,8 @@ fn baml.io.Write.write(self: baml.io.Write, data: string | uint8array) -> int {
     let _10: int // written
     let _11: uint8array
     let _12: bool
-    let _13: bool
-    let _14: int
+    let _13: int
+    let _14: bool
     let _15: int
     let _16: int
     let _17: baml.errors.Io
@@ -4954,9 +4875,9 @@ fn baml.io.Write.write(self: baml.io.Write, data: string | uint8array) -> int {
     }
 
     bb9: {
-        _14 = copy _10;
-        _13 = copy _14 <= const 0_i64;
-        _12 = short_circuit(||) copy _13 -> [eval: bb10, join: bb12];
+        _13 = copy _10;
+        _12 = copy _13 <= const 0_i64;
+        branch copy _12 -> [bb14, bb10];
     }
 
     bb10: {
@@ -4966,25 +4887,21 @@ fn baml.io.Write.write(self: baml.io.Write, data: string | uint8array) -> int {
     }
 
     bb11: {
-        _12 = copy _15 > copy _16;
-        goto -> bb12;
+        _14 = copy _15 > copy _16;
+        branch copy _14 -> [bb14, bb12];
     }
 
     bb12: {
-        branch copy _12 -> [bb15, bb13];
+        _18 = copy _10;
+        _19 = len(_3);
+        goto -> bb13;
     }
 
     bb13: {
-        _18 = copy _10;
-        _19 = len(_3);
-        goto -> bb14;
-    }
-
-    bb14: {
         _3 = call const fn baml.Uint8Array.slice(copy _3, copy _18, copy _19) -> [bb4];
     }
 
-    bb15: {
+    bb14: {
         _17 = baml.errors.Io { const "writer made invalid progress" };
         throw copy _17;
     }
@@ -5222,31 +5139,27 @@ fn baml.iter.Iterator.collect(self: baml.iter.Iterator) -> (Self as baml.iter.It
     }
 
     bb1: {
-        branch const true -> [bb2, bb5];
+        _4 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _4 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _5 = is_type(copy _4, baml.iter.Done);
+        branch copy _5 -> [bb4, bb3];
     }
 
     bb3: {
-        _5 = is_type(copy _4, baml.iter.Done);
-        branch copy _5 -> [bb5, bb4];
-    }
-
-    bb4: {
         _6 = copy _4;
         _7 = copy _6;
         _8 = load_type((#0 as baml.iter.Iterator).Item);
         _3 = call const fn baml.Array.push<copy _8>(copy _2, copy _7) -> [bb1];
     }
 
-    bb5: {
+    bb4: {
         _0 = copy _2;
-        goto -> bb6;
+        goto -> bb5;
     }
 
-    bb6: {
+    bb5: {
         return;
     }
 }
@@ -5270,31 +5183,27 @@ fn baml.iter.Iterator.reduce(self: baml.iter.Iterator, fn: (A, (Self as baml.ite
     }
 
     bb1: {
-        branch const true -> [bb2, bb5];
+        _5 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _5 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _6 = is_type(copy _5, baml.iter.Done);
+        branch copy _6 -> [bb4, bb3];
     }
 
     bb3: {
-        _6 = is_type(copy _5, baml.iter.Done);
-        branch copy _6 -> [bb5, bb4];
-    }
-
-    bb4: {
         _7 = copy _5;
         _8 = copy _4;
         _9 = copy _7;
         _4 = call copy _2(copy _8, copy _9) -> [bb1];
     }
 
-    bb5: {
+    bb4: {
         _0 = copy _4;
-        goto -> bb6;
+        goto -> bb5;
     }
 
-    bb6: {
+    bb5: {
         return;
     }
 }
@@ -5313,29 +5222,25 @@ fn baml.iter.Iterator.count(self: baml.iter.Iterator) -> int {
     }
 
     bb1: {
-        branch const true -> [bb2, bb5];
+        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _4 = is_type(copy _3, baml.iter.Done);
+        branch copy _4 -> [bb4, bb3];
     }
 
     bb3: {
-        _4 = is_type(copy _3, baml.iter.Done);
-        branch copy _4 -> [bb5, bb4];
-    }
-
-    bb4: {
         _2 = copy _2 + const 1_i64;
         goto -> bb1;
     }
 
-    bb5: {
+    bb4: {
         _0 = copy _2;
-        goto -> bb6;
+        goto -> bb5;
     }
 
-    bb6: {
+    bb5: {
         return;
     }
 }
@@ -5356,30 +5261,26 @@ fn baml.iter.Iterator.for_each(self: baml.iter.Iterator, fn: ((Self as baml.iter
     }
 
     bb1: {
-        branch const true -> [bb2, bb5];
+        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _4 = is_type(copy _3, baml.iter.Done);
+        branch copy _4 -> [bb4, bb3];
     }
 
     bb3: {
-        _4 = is_type(copy _3, baml.iter.Done);
-        branch copy _4 -> [bb5, bb4];
-    }
-
-    bb4: {
         _5 = copy _3;
         _7 = copy _5;
         _6 = call copy _2(copy _7) -> [bb1];
     }
 
-    bb5: {
+    bb4: {
         _0 = const null;
-        goto -> bb6;
+        goto -> bb5;
     }
 
-    bb6: {
+    bb5: {
         return;
     }
 }
@@ -5400,39 +5301,35 @@ fn baml.iter.Iterator.some(self: baml.iter.Iterator, predicate: ((Self as baml.i
     }
 
     bb1: {
-        branch const true -> [bb2, bb7];
+        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _4 = is_type(copy _3, baml.iter.Done);
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _4 = is_type(copy _3, baml.iter.Done);
-        branch copy _4 -> [bb7, bb4];
+        _5 = copy _3;
+        _7 = copy _5;
+        _6 = call copy _2(copy _7) -> [bb4];
     }
 
     bb4: {
-        _5 = copy _3;
-        _7 = copy _5;
-        _6 = call copy _2(copy _7) -> [bb5];
+        branch copy _6 -> [bb5, bb1];
     }
 
     bb5: {
-        branch copy _6 -> [bb6, bb1];
+        _0 = const true;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = const true;
-        goto -> bb8;
+        _0 = const false;
+        goto -> bb7;
     }
 
     bb7: {
-        _0 = const false;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }
@@ -5446,48 +5343,42 @@ fn baml.iter.Iterator.every(self: baml.iter.Iterator, predicate: ((Self as baml.
     let _4: bool
     let _5: (Self as baml.iter.Iterator).Item // x
     let _6: bool
-    let _7: bool
-    let _8: (Self as baml.iter.Iterator).Item
+    let _7: (Self as baml.iter.Iterator).Item
 
     bb0: {
         goto -> bb1;
     }
 
     bb1: {
-        branch const true -> [bb2, bb7];
+        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _4 = is_type(copy _3, baml.iter.Done);
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _4 = is_type(copy _3, baml.iter.Done);
-        branch copy _4 -> [bb7, bb4];
+        _5 = copy _3;
+        _7 = copy _5;
+        _6 = call copy _2(copy _7) -> [bb4];
     }
 
     bb4: {
-        _5 = copy _3;
-        _8 = copy _5;
-        _7 = call copy _2(copy _8) -> [bb5];
+        branch copy _6 -> [bb1, bb5];
     }
 
     bb5: {
-        _6 = !copy _7;
-        branch copy _6 -> [bb6, bb1];
+        _0 = const false;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = const false;
-        goto -> bb8;
+        _0 = const true;
+        goto -> bb7;
     }
 
     bb7: {
-        _0 = const true;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }
@@ -5508,39 +5399,35 @@ fn baml.iter.Iterator.find(self: baml.iter.Iterator, predicate: ((Self as baml.i
     }
 
     bb1: {
-        branch const true -> [bb2, bb7];
+        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb2];
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator(copy _1) -> [bb3];
+        _4 = is_type(copy _3, baml.iter.Done);
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _4 = is_type(copy _3, baml.iter.Done);
-        branch copy _4 -> [bb7, bb4];
+        _5 = copy _3;
+        _7 = copy _5;
+        _6 = call copy _2(copy _7) -> [bb4];
     }
 
     bb4: {
-        _5 = copy _3;
-        _7 = copy _5;
-        _6 = call copy _2(copy _7) -> [bb5];
+        branch copy _6 -> [bb5, bb1];
     }
 
     bb5: {
-        branch copy _6 -> [bb6, bb1];
+        _0 = copy _5;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = copy _5;
-        goto -> bb8;
+        _0 = const null;
+        goto -> bb7;
     }
 
     bb7: {
-        _0 = const null;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }
@@ -5882,46 +5769,37 @@ fn baml.iter.<(baml.iter.Filter<#0, #1, #2> as baml.iter.Iterator)>.next(self: b
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _3 = copy _1.0;
+        _2 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _0 = baml.iter.Done {  };
-        goto -> bb9;
+        _4 = is_type(copy _2, baml.iter.Done);
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _3 = copy _1.0;
-        _2 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _3) -> [bb4];
-    }
-
-    bb4: {
-        _4 = is_type(copy _2, baml.iter.Done);
-        branch copy _4 -> [bb8, bb5];
-    }
-
-    bb5: {
         _5 = copy _2;
         _7 = copy _1.1;
         _8 = copy _5;
-        _6 = call copy _7(copy _8) -> [bb6];
+        _6 = call copy _7(copy _8) -> [bb4];
+    }
+
+    bb4: {
+        branch copy _6 -> [bb5, bb1];
+    }
+
+    bb5: {
+        _0 = copy _5;
+        goto -> bb7;
     }
 
     bb6: {
-        branch copy _6 -> [bb7, bb1];
+        _0 = baml.iter.Done {  };
+        goto -> bb7;
     }
 
     bb7: {
-        _0 = copy _5;
-        goto -> bb9;
-    }
-
-    bb8: {
-        _0 = baml.iter.Done {  };
-        goto -> bb9;
-    }
-
-    bb9: {
         return;
     }
 }
@@ -5960,48 +5838,39 @@ fn baml.iter.<(baml.iter.FilterMap<#0, #1, #2, #3> as baml.iter.Iterator)>.next(
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _3 = copy _1.0;
+        _2 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _3) -> [bb2];
     }
 
     bb2: {
-        _0 = baml.iter.Done {  };
-        goto -> bb9;
+        _4 = is_type(copy _2, baml.iter.Done);
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb3: {
-        _3 = copy _1.0;
-        _2 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _3) -> [bb4];
-    }
-
-    bb4: {
-        _4 = is_type(copy _2, baml.iter.Done);
-        branch copy _4 -> [bb8, bb5];
-    }
-
-    bb5: {
         _5 = copy _2;
         _7 = copy _1.1;
         _8 = copy _5;
-        _6 = call copy _7(copy _8) -> [bb6];
+        _6 = call copy _7(copy _8) -> [bb4];
+    }
+
+    bb4: {
+        _9 = copy _6 == const null;
+        branch copy _9 -> [bb1, bb5];
+    }
+
+    bb5: {
+        _10 = copy _6;
+        _0 = copy _10;
+        goto -> bb7;
     }
 
     bb6: {
-        _9 = copy _6 == const null;
-        branch copy _9 -> [bb1, bb7];
+        _0 = baml.iter.Done {  };
+        goto -> bb7;
     }
 
     bb7: {
-        _10 = copy _6;
-        _0 = copy _10;
-        goto -> bb9;
-    }
-
-    bb8: {
-        _0 = baml.iter.Done {  };
-        goto -> bb9;
-    }
-
-    bb9: {
         return;
     }
 }
@@ -6046,81 +5915,72 @@ fn baml.iter.<(baml.iter.FlatMap<#0, #1, #2, #3, #4> as baml.iter.Iterator)>.nex
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _2 = copy _1.2;
+        _3 = copy _2;
+        _3 = narrow_bind copy _3 as Interface(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Iterator" }, [], [("Error", TypeArgRef(4)), ("Item", TypeArgRef(1))], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb10, bb2];
     }
 
     bb2: {
-        _0 = baml.iter.Done {  };
-        goto -> bb15;
+        _8 = is_type(copy _2, baml.iter.Done);
+        branch copy _8 -> [bb4, bb3];
     }
 
     bb3: {
-        _2 = copy _1.2;
-        _3 = copy _2;
-        _3 = narrow_bind copy _3 as Interface(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Iterator" }, [], [("Error", TypeArgRef(4)), ("Item", TypeArgRef(1))], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb12, bb4];
-    }
-
-    bb4: {
-        _8 = is_type(copy _2, baml.iter.Done);
-        branch copy _8 -> [bb6, bb5];
-    }
-
-    bb5: {
         unreachable;
     }
 
-    bb6: {
+    bb4: {
         _10 = copy _1.0;
-        _9 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _10) -> [bb7];
+        _9 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _10) -> [bb5];
     }
 
-    bb7: {
+    bb5: {
         _11 = is_type(copy _9, baml.iter.Done);
-        branch copy _11 -> [bb11, bb8];
+        branch copy _11 -> [bb9, bb6];
     }
 
-    bb8: {
+    bb6: {
         _12 = copy _9;
         _15 = copy _1.1;
         _16 = copy _12;
-        _14 = call copy _15(copy _16) -> [bb9];
+        _14 = call copy _15(copy _16) -> [bb7];
     }
 
-    bb9: {
-        _13 = virtual_call iter as baml.iter.Iterable<Error = #4, Item = #1>(copy _14) -> [bb10];
+    bb7: {
+        _13 = virtual_call iter as baml.iter.Iterable<Error = #4, Item = #1>(copy _14) -> [bb8];
     }
 
-    bb10: {
+    bb8: {
         _1.2 = copy _13;
         goto -> bb1;
     }
 
-    bb11: {
+    bb9: {
         _0 = baml.iter.Done {  };
-        goto -> bb15;
+        goto -> bb13;
+    }
+
+    bb10: {
+        _4 = copy _3;
+        _5 = virtual_call next as baml.iter.Iterator<Error = #4, Item = #1>(copy _4) -> [bb11];
+    }
+
+    bb11: {
+        _6 = is_type(copy _5, baml.iter.Done);
+        branch copy _6 -> [bb14, bb12];
     }
 
     bb12: {
-        _4 = copy _3;
-        _5 = virtual_call next as baml.iter.Iterator<Error = #4, Item = #1>(copy _4) -> [bb13];
+        _7 = copy _5;
+        _0 = copy _7;
+        goto -> bb13;
     }
 
     bb13: {
-        _6 = is_type(copy _5, baml.iter.Done);
-        branch copy _6 -> [bb16, bb14];
-    }
-
-    bb14: {
-        _7 = copy _5;
-        _0 = copy _7;
-        goto -> bb15;
-    }
-
-    bb15: {
         return;
     }
 
-    bb16: {
+    bb14: {
         _1.2 = baml.iter.Done {  };
         goto -> bb1;
     }
@@ -6163,75 +6023,66 @@ fn baml.iter.<(baml.iter.Flatten<#0, #1, #2, #3> as baml.iter.Iterator)>.next(se
     }
 
     bb1: {
-        branch const true -> [bb3, bb2];
+        _2 = copy _1.1;
+        _3 = copy _2;
+        _3 = narrow_bind copy _3 as Interface(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Iterator" }, [], [("Error", TypeArgRef(3)), ("Item", TypeArgRef(1))], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb2];
     }
 
     bb2: {
-        _0 = baml.iter.Done {  };
-        goto -> bb14;
+        _8 = is_type(copy _2, baml.iter.Done);
+        branch copy _8 -> [bb4, bb3];
     }
 
     bb3: {
-        _2 = copy _1.1;
-        _3 = copy _2;
-        _3 = narrow_bind copy _3 as Interface(QualifiedTypeName { pkg: Dep("baml"), namespace: ["iter"], name: "Iterator" }, [], [("Error", TypeArgRef(3)), ("Item", TypeArgRef(1))], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb11, bb4];
-    }
-
-    bb4: {
-        _8 = is_type(copy _2, baml.iter.Done);
-        branch copy _8 -> [bb6, bb5];
-    }
-
-    bb5: {
         unreachable;
     }
 
-    bb6: {
+    bb4: {
         _10 = copy _1.0;
-        _9 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _10) -> [bb7];
+        _9 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _10) -> [bb5];
+    }
+
+    bb5: {
+        _11 = is_type(copy _9, baml.iter.Done);
+        branch copy _11 -> [bb8, bb6];
+    }
+
+    bb6: {
+        _12 = copy _9;
+        _13 = virtual_call iter as baml.iter.Iterable<Error = #3, Item = #1>(copy _12) -> [bb7];
     }
 
     bb7: {
-        _11 = is_type(copy _9, baml.iter.Done);
-        branch copy _11 -> [bb10, bb8];
-    }
-
-    bb8: {
-        _12 = copy _9;
-        _13 = virtual_call iter as baml.iter.Iterable<Error = #3, Item = #1>(copy _12) -> [bb9];
-    }
-
-    bb9: {
         _1.1 = copy _13;
         goto -> bb1;
     }
 
-    bb10: {
+    bb8: {
         _0 = baml.iter.Done {  };
-        goto -> bb14;
+        goto -> bb12;
+    }
+
+    bb9: {
+        _4 = copy _3;
+        _5 = virtual_call next as baml.iter.Iterator<Error = #3, Item = #1>(copy _4) -> [bb10];
+    }
+
+    bb10: {
+        _6 = is_type(copy _5, baml.iter.Done);
+        branch copy _6 -> [bb13, bb11];
     }
 
     bb11: {
-        _4 = copy _3;
-        _5 = virtual_call next as baml.iter.Iterator<Error = #3, Item = #1>(copy _4) -> [bb12];
+        _7 = copy _5;
+        _0 = copy _7;
+        goto -> bb12;
     }
 
     bb12: {
-        _6 = is_type(copy _5, baml.iter.Done);
-        branch copy _6 -> [bb15, bb13];
-    }
-
-    bb13: {
-        _7 = copy _5;
-        _0 = copy _7;
-        goto -> bb14;
-    }
-
-    bb14: {
         return;
     }
 
-    bb15: {
+    bb13: {
         _1.1 = baml.iter.Done {  };
         goto -> bb1;
     }
@@ -6423,32 +6274,30 @@ fn baml.iter.<(baml.iter.Chain<#0, #1, #2> as baml.iter.Iterator)>.next(self: ba
     let _0: baml.iter.Done | T // _0 // return
     let _1: baml.iter.Chain // self // param
     let _2: bool
-    let _3: bool
-    let _4: baml.iter.Done | T
-    let _5: baml.iter.Iterator<Error = E, Item = T>
-    let _6: bool
-    let _7: T // x
-    let _8: baml.iter.Iterator<Error = E2, Item = T>
+    let _3: baml.iter.Done | T
+    let _4: baml.iter.Iterator<Error = E, Item = T>
+    let _5: bool
+    let _6: T // x
+    let _7: baml.iter.Iterator<Error = E2, Item = T>
 
     bb0: {
-        _3 = copy _1.2;
-        _2 = !copy _3;
-        branch copy _2 -> [bb1, bb5];
+        _2 = copy _1.2;
+        branch copy _2 -> [bb5, bb1];
     }
 
     bb1: {
-        _5 = copy _1.0;
-        _4 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _5) -> [bb2];
+        _4 = copy _1.0;
+        _3 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _4) -> [bb2];
     }
 
     bb2: {
-        _6 = is_type(copy _4, baml.iter.Done);
-        branch copy _6 -> [bb4, bb3];
+        _5 = is_type(copy _3, baml.iter.Done);
+        branch copy _5 -> [bb4, bb3];
     }
 
     bb3: {
-        _7 = copy _4;
-        _0 = copy _7;
+        _6 = copy _3;
+        _0 = copy _6;
         goto -> bb6;
     }
 
@@ -6458,8 +6307,8 @@ fn baml.iter.<(baml.iter.Chain<#0, #1, #2> as baml.iter.Iterator)>.next(self: ba
     }
 
     bb5: {
-        _8 = copy _1.1;
-        _0 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _8) -> [bb6];
+        _7 = copy _1.1;
+        _0 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _7) -> [bb6];
     }
 
     bb6: {
@@ -6712,10 +6561,9 @@ fn baml.iter.<(baml.iter.SkipWhile<#0, #1, #2> as baml.iter.Iterator)>.next(self
     let _5: bool
     let _6: T // x
     let _7: bool
-    let _8: bool
-    let _9: (T) -> bool throws E2
-    let _10: T
-    let _11: baml.iter.Iterator<Error = E, Item = T>
+    let _8: (T) -> bool throws E2
+    let _9: T
+    let _10: baml.iter.Iterator<Error = E, Item = T>
 
     bb0: {
         goto -> bb1;
@@ -6727,8 +6575,8 @@ fn baml.iter.<(baml.iter.SkipWhile<#0, #1, #2> as baml.iter.Iterator)>.next(self
     }
 
     bb2: {
-        _11 = copy _1.0;
-        _0 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _11) -> [bb9];
+        _10 = copy _1.0;
+        _0 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _10) -> [bb9];
     }
 
     bb3: {
@@ -6743,14 +6591,13 @@ fn baml.iter.<(baml.iter.SkipWhile<#0, #1, #2> as baml.iter.Iterator)>.next(self
 
     bb5: {
         _6 = copy _3;
-        _9 = copy _1.1;
-        _10 = copy _6;
-        _8 = call copy _9(copy _10) -> [bb6];
+        _8 = copy _1.1;
+        _9 = copy _6;
+        _7 = call copy _8(copy _9) -> [bb6];
     }
 
     bb6: {
-        _7 = !copy _8;
-        branch copy _7 -> [bb7, bb1];
+        branch copy _7 -> [bb1, bb7];
     }
 
     bb7: {
@@ -6879,17 +6726,16 @@ fn baml.json._path_field(current: int | float | string | bool | null | baml.json
     let _4: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
     let _5: map<string, baml.json.json> // m
     let _6: bool
-    let _7: bool
+    let _7: reflect.Type
     let _8: reflect.Type
-    let _9: reflect.Type
-    let _10: baml.json.PathError
+    let _9: baml.json.PathError
+    let _10: string
     let _11: string
-    let _12: string
+    let _12: reflect.Type
     let _13: reflect.Type
-    let _14: reflect.Type
-    let _15: baml.json.PathError
+    let _14: baml.json.PathError
+    let _15: string
     let _16: string
-    let _17: string
 
     bb0: {
         _4 = copy _1;
@@ -6897,39 +6743,38 @@ fn baml.json._path_field(current: int | float | string | bool | null | baml.json
     }
 
     bb1: {
-        _17 = const "field access '." + copy _2;
-        _16 = copy _17 + const "' on a non-object";
-        _15 = baml.json.PathError { copy _16, copy _3 };
-        throw copy _15;
+        _16 = const "field access '." + copy _2;
+        _15 = copy _16 + const "' on a non-object";
+        _14 = baml.json.PathError { copy _15, copy _3 };
+        throw copy _14;
     }
 
     bb2: {
         _5 = copy _4;
-        _8 = load_type(string);
-        _9 = load_type(baml.json.json);
-        _7 = call const fn baml.Map.has<copy _8, copy _9>(copy _5, copy _2) -> [bb3];
+        _7 = load_type(string);
+        _8 = load_type(baml.json.json);
+        _6 = call const fn baml.Map.has<copy _7, copy _8>(copy _5, copy _2) -> [bb3];
     }
 
     bb3: {
-        _6 = !copy _7;
-        branch copy _6 -> [bb6, bb4];
+        branch copy _6 -> [bb5, bb4];
     }
 
     bb4: {
-        _13 = load_type(string);
-        _14 = load_type(baml.json.json);
-        _0 = call const fn baml.Map.get<copy _13, copy _14>(copy _5, copy _2) -> [bb5];
+        _11 = const "missing field '" + copy _2;
+        _10 = copy _11 + const "'";
+        _9 = baml.json.PathError { copy _10, copy _3 };
+        throw copy _9;
     }
 
     bb5: {
-        return;
+        _12 = load_type(string);
+        _13 = load_type(baml.json.json);
+        _0 = call const fn baml.Map.get<copy _12, copy _13>(copy _5, copy _2) -> [bb6];
     }
 
     bb6: {
-        _12 = const "missing field '" + copy _2;
-        _11 = copy _12 + const "'";
-        _10 = baml.json.PathError { copy _11, copy _3 };
-        throw copy _10;
+        return;
     }
 }
 
@@ -6960,6 +6805,8 @@ fn baml.json._path_index(current: int | float | string | bool | null | baml.json
     let _22: string
     let _23: string
     let _24: reflect.Type
+    let _25: string
+    let _26: string
 
     bb0: {
         _4 = copy _1;
@@ -6968,11 +6815,12 @@ fn baml.json._path_index(current: int | float | string | bool | null | baml.json
 
     bb1: {
         _24 = load_type(int);
+        _26 = const "index [";
         _23 = call const fn baml.String.from<copy _24>(copy _2) -> [bb2];
     }
 
     bb2: {
-        _22 = const "index [" + copy _23;
+        _22 = copy _26 + copy _23;
         _21 = copy _22 + const "] on a non-array";
         _20 = baml.json.PathError { copy _21, copy _3 };
         throw copy _20;
@@ -6980,8 +6828,8 @@ fn baml.json._path_index(current: int | float | string | bool | null | baml.json
 
     bb3: {
         _5 = copy _4;
-        _7 = copy _2 < const 0_i64;
-        _6 = short_circuit(||) copy _7 -> [eval: bb4, join: bb6];
+        _6 = copy _2 < const 0_i64;
+        branch copy _6 -> [bb8, bb4];
     }
 
     bb4: {
@@ -6990,41 +6838,38 @@ fn baml.json._path_index(current: int | float | string | bool | null | baml.json
     }
 
     bb5: {
-        _6 = copy _2 >= copy _8;
-        goto -> bb6;
+        _7 = copy _2 >= copy _8;
+        branch copy _7 -> [bb8, bb6];
     }
 
     bb6: {
-        branch copy _6 -> [bb9, bb7];
+        _19 = load_type(baml.json.json);
+        _0 = call const fn baml.Array.at<copy _19>(copy _5, copy _2) -> [bb7];
     }
 
     bb7: {
-        _19 = load_type(baml.json.json);
-        _0 = call const fn baml.Array.at<copy _19>(copy _5, copy _2) -> [bb8];
-    }
-
-    bb8: {
         return;
     }
 
-    bb9: {
+    bb8: {
         _15 = load_type(int);
-        _14 = call const fn baml.String.from<copy _15>(copy _2) -> [bb10];
+        _25 = const "index [";
+        _14 = call const fn baml.String.from<copy _15>(copy _2) -> [bb9];
+    }
+
+    bb9: {
+        _13 = copy _25 + copy _14;
+        _12 = copy _13 + const "] out of bounds (length ";
+        _17 = len(_5);
+        goto -> bb10;
     }
 
     bb10: {
-        _13 = const "index [" + copy _14;
-        _12 = copy _13 + const "] out of bounds (length ";
-        _17 = len(_5);
-        goto -> bb11;
+        _18 = load_type(int);
+        _16 = call const fn baml.String.from<copy _18>(copy _17) -> [bb11];
     }
 
     bb11: {
-        _18 = load_type(int);
-        _16 = call const fn baml.String.from<copy _18>(copy _17) -> [bb12];
-    }
-
-    bb12: {
         _11 = copy _12 + copy _16;
         _10 = copy _11 + const ")";
         _9 = baml.json.PathError { copy _10, copy _3 };
@@ -7039,139 +6884,138 @@ fn baml.json.path(j: int | float | string | bool | null | baml.json.json[] | map
     let _2: string // selector // param
     let _3: bool
     let _4: bool
-    let _5: bool
-    let _6: baml.json.PathError
+    let _5: baml.json.PathError
+    let _6: string
     let _7: string
-    let _8: string
-    let _9: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // current
-    let _10: int // i
-    let _11: bool
+    let _8: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // current
+    let _9: int // i
+    let _10: bool
+    let _11: int
     let _12: int
-    let _13: int
-    let _14: string // marker
+    let _13: string // marker
+    let _14: int
     let _15: int
     let _16: int
-    let _17: int
-    let _18: bool
-    let _19: string
-    let _20: int // start
-    let _21: bool
-    let _22: bool
+    let _17: bool
+    let _18: string
+    let _19: int // start
+    let _20: bool
+    let _21: int
+    let _22: int
     let _23: bool
-    let _24: int
+    let _24: string
     let _25: int
-    let _26: string
+    let _26: int
     let _27: int
-    let _28: int
-    let _29: int
-    let _30: string
+    let _28: bool
+    let _29: string
+    let _30: int
     let _31: int
     let _32: int
-    let _33: int
-    let _34: bool
+    let _33: bool
+    let _34: int
     let _35: int
-    let _36: int
-    let _37: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _38: string
+    let _36: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _37: string
+    let _38: int
     let _39: int
-    let _40: int
-    let _41: bool
-    let _42: string
-    let _43: baml.json.PathError
+    let _40: bool
+    let _41: string
+    let _42: baml.json.PathError
+    let _43: string
     let _44: string
-    let _45: string
-    let _46: reflect.Type
-    let _47: bool
+    let _45: reflect.Type
+    let _46: bool
+    let _47: int
     let _48: int
-    let _49: int
-    let _50: baml.json.PathError
-    let _51: string // first
+    let _49: baml.json.PathError
+    let _50: string // first
+    let _51: int
     let _52: int
     let _53: int
-    let _54: int
-    let _55: bool
+    let _54: bool
+    let _55: string
     let _56: bool
     let _57: string
-    let _58: string
-    let _59: string // quote
-    let _60: string // key
-    let _61: bool // closed
-    let _62: bool
+    let _58: string // quote
+    let _59: string // key
+    let _60: bool // closed
+    let _61: bool
+    let _62: int
     let _63: int
-    let _64: int
-    let _65: string // ch
+    let _64: string // ch
+    let _65: int
     let _66: int
     let _67: int
-    let _68: int
-    let _69: bool
-    let _70: string
-    let _71: bool
+    let _68: bool
+    let _69: string
+    let _70: bool
+    let _71: int
     let _72: int
     let _73: int
-    let _74: int
-    let _75: baml.json.PathError
+    let _74: baml.json.PathError
+    let _75: string
     let _76: string
-    let _77: string
+    let _77: int
     let _78: int
     let _79: int
     let _80: int
-    let _81: int
-    let _82: bool
+    let _81: bool
+    let _82: string
     let _83: string
     let _84: string
     let _85: string
-    let _86: string
+    let _86: bool
     let _87: bool
-    let _88: bool
-    let _89: bool
+    let _88: int
+    let _89: int
     let _90: bool
-    let _91: int
+    let _91: string
     let _92: int
-    let _93: string
+    let _93: int
     let _94: int
-    let _95: int
-    let _96: int
-    let _97: baml.json.PathError
-    let _98: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _99: string
-    let _100: int // start
-    let _101: bool
+    let _95: baml.json.PathError
+    let _96: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _97: string
+    let _98: int // start
+    let _99: bool
+    let _100: int
+    let _101: int
     let _102: bool
-    let _103: int
+    let _103: string
     let _104: int
-    let _105: string
+    let _105: int
     let _106: int
-    let _107: int
+    let _107: bool
     let _108: int
-    let _109: bool
-    let _110: int
-    let _111: int
-    let _112: baml.json.PathError
-    let _113: string // token
-    let _114: int
-    let _115: int
-    let _116: int // idx
-    let _117: unknown // _
-    let _118: string
-    let _119: bool
-    let _120: baml.json.PathError
+    let _109: int
+    let _110: baml.json.PathError
+    let _111: string // token
+    let _112: int
+    let _113: int
+    let _114: int // idx
+    let _115: unknown // _
+    let _116: string
+    let _117: bool
+    let _118: baml.json.PathError
+    let _119: string
+    let _120: string
     let _121: string
-    let _122: string
-    let _123: string
-    let _124: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _125: int
-    let _126: unknown // _
-    let _127: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _128: reflect.Type
-    let _129: bool
-    let _130: baml.json.PathError
+    let _122: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _123: int
+    let _124: unknown // _
+    let _125: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _126: reflect.Type
+    let _127: bool
+    let _128: baml.json.PathError
+    let _129: string
 
     bb0: {
-        _5 = call const fn baml.String.starts_with(copy _2, const ".") -> [bb1];
+        _3 = call const fn baml.String.starts_with(copy _2, const ".") -> [bb1];
     }
 
     bb1: {
-        _4 = short_circuit(||) copy _5 -> [eval: bb2, join: bb3];
+        branch copy _3 -> [bb5, bb2];
     }
 
     bb2: {
@@ -7179,412 +7023,387 @@ fn baml.json.path(j: int | float | string | bool | null | baml.json.json[] | map
     }
 
     bb3: {
-        _3 = !copy _4;
-        branch copy _3 -> [bb69, bb4];
+        branch copy _4 -> [bb5, bb4];
     }
 
     bb4: {
-        _9 = copy _1;
-        _10 = const 0_i64;
-        goto -> bb5;
+        _7 = const "selector must start with '.' or '[' (jq style), got '" + copy _2;
+        _6 = copy _7 + const "'";
+        _5 = baml.json.PathError { copy _6, copy _2 };
+        throw copy _5;
     }
 
     bb5: {
-        _12 = copy _10;
-        _13 = call const fn baml.String.length(copy _2) -> [bb6];
+        _8 = copy _1;
+        _9 = const 0_i64;
+        goto -> bb6;
     }
 
     bb6: {
-        _11 = copy _12 < copy _13;
-        branch copy _11 -> [bb9, bb7];
+        _11 = copy _9;
+        _12 = call const fn baml.String.length(copy _2) -> [bb7];
     }
 
     bb7: {
-        _127 = copy _9;
-        _128 = load_type(#0);
-        _0 = call const fn baml.json.to<copy _128>(copy _127) -> [bb8, unwind: bb73];
+        _10 = copy _11 < copy _12;
+        branch copy _10 -> [bb10, bb8];
     }
 
     bb8: {
-        return;
+        _125 = copy _8;
+        _126 = load_type(#0);
+        _0 = call const fn baml.json.to<copy _126>(copy _125) -> [bb9, unwind: bb67];
     }
 
     bb9: {
-        _15 = copy _10;
-        _17 = copy _10;
-        _16 = copy _17 + const 1_i64;
-        _14 = call const fn baml.String.slice(copy _2, copy _15, copy _16) -> [bb10];
+        return;
     }
 
     bb10: {
-        _19 = copy _14;
-        _18 = copy _19 == const ".";
-        branch copy _18 -> [bb56, bb11];
+        _14 = copy _9;
+        _16 = copy _9;
+        _15 = copy _16 + const 1_i64;
+        _13 = call const fn baml.String.slice(copy _2, copy _14, copy _15) -> [bb11];
     }
 
     bb11: {
-        _42 = copy _14;
-        _41 = copy _42 != const "[";
-        branch copy _41 -> [bb54, bb12];
+        _18 = copy _13;
+        _17 = copy _18 == const ".";
+        branch copy _17 -> [bb53, bb12];
     }
 
     bb12: {
-        _10 = copy _10 + const 1_i64;
-        _48 = copy _10;
-        _49 = call const fn baml.String.length(copy _2) -> [bb13];
+        _41 = copy _13;
+        _40 = copy _41 != const "[";
+        branch copy _40 -> [bb51, bb13];
     }
 
     bb13: {
-        _47 = copy _48 >= copy _49;
-        branch copy _47 -> [bb53, bb14];
+        _9 = copy _9 + const 1_i64;
+        _47 = copy _9;
+        _48 = call const fn baml.String.length(copy _2) -> [bb14];
     }
 
     bb14: {
-        _52 = copy _10;
-        _54 = copy _10;
-        _53 = copy _54 + const 1_i64;
-        _51 = call const fn baml.String.slice(copy _2, copy _52, copy _53) -> [bb15];
+        _46 = copy _47 >= copy _48;
+        branch copy _46 -> [bb50, bb15];
     }
 
     bb15: {
-        _57 = copy _51;
-        _56 = copy _57 == const "\"";
-        _55 = short_circuit(||) copy _56 -> [eval: bb16, join: bb17];
+        _51 = copy _9;
+        _53 = copy _9;
+        _52 = copy _53 + const 1_i64;
+        _50 = call const fn baml.String.slice(copy _2, copy _51, copy _52) -> [bb16];
     }
 
     bb16: {
-        _58 = copy _51;
-        _55 = copy _58 == const "'";
-        goto -> bb17;
+        _55 = copy _50;
+        _54 = copy _55 == const "\"";
+        branch copy _54 -> [bb30, bb17];
     }
 
     bb17: {
-        branch copy _55 -> [bb31, bb18];
+        _57 = copy _50;
+        _56 = copy _57 == const "'";
+        branch copy _56 -> [bb30, bb18];
     }
 
     bb18: {
-        _100 = copy _10;
+        _98 = copy _9;
         goto -> bb19;
     }
 
     bb19: {
-        _103 = copy _10;
-        _104 = call const fn baml.String.length(copy _2) -> [bb20];
+        _100 = copy _9;
+        _101 = call const fn baml.String.length(copy _2) -> [bb20];
     }
 
     bb20: {
-        _102 = copy _103 < copy _104;
-        _101 = short_circuit(&&) copy _102 -> [eval: bb21, join: bb23];
+        _99 = copy _100 < copy _101;
+        branch copy _99 -> [bb21, bb23];
     }
 
     bb21: {
-        _106 = copy _10;
-        _108 = copy _10;
-        _107 = copy _108 + const 1_i64;
-        _105 = call const fn baml.String.slice(copy _2, copy _106, copy _107) -> [bb22];
+        _104 = copy _9;
+        _106 = copy _9;
+        _105 = copy _106 + const 1_i64;
+        _103 = call const fn baml.String.slice(copy _2, copy _104, copy _105) -> [bb22];
     }
 
     bb22: {
-        _101 = copy _105 != const "]";
-        goto -> bb23;
+        _102 = copy _103 != const "]";
+        branch copy _102 -> [bb29, bb23];
     }
 
     bb23: {
-        branch copy _101 -> [bb30, bb24];
+        _108 = copy _9;
+        _109 = call const fn baml.String.length(copy _2) -> [bb24];
     }
 
     bb24: {
-        _110 = copy _10;
-        _111 = call const fn baml.String.length(copy _2) -> [bb25];
+        _107 = copy _108 >= copy _109;
+        branch copy _107 -> [bb28, bb25];
     }
 
     bb25: {
-        _109 = copy _110 >= copy _111;
-        branch copy _109 -> [bb29, bb26];
+        _112 = copy _98;
+        _113 = copy _9;
+        _111 = call const fn baml.String.slice(copy _2, copy _112, copy _113) -> [bb26];
     }
 
     bb26: {
-        _114 = copy _100;
-        _115 = copy _10;
-        _113 = call const fn baml.String.slice(copy _2, copy _114, copy _115) -> [bb27];
+        _9 = copy _9 + const 1_i64;
+        _116 = copy _111;
+        _114 = call const fn baml.Int.parse(copy _116) -> [bb27, unwind: bb64];
     }
 
     bb27: {
-        _10 = copy _10 + const 1_i64;
-        _118 = copy _113;
-        _116 = call const fn baml.Int.parse(copy _118) -> [bb28, unwind: bb70];
+        _122 = copy _8;
+        _123 = copy _114;
+        _8 = call const fn baml.json._path_index(copy _122, copy _123, copy _2) -> [bb6];
     }
 
     bb28: {
-        _124 = copy _9;
-        _125 = copy _116;
-        _9 = call const fn baml.json._path_index(copy _124, copy _125, copy _2) -> [bb5];
+        _110 = baml.json.PathError { const "unterminated '[' segment", copy _2 };
+        throw copy _110;
     }
 
     bb29: {
-        _112 = baml.json.PathError { const "unterminated '[' segment", copy _2 };
-        throw copy _112;
-    }
-
-    bb30: {
-        _10 = copy _10 + const 1_i64;
+        _9 = copy _9 + const 1_i64;
         goto -> bb19;
     }
 
+    bb30: {
+        _58 = copy _50;
+        _9 = copy _9 + const 1_i64;
+        _59 = const "";
+        _60 = const false;
+        goto -> bb31;
+    }
+
     bb31: {
-        _59 = copy _51;
-        _10 = copy _10 + const 1_i64;
-        _60 = const "";
-        _61 = const false;
-        goto -> bb32;
+        _62 = copy _9;
+        _63 = call const fn baml.String.length(copy _2) -> [bb32];
     }
 
     bb32: {
-        _63 = copy _10;
-        _64 = call const fn baml.String.length(copy _2) -> [bb33];
+        _61 = copy _62 < copy _63;
+        branch copy _61 -> [bb33, bb38];
     }
 
     bb33: {
-        _62 = copy _63 < copy _64;
-        branch copy _62 -> [bb34, bb39];
+        _65 = copy _9;
+        _67 = copy _9;
+        _66 = copy _67 + const 1_i64;
+        _64 = call const fn baml.String.slice(copy _2, copy _65, copy _66) -> [bb34];
     }
 
     bb34: {
-        _66 = copy _10;
-        _68 = copy _10;
-        _67 = copy _68 + const 1_i64;
-        _65 = call const fn baml.String.slice(copy _2, copy _66, copy _67) -> [bb35];
+        _69 = copy _64;
+        _68 = copy _69 == const "\\";
+        branch copy _68 -> [bb45, bb35];
     }
 
     bb35: {
-        _70 = copy _65;
-        _69 = copy _70 == const "\\";
-        branch copy _69 -> [bb48, bb36];
+        _82 = copy _64;
+        _83 = copy _58;
+        _81 = copy _82 == copy _83;
+        branch copy _81 -> [bb37, bb36];
     }
 
     bb36: {
-        _83 = copy _65;
         _84 = copy _59;
-        _82 = copy _83 == copy _84;
-        branch copy _82 -> [bb38, bb37];
+        _85 = copy _64;
+        _59 = copy _84 + copy _85;
+        _9 = copy _9 + const 1_i64;
+        goto -> bb31;
     }
 
     bb37: {
-        _85 = copy _60;
-        _86 = copy _65;
-        _60 = copy _85 + copy _86;
-        _10 = copy _10 + const 1_i64;
-        goto -> bb32;
+        _60 = const true;
+        _9 = copy _9 + const 1_i64;
+        goto -> bb38;
     }
 
     bb38: {
-        _61 = const true;
-        _10 = copy _10 + const 1_i64;
-        goto -> bb39;
+        _86 = copy _60;
+        branch copy _86 -> [bb39, bb44];
     }
 
     bb39: {
-        _90 = copy _61;
-        _89 = !copy _90;
-        _88 = short_circuit(||) copy _89 -> [eval: bb40, join: bb42];
+        _88 = copy _9;
+        _89 = call const fn baml.String.length(copy _2) -> [bb40];
     }
 
     bb40: {
-        _91 = copy _10;
-        _92 = call const fn baml.String.length(copy _2) -> [bb41];
+        _87 = copy _88 >= copy _89;
+        branch copy _87 -> [bb44, bb41];
     }
 
     bb41: {
-        _88 = copy _91 >= copy _92;
-        goto -> bb42;
+        _92 = copy _9;
+        _94 = copy _9;
+        _93 = copy _94 + const 1_i64;
+        _91 = call const fn baml.String.slice(copy _2, copy _92, copy _93) -> [bb42];
     }
 
     bb42: {
-        _87 = short_circuit(||) copy _88 -> [eval: bb43, join: bb45];
+        _90 = copy _91 != const "]";
+        branch copy _90 -> [bb44, bb43];
     }
 
     bb43: {
-        _94 = copy _10;
-        _96 = copy _10;
-        _95 = copy _96 + const 1_i64;
-        _93 = call const fn baml.String.slice(copy _2, copy _94, copy _95) -> [bb44];
+        _9 = copy _9 + const 1_i64;
+        _96 = copy _8;
+        _97 = copy _59;
+        _8 = call const fn baml.json._path_field(copy _96, copy _97, copy _2) -> [bb6];
     }
 
     bb44: {
-        _87 = copy _93 != const "]";
-        goto -> bb45;
+        _95 = baml.json.PathError { const "unterminated quoted bracket key", copy _2 };
+        throw copy _95;
     }
 
     bb45: {
-        branch copy _87 -> [bb47, bb46];
+        _72 = copy _9;
+        _71 = copy _72 + const 1_i64;
+        _73 = call const fn baml.String.length(copy _2) -> [bb46];
     }
 
     bb46: {
-        _10 = copy _10 + const 1_i64;
-        _98 = copy _9;
-        _99 = copy _60;
-        _9 = call const fn baml.json._path_field(copy _98, copy _99, copy _2) -> [bb5];
+        _70 = copy _71 >= copy _73;
+        branch copy _70 -> [bb49, bb47];
     }
 
     bb47: {
-        _97 = baml.json.PathError { const "unterminated quoted bracket key", copy _2 };
-        throw copy _97;
+        _75 = copy _59;
+        _78 = copy _9;
+        _77 = copy _78 + const 1_i64;
+        _80 = copy _9;
+        _79 = copy _80 + const 2_i64;
+        _76 = call const fn baml.String.slice(copy _2, copy _77, copy _79) -> [bb48];
     }
 
     bb48: {
-        _73 = copy _10;
-        _72 = copy _73 + const 1_i64;
-        _74 = call const fn baml.String.length(copy _2) -> [bb49];
+        _59 = copy _75 + copy _76;
+        _9 = copy _9 + const 2_i64;
+        goto -> bb31;
     }
 
     bb49: {
-        _71 = copy _72 >= copy _74;
-        branch copy _71 -> [bb52, bb50];
+        _74 = baml.json.PathError { const "unterminated escape in quoted bracket key", copy _2 };
+        throw copy _74;
     }
 
     bb50: {
-        _76 = copy _60;
-        _79 = copy _10;
-        _78 = copy _79 + const 1_i64;
-        _81 = copy _10;
-        _80 = copy _81 + const 2_i64;
-        _77 = call const fn baml.String.slice(copy _2, copy _78, copy _80) -> [bb51];
+        _49 = baml.json.PathError { const "unterminated '[' segment", copy _2 };
+        throw copy _49;
     }
 
     bb51: {
-        _60 = copy _76 + copy _77;
-        _10 = copy _10 + const 2_i64;
-        goto -> bb32;
+        _45 = load_type(int);
+        _129 = const "expected '.' or '[' at offset ";
+        _44 = call const fn baml.String.from<copy _45>(copy _9) -> [bb52];
     }
 
     bb52: {
-        _75 = baml.json.PathError { const "unterminated escape in quoted bracket key", copy _2 };
-        throw copy _75;
+        _43 = copy _129 + copy _44;
+        _42 = baml.json.PathError { copy _43, copy _2 };
+        throw copy _42;
     }
 
     bb53: {
-        _50 = baml.json.PathError { const "unterminated '[' segment", copy _2 };
-        throw copy _50;
+        _9 = copy _9 + const 1_i64;
+        _19 = copy _9;
+        goto -> bb54;
     }
 
     bb54: {
-        _46 = load_type(int);
-        _45 = call const fn baml.String.from<copy _46>(copy _10) -> [bb55];
+        _21 = copy _9;
+        _22 = call const fn baml.String.length(copy _2) -> [bb55];
     }
 
     bb55: {
-        _44 = const "expected '.' or '[' at offset " + copy _45;
-        _43 = baml.json.PathError { copy _44, copy _2 };
-        throw copy _43;
+        _20 = copy _21 < copy _22;
+        branch copy _20 -> [bb56, bb60];
     }
 
     bb56: {
-        _10 = copy _10 + const 1_i64;
-        _20 = copy _10;
-        goto -> bb57;
+        _25 = copy _9;
+        _27 = copy _9;
+        _26 = copy _27 + const 1_i64;
+        _24 = call const fn baml.String.slice(copy _2, copy _25, copy _26) -> [bb57];
     }
 
     bb57: {
-        _24 = copy _10;
-        _25 = call const fn baml.String.length(copy _2) -> [bb58];
+        _23 = copy _24 != const ".";
+        branch copy _23 -> [bb58, bb60];
     }
 
     bb58: {
-        _23 = copy _24 < copy _25;
-        _22 = short_circuit(&&) copy _23 -> [eval: bb59, join: bb61];
+        _30 = copy _9;
+        _32 = copy _9;
+        _31 = copy _32 + const 1_i64;
+        _29 = call const fn baml.String.slice(copy _2, copy _30, copy _31) -> [bb59];
     }
 
     bb59: {
-        _27 = copy _10;
-        _29 = copy _10;
-        _28 = copy _29 + const 1_i64;
-        _26 = call const fn baml.String.slice(copy _2, copy _27, copy _28) -> [bb60];
+        _28 = copy _29 != const "[";
+        branch copy _28 -> [bb63, bb60];
     }
 
     bb60: {
-        _22 = copy _26 != const ".";
-        goto -> bb61;
+        _34 = copy _9;
+        _35 = copy _19;
+        _33 = copy _34 > copy _35;
+        branch copy _33 -> [bb61, bb6];
     }
 
     bb61: {
-        _21 = short_circuit(&&) copy _22 -> [eval: bb62, join: bb64];
+        _36 = copy _8;
+        _38 = copy _19;
+        _39 = copy _9;
+        _37 = call const fn baml.String.slice(copy _2, copy _38, copy _39) -> [bb62];
     }
 
     bb62: {
-        _31 = copy _10;
-        _33 = copy _10;
-        _32 = copy _33 + const 1_i64;
-        _30 = call const fn baml.String.slice(copy _2, copy _31, copy _32) -> [bb63];
+        _8 = call const fn baml.json._path_field(copy _36, copy _37, copy _2) -> [bb6];
     }
 
     bb63: {
-        _21 = copy _30 != const "[";
-        goto -> bb64;
+        _9 = copy _9 + const 1_i64;
+        goto -> bb54;
     }
 
     bb64: {
-        branch copy _21 -> [bb68, bb65];
+        _117 = is_type(copy _115, baml.errors.ParseError);
+        branch copy _117 -> [bb66, bb65];
     }
 
     bb65: {
-        _35 = copy _10;
-        _36 = copy _20;
-        _34 = copy _35 > copy _36;
-        branch copy _34 -> [bb66, bb5];
+        rethrow copy _115;
     }
 
     bb66: {
-        _37 = copy _9;
-        _39 = copy _20;
-        _40 = copy _10;
-        _38 = call const fn baml.String.slice(copy _2, copy _39, copy _40) -> [bb67];
+        _121 = copy _111;
+        _120 = const "bad bracket token '[" + copy _121;
+        _119 = copy _120 + const "]'";
+        _118 = baml.json.PathError { copy _119, copy _2 };
+        throw copy _118;
     }
 
     bb67: {
-        _9 = call const fn baml.json._path_field(copy _37, copy _38, copy _2) -> [bb5];
+        _127 = is_type(copy _124, baml.json.DecodeError);
+        branch copy _127 -> [bb69, bb68];
     }
 
     bb68: {
-        _10 = copy _10 + const 1_i64;
-        goto -> bb57;
+        rethrow copy _124;
     }
 
     bb69: {
-        _8 = const "selector must start with '.' or '[' (jq style), got '" + copy _2;
-        _7 = copy _8 + const "'";
-        _6 = baml.json.PathError { copy _7, copy _2 };
-        throw copy _6;
-    }
-
-    bb70: {
-        _119 = is_type(copy _117, baml.errors.ParseError);
-        branch copy _119 -> [bb72, bb71];
-    }
-
-    bb71: {
-        rethrow copy _117;
-    }
-
-    bb72: {
-        _123 = copy _113;
-        _122 = const "bad bracket token '[" + copy _123;
-        _121 = copy _122 + const "]'";
-        _120 = baml.json.PathError { copy _121, copy _2 };
-        throw copy _120;
-    }
-
-    bb73: {
-        _129 = is_type(copy _126, baml.json.DecodeError);
-        branch copy _129 -> [bb75, bb74];
-    }
-
-    bb74: {
-        rethrow copy _126;
-    }
-
-    bb75: {
-        _130 = baml.json.PathError { const "leaf does not coerce to the requested type", copy _2 };
-        throw copy _130;
+        _128 = baml.json.PathError { const "leaf does not coerce to the requested type", copy _2 };
+        throw copy _128;
     }
 }
 
@@ -7725,7 +7544,6 @@ fn baml.net.TcpStream.connect(addr: string, timeout: null | baml.time.Duration) 
     let _5: bigint
     let _6: bigint | null
     let _7: bool
-    let _8: bool
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -7752,9 +7570,7 @@ fn baml.net.TcpStream.connect(addr: string, timeout: null | baml.time.Duration) 
     }
 
     bb5: {
-        _5 = copy _6;
-        _8 = copy _5 == const null;
-        branch copy _8 -> [bb6, bb7];
+        _5 = short_circuit(??) copy _6 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
@@ -7815,7 +7631,6 @@ fn baml.net.UdpSocket.send_to(self: baml.net.UdpSocket, data: uint8array, addr: 
     let _7: bigint
     let _8: bigint | null
     let _9: bool
-    let _10: bool
 
     bb0: {
         _5 = copy _4 == const <omitted>;
@@ -7842,9 +7657,7 @@ fn baml.net.UdpSocket.send_to(self: baml.net.UdpSocket, data: uint8array, addr: 
     }
 
     bb5: {
-        _7 = copy _8;
-        _10 = copy _7 == const null;
-        branch copy _10 -> [bb6, bb7];
+        _7 = short_circuit(??) copy _8 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
@@ -7874,7 +7687,6 @@ fn baml.net.UdpSocket.recv_from(self: baml.net.UdpSocket, timeout: null | baml.t
     let _5: bigint
     let _6: bigint | null
     let _7: bool
-    let _8: bool
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -7901,9 +7713,7 @@ fn baml.net.UdpSocket.recv_from(self: baml.net.UdpSocket, timeout: null | baml.t
     }
 
     bb5: {
-        _5 = copy _6;
-        _8 = copy _5 == const null;
-        branch copy _8 -> [bb6, bb7];
+        _5 = short_circuit(??) copy _6 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
@@ -8970,10 +8780,9 @@ fn baml.sap.parse(text: string) -> T {
     let _7: reflect.Type
     let _8: bool
     let _9: string
-    let _10: string
-    let _11: string // message
-    let _12: baml.errors.ParseError
-    let _13: string
+    let _10: string // message
+    let _11: baml.errors.ParseError
+    let _12: string
 
     bb0: {
         _3 = load_type(#0);
@@ -9002,16 +8811,10 @@ fn baml.sap.parse(text: string) -> T {
 
     bb5: {
         _9 = copy _5.0;
-        drop(_9);
-        goto -> bb6;
-    }
-
-    bb6: {
-        _10 = copy _5.0;
-        _11 = copy _10;
-        _13 = copy _11;
-        _12 = baml.errors.ParseError { copy _13 };
-        throw copy _12;
+        _10 = copy _9;
+        _12 = copy _10;
+        _11 = baml.errors.ParseError { copy _12 };
+        throw copy _11;
     }
 }
 
@@ -9115,23 +8918,18 @@ fn .<lambda(options, 0)>(params: baml.spawn.Params<T, E>) -> baml.spawn.Params<T
     let _4: null | baml.spawn.TaskGroup
     let _5: null | baml.spawn.TaskGroup
     let _6: null | baml.spawn.TaskGroup
-    let _7: bool
+    let _7: null | baml.spawn.CancelToken
     let _8: null | baml.spawn.CancelToken
     let _9: null | baml.spawn.CancelToken
-    let _10: null | baml.spawn.CancelToken
+    let _10: bool
     let _11: bool
-    let _12: bool
-    let _13: bool
-    let _14: bool | null
-    let _15: bool
+    let _12: bool | null
 
     bb0: {
         _2 = copy _1.0;
         _3 = copy _1.1;
         _6 = copy capture[0];
-        _5 = copy _6;
-        _7 = copy _5 == const null;
-        branch copy _7 -> [bb1, bb2];
+        _5 = short_circuit(??) copy _6 -> [eval: bb1, join: bb2];
     }
 
     bb1: {
@@ -9141,33 +8939,29 @@ fn .<lambda(options, 0)>(params: baml.spawn.Params<T, E>) -> baml.spawn.Params<T
 
     bb2: {
         _4 = copy _5;
-        _10 = copy capture[1];
-        _9 = copy _10;
-        _11 = copy _9 == const null;
-        branch copy _11 -> [bb3, bb4];
+        _9 = copy capture[1];
+        _8 = short_circuit(??) copy _9 -> [eval: bb3, join: bb4];
     }
 
     bb3: {
-        _9 = copy _1.3;
+        _8 = copy _1.3;
         goto -> bb4;
     }
 
     bb4: {
-        _8 = copy _9;
-        _14 = copy capture[2];
-        _13 = copy _14;
-        _15 = copy _13 == const null;
-        branch copy _15 -> [bb5, bb6];
+        _7 = copy _8;
+        _12 = copy capture[2];
+        _11 = short_circuit(??) copy _12 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
-        _13 = copy _1.4;
+        _11 = copy _1.4;
         goto -> bb6;
     }
 
     bb6: {
-        _12 = copy _13;
-        _0 = baml.spawn.Params<#0, #1> { copy _2, copy _3, copy _4, copy _8, copy _12 };
+        _10 = copy _11;
+        _0 = baml.spawn.Params<#0, #1> { copy _2, copy _3, copy _4, copy _7, copy _10 };
         goto -> bb7;
     }
 
@@ -10065,13 +9859,12 @@ fn baml.time.<(baml.time.Instant as baml.ToString)>.to_string(self: baml.time.In
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string
-    let _6: string // message
+    let _5: string // message
+    let _6: string
     let _7: string
-    let _8: string
 
     bb0: {
-        _0 = call const fn baml.time.Instant._to_string_impl(copy _1) -> [bb5, unwind: bb1];
+        _0 = call const fn baml.time.Instant._to_string_impl(copy _1) -> [bb4, unwind: bb1];
     }
 
     bb1: {
@@ -10085,19 +9878,13 @@ fn baml.time.<(baml.time.Instant as baml.ToString)>.to_string(self: baml.time.In
 
     bb3: {
         _4 = copy _2.0;
-        drop(_4);
-        goto -> bb4;
+        _5 = copy _4;
+        _7 = copy _5;
+        _6 = const "Instant.to_string: " + copy _7;
+        _0 = call const fn baml.sys.panic(copy _6) -> [bb4];
     }
 
     bb4: {
-        _5 = copy _2.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = const "Instant.to_string: " + copy _8;
-        _0 = call const fn baml.sys.panic(copy _7) -> [bb5];
-    }
-
-    bb5: {
         return;
     }
 }
@@ -10112,11 +9899,10 @@ fn baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: int | float | s
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string
-    let _7: string // message
-    let _8: baml.json.DecodeError
-    let _9: string
-    let _10: baml.json.DecodeError
+    let _6: string // message
+    let _7: baml.json.DecodeError
+    let _8: string
+    let _9: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -10124,8 +9910,8 @@ fn baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: int | float | s
     }
 
     bb1: {
-        _10 = baml.json.DecodeError { const "Expected timestamp string", const "" };
-        throw copy _10;
+        _9 = baml.json.DecodeError { const "Expected timestamp string", const "" };
+        throw copy _9;
     }
 
     bb2: {
@@ -10147,16 +9933,10 @@ fn baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: int | float | s
 
     bb6: {
         _5 = copy _3.0;
-        drop(_5);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _6 = copy _3.0;
-        _7 = copy _6;
-        _9 = copy _7;
-        _8 = baml.json.DecodeError { copy _9, const "" };
-        throw copy _8;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.DecodeError { copy _8, const "" };
+        throw copy _7;
     }
 }
 
@@ -10167,10 +9947,9 @@ fn baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.Instan
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string
-    let _6: string // message
-    let _7: baml.json.SerializationError
-    let _8: string
+    let _5: string // message
+    let _6: baml.json.SerializationError
+    let _7: string
 
     bb0: {
         _0 = call const fn baml.time.Instant._to_string_impl(copy _1) -> [bb1, unwind: bb2];
@@ -10191,16 +9970,10 @@ fn baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.Instan
 
     bb4: {
         _4 = copy _2.0;
-        drop(_4);
-        goto -> bb5;
-    }
-
-    bb5: {
-        _5 = copy _2.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.SerializationError { copy _8, const "", const "unserializable" };
-        throw copy _7;
+        _5 = copy _4;
+        _7 = copy _5;
+        _6 = baml.json.SerializationError { copy _7, const "", const "unserializable" };
+        throw copy _6;
     }
 }
 
@@ -10516,13 +10289,12 @@ fn baml.time.<(baml.time.PlainDate as baml.ToString)>.to_string(self: baml.time.
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string
-    let _6: string // message
+    let _5: string // message
+    let _6: string
     let _7: string
-    let _8: string
 
     bb0: {
-        _0 = call const fn baml.time.PlainDate._to_string_impl(copy _1) -> [bb5, unwind: bb1];
+        _0 = call const fn baml.time.PlainDate._to_string_impl(copy _1) -> [bb4, unwind: bb1];
     }
 
     bb1: {
@@ -10536,19 +10308,13 @@ fn baml.time.<(baml.time.PlainDate as baml.ToString)>.to_string(self: baml.time.
 
     bb3: {
         _4 = copy _2.0;
-        drop(_4);
-        goto -> bb4;
+        _5 = copy _4;
+        _7 = copy _5;
+        _6 = const "PlainDate.to_string: " + copy _7;
+        _0 = call const fn baml.sys.panic(copy _6) -> [bb4];
     }
 
     bb4: {
-        _5 = copy _2.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = const "PlainDate.to_string: " + copy _8;
-        _0 = call const fn baml.sys.panic(copy _7) -> [bb5];
-    }
-
-    bb5: {
         return;
     }
 }
@@ -10599,11 +10365,10 @@ fn baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: int | float |
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string
-    let _7: string // message
-    let _8: baml.json.DecodeError
-    let _9: string
-    let _10: baml.json.DecodeError
+    let _6: string // message
+    let _7: baml.json.DecodeError
+    let _8: string
+    let _9: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -10611,8 +10376,8 @@ fn baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: int | float |
     }
 
     bb1: {
-        _10 = baml.json.DecodeError { const "Expected ISO 8601 date string", const "" };
-        throw copy _10;
+        _9 = baml.json.DecodeError { const "Expected ISO 8601 date string", const "" };
+        throw copy _9;
     }
 
     bb2: {
@@ -10634,16 +10399,10 @@ fn baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: int | float |
 
     bb6: {
         _5 = copy _3.0;
-        drop(_5);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _6 = copy _3.0;
-        _7 = copy _6;
-        _9 = copy _7;
-        _8 = baml.json.DecodeError { copy _9, const "" };
-        throw copy _8;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.DecodeError { copy _8, const "" };
+        throw copy _7;
     }
 }
 
@@ -10654,10 +10413,9 @@ fn baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.time.Plai
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string
-    let _6: string // message
-    let _7: baml.json.SerializationError
-    let _8: string
+    let _5: string // message
+    let _6: baml.json.SerializationError
+    let _7: string
 
     bb0: {
         _0 = call const fn baml.time.PlainDate._to_string_impl(copy _1) -> [bb1, unwind: bb2];
@@ -10678,16 +10436,10 @@ fn baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.time.Plai
 
     bb4: {
         _4 = copy _2.0;
-        drop(_4);
-        goto -> bb5;
-    }
-
-    bb5: {
-        _5 = copy _2.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.SerializationError { copy _8, const "", const "unserializable" };
-        throw copy _7;
+        _5 = copy _4;
+        _7 = copy _5;
+        _6 = baml.json.SerializationError { copy _7, const "", const "unserializable" };
+        throw copy _6;
     }
 }
 
@@ -10790,13 +10542,12 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToString)>.to_string(self: baml.t
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string
-    let _6: string // message
+    let _5: string // message
+    let _6: string
     let _7: string
-    let _8: string
 
     bb0: {
-        _0 = call const fn baml.time.PlainDateTime._to_string_impl(copy _1) -> [bb5, unwind: bb1];
+        _0 = call const fn baml.time.PlainDateTime._to_string_impl(copy _1) -> [bb4, unwind: bb1];
     }
 
     bb1: {
@@ -10810,19 +10561,13 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToString)>.to_string(self: baml.t
 
     bb3: {
         _4 = copy _2.0;
-        drop(_4);
-        goto -> bb4;
+        _5 = copy _4;
+        _7 = copy _5;
+        _6 = const "PlainDateTime.to_string: " + copy _7;
+        _0 = call const fn baml.sys.panic(copy _6) -> [bb4];
     }
 
     bb4: {
-        _5 = copy _2.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = const "PlainDateTime.to_string: " + copy _8;
-        _0 = call const fn baml.sys.panic(copy _7) -> [bb5];
-    }
-
-    bb5: {
         return;
     }
 }
@@ -10858,18 +10603,16 @@ fn baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezone: str
     let _24: bigint
     let _25: bigint
     let _26: bigint | null
-    let _27: bool
-    let _28: baml.time.AmbiguousTimeError
-    let _29: string
-    let _30: bigint | null
-    let _31: bigint
-    let _32: bool
-    let _33: baml.time.UnknownTimezoneError
-    let _34: bigint | null // resolved
+    let _27: baml.time.AmbiguousTimeError
+    let _28: string
+    let _29: bigint | null
+    let _30: bigint
+    let _31: bool
+    let _32: baml.time.UnknownTimezoneError
+    let _33: bigint | null // resolved
+    let _34: bigint
     let _35: bigint
-    let _36: bigint
-    let _37: bigint | null
-    let _38: bool
+    let _36: bigint | null
 
     bb0: {
         _4 = copy _3 == const <omitted>;
@@ -10895,37 +10638,35 @@ fn baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezone: str
     }
 
     bb5: {
-        _31 = copy _1.0;
-        _30 = sys_op const fn baml.time._tz_to_instant(copy _2, copy _31, copy _3) -> bb6;
+        _30 = copy _1.0;
+        _29 = sys_op const fn baml.time._tz_to_instant(copy _2, copy _30, copy _3) -> bb6;
     }
 
     bb6: {
-        _32 = copy _30 == const null;
-        branch copy _32 -> [bb10, bb7];
+        _31 = copy _29 == const null;
+        branch copy _31 -> [bb10, bb7];
     }
 
     bb7: {
-        _34 = copy _30;
-        _37 = copy _34;
-        _36 = copy _37;
-        _38 = copy _36 == const null;
-        branch copy _38 -> [bb8, bb9];
+        _33 = copy _29;
+        _36 = copy _33;
+        _35 = short_circuit(??) copy _36 -> [eval: bb8, join: bb9];
     }
 
     bb8: {
-        _36 = const 0n;
+        _35 = const 0n;
         goto -> bb9;
     }
 
     bb9: {
-        _35 = copy _36;
-        _0 = baml.time.ZonedDateTime { copy _35, const null, copy _2 };
+        _34 = copy _35;
+        _0 = baml.time.ZonedDateTime { copy _34, const null, copy _2 };
         goto -> bb24;
     }
 
     bb10: {
-        _33 = baml.time.UnknownTimezoneError { copy _2 };
-        throw copy _33;
+        _32 = baml.time.UnknownTimezoneError { copy _2 };
+        throw copy _32;
     }
 
     bb11: {
@@ -10961,16 +10702,14 @@ fn baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezone: str
     }
 
     bb17: {
-        _29 = const "wall-clock time is ambiguous or skipped in timezone " + copy _2;
-        _28 = baml.time.AmbiguousTimeError { copy _29 };
-        throw copy _28;
+        _28 = const "wall-clock time is ambiguous or skipped in timezone " + copy _2;
+        _27 = baml.time.AmbiguousTimeError { copy _28 };
+        throw copy _27;
     }
 
     bb18: {
         _26 = copy _15;
-        _25 = copy _26;
-        _27 = copy _25 == const null;
-        branch copy _27 -> [bb19, bb20];
+        _25 = short_circuit(??) copy _26 -> [eval: bb19, join: bb20];
     }
 
     bb19: {
@@ -11096,11 +10835,10 @@ fn baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: int | flo
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string
-    let _7: string // message
-    let _8: baml.json.DecodeError
-    let _9: string
-    let _10: baml.json.DecodeError
+    let _6: string // message
+    let _7: baml.json.DecodeError
+    let _8: string
+    let _9: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -11108,8 +10846,8 @@ fn baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: int | flo
     }
 
     bb1: {
-        _10 = baml.json.DecodeError { const "Expected zoneless ISO 8601 string", const "" };
-        throw copy _10;
+        _9 = baml.json.DecodeError { const "Expected zoneless ISO 8601 string", const "" };
+        throw copy _9;
     }
 
     bb2: {
@@ -11131,16 +10869,10 @@ fn baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: int | flo
 
     bb6: {
         _5 = copy _3.0;
-        drop(_5);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _6 = copy _3.0;
-        _7 = copy _6;
-        _9 = copy _7;
-        _8 = baml.json.DecodeError { copy _9, const "" };
-        throw copy _8;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.DecodeError { copy _8, const "" };
+        throw copy _7;
     }
 }
 
@@ -11151,10 +10883,9 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml.time.
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string
-    let _6: string // message
-    let _7: baml.json.SerializationError
-    let _8: string
+    let _5: string // message
+    let _6: baml.json.SerializationError
+    let _7: string
 
     bb0: {
         _0 = call const fn baml.time.PlainDateTime._to_string_impl(copy _1) -> [bb1, unwind: bb2];
@@ -11175,16 +10906,10 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml.time.
 
     bb4: {
         _4 = copy _2.0;
-        drop(_4);
-        goto -> bb5;
-    }
-
-    bb5: {
-        _5 = copy _2.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.SerializationError { copy _8, const "", const "unserializable" };
-        throw copy _7;
+        _5 = copy _4;
+        _7 = copy _5;
+        _6 = baml.json.SerializationError { copy _7, const "", const "unserializable" };
+        throw copy _6;
     }
 }
 
@@ -11445,11 +11170,10 @@ fn baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: int | float |
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string
-    let _7: string // message
-    let _8: baml.json.DecodeError
-    let _9: string
-    let _10: baml.json.DecodeError
+    let _6: string // message
+    let _7: baml.json.DecodeError
+    let _8: string
+    let _9: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -11457,8 +11181,8 @@ fn baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: int | float |
     }
 
     bb1: {
-        _10 = baml.json.DecodeError { const "Expected ISO 8601 time string", const "" };
-        throw copy _10;
+        _9 = baml.json.DecodeError { const "Expected ISO 8601 time string", const "" };
+        throw copy _9;
     }
 
     bb2: {
@@ -11480,16 +11204,10 @@ fn baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: int | float |
 
     bb6: {
         _5 = copy _3.0;
-        drop(_5);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _6 = copy _3.0;
-        _7 = copy _6;
-        _9 = copy _7;
-        _8 = baml.json.DecodeError { copy _9, const "" };
-        throw copy _8;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.DecodeError { copy _8, const "" };
+        throw copy _7;
     }
 }
 
@@ -11664,76 +11382,64 @@ fn baml.time.TimeZoneOffset.new(hours: int, minutes: int) -> baml.time.TimeZoneO
     let _10: int
     let _11: int
     let _12: bool
-    let _13: bool
-    let _14: int
+    let _13: int
+    let _14: bool
     let _15: int
     let _16: baml.errors.InvalidArgument
     let _17: int
 
     bb0: {
-        _5 = copy _1 > const 0_i64;
-        _4 = short_circuit(&&) copy _5 -> [eval: bb1, join: bb2];
+        _3 = copy _1 > const 0_i64;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
         _4 = copy _2 < const 0_i64;
-        goto -> bb2;
+        branch copy _4 -> [bb9, bb2];
     }
 
     bb2: {
-        _3 = short_circuit(||) copy _4 -> [eval: bb3, join: bb5];
+        _5 = copy _1 < const 0_i64;
+        branch copy _5 -> [bb3, bb4];
     }
 
     bb3: {
-        _6 = copy _1 < const 0_i64;
-        _3 = short_circuit(&&) copy _6 -> [eval: bb4, join: bb5];
+        _6 = copy _2 > const 0_i64;
+        branch copy _6 -> [bb9, bb4];
     }
 
     bb4: {
-        _3 = copy _2 > const 0_i64;
-        goto -> bb5;
-    }
-
-    bb5: {
-        branch copy _3 -> [bb12, bb6];
-    }
-
-    bb6: {
         _11 = copy _1 * const 60_i64;
         _10 = copy _11 + copy _2;
         _9 = copy _10 * const 60_i64;
         _8 = copy _9 * const 1000000000_i64;
-        _14 = copy _8;
-        _13 = copy _14 > const 86400000000000_i64;
-        _12 = short_circuit(||) copy _13 -> [eval: bb7, join: bb8];
+        _13 = copy _8;
+        _12 = copy _13 > const 86400000000000_i64;
+        branch copy _12 -> [bb8, bb5];
+    }
+
+    bb5: {
+        _15 = copy _8;
+        _14 = copy _15 < const -86400000000000_i64;
+        branch copy _14 -> [bb8, bb6];
+    }
+
+    bb6: {
+        _17 = copy _8;
+        _0 = baml.time.TimeZoneOffset { copy _17 };
+        goto -> bb7;
     }
 
     bb7: {
-        _15 = copy _8;
-        _12 = copy _15 < const -86400000000000_i64;
-        goto -> bb8;
-    }
-
-    bb8: {
-        branch copy _12 -> [bb11, bb9];
-    }
-
-    bb9: {
-        _17 = copy _8;
-        _0 = baml.time.TimeZoneOffset { copy _17 };
-        goto -> bb10;
-    }
-
-    bb10: {
         return;
     }
 
-    bb11: {
+    bb8: {
         _16 = baml.errors.InvalidArgument { const "TimeZoneOffset out of range: must be within ±24 hours" };
         throw copy _16;
     }
 
-    bb12: {
+    bb9: {
         _7 = baml.errors.InvalidArgument { const "TimeZoneOffset.new: hours and minutes must carry the same sign" };
         throw copy _7;
     }
@@ -11752,7 +11458,6 @@ fn baml.time.TimeZoneOffset.from_timezone(timezone: string, at: baml.time.Instan
     let _8: int
     let _9: int
     let _10: int | null
-    let _11: bool
 
     bb0: {
         _4 = copy _2.0;
@@ -11767,9 +11472,7 @@ fn baml.time.TimeZoneOffset.from_timezone(timezone: string, at: baml.time.Instan
     bb2: {
         _7 = copy _3;
         _10 = copy _7;
-        _9 = copy _10;
-        _11 = copy _9 == const null;
-        branch copy _11 -> [bb3, bb4];
+        _9 = short_circuit(??) copy _10 -> [eval: bb3, join: bb4];
     }
 
     bb3: {
@@ -12204,11 +11907,9 @@ fn baml.time.ZonedDateTime.timezone(self: baml.time.ZonedDateTime) -> string | b
     let _4: int
     let _5: int
     let _6: int | null
-    let _7: bool
-    let _8: string | null // iana
-    let _9: string
-    let _10: string | null
-    let _11: bool
+    let _7: string | null // iana
+    let _8: string
+    let _9: string | null
 
     bb0: {
         _2 = copy _1.2;
@@ -12217,28 +11918,24 @@ fn baml.time.ZonedDateTime.timezone(self: baml.time.ZonedDateTime) -> string | b
     }
 
     bb1: {
-        _8 = copy _2;
-        _10 = copy _8;
-        _9 = copy _10;
-        _11 = copy _9 == const null;
-        branch copy _11 -> [bb2, bb3];
+        _7 = copy _2;
+        _9 = copy _7;
+        _8 = short_circuit(??) copy _9 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _9 = const "";
+        _8 = const "";
         goto -> bb3;
     }
 
     bb3: {
-        _0 = copy _9;
+        _0 = copy _8;
         goto -> bb7;
     }
 
     bb4: {
         _6 = copy _1.1;
-        _5 = copy _6;
-        _7 = copy _5 == const null;
-        branch copy _7 -> [bb5, bb6];
+        _5 = short_circuit(??) copy _6 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
@@ -12266,25 +11963,21 @@ fn baml.time.ZonedDateTime.timezone_offset(self: baml.time.ZonedDateTime) -> bam
     let _4: int
     let _5: int
     let _6: int | null
-    let _7: bool
-    let _8: string | null // iana
-    let _9: int | null
+    let _7: string | null // iana
+    let _8: int | null
+    let _9: string
     let _10: string
-    let _11: string
-    let _12: string | null
+    let _11: string | null
+    let _12: bigint
     let _13: bool
-    let _14: bigint
-    let _15: bool
-    let _16: baml.time.UnknownTimezoneError
-    let _17: string
-    let _18: string
-    let _19: string | null
-    let _20: bool
-    let _21: int | null // offset
-    let _22: int
-    let _23: int
-    let _24: int | null
-    let _25: bool
+    let _14: baml.time.UnknownTimezoneError
+    let _15: string
+    let _16: string
+    let _17: string | null
+    let _18: int | null // offset
+    let _19: int
+    let _20: int
+    let _21: int | null
 
     bb0: {
         _2 = copy _1.2;
@@ -12293,71 +11986,63 @@ fn baml.time.ZonedDateTime.timezone_offset(self: baml.time.ZonedDateTime) -> bam
     }
 
     bb1: {
-        _8 = copy _2;
-        _12 = copy _8;
-        _11 = copy _12;
-        _13 = copy _11 == const null;
-        branch copy _13 -> [bb2, bb3];
+        _7 = copy _2;
+        _11 = copy _7;
+        _10 = short_circuit(??) copy _11 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _11 = const "";
+        _10 = const "";
         goto -> bb3;
     }
 
     bb3: {
-        _10 = copy _11;
-        _14 = copy _1.0;
-        _9 = sys_op const fn baml.time._tz_offset_at(copy _10, copy _14) -> bb4;
+        _9 = copy _10;
+        _12 = copy _1.0;
+        _8 = sys_op const fn baml.time._tz_offset_at(copy _9, copy _12) -> bb4;
     }
 
     bb4: {
-        _15 = copy _9 == const null;
-        branch copy _15 -> [bb8, bb5];
+        _13 = copy _8 == const null;
+        branch copy _13 -> [bb8, bb5];
     }
 
     bb5: {
-        _21 = copy _9;
-        _24 = copy _21;
-        _23 = copy _24;
-        _25 = copy _23 == const null;
-        branch copy _25 -> [bb6, bb7];
+        _18 = copy _8;
+        _21 = copy _18;
+        _20 = short_circuit(??) copy _21 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
-        _23 = const 0_i64;
+        _20 = const 0_i64;
         goto -> bb7;
     }
 
     bb7: {
-        _22 = copy _23;
-        _0 = baml.time.TimeZoneOffset { copy _22 };
+        _19 = copy _20;
+        _0 = baml.time.TimeZoneOffset { copy _19 };
         goto -> bb14;
     }
 
     bb8: {
-        _19 = copy _8;
-        _18 = copy _19;
-        _20 = copy _18 == const null;
-        branch copy _20 -> [bb9, bb10];
+        _17 = copy _7;
+        _16 = short_circuit(??) copy _17 -> [eval: bb9, join: bb10];
     }
 
     bb9: {
-        _18 = const "";
+        _16 = const "";
         goto -> bb10;
     }
 
     bb10: {
-        _17 = copy _18;
-        _16 = baml.time.UnknownTimezoneError { copy _17 };
-        throw copy _16;
+        _15 = copy _16;
+        _14 = baml.time.UnknownTimezoneError { copy _15 };
+        throw copy _14;
     }
 
     bb11: {
         _6 = copy _1.1;
-        _5 = copy _6;
-        _7 = copy _5 == const null;
-        branch copy _7 -> [bb12, bb13];
+        _5 = short_circuit(??) copy _6 -> [eval: bb12, join: bb13];
     }
 
     bb12: {
@@ -12543,11 +12228,10 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: int | flo
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string
-    let _7: string // message
-    let _8: baml.json.DecodeError
-    let _9: string
-    let _10: baml.json.DecodeError
+    let _6: string // message
+    let _7: baml.json.DecodeError
+    let _8: string
+    let _9: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -12555,8 +12239,8 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: int | flo
     }
 
     bb1: {
-        _10 = baml.json.DecodeError { const "Expected RFC 3339 / RFC 9557 timestamp string", const "" };
-        throw copy _10;
+        _9 = baml.json.DecodeError { const "Expected RFC 3339 / RFC 9557 timestamp string", const "" };
+        throw copy _9;
     }
 
     bb2: {
@@ -12578,16 +12262,10 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: int | flo
 
     bb6: {
         _5 = copy _3.0;
-        drop(_5);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _6 = copy _3.0;
-        _7 = copy _6;
-        _9 = copy _7;
-        _8 = baml.json.DecodeError { copy _9, const "" };
-        throw copy _8;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.DecodeError { copy _8, const "" };
+        throw copy _7;
     }
 }
 
@@ -12601,18 +12279,16 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml.time.
     let _5: baml.time.TimeZoneOffset
     let _6: string | null
     let _7: bool
-    let _8: string
-    let _9: bool
-    let _10: string
-    let _11: string
-    let _12: string // message
-    let _13: baml.json.SerializationError
-    let _14: string
-    let _15: string
-    let _16: string // timezone
-    let _17: baml.json.SerializationError
-    let _18: string
-    let _19: string
+    let _8: bool
+    let _9: string
+    let _10: string // message
+    let _11: baml.json.SerializationError
+    let _12: string
+    let _13: string
+    let _14: string // timezone
+    let _15: baml.json.SerializationError
+    let _16: string
+    let _17: string
 
     bb0: {
         _3 = copy _1.0;
@@ -12631,12 +12307,12 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml.time.
 
     bb3: {
         _7 = is_type(copy _2, baml.errors.InvalidArgument);
-        branch copy _7 -> [bb8, bb4];
+        branch copy _7 -> [bb7, bb4];
     }
 
     bb4: {
-        _9 = is_type(copy _2, baml.time.UnknownTimezoneError);
-        branch copy _9 -> [bb6, bb5];
+        _8 = is_type(copy _2, baml.time.UnknownTimezoneError);
+        branch copy _8 -> [bb6, bb5];
     }
 
     bb5: {
@@ -12644,32 +12320,20 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml.time.
     }
 
     bb6: {
-        _10 = copy _2.0;
-        drop(_10);
-        goto -> bb7;
+        _13 = copy _2.0;
+        _14 = copy _13;
+        _17 = copy _14;
+        _16 = const "unknown timezone: " + copy _17;
+        _15 = baml.json.SerializationError { copy _16, const "", const "unserializable" };
+        throw copy _15;
     }
 
     bb7: {
-        _15 = copy _2.0;
-        _16 = copy _15;
-        _19 = copy _16;
-        _18 = const "unknown timezone: " + copy _19;
-        _17 = baml.json.SerializationError { copy _18, const "", const "unserializable" };
-        throw copy _17;
-    }
-
-    bb8: {
-        _8 = copy _2.0;
-        drop(_8);
-        goto -> bb9;
-    }
-
-    bb9: {
-        _11 = copy _2.0;
-        _12 = copy _11;
-        _14 = copy _12;
-        _13 = baml.json.SerializationError { copy _14, const "", const "unserializable" };
-        throw copy _13;
+        _9 = copy _2.0;
+        _10 = copy _9;
+        _12 = copy _10;
+        _11 = baml.json.SerializationError { copy _12, const "", const "unserializable" };
+        throw copy _11;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -643,26 +643,27 @@ fn baml.Array.join(self: baml.Array, separator: string) -> string {
     let _7: int
     let _8: bool
     let _9: int
-    let _10: int
-    let _11: T
-    let _12: T // first
-    let _13: T[]
-    let _14: int
-    let _15: T[] // rest
-    let _16: string // joined
-    let _17: T
-    let _18: reflect.Type
-    let _19: T[]
-    let _20: baml.iter.Iterator<Error = never, Item = T>
-    let _21: unknown
-    let _22: bool
-    let _23: T
-    let _24: T // item
-    let _25: string
+    let _10: T
+    let _11: int
+    let _12: T
+    let _13: T // first
+    let _14: T[]
+    let _15: int
+    let _16: T[] // rest
+    let _17: string // joined
+    let _18: T
+    let _19: reflect.Type
+    let _20: T[]
+    let _21: baml.iter.Iterator<Error = never, Item = T>
+    let _22: unknown
+    let _23: bool
+    let _24: T
+    let _25: T // item
     let _26: string
     let _27: string
-    let _28: T
-    let _29: reflect.Type
+    let _28: string
+    let _29: T
+    let _30: reflect.Type
 
     bb0: {
         _3 = is_type_tag(copy _1, LIST);
@@ -692,56 +693,58 @@ fn baml.Array.join(self: baml.Array, separator: string) -> string {
 
     bb5: {
         _9 = const 0_i64;
+        _10 = copy _1[_9];
+        drop(_10);
         goto -> bb6;
     }
 
     bb6: {
-        _10 = const 0_i64;
-        _11 = copy _1[_10];
-        _12 = copy _11;
-        _14 = len(_1);
-        _13 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _14) -> [bb7];
+        _11 = const 0_i64;
+        _12 = copy _1[_11];
+        _13 = copy _12;
+        _15 = len(_1);
+        _14 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _15) -> [bb7];
     }
 
     bb7: {
-        _15 = copy _13;
-        _17 = copy _12;
-        _18 = load_type(#0);
-        _16 = call const fn baml.String.from<copy _18>(copy _17) -> [bb8];
+        _16 = copy _14;
+        _18 = copy _13;
+        _19 = load_type(#0);
+        _17 = call const fn baml.String.from<copy _19>(copy _18) -> [bb8];
     }
 
     bb8: {
-        _19 = copy _15;
-        _20 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _19) -> [bb9];
+        _20 = copy _16;
+        _21 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _20) -> [bb9];
     }
 
     bb9: {
-        _21 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _20) -> [bb10];
+        _22 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _21) -> [bb10];
     }
 
     bb10: {
-        _22 = is_type(copy _21, baml.iter.Done);
-        branch copy _22 -> [bb13, bb11];
+        _23 = is_type(copy _22, baml.iter.Done);
+        branch copy _23 -> [bb13, bb11];
     }
 
     bb11: {
-        _23 = copy _21;
-        fresh_cell(_24);
-        _24 = copy _23;
-        _26 = copy _16;
-        _25 = copy _26 + copy _2;
-        _28 = copy _24;
-        _29 = load_type(#0);
-        _27 = call const fn baml.String.from<copy _29>(copy _28) -> [bb12];
+        _24 = copy _22;
+        fresh_cell(_25);
+        _25 = copy _24;
+        _27 = copy _17;
+        _26 = copy _27 + copy _2;
+        _29 = copy _25;
+        _30 = load_type(#0);
+        _28 = call const fn baml.String.from<copy _30>(copy _29) -> [bb12];
     }
 
     bb12: {
-        _16 = copy _25 + copy _27;
+        _17 = copy _26 + copy _28;
         goto -> bb9;
     }
 
     bb13: {
-        _0 = copy _16;
+        _0 = copy _17;
         goto -> bb15;
     }
 
@@ -2186,10 +2189,11 @@ fn baml.csv.open(path: string, options: null | baml.csv.ReaderOptions) -> baml.c
     let _5: unknown // _
     let _6: bool
     let _7: string
-    let _8: string // message
-    let _9: baml.errors.Io
-    let _10: string
-    let _11: baml.fs.File
+    let _8: string
+    let _9: string // message
+    let _10: baml.errors.Io
+    let _11: string
+    let _12: baml.fs.File
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2206,8 +2210,8 @@ fn baml.csv.open(path: string, options: null | baml.csv.ReaderOptions) -> baml.c
     }
 
     bb3: {
-        _11 = copy _4;
-        _0 = call const fn baml.csv._reader(copy _11, copy _2, const true) -> [bb4];
+        _12 = copy _4;
+        _0 = call const fn baml.csv._reader(copy _12, copy _2, const true) -> [bb4];
     }
 
     bb4: {
@@ -2225,10 +2229,16 @@ fn baml.csv.open(path: string, options: null | baml.csv.ReaderOptions) -> baml.c
 
     bb7: {
         _7 = copy _5.0;
-        _8 = copy _7;
-        _10 = copy _8;
-        _9 = baml.errors.Io { copy _10 };
-        throw copy _9;
+        drop(_7);
+        goto -> bb8;
+    }
+
+    bb8: {
+        _8 = copy _5.0;
+        _9 = copy _8;
+        _11 = copy _9;
+        _10 = baml.errors.Io { copy _11 };
+        throw copy _10;
     }
 }
 
@@ -2298,9 +2308,10 @@ fn baml.csv.parse(source: string | uint8array, options: null | baml.csv.ReaderOp
     let _12: reflect.Type
     let _13: bool
     let _14: string
-    let _15: string // message
-    let _16: string
+    let _15: string
+    let _16: string // message
     let _17: string
+    let _18: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2346,7 +2357,7 @@ fn baml.csv.parse(source: string | uint8array, options: null | baml.csv.ReaderOp
 
     bb9: {
         _0 = copy _6;
-        goto -> bb13;
+        goto -> bb14;
     }
 
     bb10: {
@@ -2360,13 +2371,19 @@ fn baml.csv.parse(source: string | uint8array, options: null | baml.csv.ReaderOp
 
     bb12: {
         _14 = copy _4.0;
-        _15 = copy _14;
-        _17 = copy _15;
-        _16 = const "unreachable: in-memory CSV source raised Io: " + copy _17;
-        _0 = call const fn baml.sys.panic(copy _16) -> [bb13];
+        drop(_14);
+        goto -> bb13;
     }
 
     bb13: {
+        _15 = copy _4.0;
+        _16 = copy _15;
+        _18 = copy _16;
+        _17 = const "unreachable: in-memory CSV source raised Io: " + copy _18;
+        _0 = call const fn baml.sys.panic(copy _17) -> [bb14];
+    }
+
+    bb14: {
         return;
     }
 }
@@ -2383,9 +2400,10 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
     let _7: reflect.Type
     let _8: bool
     let _9: string
-    let _10: string // message
-    let _11: string
+    let _10: string
+    let _11: string // message
     let _12: string
+    let _13: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2407,7 +2425,7 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
     }
 
     bb4: {
-        _0 = virtual_call collect as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = #0>(copy _5) -> [bb8, unwind: bb5];
+        _0 = virtual_call collect as baml.iter.Iterator<Error = baml.csv.Error | baml.errors.Io, Item = #0>(copy _5) -> [bb9, unwind: bb5];
     }
 
     bb5: {
@@ -2421,13 +2439,19 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
 
     bb7: {
         _9 = copy _4.0;
-        _10 = copy _9;
-        _12 = copy _10;
-        _11 = const "unreachable: in-memory CSV source raised Io: " + copy _12;
-        _0 = call const fn baml.sys.panic(copy _11) -> [bb8];
+        drop(_9);
+        goto -> bb8;
     }
 
     bb8: {
+        _10 = copy _4.0;
+        _11 = copy _10;
+        _13 = copy _11;
+        _12 = const "unreachable: in-memory CSV source raised Io: " + copy _13;
+        _0 = call const fn baml.sys.panic(copy _12) -> [bb9];
+    }
+
+    bb9: {
         return;
     }
 }
@@ -2645,10 +2669,11 @@ fn baml.csv.create(path: string, options: null | baml.csv.WriterOptions) -> baml
     let _5: unknown // _
     let _6: bool
     let _7: string
-    let _8: string // message
-    let _9: baml.errors.Io
-    let _10: string
-    let _11: baml.fs.File
+    let _8: string
+    let _9: string // message
+    let _10: baml.errors.Io
+    let _11: string
+    let _12: baml.fs.File
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2665,8 +2690,8 @@ fn baml.csv.create(path: string, options: null | baml.csv.WriterOptions) -> baml
     }
 
     bb3: {
-        _11 = copy _4;
-        _0 = call const fn baml.csv._writer(copy _11, copy _2, const true) -> [bb4];
+        _12 = copy _4;
+        _0 = call const fn baml.csv._writer(copy _12, copy _2, const true) -> [bb4];
     }
 
     bb4: {
@@ -2684,10 +2709,16 @@ fn baml.csv.create(path: string, options: null | baml.csv.WriterOptions) -> baml
 
     bb7: {
         _7 = copy _5.0;
-        _8 = copy _7;
-        _10 = copy _8;
-        _9 = baml.errors.Io { copy _10 };
-        throw copy _9;
+        drop(_7);
+        goto -> bb8;
+    }
+
+    bb8: {
+        _8 = copy _5.0;
+        _9 = copy _8;
+        _11 = copy _9;
+        _10 = baml.errors.Io { copy _11 };
+        throw copy _10;
     }
 }
 
@@ -2772,9 +2803,10 @@ fn baml.csv.stringify(rows: T[], options: null | baml.csv.WriterOptions) -> stri
     let _7: reflect.Type
     let _8: bool
     let _9: string
-    let _10: string // message
-    let _11: string
+    let _10: string
+    let _11: string // message
     let _12: string
+    let _13: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2796,7 +2828,7 @@ fn baml.csv.stringify(rows: T[], options: null | baml.csv.WriterOptions) -> stri
     }
 
     bb4: {
-        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb8, unwind: bb5];
+        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb9, unwind: bb5];
     }
 
     bb5: {
@@ -2810,13 +2842,19 @@ fn baml.csv.stringify(rows: T[], options: null | baml.csv.WriterOptions) -> stri
 
     bb7: {
         _9 = copy _4.0;
-        _10 = copy _9;
-        _12 = copy _10;
-        _11 = const "unreachable: buffer writer raised Io: " + copy _12;
-        _0 = call const fn baml.sys.panic(copy _11) -> [bb8];
+        drop(_9);
+        goto -> bb8;
     }
 
     bb8: {
+        _10 = copy _4.0;
+        _11 = copy _10;
+        _13 = copy _11;
+        _12 = const "unreachable: buffer writer raised Io: " + copy _13;
+        _0 = call const fn baml.sys.panic(copy _12) -> [bb9];
+    }
+
+    bb9: {
         return;
     }
 }
@@ -2838,9 +2876,10 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
     let _12: (int | bigint | float | string | bool | null)[]
     let _13: bool
     let _14: string
-    let _15: string // message
-    let _16: string
+    let _15: string
+    let _16: string // message
     let _17: string
+    let _18: string
 
     bb0: {
         _3 = copy _2 == const <omitted>;
@@ -2878,7 +2917,7 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
     }
 
     bb7: {
-        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb11, unwind: bb8];
+        _0 = call const fn baml.csv.Writer.text(copy _5) -> [bb12, unwind: bb8];
     }
 
     bb8: {
@@ -2892,13 +2931,19 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
 
     bb10: {
         _14 = copy _4.0;
-        _15 = copy _14;
-        _17 = copy _15;
-        _16 = const "unreachable: buffer writer raised Io: " + copy _17;
-        _0 = call const fn baml.sys.panic(copy _16) -> [bb11];
+        drop(_14);
+        goto -> bb11;
     }
 
     bb11: {
+        _15 = copy _4.0;
+        _16 = copy _15;
+        _18 = copy _16;
+        _17 = const "unreachable: buffer writer raised Io: " + copy _18;
+        _0 = call const fn baml.sys.panic(copy _17) -> [bb12];
+    }
+
+    bb12: {
         return;
     }
 }
@@ -3242,17 +3287,18 @@ fn baml.errors.UnknownError.from(data: unknown) -> baml.errors.UnknownError | T 
     let _6: bool
     let _7: unknown
     let _8: unknown
-    let _9: T // inner
-    let _10: null
-    let _11: T
-    let _12: unknown
-    let _13: baml.errors.UnknownError // error
-    let _14: null
-    let _15: baml.errors.UnknownError
-    let _16: baml.errors.UnknownError // error
-    let _17: string[]
-    let _18: null
-    let _19: baml.errors.UnknownError
+    let _9: unknown
+    let _10: T // inner
+    let _11: null
+    let _12: T
+    let _13: unknown
+    let _14: baml.errors.UnknownError // error
+    let _15: null
+    let _16: baml.errors.UnknownError
+    let _17: baml.errors.UnknownError // error
+    let _18: string[]
+    let _19: null
+    let _20: baml.errors.UnknownError
 
     bb0: {
         _2 = copy _1;
@@ -3271,41 +3317,43 @@ fn baml.errors.UnknownError.from(data: unknown) -> baml.errors.UnknownError | T 
     }
 
     bb3: {
-        _12 = copy _1;
-        _12 = narrow_bind copy _12 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
+        _13 = copy _1;
+        _13 = narrow_bind copy _13 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
     }
 
     bb4: {
-        _17 = []: string[];
-        _16 = baml.errors.UnknownError { copy _1, copy _17 };
-        _19 = copy _16;
-        _18 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _19) -> [bb5];
+        _18 = []: string[];
+        _17 = baml.errors.UnknownError { copy _1, copy _18 };
+        _20 = copy _17;
+        _19 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _20) -> [bb5];
     }
 
     bb5: {
-        _0 = copy _16;
+        _0 = copy _17;
         goto -> bb12;
     }
 
     bb6: {
-        _13 = copy _12;
-        _15 = copy _13;
-        _14 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _15) -> [bb7];
+        _14 = copy _13;
+        _16 = copy _14;
+        _15 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _16) -> [bb7];
     }
 
     bb7: {
-        _0 = copy _13;
+        _0 = copy _14;
         goto -> bb12;
     }
 
     bb8: {
-        _9 = copy _8;
-        _11 = copy _9;
-        _10 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _11) -> [bb9];
+        _9 = copy _1.0;
+        drop(_9);
+        _10 = copy _8;
+        _12 = copy _10;
+        _11 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _12) -> [bb9];
     }
 
     bb9: {
-        _0 = copy _9;
+        _0 = copy _10;
         goto -> bb12;
     }
 
@@ -3337,21 +3385,22 @@ fn baml.errors.UnknownError.with_message(data: unknown, message: string) -> baml
     let _7: bool
     let _8: unknown
     let _9: unknown
-    let _10: T // inner
-    let _11: null
-    let _12: T
-    let _13: unknown
-    let _14: baml.errors.UnknownError // error
-    let _15: (string[], string[]) -> string[] throws never
-    let _16: string[]
-    let _17: reflect.Type
-    let _18: string[]
-    let _19: null
-    let _20: baml.errors.UnknownError
-    let _21: baml.errors.UnknownError // error
-    let _22: string[]
-    let _23: null
-    let _24: baml.errors.UnknownError
+    let _10: unknown
+    let _11: T // inner
+    let _12: null
+    let _13: T
+    let _14: unknown
+    let _15: baml.errors.UnknownError // error
+    let _16: (string[], string[]) -> string[] throws never
+    let _17: string[]
+    let _18: reflect.Type
+    let _19: string[]
+    let _20: null
+    let _21: baml.errors.UnknownError
+    let _22: baml.errors.UnknownError // error
+    let _23: string[]
+    let _24: null
+    let _25: baml.errors.UnknownError
 
     bb0: {
         _3 = copy _1;
@@ -3370,53 +3419,55 @@ fn baml.errors.UnknownError.with_message(data: unknown, message: string) -> baml
     }
 
     bb3: {
-        _13 = copy _1;
-        _13 = narrow_bind copy _13 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
+        _14 = copy _1;
+        _14 = narrow_bind copy _14 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["errors"], name: "UnknownError" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb4];
     }
 
     bb4: {
-        _22 = [copy _2]: string[];
-        _21 = baml.errors.UnknownError { copy _1, copy _22 };
-        _24 = copy _21;
-        _23 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _24) -> [bb5];
+        _23 = [copy _2]: string[];
+        _22 = baml.errors.UnknownError { copy _1, copy _23 };
+        _25 = copy _22;
+        _24 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _25) -> [bb5];
     }
 
     bb5: {
-        _0 = copy _21;
+        _0 = copy _22;
         goto -> bb14;
     }
 
     bb6: {
-        _14 = copy _13;
-        _15 = copy _14.1;
-        _16 = [copy _2]: string[];
-        _17 = load_type(string);
-        _18 = call const fn baml.Array.concat<copy _17>(copy _15, copy _16) -> [bb7];
+        _15 = copy _14;
+        _16 = copy _15.1;
+        _17 = [copy _2]: string[];
+        _18 = load_type(string);
+        _19 = call const fn baml.Array.concat<copy _18>(copy _16, copy _17) -> [bb7];
     }
 
     bb7: {
-        _14.1 = copy _18;
+        _15.1 = copy _19;
         goto -> bb8;
     }
 
     bb8: {
-        _20 = copy _14;
-        _19 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _20) -> [bb9];
+        _21 = copy _15;
+        _20 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _21) -> [bb9];
     }
 
     bb9: {
-        _0 = copy _14;
+        _0 = copy _15;
         goto -> bb14;
     }
 
     bb10: {
-        _10 = copy _9;
-        _12 = copy _10;
-        _11 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _12) -> [bb11];
+        _10 = copy _1.0;
+        drop(_10);
+        _11 = copy _9;
+        _13 = copy _11;
+        _12 = call const fn baml.errors.UnknownError._preserve_context(copy _1, copy _13) -> [bb11];
     }
 
     bb11: {
-        _0 = copy _10;
+        _0 = copy _11;
         goto -> bb14;
     }
 
@@ -8919,9 +8970,10 @@ fn baml.sap.parse(text: string) -> T {
     let _7: reflect.Type
     let _8: bool
     let _9: string
-    let _10: string // message
-    let _11: baml.errors.ParseError
-    let _12: string
+    let _10: string
+    let _11: string // message
+    let _12: baml.errors.ParseError
+    let _13: string
 
     bb0: {
         _3 = load_type(#0);
@@ -8950,10 +9002,16 @@ fn baml.sap.parse(text: string) -> T {
 
     bb5: {
         _9 = copy _5.0;
-        _10 = copy _9;
-        _12 = copy _10;
-        _11 = baml.errors.ParseError { copy _12 };
-        throw copy _11;
+        drop(_9);
+        goto -> bb6;
+    }
+
+    bb6: {
+        _10 = copy _5.0;
+        _11 = copy _10;
+        _13 = copy _11;
+        _12 = baml.errors.ParseError { copy _13 };
+        throw copy _12;
     }
 }
 
@@ -10007,12 +10065,13 @@ fn baml.time.<(baml.time.Instant as baml.ToString)>.to_string(self: baml.time.In
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string // message
-    let _6: string
+    let _5: string
+    let _6: string // message
     let _7: string
+    let _8: string
 
     bb0: {
-        _0 = call const fn baml.time.Instant._to_string_impl(copy _1) -> [bb4, unwind: bb1];
+        _0 = call const fn baml.time.Instant._to_string_impl(copy _1) -> [bb5, unwind: bb1];
     }
 
     bb1: {
@@ -10026,13 +10085,19 @@ fn baml.time.<(baml.time.Instant as baml.ToString)>.to_string(self: baml.time.In
 
     bb3: {
         _4 = copy _2.0;
-        _5 = copy _4;
-        _7 = copy _5;
-        _6 = const "Instant.to_string: " + copy _7;
-        _0 = call const fn baml.sys.panic(copy _6) -> [bb4];
+        drop(_4);
+        goto -> bb4;
     }
 
     bb4: {
+        _5 = copy _2.0;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = const "Instant.to_string: " + copy _8;
+        _0 = call const fn baml.sys.panic(copy _7) -> [bb5];
+    }
+
+    bb5: {
         return;
     }
 }
@@ -10047,10 +10112,11 @@ fn baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: int | float | s
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string // message
-    let _7: baml.json.DecodeError
-    let _8: string
-    let _9: baml.json.DecodeError
+    let _6: string
+    let _7: string // message
+    let _8: baml.json.DecodeError
+    let _9: string
+    let _10: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -10058,8 +10124,8 @@ fn baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: int | float | s
     }
 
     bb1: {
-        _9 = baml.json.DecodeError { const "Expected timestamp string", const "" };
-        throw copy _9;
+        _10 = baml.json.DecodeError { const "Expected timestamp string", const "" };
+        throw copy _10;
     }
 
     bb2: {
@@ -10081,10 +10147,16 @@ fn baml.time.<(baml.time.Instant as baml.FromJson)>.from_json(j: int | float | s
 
     bb6: {
         _5 = copy _3.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.DecodeError { copy _8, const "" };
-        throw copy _7;
+        drop(_5);
+        goto -> bb7;
+    }
+
+    bb7: {
+        _6 = copy _3.0;
+        _7 = copy _6;
+        _9 = copy _7;
+        _8 = baml.json.DecodeError { copy _9, const "" };
+        throw copy _8;
     }
 }
 
@@ -10095,9 +10167,10 @@ fn baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.Instan
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string // message
-    let _6: baml.json.SerializationError
-    let _7: string
+    let _5: string
+    let _6: string // message
+    let _7: baml.json.SerializationError
+    let _8: string
 
     bb0: {
         _0 = call const fn baml.time.Instant._to_string_impl(copy _1) -> [bb1, unwind: bb2];
@@ -10118,10 +10191,16 @@ fn baml.time.<(baml.time.Instant as baml.ToJson)>.to_json(self: baml.time.Instan
 
     bb4: {
         _4 = copy _2.0;
-        _5 = copy _4;
-        _7 = copy _5;
-        _6 = baml.json.SerializationError { copy _7, const "", const "unserializable" };
-        throw copy _6;
+        drop(_4);
+        goto -> bb5;
+    }
+
+    bb5: {
+        _5 = copy _2.0;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.SerializationError { copy _8, const "", const "unserializable" };
+        throw copy _7;
     }
 }
 
@@ -10437,12 +10516,13 @@ fn baml.time.<(baml.time.PlainDate as baml.ToString)>.to_string(self: baml.time.
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string // message
-    let _6: string
+    let _5: string
+    let _6: string // message
     let _7: string
+    let _8: string
 
     bb0: {
-        _0 = call const fn baml.time.PlainDate._to_string_impl(copy _1) -> [bb4, unwind: bb1];
+        _0 = call const fn baml.time.PlainDate._to_string_impl(copy _1) -> [bb5, unwind: bb1];
     }
 
     bb1: {
@@ -10456,13 +10536,19 @@ fn baml.time.<(baml.time.PlainDate as baml.ToString)>.to_string(self: baml.time.
 
     bb3: {
         _4 = copy _2.0;
-        _5 = copy _4;
-        _7 = copy _5;
-        _6 = const "PlainDate.to_string: " + copy _7;
-        _0 = call const fn baml.sys.panic(copy _6) -> [bb4];
+        drop(_4);
+        goto -> bb4;
     }
 
     bb4: {
+        _5 = copy _2.0;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = const "PlainDate.to_string: " + copy _8;
+        _0 = call const fn baml.sys.panic(copy _7) -> [bb5];
+    }
+
+    bb5: {
         return;
     }
 }
@@ -10513,10 +10599,11 @@ fn baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: int | float |
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string // message
-    let _7: baml.json.DecodeError
-    let _8: string
-    let _9: baml.json.DecodeError
+    let _6: string
+    let _7: string // message
+    let _8: baml.json.DecodeError
+    let _9: string
+    let _10: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -10524,8 +10611,8 @@ fn baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: int | float |
     }
 
     bb1: {
-        _9 = baml.json.DecodeError { const "Expected ISO 8601 date string", const "" };
-        throw copy _9;
+        _10 = baml.json.DecodeError { const "Expected ISO 8601 date string", const "" };
+        throw copy _10;
     }
 
     bb2: {
@@ -10547,10 +10634,16 @@ fn baml.time.<(baml.time.PlainDate as baml.FromJson)>.from_json(j: int | float |
 
     bb6: {
         _5 = copy _3.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.DecodeError { copy _8, const "" };
-        throw copy _7;
+        drop(_5);
+        goto -> bb7;
+    }
+
+    bb7: {
+        _6 = copy _3.0;
+        _7 = copy _6;
+        _9 = copy _7;
+        _8 = baml.json.DecodeError { copy _9, const "" };
+        throw copy _8;
     }
 }
 
@@ -10561,9 +10654,10 @@ fn baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.time.Plai
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string // message
-    let _6: baml.json.SerializationError
-    let _7: string
+    let _5: string
+    let _6: string // message
+    let _7: baml.json.SerializationError
+    let _8: string
 
     bb0: {
         _0 = call const fn baml.time.PlainDate._to_string_impl(copy _1) -> [bb1, unwind: bb2];
@@ -10584,10 +10678,16 @@ fn baml.time.<(baml.time.PlainDate as baml.ToJson)>.to_json(self: baml.time.Plai
 
     bb4: {
         _4 = copy _2.0;
-        _5 = copy _4;
-        _7 = copy _5;
-        _6 = baml.json.SerializationError { copy _7, const "", const "unserializable" };
-        throw copy _6;
+        drop(_4);
+        goto -> bb5;
+    }
+
+    bb5: {
+        _5 = copy _2.0;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.SerializationError { copy _8, const "", const "unserializable" };
+        throw copy _7;
     }
 }
 
@@ -10690,12 +10790,13 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToString)>.to_string(self: baml.t
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string // message
-    let _6: string
+    let _5: string
+    let _6: string // message
     let _7: string
+    let _8: string
 
     bb0: {
-        _0 = call const fn baml.time.PlainDateTime._to_string_impl(copy _1) -> [bb4, unwind: bb1];
+        _0 = call const fn baml.time.PlainDateTime._to_string_impl(copy _1) -> [bb5, unwind: bb1];
     }
 
     bb1: {
@@ -10709,13 +10810,19 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToString)>.to_string(self: baml.t
 
     bb3: {
         _4 = copy _2.0;
-        _5 = copy _4;
-        _7 = copy _5;
-        _6 = const "PlainDateTime.to_string: " + copy _7;
-        _0 = call const fn baml.sys.panic(copy _6) -> [bb4];
+        drop(_4);
+        goto -> bb4;
     }
 
     bb4: {
+        _5 = copy _2.0;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = const "PlainDateTime.to_string: " + copy _8;
+        _0 = call const fn baml.sys.panic(copy _7) -> [bb5];
+    }
+
+    bb5: {
         return;
     }
 }
@@ -10989,10 +11096,11 @@ fn baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: int | flo
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string // message
-    let _7: baml.json.DecodeError
-    let _8: string
-    let _9: baml.json.DecodeError
+    let _6: string
+    let _7: string // message
+    let _8: baml.json.DecodeError
+    let _9: string
+    let _10: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -11000,8 +11108,8 @@ fn baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: int | flo
     }
 
     bb1: {
-        _9 = baml.json.DecodeError { const "Expected zoneless ISO 8601 string", const "" };
-        throw copy _9;
+        _10 = baml.json.DecodeError { const "Expected zoneless ISO 8601 string", const "" };
+        throw copy _10;
     }
 
     bb2: {
@@ -11023,10 +11131,16 @@ fn baml.time.<(baml.time.PlainDateTime as baml.FromJson)>.from_json(j: int | flo
 
     bb6: {
         _5 = copy _3.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.DecodeError { copy _8, const "" };
-        throw copy _7;
+        drop(_5);
+        goto -> bb7;
+    }
+
+    bb7: {
+        _6 = copy _3.0;
+        _7 = copy _6;
+        _9 = copy _7;
+        _8 = baml.json.DecodeError { copy _9, const "" };
+        throw copy _8;
     }
 }
 
@@ -11037,9 +11151,10 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml.time.
     let _2: unknown // _
     let _3: bool
     let _4: string
-    let _5: string // message
-    let _6: baml.json.SerializationError
-    let _7: string
+    let _5: string
+    let _6: string // message
+    let _7: baml.json.SerializationError
+    let _8: string
 
     bb0: {
         _0 = call const fn baml.time.PlainDateTime._to_string_impl(copy _1) -> [bb1, unwind: bb2];
@@ -11060,10 +11175,16 @@ fn baml.time.<(baml.time.PlainDateTime as baml.ToJson)>.to_json(self: baml.time.
 
     bb4: {
         _4 = copy _2.0;
-        _5 = copy _4;
-        _7 = copy _5;
-        _6 = baml.json.SerializationError { copy _7, const "", const "unserializable" };
-        throw copy _6;
+        drop(_4);
+        goto -> bb5;
+    }
+
+    bb5: {
+        _5 = copy _2.0;
+        _6 = copy _5;
+        _8 = copy _6;
+        _7 = baml.json.SerializationError { copy _8, const "", const "unserializable" };
+        throw copy _7;
     }
 }
 
@@ -11324,10 +11445,11 @@ fn baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: int | float |
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string // message
-    let _7: baml.json.DecodeError
-    let _8: string
-    let _9: baml.json.DecodeError
+    let _6: string
+    let _7: string // message
+    let _8: baml.json.DecodeError
+    let _9: string
+    let _10: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -11335,8 +11457,8 @@ fn baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: int | float |
     }
 
     bb1: {
-        _9 = baml.json.DecodeError { const "Expected ISO 8601 time string", const "" };
-        throw copy _9;
+        _10 = baml.json.DecodeError { const "Expected ISO 8601 time string", const "" };
+        throw copy _10;
     }
 
     bb2: {
@@ -11358,10 +11480,16 @@ fn baml.time.<(baml.time.PlainTime as baml.FromJson)>.from_json(j: int | float |
 
     bb6: {
         _5 = copy _3.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.DecodeError { copy _8, const "" };
-        throw copy _7;
+        drop(_5);
+        goto -> bb7;
+    }
+
+    bb7: {
+        _6 = copy _3.0;
+        _7 = copy _6;
+        _9 = copy _7;
+        _8 = baml.json.DecodeError { copy _9, const "" };
+        throw copy _8;
     }
 }
 
@@ -12415,10 +12543,11 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: int | flo
     let _3: unknown // _
     let _4: bool
     let _5: string
-    let _6: string // message
-    let _7: baml.json.DecodeError
-    let _8: string
-    let _9: baml.json.DecodeError
+    let _6: string
+    let _7: string // message
+    let _8: baml.json.DecodeError
+    let _9: string
+    let _10: baml.json.DecodeError
 
     bb0: {
         _2 = is_type(copy _1, string);
@@ -12426,8 +12555,8 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: int | flo
     }
 
     bb1: {
-        _9 = baml.json.DecodeError { const "Expected RFC 3339 / RFC 9557 timestamp string", const "" };
-        throw copy _9;
+        _10 = baml.json.DecodeError { const "Expected RFC 3339 / RFC 9557 timestamp string", const "" };
+        throw copy _10;
     }
 
     bb2: {
@@ -12449,10 +12578,16 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.FromJson)>.from_json(j: int | flo
 
     bb6: {
         _5 = copy _3.0;
-        _6 = copy _5;
-        _8 = copy _6;
-        _7 = baml.json.DecodeError { copy _8, const "" };
-        throw copy _7;
+        drop(_5);
+        goto -> bb7;
+    }
+
+    bb7: {
+        _6 = copy _3.0;
+        _7 = copy _6;
+        _9 = copy _7;
+        _8 = baml.json.DecodeError { copy _9, const "" };
+        throw copy _8;
     }
 }
 
@@ -12466,16 +12601,18 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml.time.
     let _5: baml.time.TimeZoneOffset
     let _6: string | null
     let _7: bool
-    let _8: bool
-    let _9: string
-    let _10: string // message
-    let _11: baml.json.SerializationError
-    let _12: string
-    let _13: string
-    let _14: string // timezone
-    let _15: baml.json.SerializationError
-    let _16: string
-    let _17: string
+    let _8: string
+    let _9: bool
+    let _10: string
+    let _11: string
+    let _12: string // message
+    let _13: baml.json.SerializationError
+    let _14: string
+    let _15: string
+    let _16: string // timezone
+    let _17: baml.json.SerializationError
+    let _18: string
+    let _19: string
 
     bb0: {
         _3 = copy _1.0;
@@ -12494,12 +12631,12 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml.time.
 
     bb3: {
         _7 = is_type(copy _2, baml.errors.InvalidArgument);
-        branch copy _7 -> [bb7, bb4];
+        branch copy _7 -> [bb8, bb4];
     }
 
     bb4: {
-        _8 = is_type(copy _2, baml.time.UnknownTimezoneError);
-        branch copy _8 -> [bb6, bb5];
+        _9 = is_type(copy _2, baml.time.UnknownTimezoneError);
+        branch copy _9 -> [bb6, bb5];
     }
 
     bb5: {
@@ -12507,20 +12644,32 @@ fn baml.time.<(baml.time.ZonedDateTime as baml.ToJson)>.to_json(self: baml.time.
     }
 
     bb6: {
-        _13 = copy _2.0;
-        _14 = copy _13;
-        _17 = copy _14;
-        _16 = const "unknown timezone: " + copy _17;
-        _15 = baml.json.SerializationError { copy _16, const "", const "unserializable" };
-        throw copy _15;
+        _10 = copy _2.0;
+        drop(_10);
+        goto -> bb7;
     }
 
     bb7: {
-        _9 = copy _2.0;
-        _10 = copy _9;
-        _12 = copy _10;
-        _11 = baml.json.SerializationError { copy _12, const "", const "unserializable" };
-        throw copy _11;
+        _15 = copy _2.0;
+        _16 = copy _15;
+        _19 = copy _16;
+        _18 = const "unknown timezone: " + copy _19;
+        _17 = baml.json.SerializationError { copy _18, const "", const "unserializable" };
+        throw copy _17;
+    }
+
+    bb8: {
+        _8 = copy _2.0;
+        drop(_8);
+        goto -> bb9;
+    }
+
+    bb9: {
+        _11 = copy _2.0;
+        _12 = copy _11;
+        _14 = copy _12;
+        _13 = baml.json.SerializationError { copy _14, const "", const "unserializable" };
+        throw copy _13;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
@@ -488,6 +488,9 @@ function reflect.class.Field.value(self: reflect.class.Field) -> #0 | null {
   L3:
     load_var e
     load_field .0
+    pop 1
+    load_var e
+    load_field .0
     init_instance reflect.errors.TypeMismatch .message
     throw
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/bytecode.snap
@@ -8,10 +8,7 @@ function reflect.AnyClass.attributes(self: reflect.AnyClass) -> reflect.Meta {
     store_var _4
     load_var _4
     narrow_bind reflect.class.Type, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_const null
     load_const null
     load_const null
@@ -19,13 +16,13 @@ function reflect.AnyClass.attributes(self: reflect.AnyClass) -> reflect.Meta {
     load_type string
     alloc_map 0
     init_instance reflect.Meta .alias, .description, .docstring, .other
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var _4
     call reflect.class.Type.meta
 
-  L2:
+  L1:
     return
 }
 
@@ -34,11 +31,9 @@ function reflect.AnyClass.get(self: reflect.AnyClass, name: string) -> #1 | null
     load_type reflect.AnyClass
     load_const "has_field"
     virtual_call nargs=2 ntypeargs=0
-    store_var _4
-    load_var _4
-    unary_op !
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L0
+    load_const null
+    jump L2
 
   L0:
     load_var2 1 2
@@ -47,26 +42,17 @@ function reflect.AnyClass.get(self: reflect.AnyClass, name: string) -> #1 | null
     virtual_call nargs=2 ntypeargs=0
     store_var _5
     load_var _5
-    store_var _6
-    load_var _6
-    narrow_bind reflect.class.Field, slot=5
-    pop_jump_if_false L1
+    narrow_bind reflect.class.Field, slot=3
+    pop_jump_if_true L1
+    load_const null
     jump L2
 
   L1:
-    load_const null
-    jump L4
+    load_type #1
+    load_var _5
+    call reflect.class.Field.value
 
   L2:
-    load_type #1
-    load_var _6
-    call reflect.class.Field.value
-    jump L4
-
-  L3:
-    load_const null
-
-  L4:
     return
 }
 
@@ -77,14 +63,11 @@ function reflect.AnyClass.get_field(self: reflect.AnyClass, name: string) -> ref
     store_var _5
     load_var _5
     narrow_bind reflect.class.Type, slot=3
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const null
+    jump L3
 
   L0:
-    load_const null
-    jump L5
-
-  L1:
     load_var _5
     call reflect.class.Type.fields
     load_type baml.iter.Iterable<Error = never, Item = reflect.class.Field>
@@ -92,7 +75,7 @@ function reflect.AnyClass.get_field(self: reflect.AnyClass, name: string) -> ref
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
-  L2:
+  L1:
     load_var _8
     load_type baml.iter.Iterator<Error = never, Item = reflect.class.Field>
     load_const "next"
@@ -100,16 +83,13 @@ function reflect.AnyClass.get_field(self: reflect.AnyClass, name: string) -> ref
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _9
     store_var_load_var field
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_var field
     load_field .name
     load_var field
@@ -118,12 +98,12 @@ function reflect.AnyClass.get_field(self: reflect.AnyClass, name: string) -> ref
     load_field .meta
     load_var self
     init_instance reflect.class.Field .name, .type, .meta, ._owner
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const null
 
-  L5:
+  L3:
     return
 }
 
@@ -134,14 +114,11 @@ function reflect.AnyClass.has_field(self: reflect.AnyClass, name: string) -> boo
     store_var _5
     load_var _5
     narrow_bind reflect.class.Type, slot=3
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const false
+    jump L3
 
   L0:
-    load_const false
-    jump L5
-
-  L1:
     load_var _5
     call reflect.class.Type.fields
     load_type baml.iter.Iterable<Error = never, Item = reflect.class.Field>
@@ -149,7 +126,7 @@ function reflect.AnyClass.has_field(self: reflect.AnyClass, name: string) -> boo
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
-  L2:
+  L1:
     load_var _8
     load_type baml.iter.Iterator<Error = never, Item = reflect.class.Field>
     load_const "next"
@@ -157,22 +134,19 @@ function reflect.AnyClass.has_field(self: reflect.AnyClass, name: string) -> boo
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _9
     load_field .name
     load_var name
     cmp_op ==
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_const true
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_const false
 
-  L5:
+  L3:
     return
 }
 
@@ -183,15 +157,12 @@ function reflect.AnyClass.list_fields(self: reflect.AnyClass) -> reflect.class.F
     store_var _4
     load_var _4
     narrow_bind reflect.class.Type, slot=2
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_type reflect.class.Field
     alloc_array 0
-    jump L5
+    jump L3
 
-  L1:
+  L0:
     load_type reflect.class.Field
     alloc_array 0
     store_var fields
@@ -202,7 +173,7 @@ function reflect.AnyClass.list_fields(self: reflect.AnyClass) -> reflect.class.F
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
-  L2:
+  L1:
     load_var _8
     load_type baml.iter.Iterator<Error = never, Item = reflect.class.Field>
     load_const "next"
@@ -210,10 +181,7 @@ function reflect.AnyClass.list_fields(self: reflect.AnyClass) -> reflect.class.F
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L2
     load_var _9
     store_var field
     load_type reflect.class.Field
@@ -227,12 +195,12 @@ function reflect.AnyClass.list_fields(self: reflect.AnyClass) -> reflect.class.F
     init_instance reflect.class.Field .name, .type, .meta, ._owner
     call baml.Array.push
     pop 1
-    jump L2
+    jump L1
 
-  L4:
+  L2:
     load_var fields
 
-  L5:
+  L3:
     return
 }
 
@@ -463,38 +431,29 @@ function reflect.class.Field.value(self: reflect.class.Field) -> #0 | null {
     store_var _3
     load_var _3
     narrow_bind reflect.AnyClass, slot=2
-    pop_jump_if_false L0
-    jump L1
+    pop_jump_if_true L0
+    load_const null
+    jump L2
 
   L0:
-    load_const null
-    jump L4
-
-  L1:
     load_type #0
     load_var2 2 1
     load_field .name
     call reflect.class.get_field
-    jump L4
+    jump L2
     load_var e
     is_type reflect.errors.CompilationError
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     rethrow
 
-  L3:
-    load_var e
-    load_field .0
-    pop 1
+  L1:
     load_var e
     load_field .0
     init_instance reflect.errors.TypeMismatch .message
     throw
 
-  L4:
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
@@ -34,9 +34,10 @@ fn reflect.class.Field.value(self: reflect.class.Field) -> null | T {
     let _8: reflect.Type
     let _9: bool
     let _10: string
-    let _11: string // message
-    let _12: reflect.errors.TypeMismatch
-    let _13: string
+    let _11: string
+    let _12: string // message
+    let _13: reflect.errors.TypeMismatch
+    let _14: string
 
     bb0: {
         _2 = copy _1.3;
@@ -72,10 +73,16 @@ fn reflect.class.Field.value(self: reflect.class.Field) -> null | T {
 
     bb6: {
         _10 = copy _5.0;
-        _11 = copy _10;
-        _13 = copy _11;
-        _12 = reflect.errors.TypeMismatch { copy _13 };
-        throw copy _12;
+        drop(_10);
+        goto -> bb7;
+    }
+
+    bb7: {
+        _11 = copy _5.0;
+        _12 = copy _11;
+        _14 = copy _12;
+        _13 = reflect.errors.TypeMismatch { copy _14 };
+        throw copy _13;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/reflect/mir.snap
@@ -34,10 +34,9 @@ fn reflect.class.Field.value(self: reflect.class.Field) -> null | T {
     let _8: reflect.Type
     let _9: bool
     let _10: string
-    let _11: string
-    let _12: string // message
-    let _13: reflect.errors.TypeMismatch
-    let _14: string
+    let _11: string // message
+    let _12: reflect.errors.TypeMismatch
+    let _13: string
 
     bb0: {
         _2 = copy _1.3;
@@ -73,16 +72,10 @@ fn reflect.class.Field.value(self: reflect.class.Field) -> null | T {
 
     bb6: {
         _10 = copy _5.0;
-        drop(_10);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _11 = copy _5.0;
-        _12 = copy _11;
-        _14 = copy _12;
-        _13 = reflect.errors.TypeMismatch { copy _14 };
-        throw copy _13;
+        _11 = copy _10;
+        _13 = copy _11;
+        _12 = reflect.errors.TypeMismatch { copy _13 };
+        throw copy _12;
     }
 }
 
@@ -229,44 +222,42 @@ fn reflect.AnyClass.get(self: reflect.AnyClass, name: string) -> null | T {
     let _1: reflect.AnyClass // self // param
     let _2: string // name // param
     let _3: bool
-    let _4: bool
+    let _4: null | reflect.class.Field
     let _5: null | reflect.class.Field
-    let _6: null | reflect.class.Field
-    let _7: reflect.class.Field // field
-    let _8: reflect.Type
+    let _6: reflect.class.Field // field
+    let _7: reflect.Type
 
     bb0: {
-        _4 = virtual_call has_field as reflect.AnyClass(copy _1, copy _2) -> [bb1];
+        _3 = virtual_call has_field as reflect.AnyClass(copy _1, copy _2) -> [bb1];
     }
 
     bb1: {
-        _3 = !copy _4;
-        branch copy _3 -> [bb6, bb2];
+        branch copy _3 -> [bb3, bb2];
     }
 
     bb2: {
-        _5 = virtual_call get_field as reflect.AnyClass(copy _1, copy _2) -> [bb3];
+        _0 = const null;
+        goto -> bb7;
     }
 
     bb3: {
-        _6 = copy _5;
-        _6 = narrow_bind copy _6 as Class(QualifiedTypeName { pkg: Dep("reflect"), namespace: ["class"], name: "Field" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb5, bb4];
+        _4 = virtual_call get_field as reflect.AnyClass(copy _1, copy _2) -> [bb4];
     }
 
     bb4: {
-        _0 = const null;
-        goto -> bb7;
+        _5 = copy _4;
+        _5 = narrow_bind copy _5 as Class(QualifiedTypeName { pkg: Dep("reflect"), namespace: ["class"], name: "Field" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb5];
     }
 
     bb5: {
-        _7 = copy _6;
-        _8 = load_type(#1);
-        _0 = call const fn reflect.class.Field.value<copy _8>(copy _7) -> [bb7];
+        _0 = const null;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = const null;
-        goto -> bb7;
+        _6 = copy _5;
+        _7 = load_type(#1);
+        _0 = call const fn reflect.class.Field.value<copy _7>(copy _6) -> [bb7];
     }
 
     bb7: {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
@@ -508,6 +508,9 @@ function testing.TestRegistry._expand_testset_registry(self: testing.TestRegistr
     rethrow
 
   L2:
+    load_var _
+    load_field .0
+    pop 1
     load_const "testing: expansion duration: "
     load_var _
     load_field .0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
@@ -19,22 +19,18 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
     load_deref ?1
     load_const 0.0
     cmp_float_op <
-    jump_if_false L0
-    jump L1
-
-  L0:
-    pop 1
+    pop_jump_if_true L0
     load_deref ?1
     load_const 1.0
     cmp_float_op >
+    pop_jump_if_false L1
 
-  L1:
-    pop_jump_if_false L2
+  L0:
     load_const "testing.PassRate requires 0.0 <= threshold <= 1.0"
     call baml.sys.panic
     pop 1
 
-  L2:
+  L1:
     load_var threshold
     make_closure .<lambda(PassRate, 0)>, 1
     return
@@ -50,35 +46,28 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
     load_deref ?1
     load_const 0
     cmp_int_op <=
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_deref ?2
     load_const 0
     cmp_int_op <
-    jump_if_false L1
-    jump L2
-
-  L1:
-    pop 1
+    pop_jump_if_true L0
     load_deref ?2
     load_deref ?1
     cmp_int_op >
+    pop_jump_if_false L2
 
-  L2:
-    pop_jump_if_false L4
+  L0:
     load_const "testing.Quorum requires 0 <= m <= n"
     call baml.sys.panic
     pop 1
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_const "testing.Quorum requires n > 0"
     call baml.sys.panic
     pop 1
 
-  L4:
+  L2:
     load_var2 1 2
     make_closure .<lambda(Quorum, 0)>, 2
     return
@@ -123,10 +112,7 @@ function testing.TestCollector._find_test(self: testing.TestCollector, name: str
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var_load_var t
     load_field .name
@@ -136,7 +122,7 @@ function testing.TestCollector._find_test(self: testing.TestCollector, name: str
     load_var t
     return
 
-  L2:
+  L1:
     load_const "Test not found: "
     load_var name
     bin_op +
@@ -159,10 +145,7 @@ function testing.TestCollector._find_testset(self: testing.TestCollector, name: 
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var_load_var ts
     load_field .name
@@ -172,7 +155,7 @@ function testing.TestCollector._find_testset(self: testing.TestCollector, name: 
     load_var ts
     return
 
-  L2:
+  L1:
     load_const "TestSet not found: "
     load_var name
     bin_op +
@@ -193,18 +176,12 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_var name
     load_const "::"
     call baml.String.includes
-    pop_jump_if_false L0
-    jump L12
-
-  L0:
+    pop_jump_if_true L7
     load_var self
     load_field .prefix
     load_const ""
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var self
     load_field .prefix
     load_const "::"
@@ -212,13 +189,13 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_var name
     bin_op +
     store_var full_name
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var name
     store_var full_name
 
-  L3:
+  L1:
     load_const 0
     store_var count
     load_var full_name
@@ -232,7 +209,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
-  L4:
+  L2:
     load_var _17
     load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
@@ -240,46 +217,36 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var _18
     load_var _18
     is_type baml.iter.Done
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L4
     load_var _18
     store_var_load_var t
     load_field .name
     load_var full_name
     cmp_op ==
-    jump_if_false L6
-    jump L7
-
-  L6:
-    pop 1
+    pop_jump_if_true L3
     load_var t
     load_field .name
     load_var hash_prefix
     call baml.String.starts_with
+    pop_jump_if_false L2
 
-  L7:
-    pop_jump_if_false L4
+  L3:
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L4
+    jump L2
 
-  L8:
+  L4:
     load_var count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
+    pop_jump_if_true L5
     load_var full_name
     store_var final_name
-    jump L11
+    jump L6
 
-  L10:
+  L5:
     load_var full_name
     load_const "#"
     bin_op +
@@ -294,7 +261,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     bin_op +
     store_var final_name
 
-  L11:
+  L6:
     load_type testing.TestRegistration
     load_var self
     load_field .tests
@@ -306,7 +273,7 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     load_const null
     return
 
-  L12:
+  L7:
     load_const "test name may not contain reserved separator `::`: "
     load_var name
     bin_op +
@@ -330,18 +297,12 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_var name
     load_const "::"
     call baml.String.includes
-    pop_jump_if_false L0
-    jump L12
-
-  L0:
+    pop_jump_if_true L7
     load_var self
     load_field .prefix
     load_const ""
     cmp_op ==
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var self
     load_field .prefix
     load_const "::"
@@ -349,13 +310,13 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_var name
     bin_op +
     store_var full_name
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var name
     store_var full_name
 
-  L3:
+  L1:
     load_const 0
     store_var count
     load_var full_name
@@ -369,7 +330,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
-  L4:
+  L2:
     load_var _17
     load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
@@ -377,46 +338,36 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var _18
     load_var _18
     is_type baml.iter.Done
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L4
     load_var _18
     store_var_load_var ts
     load_field .name
     load_var full_name
     cmp_op ==
-    jump_if_false L6
-    jump L7
-
-  L6:
-    pop 1
+    pop_jump_if_true L3
     load_var ts
     load_field .name
     load_var hash_prefix
     call baml.String.starts_with
+    pop_jump_if_false L2
 
-  L7:
-    pop_jump_if_false L4
+  L3:
     load_var count
     load_const 1
     add_int
     store_var count
-    jump L4
+    jump L2
 
-  L8:
+  L4:
     load_var count
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L9
-    jump L10
-
-  L9:
+    pop_jump_if_true L5
     load_var full_name
     store_var final_name
-    jump L11
+    jump L6
 
-  L10:
+  L5:
     load_var full_name
     load_const "#"
     bin_op +
@@ -431,7 +382,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     bin_op +
     store_var final_name
 
-  L11:
+  L6:
     load_type testing.TestSetRegistration
     load_var self
     load_field .testsets
@@ -443,7 +394,7 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     load_const null
     return
 
-  L12:
+  L7:
     load_const "testset name may not contain reserved separator `::`: "
     load_var name
     bin_op +
@@ -474,10 +425,7 @@ function testing.TestRegistry._expand_testset_registry(self: testing.TestRegistr
     store_var _8
     load_var _8
     narrow_bind testing.TestRegistry, slot=3
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     sys_op baml.time.Instant.now
     store_var start
     load_var ts
@@ -497,20 +445,14 @@ function testing.TestRegistry._expand_testset_registry(self: testing.TestRegistr
     call baml.time.Duration.to_milliseconds
     call baml.Bigint.to_int
     store_var elapsed
-    jump L3
+    jump L1
     load_var _
     is_type baml.errors.InvalidArgument
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var _
     rethrow
 
-  L2:
-    load_var _
-    load_field .0
-    pop 1
+  L0:
     load_const "testing: expansion duration: "
     load_var _
     load_field .0
@@ -518,7 +460,7 @@ function testing.TestRegistry._expand_testset_registry(self: testing.TestRegistr
     call baml.sys.panic
     store_var elapsed
 
-  L3:
+  L1:
     load_var sub_collector
     load_type string
     load_type testing.TestRegistry
@@ -536,12 +478,12 @@ function testing.TestRegistry._expand_testset_registry(self: testing.TestRegistr
     call baml.Map.set
     pop 1
     load_var sub_registry
-    jump L5
+    jump L3
 
-  L4:
+  L2:
     load_var _8
 
-  L5:
+  L3:
     return
 }
 
@@ -591,10 +533,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var_load_var ts
     load_field .name
@@ -606,9 +545,9 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     pop 1
     load_var self
     call testing.TestRegistry.serialize
-    jump L5
+    jump L3
 
-  L2:
+  L1:
     load_type string
     load_type testing.TestRegistry
     load_var self
@@ -619,7 +558,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
-  L3:
+  L2:
     load_var _17
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -627,10 +566,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     store_var _18
     load_var _18
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L4
     load_var _18
     store_var k
     load_var self
@@ -642,14 +578,14 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_const "::"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var2 9 2
     call testing.TestRegistry.expand_set
 
-  L5:
+  L3:
     return
 
-  L6:
+  L4:
     load_const "TestSet not found for expansion: "
     load_var name
     bin_op +
@@ -694,54 +630,44 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
     store_var pool
     load_var profile_include
     container_len
-    store_var _14
-    load_var _14
+    store_var _11
+    load_var _11
     load_const 0
     cmp_int_op ==
-    jump_if_false L0
-    pop 1
+    pop_jump_if_false L0
     load_var profile_exclude
+    container_len
+    store_var _13
+    load_var _13
+    load_const 0
+    cmp_int_op ==
+    pop_jump_if_false L0
+    load_var cli_include
     container_len
     store_var _15
     load_var _15
     load_const 0
     cmp_int_op ==
-
-  L0:
-    jump_if_false L1
-    pop 1
-    load_var cli_include
-    container_len
-    store_var _16
-    load_var _16
-    load_const 0
-    cmp_int_op ==
-
-  L1:
-    jump_if_false L2
-    pop 1
+    pop_jump_if_false L0
     load_var cli_exclude
     container_len
     store_var _17
     load_var _17
     load_const 0
     cmp_int_op ==
+    pop_jump_if_true L1
 
-  L2:
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+  L0:
     load_var2 1 7
     load_var pool
     call testing.TestRegistry._run_selected_pooled
-    jump L5
+    jump L2
 
-  L4:
+  L1:
     load_var2 1 8
     call testing.TestRegistry._run_all_pooled
 
-  L5:
+  L2:
     load_var selected_names
     call testing._flatten_with_tolerated
     return
@@ -764,10 +690,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var_load_var t
     load_field .name
@@ -779,9 +702,9 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var t
     load_field .runner
     call testing._run_test
-    jump L5
+    jump L3
 
-  L2:
+  L1:
     load_type string
     load_type testing.TestRegistry
     load_var self
@@ -792,7 +715,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
-  L3:
+  L2:
     load_var _17
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -800,10 +723,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     store_var _18
     load_var _18
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L4
     load_var _18
     store_var k
     load_var self
@@ -815,14 +735,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_const "::"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var2 9 2
     call testing.TestRegistry.run_test
 
-  L5:
+  L3:
     return
 
-  L6:
+  L4:
     load_const "Test not found: "
     load_var name
     bin_op +
@@ -846,10 +766,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var_load_var ts
     load_field .name
@@ -867,9 +784,9 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     load_field .runner
     load_var pool
     call testing._run_testset
-    jump L5
+    jump L3
 
-  L2:
+  L1:
     load_type string
     load_type testing.TestRegistry
     load_var self
@@ -880,7 +797,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     virtual_call nargs=1 ntypeargs=0
     store_var _22
 
-  L3:
+  L2:
     load_var _22
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -888,10 +805,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     store_var _23
     load_var _23
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
+    pop_jump_if_true L4
     load_var _23
     store_var k
     load_var self
@@ -903,14 +817,14 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     load_const "::"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var2 10 2
     call testing.TestRegistry.run_testset
 
-  L5:
+  L3:
     return
 
-  L6:
+  L4:
     load_const "TestSet not found: "
     load_var name
     bin_op +
@@ -937,10 +851,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type testing.SerializedTest | testing.SerializedTestSet
     load_var items
     load_const "test"
@@ -951,7 +862,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var self
     load_field .collector
     load_field .testsets
@@ -960,7 +871,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     virtual_call nargs=1 ntypeargs=0
     store_var _14
 
-  L3:
+  L2:
     load_var _14
     load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
@@ -968,10 +879,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var _15
     load_var _15
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L4
     load_var _15
     store_var ts
     load_type string
@@ -984,10 +892,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     store_var _25
     load_var _25
     narrow_bind testing.TestRegistry, slot=8
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_type testing.SerializedTest | testing.SerializedTestSet
     load_var items
     load_const "lazyTestSet"
@@ -996,9 +901,9 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     init_instance testing.SerializedTest .type, .name
     call baml.Array.push
     pop 1
-    jump L3
+    jump L2
 
-  L6:
+  L3:
     load_var _25
     store_var sub
     load_var ts
@@ -1014,24 +919,15 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     init_instance testing.SerializedTestSet .name, .items, .loadingTimeMs
     call baml.Array.push
     pop 1
-    jump L3
+    jump L2
 
-  L7:
+  L4:
     load_var items
     return
 }
 
 function testing._TestPool.acquire(self: testing._TestPool) -> null {
   L0:
-    load_const true
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
-    load_const null
-    jump L5
-
-  L2:
     load_type int
     load_var self
     load_field .tokens
@@ -1039,10 +935,7 @@ function testing._TestPool.acquire(self: testing._TestPool) -> null {
     store_var _5
     load_var _5
     narrow_bind int, slot=2
-    pop_jump_if_false L3
-    jump L4
-
-  L3:
+    pop_jump_if_true L1
     load_const 10
     call baml.time.Duration.from_milliseconds
     sys_op baml.sys.sleep
@@ -1052,10 +945,8 @@ function testing._TestPool.acquire(self: testing._TestPool) -> null {
     throw_if_panic
     jump L0
 
-  L4:
+  L1:
     load_const null
-
-  L5:
     return
 }
 
@@ -1100,10 +991,7 @@ function testing._aggregate_reports(named_results: testing._NamedChildReport[]) 
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L15
-
-  L1:
+    pop_jump_if_true L9
     load_var _9
     store_var named_result
     load_var named_result
@@ -1122,28 +1010,22 @@ function testing._aggregate_reports(named_results: testing._NamedChildReport[]) 
     store_var _21
     load_var _21
     narrow_bind testing.TestReport, slot=13
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var result
     load_field .outcome
     store_var outcome
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _21
     load_field .outcome
     store_var outcome
 
-  L4:
+  L2:
     load_var outcome
     load_const "pass"
     call baml.ops.equals_equals
-    pop_jump_if_false L5
-    jump L14
-
-  L5:
+    pop_jump_if_true L8
     load_var failed
     load_const 1
     add_int
@@ -1152,10 +1034,7 @@ function testing._aggregate_reports(named_results: testing._NamedChildReport[]) 
     store_var _27
     load_var _27
     narrow_bind testing.TestReport, slot=14
-    pop_jump_if_false L6
-    jump L9
-
-  L6:
+    pop_jump_if_true L4
     load_var result
     store_var_load_var report
     load_field .failed_names
@@ -1164,34 +1043,31 @@ function testing._aggregate_reports(named_results: testing._NamedChildReport[]) 
     load_var _31
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L7
-    jump L8
-
-  L7:
+    pop_jump_if_true L3
     load_var named_result
     load_field .name
     load_type string
     alloc_array 1
-    jump L10
+    jump L5
 
-  L8:
+  L3:
     load_var report
     load_field .failed_names
-    jump L10
+    jump L5
 
-  L9:
+  L4:
     load_var named_result
     load_field .name
     load_type string
     alloc_array 1
 
-  L10:
+  L5:
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _35
 
-  L11:
+  L6:
     load_var _35
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -1199,17 +1075,14 @@ function testing._aggregate_reports(named_results: testing._NamedChildReport[]) 
     store_var _36
     load_var _36
     is_type baml.iter.Done
-    pop_jump_if_false L12
-    jump L13
-
-  L12:
+    pop_jump_if_true L7
     load_type string
     load_var2 5 18
     call baml.Array.push
     pop 1
-    jump L11
+    jump L6
 
-  L13:
+  L7:
     load_var outcome
     load_const "error"
     call baml.ops.equals_equals
@@ -1218,37 +1091,31 @@ function testing._aggregate_reports(named_results: testing._NamedChildReport[]) 
     store_var has_error
     jump L0
 
-  L14:
+  L8:
     load_var passed
     load_const 1
     add_int
     store_var passed
     jump L0
 
-  L15:
+  L9:
     load_var has_error
-    pop_jump_if_false L16
-    jump L19
-
-  L16:
+    pop_jump_if_true L11
     load_var failed
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L17
-    jump L18
-
-  L17:
+    pop_jump_if_true L10
     load_const "fail"
-    jump L20
+    jump L12
 
-  L18:
+  L10:
     load_const "pass"
-    jump L20
+    jump L12
 
-  L19:
+  L11:
     load_const "error"
 
-  L20:
+  L12:
     store_var _49
     load_var passed
     store_var _50
@@ -1280,20 +1147,17 @@ function testing._any_pattern_matches(pats: string[], canonical_id: string) -> b
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 2 4
     call testing._glob_match
     pop_jump_if_false L0
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -1326,18 +1190,12 @@ function testing._classify_selected_names(selected_names: string[], hard_failed_
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L3
     load_var _12
     store_var_load_var name
     load_var all_failed_names
     call testing._failure_matches_selected
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_type string
     load_var out
     load_field .passed
@@ -1346,13 +1204,10 @@ function testing._classify_selected_names(selected_names: string[], hard_failed_
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_var2 7 2
     call testing._failure_matches_selected
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L2
     load_type string
     load_var out
     load_field .tolerated
@@ -1361,7 +1216,7 @@ function testing._classify_selected_names(selected_names: string[], hard_failed_
     pop 1
     jump L0
 
-  L5:
+  L2:
     load_type string
     load_var out
     load_field .failed
@@ -1370,7 +1225,7 @@ function testing._classify_selected_names(selected_names: string[], hard_failed_
     pop 1
     jump L0
 
-  L6:
+  L3:
     load_var out
     return
 }
@@ -1391,55 +1246,45 @@ function testing._collect_all_failed_names(report: testing.TestSetReport, out: s
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _5
     store_var_load_var name
     load_var out
     call testing._name_in
-    unary_op !
-    pop_jump_if_false L0
+    pop_jump_if_true L0
     load_type string
     load_var2 2 5
     call baml.Array.push
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var report
     load_field .results
     load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _16
+    store_var _15
 
-  L3:
-    load_var _16
+  L2:
+    load_var _15
     load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _17
-    load_var _17
+    store_var _16
+    load_var _16
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L6
-
-  L4:
-    load_var _17
+    pop_jump_if_true L3
+    load_var _16
     store_var_load_var child
     is_type testing.TestReport
-    pop_jump_if_false L5
-    jump L3
-
-  L5:
+    pop_jump_if_true L2
     load_var2 8 2
     call testing._collect_all_failed_names
     pop 1
-    jump L3
+    jump L2
 
-  L6:
+  L3:
     load_const null
     return
 }
@@ -1450,10 +1295,7 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     store_var_load_var _5
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L28
-
-  L0:
+    pop_jump_if_true L16
     load_var _5
     store_var names
     load_var names
@@ -1465,36 +1307,30 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     store_var _11
     load_var2 8 9
     cmp_int_op <
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L0
     load_var report
     load_field .results
     container_len
     store_var limit
-    jump L3
+    jump L1
 
-  L2:
+  L0:
     load_var names
     container_len
     store_var limit
 
-  L3:
+  L1:
     load_const 0
     store_var i
 
-  L4:
+  L2:
     load_var2 10 7
     cmp_int_op <
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_const null
-    jump L29
+    jump L17
 
-  L6:
+  L3:
     load_var2 6 10
     load_array_element
     store_var name
@@ -1507,87 +1343,67 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     store_var _25
     load_var _25
     narrow_bind testing.TestReport, slot=13
-    pop_jump_if_false L7
-    jump L19
-
-  L7:
+    pop_jump_if_true L10
     load_var _22
     store_var nested
     load_var tolerated_by_parent
-    jump_if_false L8
-    store_var nested_tolerated
-    jump L9
-
-  L8:
-    pop 1
+    jump_if_true_or_pop L4
     load_var nested
     load_field .outcome
     load_const "pass"
     call baml.ops.equals_equals
-    store_var nested_tolerated
 
-  L9:
+  L4:
+    store_var nested_tolerated
     load_var nested
     load_field .results
     container_len
-    store_var _61
-    load_var _61
+    store_var _62
+    load_var _62
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L10
-    jump L18
-
-  L10:
+    pop_jump_if_true L9
     load_var nested
     load_field .failed
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L27
+    pop_jump_if_false L15
     load_var name
     load_const "::(failed to expand)"
     bin_op +
     store_var_load_var sentinel
     load_var selected_names
     call testing._name_in
-    pop_jump_if_false L11
-    jump L14
-
-  L11:
+    pop_jump_if_true L6
     load_var nested
     load_field .failed_names
     container_len
-    store_var _73
-    load_var _73
+    store_var _74
+    load_var _74
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L12
-    jump L13
-
-  L12:
+    pop_jump_if_true L5
     load_var name
     load_const "::(testset error)"
     bin_op +
     store_var identity
-    jump L15
+    jump L7
 
-  L13:
+  L5:
     load_var nested
     load_field .failed_names
     load_const 0
     load_array_element
     store_var identity
-    jump L15
+    jump L7
 
-  L14:
+  L6:
     load_var sentinel
     store_var identity
 
-  L15:
+  L7:
     load_var nested_tolerated
-    pop_jump_if_false L16
-    jump L17
-
-  L16:
+    pop_jump_if_true L8
     load_type string
     load_var out
     load_field .failed
@@ -1600,9 +1416,9 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     load_const -1
     call baml.Array.push
     pop 1
-    jump L27
+    jump L15
 
-  L17:
+  L8:
     load_type string
     load_var out
     load_field .tolerated
@@ -1615,16 +1431,16 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     load_const -1
     call baml.Array.push
     pop 1
-    jump L27
+    jump L15
 
-  L18:
+  L9:
     load_var2 17 18
     load_var2 3 4
     call testing._collect_leaf_identities
     pop 1
-    jump L27
+    jump L15
 
-  L19:
+  L10:
     load_var _25
     store_var_load_var leaf
     load_field .runs
@@ -1633,15 +1449,12 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     load_var _29
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L20
-    jump L21
-
-  L20:
+    pop_jump_if_true L11
     load_const -1
     store_var leaf_ms
-    jump L22
+    jump L12
 
-  L21:
+  L11:
     load_var leaf
     load_field .runs
     load_const 0
@@ -1649,20 +1462,14 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     load_field .duration_ms
     store_var leaf_ms
 
-  L22:
+  L12:
     load_var leaf
     load_field .outcome
     load_const "pass"
     call baml.ops.equals_equals
-    pop_jump_if_false L23
-    jump L26
-
-  L23:
+    pop_jump_if_true L14
     load_var tolerated_by_parent
-    pop_jump_if_false L24
-    jump L25
-
-  L24:
+    pop_jump_if_true L13
     load_type string
     load_var out
     load_field .failed
@@ -1675,9 +1482,9 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     load_var leaf_ms
     call baml.Array.push
     pop 1
-    jump L27
+    jump L15
 
-  L25:
+  L13:
     load_type string
     load_var out
     load_field .tolerated
@@ -1690,9 +1497,9 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     load_var leaf_ms
     call baml.Array.push
     pop 1
-    jump L27
+    jump L15
 
-  L26:
+  L14:
     load_type string
     load_var out
     load_field .passed
@@ -1706,17 +1513,17 @@ function testing._collect_leaf_identities(report: testing.TestSetReport, tolerat
     call baml.Array.push
     pop 1
 
-  L27:
+  L15:
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L4
+    jump L2
 
-  L28:
+  L16:
     load_const null
 
-  L29:
+  L17:
     return
 }
 
@@ -1735,20 +1542,14 @@ function testing._collect_leaf_messages(results: (testing.TestReport | testing.T
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L3
     load_var _4
     store_var r
     load_var r
     store_var _8
     load_var _8
     narrow_bind testing.TestReport, slot=6
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var r
     load_field .results
     load_var out
@@ -1756,7 +1557,7 @@ function testing._collect_leaf_messages(results: (testing.TestReport | testing.T
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_var _8
     load_field .runs
     load_type baml.iter.Iterable<Error = never, Item = testing.RunReport>
@@ -1764,7 +1565,7 @@ function testing._collect_leaf_messages(results: (testing.TestReport | testing.T
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
-  L4:
+  L2:
     load_var _11
     load_type baml.iter.Iterator<Error = never, Item = testing.RunReport>
     load_const "next"
@@ -1772,30 +1573,27 @@ function testing._collect_leaf_messages(results: (testing.TestReport | testing.T
     store_var _12
     load_var _12
     is_type baml.iter.Done
-    pop_jump_if_false L5
-    jump L0
-
-  L5:
+    pop_jump_if_true L0
     load_var _12
     store_var_load_var run
     load_field .outcome
     load_const "pass"
     call baml.ops.equals_equals
     unary_op !
-    pop_jump_if_false L4
+    pop_jump_if_false L2
     load_var run
     load_field .message
     store_var _20
     load_var _20
     narrow_bind string, slot=10
-    pop_jump_if_false L4
+    pop_jump_if_false L2
     load_type string
     load_var2 2 10
     call baml.Array.push
     pop 1
-    jump L4
+    jump L2
 
-  L6:
+  L3:
     load_const null
     return
 }
@@ -1820,10 +1618,7 @@ function testing._collect_leaf_names(registry: testing.TestRegistry) -> string[]
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_type string
     load_var2 2 4
     load_field .name
@@ -1831,7 +1626,7 @@ function testing._collect_leaf_names(registry: testing.TestRegistry) -> string[]
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var registry
     load_field .collector
     load_field .testsets
@@ -1840,7 +1635,7 @@ function testing._collect_leaf_names(registry: testing.TestRegistry) -> string[]
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
-  L3:
+  L2:
     load_var _13
     load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
@@ -1848,10 +1643,7 @@ function testing._collect_leaf_names(registry: testing.TestRegistry) -> string[]
     store_var _14
     load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L7
-
-  L4:
+    pop_jump_if_true L4
     load_var2 1 6
     call testing._collect_subtree_names
     load_type baml.iter.Iterable<Error = never, Item = string>
@@ -1859,7 +1651,7 @@ function testing._collect_leaf_names(registry: testing.TestRegistry) -> string[]
     virtual_call nargs=1 ntypeargs=0
     store_var _20
 
-  L5:
+  L3:
     load_var _20
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -1867,17 +1659,14 @@ function testing._collect_leaf_names(registry: testing.TestRegistry) -> string[]
     store_var _21
     load_var _21
     is_type baml.iter.Done
-    pop_jump_if_false L6
-    jump L3
-
-  L6:
+    pop_jump_if_true L2
     load_type string
     load_var2 2 8
     call baml.Array.push
     pop 1
-    jump L5
+    jump L3
 
-  L7:
+  L4:
     load_var out
     return
 }
@@ -1886,111 +1675,60 @@ function testing._collect_subtree_names(registry: testing.TestRegistry, ts: test
     load_var2 1 2
     call testing.TestRegistry._expand_testset_registry
     call testing._collect_leaf_names
-    jump L19
+    jump L2
     load_var e
     store_var _5
     load_var _5
     narrow_bind testing.InvalidTestName, slot=4
-    pop_jump_if_false L0
-    jump L18
-
-  L0:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L17
-
-  L1:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L2
-    jump L17
-
-  L2:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.InvalidFieldAccess
-    pop_jump_if_false L3
-    jump L17
-
-  L3:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.MapKeyNotFound
-    pop_jump_if_false L4
-    jump L17
-
-  L4:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.StackOverflow
-    pop_jump_if_false L5
-    jump L17
-
-  L5:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.AssertionFailed
-    pop_jump_if_false L6
-    jump L17
-
-  L6:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.Unreachable
-    pop_jump_if_false L7
-    jump L17
-
-  L7:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L8
-    jump L17
-
-  L8:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.UserPanic
-    pop_jump_if_false L9
-    jump L17
-
-  L9:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.Exit
-    pop_jump_if_false L10
-    jump L17
-
-  L10:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.AllocFailure
-    pop_jump_if_false L11
-    jump L17
-
-  L11:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.HostUnavailable
-    pop_jump_if_false L12
-    jump L17
-
-  L12:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.NegativeBitShift
-    pop_jump_if_false L13
-    jump L17
-
-  L13:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.SdkPanic
-    pop_jump_if_false L14
-    jump L17
-
-  L14:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.HostContractViolation
-    pop_jump_if_false L15
-    jump L17
-
-  L15:
+    pop_jump_if_true L0
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L16
-    jump L17
-
-  L16:
+    pop_jump_if_true L0
     load_var e
     throw_if_panic
     load_var ts
@@ -1999,22 +1737,22 @@ function testing._collect_subtree_names(registry: testing.TestRegistry, ts: test
     bin_op +
     load_type string
     alloc_array 1
-    jump L19
+    jump L2
 
-  L17:
+  L0:
     load_var ts
     load_field .name
     load_const "::(failed to expand)"
     bin_op +
     load_type string
     alloc_array 1
-    jump L19
+    jump L2
 
-  L18:
+  L1:
     load_var _5
     throw
 
-  L19:
+  L2:
     return
 }
 
@@ -2024,111 +1762,60 @@ function testing._collect_subtree_names_layered(registry: testing.TestRegistry, 
     load_var2 3 4
     load_var2 5 6
     call testing._select_names_layered
-    jump L23
+    jump L4
     load_var e
     store_var _9
     load_var _9
     narrow_bind testing.InvalidTestName, slot=8
-    pop_jump_if_false L0
-    jump L22
-
-  L0:
+    pop_jump_if_true L3
     load_var e
     is_type baml.panics.DivisionByZero
-    pop_jump_if_false L1
-    jump L19
-
-  L1:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.IndexOutOfBounds
-    pop_jump_if_false L2
-    jump L19
-
-  L2:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.InvalidFieldAccess
-    pop_jump_if_false L3
-    jump L19
-
-  L3:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.MapKeyNotFound
-    pop_jump_if_false L4
-    jump L19
-
-  L4:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.StackOverflow
-    pop_jump_if_false L5
-    jump L19
-
-  L5:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.AssertionFailed
-    pop_jump_if_false L6
-    jump L19
-
-  L6:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.Unreachable
-    pop_jump_if_false L7
-    jump L19
-
-  L7:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.Cancelled
-    pop_jump_if_false L8
-    jump L19
-
-  L8:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.UserPanic
-    pop_jump_if_false L9
-    jump L19
-
-  L9:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.Exit
-    pop_jump_if_false L10
-    jump L19
-
-  L10:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.AllocFailure
-    pop_jump_if_false L11
-    jump L19
-
-  L11:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.HostUnavailable
-    pop_jump_if_false L12
-    jump L19
-
-  L12:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.NegativeBitShift
-    pop_jump_if_false L13
-    jump L19
-
-  L13:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.SdkPanic
-    pop_jump_if_false L14
-    jump L19
-
-  L14:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.HostContractViolation
-    pop_jump_if_false L15
-    jump L19
-
-  L15:
+    pop_jump_if_true L1
     load_var e
     is_type baml.panics.IntegerOverflow
-    pop_jump_if_false L16
-    jump L19
-
-  L16:
+    pop_jump_if_true L1
     load_var e
     throw_if_panic
     load_var ts
@@ -2139,21 +1826,18 @@ function testing._collect_subtree_names_layered(registry: testing.TestRegistry, 
     load_var2 3 4
     load_var2 5 6
     call testing._leaf_selected_layered
-    pop_jump_if_false L17
-    jump L18
-
-  L17:
+    pop_jump_if_true L0
     load_type string
     alloc_array 0
-    jump L23
+    jump L4
 
-  L18:
+  L0:
     load_var sentinel
     load_type string
     alloc_array 1
-    jump L23
+    jump L4
 
-  L19:
+  L1:
     load_var ts
     load_field .name
     load_const "::(failed to expand)"
@@ -2162,25 +1846,22 @@ function testing._collect_subtree_names_layered(registry: testing.TestRegistry, 
     load_var2 3 4
     load_var2 5 6
     call testing._leaf_selected_layered
-    pop_jump_if_false L20
-    jump L21
-
-  L20:
+    pop_jump_if_true L2
     load_type string
     alloc_array 0
-    jump L23
+    jump L4
 
-  L21:
+  L2:
     load_var sentinel
     load_type string
     alloc_array 1
-    jump L23
+    jump L4
 
-  L22:
+  L3:
     load_var _9
     throw
 
-  L23:
+  L4:
     return
 }
 
@@ -2207,64 +1888,47 @@ function testing._count_leaves(results: (testing.TestReport | testing.TestSetRep
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L15
-
-  L1:
+    pop_jump_if_true L8
     load_var _8
     store_var r
     load_var r
     store_var _13
     load_var _13
     narrow_bind testing.TestReport, slot=11
-    pop_jump_if_false L2
-    jump L9
-
-  L2:
+    pop_jump_if_true L4
     load_var r
     store_var tsr
     load_var tolerated_by_parent
-    jump_if_false L3
-    store_var ft
-    jump L4
-
-  L3:
-    pop 1
+    jump_if_true_or_pop L1
     load_var tsr
     load_field .outcome
     load_const "pass"
     call baml.ops.equals_equals
-    store_var ft
 
-  L4:
+  L1:
+    store_var ft
     load_var tsr
     load_field .results
     container_len
-    store_var _21
-    load_var _21
+    store_var _22
+    load_var _22
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L5
-    jump L8
-
-  L5:
+    pop_jump_if_true L3
     load_var ft
-    pop_jump_if_false L6
+    pop_jump_if_true L2
+    load_var tsr
+    load_field .passed
+    load_var tsr
+    load_field .failed
+    load_const 0
+    load_var tsr
+    load_field .total
+    init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
+    store_var delta
     jump L7
 
-  L6:
-    load_var tsr
-    load_field .passed
-    load_var tsr
-    load_field .failed
-    load_const 0
-    load_var tsr
-    load_field .total
-    init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
-    store_var delta
-    jump L14
-
-  L7:
+  L2:
     load_var tsr
     load_field .passed
     load_const 0
@@ -2274,48 +1938,42 @@ function testing._count_leaves(results: (testing.TestReport | testing.TestSetRep
     load_field .total
     init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
     store_var delta
-    jump L14
+    jump L7
 
-  L8:
+  L3:
     load_var tsr
     load_field .results
     load_var ft
     call testing._count_leaves
     store_var delta
-    jump L14
+    jump L7
 
-  L9:
+  L4:
     load_var _13
     load_field .outcome
     load_const "pass"
     call baml.ops.equals_equals
-    pop_jump_if_false L10
-    jump L13
-
-  L10:
+    pop_jump_if_true L6
     load_var tolerated_by_parent
-    pop_jump_if_false L11
-    jump L12
-
-  L11:
+    pop_jump_if_true L5
     load_const 0
     load_const 1
     load_const 0
     load_const 1
     init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
     store_var delta
-    jump L14
+    jump L7
 
-  L12:
+  L5:
     load_const 0
     load_const 0
     load_const 1
     load_const 1
     init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
     store_var delta
-    jump L14
+    jump L7
 
-  L13:
+  L6:
     load_const 1
     load_const 0
     load_const 0
@@ -2323,7 +1981,7 @@ function testing._count_leaves(results: (testing.TestReport | testing.TestSetRep
     init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
     store_var delta
 
-  L14:
+  L7:
     load_var2 3 10
     load_field .passed
     add_int
@@ -2342,7 +2000,7 @@ function testing._count_leaves(results: (testing.TestReport | testing.TestSetRep
     store_var total
     jump L0
 
-  L15:
+  L8:
     load_var2 3 4
     load_var2 5 6
     init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
@@ -2370,60 +2028,54 @@ function testing._expansion_error_report(name: string) -> testing.TestSetReport 
 function testing._failure_matches_selected(selected: string, failed_names: string[]) -> bool {
     load_var2 1 2
     call testing._name_in
-    pop_jump_if_false L0
-    jump L4
-
-  L0:
+    pop_jump_if_true L2
     load_var selected
     load_const "::(failed to expand)"
     call baml.String.ends_with
-    pop_jump_if_false L3
+    pop_jump_if_false L1
     load_var selected
     call baml.String.length
-    store_var _10
+    store_var _8
     load_const "::(failed to expand)"
     call baml.String.length
-    store_var _11
+    store_var _9
     load_var selected
     load_const 0
     load_var2 4 5
     sub_int
     call baml.String.slice
-    store_var _8
+    store_var _6
     load_var failed_names
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _12
+    store_var _10
 
-  L1:
-    load_var _12
+  L0:
+    load_var _10
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _13
-    load_var _13
+    store_var _11
+    load_var _11
     is_type baml.iter.Done
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var2 7 3
     load_const "::"
     bin_op +
     call baml.String.starts_with
-    pop_jump_if_false L1
+    pop_jump_if_false L0
     load_const true
-    jump L5
+    jump L3
+
+  L1:
+    load_const false
+    jump L3
+
+  L2:
+    load_const true
 
   L3:
-    load_const false
-    jump L5
-
-  L4:
-    load_const true
-
-  L5:
     return
 }
 
@@ -2440,46 +2092,40 @@ function testing._flatten_with_tolerated(report: testing.TestSetReport, selected
     load_var _7
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
-    jump L3
+    pop_jump_if_true L1
+    load_var top_tolerated
+    pop_jump_if_true L0
+    load_var report
+    load_field .passed
+    load_var report
+    load_field .failed
+    load_const 0
+    load_var report
+    load_field .total
+    init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
+    store_var counts
+    jump L2
 
   L0:
-    load_var top_tolerated
-    pop_jump_if_false L1
+    load_var report
+    load_field .passed
+    load_const 0
+    load_var report
+    load_field .failed
+    load_var report
+    load_field .total
+    init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
+    store_var counts
     jump L2
 
   L1:
-    load_var report
-    load_field .passed
-    load_var report
-    load_field .failed
-    load_const 0
-    load_var report
-    load_field .total
-    init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
-    store_var counts
-    jump L4
-
-  L2:
-    load_var report
-    load_field .passed
-    load_const 0
-    load_var report
-    load_field .failed
-    load_var report
-    load_field .total
-    init_instance testing._LeafCounts .passed, .failed, .tolerated, .total
-    store_var counts
-    jump L4
-
-  L3:
     load_var report
     load_field .results
     load_var top_tolerated
     call testing._count_leaves
     store_var counts
 
-  L4:
+  L2:
     load_type string
     alloc_array 0
     store_var messages
@@ -2515,23 +2161,19 @@ function testing._flatten_with_tolerated(report: testing.TestSetReport, selected
     load_var executed
     load_field .passed
     container_len
-    store_var _39
+    store_var _37
     load_var2 10 4
     load_field .passed
     cmp_int_op ==
-    jump_if_false L5
-    pop 1
+    pop_jump_if_false L3
     load_var executed
     load_field .failed
     container_len
-    store_var _42
+    store_var _41
     load_var2 11 4
     load_field .failed
     cmp_int_op ==
-
-  L5:
-    jump_if_false L6
-    pop 1
+    pop_jump_if_false L3
     load_var executed
     load_field .tolerated
     container_len
@@ -2539,22 +2181,16 @@ function testing._flatten_with_tolerated(report: testing.TestSetReport, selected
     load_var2 12 4
     load_field .tolerated
     cmp_int_op ==
+    pop_jump_if_true L5
 
-  L6:
-    pop_jump_if_false L7
-    jump L10
-
-  L7:
+  L3:
     load_var selected_names
     container_len
     store_var _49
     load_var2 13 4
     load_field .total
     cmp_int_op ==
-    pop_jump_if_false L8
-    jump L9
-
-  L8:
+    pop_jump_if_true L4
     load_type string
     alloc_array 0
     load_type string
@@ -2569,21 +2205,21 @@ function testing._flatten_with_tolerated(report: testing.TestSetReport, selected
     alloc_array 0
     init_instance testing._LeafIdentities .passed, .failed, .tolerated, .passed_ms, .failed_ms, .tolerated_ms
     store_var identities
-    jump L11
+    jump L6
 
-  L9:
+  L4:
     load_var2 2 1
     load_field .failed_names
     load_var all_failed_names
     call testing._classify_selected_names
     store_var identities
-    jump L11
+    jump L6
 
-  L10:
+  L5:
     load_var executed
     store_var identities
 
-  L11:
+  L6:
     load_var report
     load_field .outcome
     load_var counts
@@ -2622,10 +2258,7 @@ function testing._glob_match(subject: string, pattern: string) -> bool {
     load_var n
     load_const 1
     cmp_int_op ==
-    pop_jump_if_false L0
-    jump L13
-
-  L0:
+    pop_jump_if_true L7
     load_var parts
     load_const 0
     load_array_element
@@ -2637,144 +2270,118 @@ function testing._glob_match(subject: string, pattern: string) -> bool {
     store_var last
     load_var2 1 5
     call baml.String.starts_with
-    unary_op !
-    pop_jump_if_false L1
-    jump L12
+    pop_jump_if_true L0
+    load_const false
+    jump L8
 
-  L1:
+  L0:
     load_var2 1 6
     call baml.String.ends_with
-    unary_op !
-    pop_jump_if_false L2
-    jump L11
+    pop_jump_if_true L1
+    load_const false
+    jump L8
 
-  L2:
+  L1:
     load_var first
     call baml.String.length
     store_var start
     load_var subject
     call baml.String.length
-    store_var _24
     load_var last
     call baml.String.length
-    store_var _25
-    load_var2 9 10
     sub_int
     store_var end_limit
     load_var2 7 8
     cmp_int_op >
-    pop_jump_if_false L3
-    jump L10
-
-  L3:
+    pop_jump_if_true L6
     load_var start
     store_var pos
     load_const 1
     store_var i
 
-  L4:
-    load_var2 12 4
+  L2:
+    load_var2 10 4
     load_const 1
     sub_int
     cmp_int_op <
-    pop_jump_if_false L5
-    jump L6
-
-  L5:
+    pop_jump_if_true L3
     load_const true
-    jump L14
+    jump L8
 
-  L6:
-    load_var2 3 12
+  L3:
+    load_var2 3 10
     load_array_element
     store_var_load_var part
     load_const ""
     cmp_op !=
-    pop_jump_if_false L9
-    load_var2 1 11
+    pop_jump_if_false L5
+    load_var2 1 9
     load_var end_limit
     call baml.String.slice
     load_var part
     call baml.String.index_of
-    store_var _45
-    load_var _45
-    narrow_bind int, slot=14
-    pop_jump_if_false L7
+    store_var _43
+    load_var _43
+    narrow_bind int, slot=12
+    pop_jump_if_true L4
+    load_const false
     jump L8
 
-  L7:
-    load_const false
-    jump L14
-
-  L8:
-    load_var2 11 14
+  L4:
+    load_var2 9 12
     add_int
-    store_var _47
+    store_var _45
     load_var part
     call baml.String.length
-    load_var _47
+    load_var _45
     add_int
     store_var pos
 
-  L9:
+  L5:
     load_var i
     load_const 1
     add_int
     store_var i
-    jump L4
+    jump L2
 
-  L10:
+  L6:
     load_const false
-    jump L14
+    jump L8
 
-  L11:
-    load_const false
-    jump L14
-
-  L12:
-    load_const false
-    jump L14
-
-  L13:
+  L7:
     load_var2 1 2
     call baml.String.index_of
     load_const null
     call baml.ops.equals_equals
     unary_op !
 
-  L14:
+  L8:
     return
 }
 
 function testing._leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
     load_var2 3 1
     call testing._any_pattern_matches
-    pop_jump_if_false L0
-    jump L3
-
-  L0:
+    pop_jump_if_true L1
     load_var include
     container_len
     store_var _6
     load_var _6
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L1
+    pop_jump_if_true L0
+    load_var2 2 1
+    call testing._any_pattern_matches
+    jump L2
+
+  L0:
+    load_const true
     jump L2
 
   L1:
-    load_var2 2 1
-    call testing._any_pattern_matches
-    jump L4
-
-  L2:
-    load_const true
-    jump L4
-
-  L3:
     load_const false
 
-  L4:
+  L2:
     return
 }
 
@@ -2782,8 +2389,7 @@ function testing._leaf_selected_layered(name: string, profile_include: string[],
     load_var2 1 2
     load_var profile_exclude
     call testing._leaf_selected
-    jump_if_false L0
-    pop 1
+    jump_if_false_or_pop L0
     load_var2 1 4
     load_var cli_exclude
     call testing._leaf_selected
@@ -2807,20 +2413,17 @@ function testing._name_in(name: string, names: string[]) -> bool {
     store_var _4
     load_var _4
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var2 4 1
     cmp_op ==
     pop_jump_if_false L0
     load_const true
-    jump L3
+    jump L2
 
-  L2:
+  L1:
     load_const false
 
-  L3:
+  L2:
     return
 }
 
@@ -2836,10 +2439,7 @@ function testing._pattern_may_match_descendant(pattern: string, prefix: string) 
     load_var _4
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L2
-
-  L0:
+    pop_jump_if_true L1
     load_var pattern
     load_const 0
     load_var _4
@@ -2847,19 +2447,17 @@ function testing._pattern_may_match_descendant(pattern: string, prefix: string) 
     store_var literal
     load_var2 3 5
     call baml.String.starts_with
-    jump_if_false L1
-    jump L3
-
-  L1:
-    pop 1
+    jump_if_true_or_pop L0
     load_var2 5 3
     call baml.String.starts_with
-    jump L3
 
-  L2:
+  L0:
+    jump L2
+
+  L1:
     load_const true
 
-  L3:
+  L2:
     return
 }
 
@@ -2887,10 +2485,7 @@ function testing._run_children_parallel(children: testing.TestSetChild[], pool: 
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L4
-
-  L1:
+    pop_jump_if_true L2
     load_const null
     make_cell
     store_var child
@@ -2898,10 +2493,7 @@ function testing._run_children_parallel(children: testing.TestSetChild[], pool: 
     store_deref ?6
     load_deref ?6
     load_field .is_container
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_deref ?2
     call testing._TestPool.acquire
     pop 1
@@ -2919,7 +2511,7 @@ function testing._run_children_parallel(children: testing.TestSetChild[], pool: 
     pop 1
     jump L0
 
-  L3:
+  L1:
     load_var child
     make_closure .<lambda(_run_children_parallel, 0)>, 1
     load_const null
@@ -2934,7 +2526,7 @@ function testing._run_children_parallel(children: testing.TestSetChild[], pool: 
     pop 1
     jump L0
 
-  L4:
+  L2:
     load_type testing._NamedChildReport
     load_type never
     load_var futures
@@ -2962,10 +2554,7 @@ function testing._run_children_sequential(children: testing.TestSetChild[], fail
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L3
     load_var _5
     store_var_load_var child
     load_field .run
@@ -2982,40 +2571,34 @@ function testing._run_children_sequential(children: testing.TestSetChild[], fail
     store_var _17
     load_var _17
     narrow_bind testing.TestReport, slot=9
-    pop_jump_if_false L2
-    jump L3
-
-  L2:
+    pop_jump_if_true L1
     load_var report
     load_field .outcome
     store_var outcome
-    jump L4
+    jump L2
 
-  L3:
+  L1:
     load_var _17
     load_field .outcome
     store_var outcome
 
-  L4:
+  L2:
     load_var fail_fast
-    jump_if_false L5
-    pop 1
+    pop_jump_if_false L0
     load_var outcome
     load_const "pass"
     call baml.ops.equals_equals
     unary_op !
-
-  L5:
     pop_jump_if_false L0
     load_var named_results
     call testing._aggregate_reports
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_var named_results
     call testing._aggregate_reports
 
-  L7:
+  L4:
     return
 }
 
@@ -3029,14 +2612,11 @@ function testing._run_test(body: () -> void throws unknown, runner: ((() -> test
     load_var runner
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
+    pop_jump_if_true L0
     load_var2 3 2
     call_indirect
     call_indirect
-    jump L2
+    jump L1
     load_var e
     throw_if_panic
     load_var _8
@@ -3054,13 +2634,13 @@ function testing._run_test(body: () -> void throws unknown, runner: ((() -> test
     load_type testing.RunReport
     alloc_array 1
     init_instance testing.TestReport .outcome, .runs
-    jump L2
+    jump L1
 
-  L1:
+  L0:
     load_var base_run
     call_indirect
 
-  L2:
+  L1:
     return
 }
 
@@ -3068,19 +2648,16 @@ function testing._run_testset(children: testing.TestSetChild[], runner: ((testin
     load_var runner
     load_const null
     cmp_op ==
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_var2 1 2
+    call_indirect
     jump L1
 
   L0:
-    load_var2 1 2
-    call_indirect
-    jump L2
-
-  L1:
     load_var2 1 3
     call testing._run_children_parallel
 
-  L2:
+  L1:
     return
 }
 
@@ -3115,10 +2692,7 @@ function testing._select_names_layered(registry: testing.TestRegistry, profile_i
     store_var _9
     load_var _9
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _9
     store_var_load_var t
     load_field .name
@@ -3133,7 +2707,7 @@ function testing._select_names_layered(registry: testing.TestRegistry, profile_i
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var registry
     load_field .collector
     load_field .testsets
@@ -3142,7 +2716,7 @@ function testing._select_names_layered(registry: testing.TestRegistry, profile_i
     virtual_call nargs=1 ntypeargs=0
     store_var _19
 
-  L3:
+  L2:
     load_var _19
     load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
@@ -3150,24 +2724,18 @@ function testing._select_names_layered(registry: testing.TestRegistry, profile_i
     store_var _20
     load_var _20
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L8
-
-  L4:
+    pop_jump_if_true L4
     load_var _20
     store_var_load_var ts
     load_field .name
     load_var2 2 3
     call testing._subtree_may_be_selected
-    jump_if_false L5
-    pop 1
+    pop_jump_if_false L2
     load_var ts
     load_field .name
     load_var2 4 5
     call testing._subtree_may_be_selected
-
-  L5:
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var2 1 12
     load_var2 2 3
     load_var2 4 5
@@ -3177,7 +2745,7 @@ function testing._select_names_layered(registry: testing.TestRegistry, profile_i
     virtual_call nargs=1 ntypeargs=0
     store_var _31
 
-  L6:
+  L3:
     load_var _31
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -3185,17 +2753,14 @@ function testing._select_names_layered(registry: testing.TestRegistry, profile_i
     store_var _32
     load_var _32
     is_type baml.iter.Done
-    pop_jump_if_false L7
-    jump L3
-
-  L7:
+    pop_jump_if_true L2
     load_type string
     load_var2 6 14
     call baml.Array.push
     pop 1
-    jump L6
+    jump L3
 
-  L8:
+  L4:
     load_var out
     return
 }
@@ -3219,10 +2784,7 @@ function testing._subtree_excluded(prefix: string, excludes: string[]) -> bool {
     store_var _5
     load_var _5
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L6
-
-  L1:
+    pop_jump_if_true L3
     load_var _5
     store_var pattern
     load_var pattern
@@ -3230,67 +2792,54 @@ function testing._subtree_excluded(prefix: string, excludes: string[]) -> bool {
     call baml.String.index_of
     load_const null
     call baml.ops.equals_equals
-    jump_if_false L2
-    pop 1
+    pop_jump_if_false L1
     load_var2 3 6
     call baml.String.index_of
     load_const null
     call baml.ops.equals_equals
     unary_op !
+    pop_jump_if_true L2
 
-  L2:
-    pop_jump_if_false L3
-    jump L5
-
-  L3:
+  L1:
     load_var pattern
     load_const "*"
     call baml.String.ends_with
-    jump_if_false L4
-    pop 1
+    pop_jump_if_false L0
     load_var2 3 6
     call testing._glob_match
-
-  L4:
     pop_jump_if_false L0
     load_const true
-    jump L7
+    jump L4
 
-  L5:
+  L2:
     load_const true
-    jump L7
+    jump L4
 
-  L6:
+  L3:
     load_const false
 
-  L7:
+  L4:
     return
 }
 
 function testing._subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
     load_var2 1 3
     call testing._subtree_excluded
-    pop_jump_if_false L0
-    jump L6
-
-  L0:
+    pop_jump_if_true L3
     load_var include
     container_len
     store_var _6
     load_var _6
     load_const 0
     cmp_int_op ==
-    pop_jump_if_false L1
-    jump L5
-
-  L1:
+    pop_jump_if_true L2
     load_var include
     load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
-  L2:
+  L0:
     load_var _7
     load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
@@ -3298,28 +2847,25 @@ function testing._subtree_may_be_selected(prefix: string, include: string[], exc
     store_var _8
     load_var _8
     is_type baml.iter.Done
-    pop_jump_if_false L3
+    pop_jump_if_true L1
+    load_var2 6 1
+    call testing._pattern_may_match_descendant
+    pop_jump_if_false L0
+    load_const true
+    jump L4
+
+  L1:
+    load_const false
+    jump L4
+
+  L2:
+    load_const true
     jump L4
 
   L3:
-    load_var2 6 1
-    call testing._pattern_may_match_descendant
-    pop_jump_if_false L2
-    load_const true
-    jump L7
+    load_const false
 
   L4:
-    load_const false
-    jump L7
-
-  L5:
-    load_const true
-    jump L7
-
-  L6:
-    load_const false
-
-  L7:
     return
 }
 
@@ -3342,37 +2888,31 @@ function testing._test_pool(max_concurrency: int) -> testing._TestPool {
     load_var max_concurrency
     load_const 0
     cmp_int_op >
-    pop_jump_if_false L0
+    pop_jump_if_true L0
+    load_const 64
+    store_var limit
     jump L1
 
   L0:
-    load_const 64
-    store_var limit
-    jump L2
-
-  L1:
     load_var max_concurrency
     store_var limit
 
-  L2:
+  L1:
     load_type int
     alloc_array 0
     store_var tokens
     load_const 0
     store_var i
 
-  L3:
+  L2:
     load_var2 4 2
     cmp_int_op <
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var tokens
     init_instance testing._TestPool .tokens
     return
 
-  L5:
+  L3:
     load_type int
     load_var tokens
     load_const 1
@@ -3382,7 +2922,7 @@ function testing._test_pool(max_concurrency: int) -> testing._TestPool {
     load_const 1
     add_int
     store_var i
-    jump L3
+    jump L2
 }
 
 function testing._testset_child(registry: testing.TestRegistry, ts: testing.TestSetRegistration, pool: testing._TestPool) -> testing.TestSetChild {
@@ -3448,10 +2988,7 @@ function testing._testset_children(registry: testing.TestRegistry, pool: testing
     store_var _6
     load_var _6
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _6
     store_var_load_var t
     load_field .name
@@ -3467,7 +3004,7 @@ function testing._testset_children(registry: testing.TestRegistry, pool: testing
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var registry
     load_field .collector
     load_field .testsets
@@ -3476,7 +3013,7 @@ function testing._testset_children(registry: testing.TestRegistry, pool: testing
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
-  L3:
+  L2:
     load_var _17
     load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
@@ -3484,10 +3021,7 @@ function testing._testset_children(registry: testing.TestRegistry, pool: testing
     store_var _18
     load_var _18
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var2 1 9
     load_var pool
     call testing._testset_child
@@ -3496,9 +3030,9 @@ function testing._testset_children(registry: testing.TestRegistry, pool: testing
     load_var2 3 10
     call baml.Array.push
     pop 1
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var children
     return
 }
@@ -3526,10 +3060,7 @@ function testing._testset_children_selected(registry: testing.TestRegistry, name
     store_var _7
     load_var _7
     is_type baml.iter.Done
-    pop_jump_if_false L1
-    jump L2
-
-  L1:
+    pop_jump_if_true L1
     load_var _7
     store_var t
     load_type string
@@ -3551,7 +3082,7 @@ function testing._testset_children_selected(registry: testing.TestRegistry, name
     pop 1
     jump L0
 
-  L2:
+  L1:
     load_var registry
     load_field .collector
     load_field .testsets
@@ -3560,7 +3091,7 @@ function testing._testset_children_selected(registry: testing.TestRegistry, name
     virtual_call nargs=1 ntypeargs=0
     store_var _21
 
-  L3:
+  L2:
     load_var _21
     load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
@@ -3568,10 +3099,7 @@ function testing._testset_children_selected(registry: testing.TestRegistry, name
     store_var _22
     load_var _22
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
-
-  L4:
+    pop_jump_if_true L3
     load_var _22
     store_var ts
     load_type string
@@ -3586,7 +3114,7 @@ function testing._testset_children_selected(registry: testing.TestRegistry, name
     load_var2 2 12
     make_closure .<lambda(_testset_children_selected, 0)>, 1
     call baml.Array.some
-    pop_jump_if_false L3
+    pop_jump_if_false L2
     load_var2 1 11
     load_var2 2 3
     call testing._testset_child_selected
@@ -3595,9 +3123,9 @@ function testing._testset_children_selected(registry: testing.TestRegistry, name
     load_var2 4 13
     call baml.Array.push
     pop 1
-    jump L3
+    jump L2
 
-  L5:
+  L3:
     load_var children
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/mir.snap
@@ -1241,19 +1241,20 @@ fn testing.TestRegistry._expand_testset_registry(self: testing.TestRegistry, ts:
     let _21: baml.time.Duration
     let _22: bool
     let _23: string
-    let _24: string // message
-    let _25: string
+    let _24: string
+    let _25: string // message
     let _26: string
-    let _27: testing.TestRegistry // sub_registry
-    let _28: testing.TestCollector
-    let _29: map<string, testing.TestRegistry>
-    let _30: int
-    let _31: null | testing.TestRegistry
-    let _32: (map<string, testing.TestRegistry>, string, testing.TestRegistry) -> null | testing.TestRegistry throws never
-    let _33: string
-    let _34: testing.TestRegistry
-    let _35: reflect.Type
+    let _27: string
+    let _28: testing.TestRegistry // sub_registry
+    let _29: testing.TestCollector
+    let _30: map<string, testing.TestRegistry>
+    let _31: int
+    let _32: null | testing.TestRegistry
+    let _33: (map<string, testing.TestRegistry>, string, testing.TestRegistry) -> null | testing.TestRegistry throws never
+    let _34: string
+    let _35: testing.TestRegistry
     let _36: reflect.Type
+    let _37: reflect.Type
 
     bb0: {
         _4 = copy _1.1;
@@ -1291,13 +1292,13 @@ fn testing.TestRegistry._expand_testset_registry(self: testing.TestRegistry, ts:
     }
 
     bb6: {
-        _18 = call const fn baml.Bigint.to_int(copy _20) -> [bb11, unwind: bb8];
+        _18 = call const fn baml.Bigint.to_int(copy _20) -> [bb12, unwind: bb8];
     }
 
     bb7: {
         _9 = copy _8;
         _0 = copy _9;
-        goto -> bb13;
+        goto -> bb14;
     }
 
     bb8: {
@@ -1311,31 +1312,37 @@ fn testing.TestRegistry._expand_testset_registry(self: testing.TestRegistry, ts:
 
     bb10: {
         _23 = copy _19.0;
-        _24 = copy _23;
-        _26 = copy _24;
-        _25 = const "testing: expansion duration: " + copy _26;
-        _18 = call const fn baml.sys.panic(copy _25) -> [bb11];
+        drop(_23);
+        goto -> bb11;
     }
 
     bb11: {
-        _28 = copy _11;
-        _29 = {  }: map<string, testing.TestRegistry>;
-        _30 = copy _18;
-        _27 = testing.TestRegistry { copy _28, copy _29, copy _30 };
-        _32 = copy _1.1;
-        _33 = copy _2.0;
-        _34 = copy _27;
-        _35 = load_type(string);
-        _36 = load_type(testing.TestRegistry);
-        _31 = call const fn baml.Map.set<copy _35, copy _36>(copy _32, copy _33, copy _34) -> [bb12];
+        _24 = copy _19.0;
+        _25 = copy _24;
+        _27 = copy _25;
+        _26 = const "testing: expansion duration: " + copy _27;
+        _18 = call const fn baml.sys.panic(copy _26) -> [bb12];
     }
 
     bb12: {
-        _0 = copy _27;
-        goto -> bb13;
+        _29 = copy _11;
+        _30 = {  }: map<string, testing.TestRegistry>;
+        _31 = copy _18;
+        _28 = testing.TestRegistry { copy _29, copy _30, copy _31 };
+        _33 = copy _1.1;
+        _34 = copy _2.0;
+        _35 = copy _28;
+        _36 = load_type(string);
+        _37 = load_type(testing.TestRegistry);
+        _32 = call const fn baml.Map.set<copy _36, copy _37>(copy _33, copy _34, copy _35) -> [bb13];
     }
 
     bb13: {
+        _0 = copy _28;
+        goto -> bb14;
+    }
+
+    bb14: {
         return;
     }
 }
@@ -2437,15 +2444,16 @@ fn .<lambda(_run_test, 0)>() -> testing.TestReport {
     let _26: baml.time.Duration
     let _27: bool
     let _28: string
-    let _29: string // message
-    let _30: string
+    let _29: string
+    let _30: string // message
     let _31: string
-    let _32: "error" | "fail" | "pass"
-    let _33: testing.RunReport[]
-    let _34: testing.RunReport
-    let _35: "error" | "fail" | "pass"
-    let _36: int
-    let _37: string | null
+    let _32: string
+    let _33: "error" | "fail" | "pass"
+    let _34: testing.RunReport[]
+    let _35: testing.RunReport
+    let _36: "error" | "fail" | "pass"
+    let _37: int
+    let _38: string | null
 
     bb0: {
         _1 = sys_op const fn baml.time.Instant.now() -> bb1;
@@ -2532,7 +2540,7 @@ fn .<lambda(_run_test, 0)>() -> testing.TestReport {
     }
 
     bb17: {
-        _23 = call const fn baml.Bigint.to_int(copy _25) -> [bb21, unwind: bb18];
+        _23 = call const fn baml.Bigint.to_int(copy _25) -> [bb22, unwind: bb18];
     }
 
     bb18: {
@@ -2546,24 +2554,30 @@ fn .<lambda(_run_test, 0)>() -> testing.TestReport {
 
     bb20: {
         _28 = copy _24.0;
-        _29 = copy _28;
-        _31 = copy _29;
-        _30 = const "testing: test duration: " + copy _31;
-        _23 = call const fn baml.sys.panic(copy _30) -> [bb21];
+        drop(_28);
+        goto -> bb21;
     }
 
     bb21: {
-        _32 = copy _15.0;
-        _35 = copy _15.0;
-        _36 = copy _23;
-        _37 = copy _15.2;
-        _34 = testing.RunReport { copy _35, copy _36, copy _37 };
-        _33 = [copy _34]: testing.RunReport[];
-        _0 = testing.TestReport { copy _32, copy _33 };
-        goto -> bb22;
+        _29 = copy _24.0;
+        _30 = copy _29;
+        _32 = copy _30;
+        _31 = const "testing: test duration: " + copy _32;
+        _23 = call const fn baml.sys.panic(copy _31) -> [bb22];
     }
 
     bb22: {
+        _33 = copy _15.0;
+        _36 = copy _15.0;
+        _37 = copy _23;
+        _38 = copy _15.2;
+        _35 = testing.RunReport { copy _36, copy _37, copy _38 };
+        _34 = [copy _35]: testing.RunReport[];
+        _0 = testing.TestReport { copy _33, copy _34 };
+        goto -> bb23;
+    }
+
+    bb23: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/mir.snap
@@ -46,9 +46,9 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
     let _20: testing.TestRegistration
     let _21: testing.TestRegistration // t
     let _22: bool
-    let _23: bool
+    let _23: string
     let _24: string
-    let _25: string
+    let _25: bool
     let _26: (string, string) -> bool throws never
     let _27: string
     let _28: string // final_name
@@ -113,20 +113,20 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
         _20 = copy _18;
         fresh_cell(_21);
         _21 = copy _20;
-        _24 = copy _21.0;
-        _25 = copy _8;
-        _23 = copy _24 == copy _25;
-        _22 = short_circuit(||) copy _23 -> [eval: bb9, join: bb10];
+        _23 = copy _21.0;
+        _24 = copy _8;
+        _22 = copy _23 == copy _24;
+        branch copy _22 -> [bb11, bb9];
     }
 
     bb9: {
         _26 = copy _21.0;
         _27 = copy _14;
-        _22 = call const fn baml.String.starts_with(copy _26, copy _27) -> [bb10];
+        _25 = call const fn baml.String.starts_with(copy _26, copy _27) -> [bb10];
     }
 
     bb10: {
-        branch copy _22 -> [bb11, bb6];
+        branch copy _25 -> [bb11, bb6];
     }
 
     bb11: {
@@ -208,9 +208,9 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
     let _20: testing.TestSetRegistration
     let _21: testing.TestSetRegistration // ts
     let _22: bool
-    let _23: bool
+    let _23: string
     let _24: string
-    let _25: string
+    let _25: bool
     let _26: (string, string) -> bool throws never
     let _27: string
     let _28: string // final_name
@@ -275,20 +275,20 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
         _20 = copy _18;
         fresh_cell(_21);
         _21 = copy _20;
-        _24 = copy _21.0;
-        _25 = copy _8;
-        _23 = copy _24 == copy _25;
-        _22 = short_circuit(||) copy _23 -> [eval: bb9, join: bb10];
+        _23 = copy _21.0;
+        _24 = copy _8;
+        _22 = copy _23 == copy _24;
+        branch copy _22 -> [bb11, bb9];
     }
 
     bb9: {
         _26 = copy _21.0;
         _27 = copy _14;
-        _22 = call const fn baml.String.starts_with(copy _26, copy _27) -> [bb10];
+        _25 = call const fn baml.String.starts_with(copy _26, copy _27) -> [bb10];
     }
 
     bb10: {
-        branch copy _22 -> [bb11, bb6];
+        branch copy _25 -> [bb11, bb6];
     }
 
     bb11: {
@@ -988,12 +988,12 @@ fn testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_include
     let _8: testing._TestPool // pool
     let _9: testing.TestSetReport // report
     let _10: bool
-    let _11: bool
+    let _11: int
     let _12: bool
-    let _13: bool
-    let _14: int
+    let _13: int
+    let _14: bool
     let _15: int
-    let _16: int
+    let _16: bool
     let _17: int
     let _18: testing._TestPool
     let _19: string[]
@@ -1010,75 +1010,63 @@ fn testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_include
     }
 
     bb2: {
-        _14 = len(_2);
+        _11 = len(_2);
         goto -> bb3;
     }
 
     bb3: {
-        _13 = copy _14 == const 0_i64;
-        _12 = short_circuit(&&) copy _13 -> [eval: bb4, join: bb6];
+        _10 = copy _11 == const 0_i64;
+        branch copy _10 -> [bb4, bb10];
     }
 
     bb4: {
-        _15 = len(_3);
+        _13 = len(_3);
         goto -> bb5;
     }
 
     bb5: {
-        _12 = copy _15 == const 0_i64;
-        goto -> bb6;
+        _12 = copy _13 == const 0_i64;
+        branch copy _12 -> [bb6, bb10];
     }
 
     bb6: {
-        _11 = short_circuit(&&) copy _12 -> [eval: bb7, join: bb9];
+        _15 = len(_4);
+        goto -> bb7;
     }
 
     bb7: {
-        _16 = len(_4);
-        goto -> bb8;
+        _14 = copy _15 == const 0_i64;
+        branch copy _14 -> [bb8, bb10];
     }
 
     bb8: {
-        _11 = copy _16 == const 0_i64;
+        _17 = len(_5);
         goto -> bb9;
     }
 
     bb9: {
-        _10 = short_circuit(&&) copy _11 -> [eval: bb10, join: bb12];
+        _16 = copy _17 == const 0_i64;
+        branch copy _16 -> [bb11, bb10];
     }
 
     bb10: {
-        _17 = len(_5);
-        goto -> bb11;
+        _19 = copy _7;
+        _20 = copy _8;
+        _9 = call const fn testing.TestRegistry._run_selected_pooled(copy _1, copy _19, copy _20) -> [bb12];
     }
 
     bb11: {
-        _10 = copy _17 == const 0_i64;
-        goto -> bb12;
+        _18 = copy _8;
+        _9 = call const fn testing.TestRegistry._run_all_pooled(copy _1, copy _18) -> [bb12];
     }
 
     bb12: {
-        branch copy _10 -> [bb14, bb13];
+        _21 = copy _9;
+        _22 = copy _7;
+        _0 = call const fn testing._flatten_with_tolerated(copy _21, copy _22) -> [bb13];
     }
 
     bb13: {
-        _19 = copy _7;
-        _20 = copy _8;
-        _9 = call const fn testing.TestRegistry._run_selected_pooled(copy _1, copy _19, copy _20) -> [bb15];
-    }
-
-    bb14: {
-        _18 = copy _8;
-        _9 = call const fn testing.TestRegistry._run_all_pooled(copy _1, copy _18) -> [bb15];
-    }
-
-    bb15: {
-        _21 = copy _9;
-        _22 = copy _7;
-        _0 = call const fn testing._flatten_with_tolerated(copy _21, copy _22) -> [bb16];
-    }
-
-    bb16: {
         return;
     }
 }
@@ -1241,20 +1229,19 @@ fn testing.TestRegistry._expand_testset_registry(self: testing.TestRegistry, ts:
     let _21: baml.time.Duration
     let _22: bool
     let _23: string
-    let _24: string
-    let _25: string // message
+    let _24: string // message
+    let _25: string
     let _26: string
-    let _27: string
-    let _28: testing.TestRegistry // sub_registry
-    let _29: testing.TestCollector
-    let _30: map<string, testing.TestRegistry>
-    let _31: int
-    let _32: null | testing.TestRegistry
-    let _33: (map<string, testing.TestRegistry>, string, testing.TestRegistry) -> null | testing.TestRegistry throws never
-    let _34: string
-    let _35: testing.TestRegistry
+    let _27: testing.TestRegistry // sub_registry
+    let _28: testing.TestCollector
+    let _29: map<string, testing.TestRegistry>
+    let _30: int
+    let _31: null | testing.TestRegistry
+    let _32: (map<string, testing.TestRegistry>, string, testing.TestRegistry) -> null | testing.TestRegistry throws never
+    let _33: string
+    let _34: testing.TestRegistry
+    let _35: reflect.Type
     let _36: reflect.Type
-    let _37: reflect.Type
 
     bb0: {
         _4 = copy _1.1;
@@ -1292,13 +1279,13 @@ fn testing.TestRegistry._expand_testset_registry(self: testing.TestRegistry, ts:
     }
 
     bb6: {
-        _18 = call const fn baml.Bigint.to_int(copy _20) -> [bb12, unwind: bb8];
+        _18 = call const fn baml.Bigint.to_int(copy _20) -> [bb11, unwind: bb8];
     }
 
     bb7: {
         _9 = copy _8;
         _0 = copy _9;
-        goto -> bb14;
+        goto -> bb13;
     }
 
     bb8: {
@@ -1312,37 +1299,31 @@ fn testing.TestRegistry._expand_testset_registry(self: testing.TestRegistry, ts:
 
     bb10: {
         _23 = copy _19.0;
-        drop(_23);
-        goto -> bb11;
+        _24 = copy _23;
+        _26 = copy _24;
+        _25 = const "testing: expansion duration: " + copy _26;
+        _18 = call const fn baml.sys.panic(copy _25) -> [bb11];
     }
 
     bb11: {
-        _24 = copy _19.0;
-        _25 = copy _24;
-        _27 = copy _25;
-        _26 = const "testing: expansion duration: " + copy _27;
-        _18 = call const fn baml.sys.panic(copy _26) -> [bb12];
+        _28 = copy _11;
+        _29 = {  }: map<string, testing.TestRegistry>;
+        _30 = copy _18;
+        _27 = testing.TestRegistry { copy _28, copy _29, copy _30 };
+        _32 = copy _1.1;
+        _33 = copy _2.0;
+        _34 = copy _27;
+        _35 = load_type(string);
+        _36 = load_type(testing.TestRegistry);
+        _31 = call const fn baml.Map.set<copy _35, copy _36>(copy _32, copy _33, copy _34) -> [bb12];
     }
 
     bb12: {
-        _29 = copy _11;
-        _30 = {  }: map<string, testing.TestRegistry>;
-        _31 = copy _18;
-        _28 = testing.TestRegistry { copy _29, copy _30, copy _31 };
-        _33 = copy _1.1;
-        _34 = copy _2.0;
-        _35 = copy _28;
-        _36 = load_type(string);
-        _37 = load_type(testing.TestRegistry);
-        _32 = call const fn baml.Map.set<copy _36, copy _37>(copy _33, copy _34, copy _35) -> [bb13];
+        _0 = copy _27;
+        goto -> bb13;
     }
 
     bb13: {
-        _0 = copy _28;
-        goto -> bb14;
-    }
-
-    bb14: {
         return;
     }
 }
@@ -1496,7 +1477,7 @@ fn testing._testset_children_selected(registry: testing.TestRegistry, names: str
 
     bb2: {
         _8 = is_type(copy _7, baml.iter.Done);
-        branch copy _8 -> [bb8, bb3];
+        branch copy _8 -> [bb7, bb3];
     }
 
     bb3: {
@@ -1509,82 +1490,72 @@ fn testing._testset_children_selected(registry: testing.TestRegistry, names: str
     }
 
     bb4: {
-        branch copy _12 -> [bb6, bb5];
+        branch copy _12 -> [bb5, bb1];
     }
 
     bb5: {
-        _11 = const null;
-        goto -> bb1;
-    }
-
-    bb6: {
         _16 = copy _10.0;
         _17 = copy _10.1;
         _18 = copy _10.2;
-        _15 = call const fn testing._test_child(copy _16, copy _17, copy _18) -> [bb7];
+        _15 = call const fn testing._test_child(copy _16, copy _17, copy _18) -> [bb6];
     }
 
-    bb7: {
+    bb6: {
         _19 = load_type(testing.TestSetChild);
         _11 = call const fn baml.Array.push<copy _19>(copy _4, copy _15) -> [bb1];
     }
 
-    bb8: {
+    bb7: {
         _20 = copy _1.0.2;
-        _21 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _20) -> [bb9];
+        _21 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _20) -> [bb8];
+    }
+
+    bb8: {
+        _22 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _21) -> [bb9];
     }
 
     bb9: {
-        _22 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _21) -> [bb10];
+        _23 = is_type(copy _22, baml.iter.Done);
+        branch copy _23 -> [bb15, bb10];
     }
 
     bb10: {
-        _23 = is_type(copy _22, baml.iter.Done);
-        branch copy _23 -> [bb17, bb11];
-    }
-
-    bb11: {
         _24 = copy _22;
         fresh_cell(_25);
         _25 = copy _24;
         _29 = copy _25.0;
         _30 = load_type(string);
-        _28 = call const fn baml.String.from<copy _30>(copy _29) -> [bb12];
+        _28 = call const fn baml.String.from<copy _30>(copy _29) -> [bb11];
     }
 
-    bb12: {
+    bb11: {
         _27 = copy _28 + const "::";
         _32 = make_closure lambda[0](copy _27);
         _33 = load_type(never);
         _34 = load_type(string);
-        _31 = call const fn baml.Array.some<copy _34, copy _33>(copy _2, copy _32) -> [bb13];
+        _31 = call const fn baml.Array.some<copy _34, copy _33>(copy _2, copy _32) -> [bb12];
+    }
+
+    bb12: {
+        branch copy _31 -> [bb13, bb8];
     }
 
     bb13: {
-        branch copy _31 -> [bb15, bb14];
+        _36 = copy _25;
+        _35 = call const fn testing._testset_child_selected(copy _1, copy _36, copy _2, copy _3) -> [bb14];
     }
 
     bb14: {
-        _26 = const null;
-        goto -> bb9;
+        _37 = load_type(testing.TestSetChild);
+        _26 = call const fn baml.Array.push<copy _37>(copy _4, copy _35) -> [bb8];
     }
 
     bb15: {
-        _36 = copy _25;
-        _35 = call const fn testing._testset_child_selected(copy _1, copy _36, copy _2, copy _3) -> [bb16];
+        _0 = copy _4;
+        goto -> bb16;
     }
 
     bb16: {
-        _37 = load_type(testing.TestSetChild);
-        _26 = call const fn baml.Array.push<copy _37>(copy _4, copy _35) -> [bb9];
-    }
-
-    bb17: {
-        _0 = copy _4;
-        goto -> bb18;
-    }
-
-    bb18: {
         return;
     }
 }
@@ -2055,7 +2026,7 @@ fn testing._TestPool.acquire(self: testing._TestPool) -> null {
     let _8: baml.time.Duration
 
     bb0: {
-        goto -> bb3;
+        goto -> bb2;
     }
 
     bb1: {
@@ -2063,44 +2034,30 @@ fn testing._TestPool.acquire(self: testing._TestPool) -> null {
     }
 
     bb2: {
-        _6 = const null;
-        goto -> bb3;
+        _3 = copy _1.0;
+        _4 = load_type(int);
+        _2 = call const fn baml.Array.pop<copy _4>(copy _3) -> [bb3];
     }
 
     bb3: {
-        branch const true -> [bb5, bb4];
+        _5 = copy _2;
+        _5 = narrow_bind copy _5 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb6, bb4];
     }
 
     bb4: {
-        _0 = const null;
-        goto -> bb10;
+        _8 = call const fn baml.time.Duration.from_milliseconds(const 10_i64) -> [bb5, unwind: bb1];
     }
 
     bb5: {
-        _3 = copy _1.0;
-        _4 = load_type(int);
-        _2 = call const fn baml.Array.pop<copy _4>(copy _3) -> [bb6];
+        _6 = sys_op const fn baml.sys.sleep(copy _8) -> bb2 unwind bb1;
     }
 
     bb6: {
-        _5 = copy _2;
-        _5 = narrow_bind copy _5 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb9, bb7];
+        _0 = const null;
+        goto -> bb7;
     }
 
     bb7: {
-        _8 = call const fn baml.time.Duration.from_milliseconds(const 10_i64) -> [bb8, unwind: bb1];
-    }
-
-    bb8: {
-        _6 = sys_op const fn baml.sys.sleep(copy _8) -> bb3 unwind bb1;
-    }
-
-    bb9: {
-        _0 = const null;
-        goto -> bb10;
-    }
-
-    bb10: {
         return;
     }
 }
@@ -2367,6 +2324,7 @@ fn testing._run_test(body: () -> void throws unknown, runner: null | ((() -> tes
     let _14: testing.RunReport
     let _15: string
     let _16: string
+    let _17: string
 
     bb0: {
         _3 = make_closure lambda[0](copy _1);
@@ -2396,11 +2354,12 @@ fn testing._run_test(body: () -> void throws unknown, runner: null | ((() -> tes
     }
 
     bb5: {
+        _17 = const "test runner middleware failed: ";
         _16 = virtual_call to_string as baml.ToString(copy _8) -> [bb6];
     }
 
     bb6: {
-        _15 = const "test runner middleware failed: " + copy _16;
+        _15 = copy _17 + copy _16;
         _14 = testing.RunReport { const "fail", const 0_i64, copy _15 };
         _13 = [copy _14]: testing.RunReport[];
         _0 = testing.TestReport { const "fail", copy _13 };
@@ -2444,16 +2403,15 @@ fn .<lambda(_run_test, 0)>() -> testing.TestReport {
     let _26: baml.time.Duration
     let _27: bool
     let _28: string
-    let _29: string
-    let _30: string // message
+    let _29: string // message
+    let _30: string
     let _31: string
-    let _32: string
-    let _33: "error" | "fail" | "pass"
-    let _34: testing.RunReport[]
-    let _35: testing.RunReport
-    let _36: "error" | "fail" | "pass"
-    let _37: int
-    let _38: string | null
+    let _32: "error" | "fail" | "pass"
+    let _33: testing.RunReport[]
+    let _34: testing.RunReport
+    let _35: "error" | "fail" | "pass"
+    let _36: int
+    let _37: string | null
 
     bb0: {
         _1 = sys_op const fn baml.time.Instant.now() -> bb1;
@@ -2540,7 +2498,7 @@ fn .<lambda(_run_test, 0)>() -> testing.TestReport {
     }
 
     bb17: {
-        _23 = call const fn baml.Bigint.to_int(copy _25) -> [bb22, unwind: bb18];
+        _23 = call const fn baml.Bigint.to_int(copy _25) -> [bb21, unwind: bb18];
     }
 
     bb18: {
@@ -2554,30 +2512,24 @@ fn .<lambda(_run_test, 0)>() -> testing.TestReport {
 
     bb20: {
         _28 = copy _24.0;
-        drop(_28);
-        goto -> bb21;
+        _29 = copy _28;
+        _31 = copy _29;
+        _30 = const "testing: test duration: " + copy _31;
+        _23 = call const fn baml.sys.panic(copy _30) -> [bb21];
     }
 
     bb21: {
-        _29 = copy _24.0;
-        _30 = copy _29;
-        _32 = copy _30;
-        _31 = const "testing: test duration: " + copy _32;
-        _23 = call const fn baml.sys.panic(copy _31) -> [bb22];
+        _32 = copy _15.0;
+        _35 = copy _15.0;
+        _36 = copy _23;
+        _37 = copy _15.2;
+        _34 = testing.RunReport { copy _35, copy _36, copy _37 };
+        _33 = [copy _34]: testing.RunReport[];
+        _0 = testing.TestReport { copy _32, copy _33 };
+        goto -> bb22;
     }
 
     bb22: {
-        _33 = copy _15.0;
-        _36 = copy _15.0;
-        _37 = copy _23;
-        _38 = copy _15.2;
-        _35 = testing.RunReport { copy _36, copy _37, copy _38 };
-        _34 = [copy _35]: testing.RunReport[];
-        _0 = testing.TestReport { copy _33, copy _34 };
-        goto -> bb23;
-    }
-
-    bb23: {
         return;
     }
 }
@@ -2614,6 +2566,10 @@ fn .<lambda(<lambda(_run_test, 0)>, 1)>() -> testing.RunReport {
     let _26: string
     let _27: string
     let _28: string
+    let _29: string
+    let _30: int
+    let _31: string
+    let _32: int
 
     bb0: {
         _4 = copy capture[0];
@@ -2720,20 +2676,24 @@ fn .<lambda(<lambda(_run_test, 0)>, 1)>() -> testing.RunReport {
     }
 
     bb21: {
+        _31 = const "fail";
+        _32 = const 0_i64;
         _28 = virtual_call to_string as baml.ToString(copy _2) -> [bb22];
     }
 
     bb22: {
-        _0 = testing.RunReport { const "fail", const 0_i64, copy _28 };
+        _0 = testing.RunReport { copy _31, copy _32, copy _28 };
         goto -> bb27;
     }
 
     bb23: {
+        _29 = const "fail";
+        _30 = const 0_i64;
         _27 = virtual_call to_string as baml.ToString(copy _2) -> [bb24];
     }
 
     bb24: {
-        _0 = testing.RunReport { const "fail", const 0_i64, copy _27 };
+        _0 = testing.RunReport { copy _29, copy _30, copy _27 };
         goto -> bb27;
     }
 
@@ -2768,6 +2728,7 @@ fn .<lambda(<lambda(_run_test, 0)>, 2)>() -> testing.RunReport {
     let _6: string
     let _7: string
     let _8: reflect.Type
+    let _9: string
 
     bb0: {
         _4 = copy capture[0];
@@ -2775,7 +2736,7 @@ fn .<lambda(<lambda(_run_test, 0)>, 2)>() -> testing.RunReport {
     }
 
     bb1: {
-        _1 = sys_op const fn baml.sys.sleep(copy _3) -> bb4 unwind bb2;
+        _1 = sys_op const fn baml.sys.sleep(copy _3) -> bb3 unwind bb2;
     }
 
     bb2: {
@@ -2783,23 +2744,19 @@ fn .<lambda(<lambda(_run_test, 0)>, 2)>() -> testing.RunReport {
     }
 
     bb3: {
-        _1 = const null;
-        goto -> bb4;
+        _8 = load_type(int);
+        _9 = const "test timed out after ";
+        _7 = call const fn baml.String.from<copy _8>(copy capture[0]) -> [bb4];
     }
 
     bb4: {
-        _8 = load_type(int);
-        _7 = call const fn baml.String.from<copy _8>(copy capture[0]) -> [bb5];
+        _6 = copy _9 + copy _7;
+        _5 = copy _6 + const "ms (override with BAML_TEST_TIMEOUT_MS)";
+        _0 = testing.RunReport { const "fail", const 0_i64, copy _5 };
+        goto -> bb5;
     }
 
     bb5: {
-        _6 = const "test timed out after " + copy _7;
-        _5 = copy _6 + const "ms (override with BAML_TEST_TIMEOUT_MS)";
-        _0 = testing.RunReport { const "fail", const 0_i64, copy _5 };
-        goto -> bb6;
-    }
-
-    bb6: {
         return;
     }
 }
@@ -2876,40 +2833,38 @@ fn testing._glob_match(subject: string, pattern: string) -> bool {
     let _14: int
     let _15: int
     let _16: bool
-    let _17: bool
-    let _18: string
-    let _19: bool
-    let _20: bool
-    let _21: string
-    let _22: int // start
-    let _23: int // end_limit
-    let _24: int
+    let _17: string
+    let _18: bool
+    let _19: string
+    let _20: int // start
+    let _21: int // end_limit
+    let _22: int
+    let _23: int
+    let _24: bool
     let _25: int
-    let _26: bool
-    let _27: int
-    let _28: int
-    let _29: int // pos
-    let _30: int // i
-    let _31: bool
+    let _26: int
+    let _27: int // pos
+    let _28: int // i
+    let _29: bool
+    let _30: int
+    let _31: int
     let _32: int
-    let _33: int
-    let _34: int
-    let _35: string // part
-    let _36: string[]
-    let _37: int
-    let _38: bool
+    let _33: string // part
+    let _34: string[]
+    let _35: int
+    let _36: bool
+    let _37: string
+    let _38: int | null
     let _39: string
-    let _40: int | null
-    let _41: string
-    let _42: int
-    let _43: int
-    let _44: string
-    let _45: int | null
-    let _46: int // idx
+    let _40: int
+    let _41: int
+    let _42: string
+    let _43: int | null
+    let _44: int // idx
+    let _45: int
+    let _46: int
     let _47: int
     let _48: int
-    let _49: int
-    let _50: int
 
     bb0: {
         _3 = call const fn baml.String.split(copy _2, const "*") -> [bb1];
@@ -2934,120 +2889,118 @@ fn testing._glob_match(subject: string, pattern: string) -> bool {
         _15 = copy _4;
         _14 = copy _15 - const 1_i64;
         _12 = copy _13[_14];
-        _18 = copy _9;
-        _17 = call const fn baml.String.starts_with(copy _1, copy _18) -> [bb4];
+        _17 = copy _9;
+        _16 = call const fn baml.String.starts_with(copy _1, copy _17) -> [bb4];
     }
 
     bb4: {
-        _16 = !copy _17;
-        branch copy _16 -> [bb24, bb5];
+        branch copy _16 -> [bb6, bb5];
     }
 
     bb5: {
-        _21 = copy _12;
-        _20 = call const fn baml.String.ends_with(copy _1, copy _21) -> [bb6];
+        _0 = const false;
+        goto -> bb28;
     }
 
     bb6: {
-        _19 = !copy _20;
-        branch copy _19 -> [bb23, bb7];
+        _19 = copy _12;
+        _18 = call const fn baml.String.ends_with(copy _1, copy _19) -> [bb7];
     }
 
     bb7: {
-        _22 = call const fn baml.String.length(copy _9) -> [bb8];
+        branch copy _18 -> [bb9, bb8];
     }
 
     bb8: {
-        _24 = call const fn baml.String.length(copy _1) -> [bb9];
+        _0 = const false;
+        goto -> bb28;
     }
 
     bb9: {
-        _25 = call const fn baml.String.length(copy _12) -> [bb10];
+        _20 = call const fn baml.String.length(copy _9) -> [bb10];
     }
 
     bb10: {
-        _23 = copy _24 - copy _25;
-        _27 = copy _22;
-        _28 = copy _23;
-        _26 = copy _27 > copy _28;
-        branch copy _26 -> [bb22, bb11];
+        _22 = call const fn baml.String.length(copy _1) -> [bb11];
     }
 
     bb11: {
-        _29 = copy _22;
-        _30 = const 1_i64;
-        goto -> bb12;
+        _23 = call const fn baml.String.length(copy _12) -> [bb12];
     }
 
     bb12: {
-        _32 = copy _30;
-        _34 = copy _4;
-        _33 = copy _34 - const 1_i64;
-        _31 = copy _32 < copy _33;
-        branch copy _31 -> [bb14, bb13];
+        _21 = copy _22 - copy _23;
+        _25 = copy _20;
+        _26 = copy _21;
+        _24 = copy _25 > copy _26;
+        branch copy _24 -> [bb24, bb13];
     }
 
     bb13: {
+        _27 = copy _20;
+        _28 = const 1_i64;
+        goto -> bb14;
+    }
+
+    bb14: {
+        _30 = copy _28;
+        _32 = copy _4;
+        _31 = copy _32 - const 1_i64;
+        _29 = copy _30 < copy _31;
+        branch copy _29 -> [bb16, bb15];
+    }
+
+    bb15: {
         _0 = const true;
         goto -> bb28;
     }
 
-    bb14: {
-        _36 = copy _3;
-        _37 = copy _30;
-        _35 = copy _36[_37];
-        _39 = copy _35;
-        _38 = copy _39 != const "";
-        branch copy _38 -> [bb15, bb21];
-    }
-
-    bb15: {
-        _42 = copy _29;
-        _43 = copy _23;
-        _41 = call const fn baml.String.slice(copy _1, copy _42, copy _43) -> [bb16];
-    }
-
     bb16: {
-        _44 = copy _35;
-        _40 = call const fn baml.String.index_of(copy _41, copy _44) -> [bb17];
+        _34 = copy _3;
+        _35 = copy _28;
+        _33 = copy _34[_35];
+        _37 = copy _33;
+        _36 = copy _37 != const "";
+        branch copy _36 -> [bb17, bb23];
     }
 
     bb17: {
-        _45 = copy _40;
-        _45 = narrow_bind copy _45 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb19, bb18];
+        _40 = copy _27;
+        _41 = copy _21;
+        _39 = call const fn baml.String.slice(copy _1, copy _40, copy _41) -> [bb18];
     }
 
     bb18: {
-        _0 = const false;
-        goto -> bb28;
+        _42 = copy _33;
+        _38 = call const fn baml.String.index_of(copy _39, copy _42) -> [bb19];
     }
 
     bb19: {
-        _46 = copy _45;
-        _48 = copy _29;
-        _49 = copy _46;
-        _47 = copy _48 + copy _49;
-        _50 = call const fn baml.String.length(copy _35) -> [bb20];
+        _43 = copy _38;
+        _43 = narrow_bind copy _43 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb21, bb20];
     }
 
     bb20: {
-        _29 = copy _47 + copy _50;
-        goto -> bb21;
+        _0 = const false;
+        goto -> bb28;
     }
 
     bb21: {
-        _30 = copy _30 + const 1_i64;
-        goto -> bb12;
+        _44 = copy _43;
+        _46 = copy _27;
+        _47 = copy _44;
+        _45 = copy _46 + copy _47;
+        _48 = call const fn baml.String.length(copy _33) -> [bb22];
     }
 
     bb22: {
-        _0 = const false;
-        goto -> bb28;
+        _27 = copy _45 + copy _48;
+        goto -> bb23;
     }
 
     bb23: {
-        _0 = const false;
-        goto -> bb28;
+        _28 = copy _28 + const 1_i64;
+        goto -> bb14;
     }
 
     bb24: {
@@ -3182,20 +3135,26 @@ fn testing._leaf_selected_layered(name: string, profile_include: string[], profi
     let _4: string[] // cli_include // param
     let _5: string[] // cli_exclude // param
     let _6: bool
+    let _7: bool
 
     bb0: {
-        _6 = call const fn testing._leaf_selected(copy _1, copy _2, copy _3) -> [bb1];
+        _7 = call const fn testing._leaf_selected(copy _1, copy _2, copy _3) -> [bb1];
     }
 
     bb1: {
-        _0 = short_circuit(&&) copy _6 -> [eval: bb2, join: bb3];
+        _6 = short_circuit(&&) copy _7 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _0 = call const fn testing._leaf_selected(copy _1, copy _4, copy _5) -> [bb3];
+        _6 = call const fn testing._leaf_selected(copy _1, copy _4, copy _5) -> [bb3];
     }
 
     bb3: {
+        _0 = copy _6;
+        goto -> bb4;
+    }
+
+    bb4: {
         return;
     }
 }
@@ -3212,8 +3171,8 @@ fn testing._subtree_excluded(prefix: string, excludes: string[]) -> bool {
     let _7: string
     let _8: string // pattern
     let _9: bool
-    let _10: bool
-    let _11: int | null
+    let _10: int | null
+    let _11: bool
     let _12: int | null
     let _13: string
     let _14: bool
@@ -3233,22 +3192,22 @@ fn testing._subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
     bb2: {
         _6 = is_type(copy _5, baml.iter.Done);
-        branch copy _6 -> [bb16, bb3];
+        branch copy _6 -> [bb15, bb3];
     }
 
     bb3: {
         _7 = copy _5;
         fresh_cell(_8);
         _8 = copy _7;
-        _11 = call const fn baml.String.index_of(copy _8, const "*") -> [bb4];
+        _10 = call const fn baml.String.index_of(copy _8, const "*") -> [bb4];
     }
 
     bb4: {
-        _10 = call const fn baml.ops.equals_equals(copy _11, const null) -> [bb5];
+        _9 = call const fn baml.ops.equals_equals(copy _10, const null) -> [bb5];
     }
 
     bb5: {
-        _9 = short_circuit(&&) copy _10 -> [eval: bb6, join: bb9];
+        branch copy _9 -> [bb6, bb9];
     }
 
     bb6: {
@@ -3261,48 +3220,44 @@ fn testing._subtree_excluded(prefix: string, excludes: string[]) -> bool {
     }
 
     bb8: {
-        _9 = !copy _14;
-        goto -> bb9;
+        _11 = !copy _14;
+        branch copy _11 -> [bb14, bb9];
     }
 
     bb9: {
-        branch copy _9 -> [bb15, bb10];
+        _15 = call const fn baml.String.ends_with(copy _8, const "*") -> [bb10];
     }
 
     bb10: {
-        _16 = call const fn baml.String.ends_with(copy _8, const "*") -> [bb11];
+        branch copy _15 -> [bb11, bb1];
     }
 
     bb11: {
-        _15 = short_circuit(&&) copy _16 -> [eval: bb12, join: bb13];
+        _17 = copy _3;
+        _18 = copy _8;
+        _16 = call const fn testing._glob_match(copy _17, copy _18) -> [bb12];
     }
 
     bb12: {
-        _17 = copy _3;
-        _18 = copy _8;
-        _15 = call const fn testing._glob_match(copy _17, copy _18) -> [bb13];
+        branch copy _16 -> [bb13, bb1];
     }
 
     bb13: {
-        branch copy _15 -> [bb14, bb1];
+        _0 = const true;
+        goto -> bb16;
     }
 
     bb14: {
         _0 = const true;
-        goto -> bb17;
+        goto -> bb16;
     }
 
     bb15: {
-        _0 = const true;
-        goto -> bb17;
+        _0 = const false;
+        goto -> bb16;
     }
 
     bb16: {
-        _0 = const false;
-        goto -> bb17;
-    }
-
-    bb17: {
         return;
     }
 }
@@ -3319,8 +3274,9 @@ fn testing._pattern_may_match_descendant(pattern: string, prefix: string) -> boo
     let _7: string // literal
     let _8: int
     let _9: bool
-    let _10: string
+    let _10: bool
     let _11: string
+    let _12: string
 
     bb0: {
         _3 = copy _2 + const "::";
@@ -3329,7 +3285,7 @@ fn testing._pattern_may_match_descendant(pattern: string, prefix: string) -> boo
 
     bb1: {
         _5 = copy _4 == const null;
-        branch copy _5 -> [bb6, bb2];
+        branch copy _5 -> [bb7, bb2];
     }
 
     bb2: {
@@ -3339,25 +3295,30 @@ fn testing._pattern_may_match_descendant(pattern: string, prefix: string) -> boo
     }
 
     bb3: {
-        _10 = copy _7;
-        _9 = call const fn baml.String.starts_with(copy _3, copy _10) -> [bb4];
+        _11 = copy _7;
+        _10 = call const fn baml.String.starts_with(copy _3, copy _11) -> [bb4];
     }
 
     bb4: {
-        _0 = short_circuit(||) copy _9 -> [eval: bb5, join: bb7];
+        _9 = short_circuit(||) copy _10 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
-        _11 = copy _3;
-        _0 = call const fn baml.String.starts_with(copy _7, copy _11) -> [bb7];
+        _12 = copy _3;
+        _9 = call const fn baml.String.starts_with(copy _7, copy _12) -> [bb6];
     }
 
     bb6: {
-        _0 = const true;
-        goto -> bb7;
+        _0 = copy _9;
+        goto -> bb8;
     }
 
     bb7: {
+        _0 = const true;
+        goto -> bb8;
+    }
+
+    bb8: {
         return;
     }
 }
@@ -3474,8 +3435,8 @@ fn testing._select_names_layered(registry: testing.TestRegistry, profile_include
     let _22: testing.TestSetRegistration
     let _23: testing.TestSetRegistration // ts
     let _24: bool
-    let _25: bool
-    let _26: string
+    let _25: string
+    let _26: bool
     let _27: string
     let _28: string[] // names
     let _29: testing.TestSetRegistration
@@ -3501,7 +3462,7 @@ fn testing._select_names_layered(registry: testing.TestRegistry, profile_include
 
     bb2: {
         _10 = is_type(copy _9, baml.iter.Done);
-        branch copy _10 -> [bb7, bb3];
+        branch copy _10 -> [bb6, bb3];
     }
 
     bb3: {
@@ -3513,89 +3474,84 @@ fn testing._select_names_layered(registry: testing.TestRegistry, profile_include
     }
 
     bb4: {
-        branch copy _14 -> [bb6, bb5];
+        branch copy _14 -> [bb5, bb1];
     }
 
     bb5: {
-        _13 = const null;
-        goto -> bb1;
-    }
-
-    bb6: {
         _16 = copy _12.0;
         _17 = load_type(string);
         _13 = call const fn baml.Array.push<copy _17>(copy _6, copy _16) -> [bb1];
     }
 
-    bb7: {
+    bb6: {
         _18 = copy _1.0.2;
-        _19 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _18) -> [bb8];
+        _19 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _18) -> [bb7];
+    }
+
+    bb7: {
+        _20 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _19) -> [bb8];
     }
 
     bb8: {
-        _20 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _19) -> [bb9];
+        _21 = is_type(copy _20, baml.iter.Done);
+        branch copy _21 -> [bb18, bb9];
     }
 
     bb9: {
-        _21 = is_type(copy _20, baml.iter.Done);
-        branch copy _21 -> [bb19, bb10];
-    }
-
-    bb10: {
         _22 = copy _20;
         fresh_cell(_23);
         _23 = copy _22;
-        _26 = copy _23.0;
-        _25 = call const fn testing._subtree_may_be_selected(copy _26, copy _2, copy _3) -> [bb11];
+        _25 = copy _23.0;
+        _24 = call const fn testing._subtree_may_be_selected(copy _25, copy _2, copy _3) -> [bb10];
+    }
+
+    bb10: {
+        branch copy _24 -> [bb11, bb7];
     }
 
     bb11: {
-        _24 = short_circuit(&&) copy _25 -> [eval: bb12, join: bb13];
+        _27 = copy _23.0;
+        _26 = call const fn testing._subtree_may_be_selected(copy _27, copy _4, copy _5) -> [bb12];
     }
 
     bb12: {
-        _27 = copy _23.0;
-        _24 = call const fn testing._subtree_may_be_selected(copy _27, copy _4, copy _5) -> [bb13];
+        branch copy _26 -> [bb13, bb7];
     }
 
     bb13: {
-        branch copy _24 -> [bb14, bb8];
+        _29 = copy _23;
+        _28 = call const fn testing._collect_subtree_names_layered(copy _1, copy _29, copy _2, copy _3, copy _4, copy _5) -> [bb14];
     }
 
     bb14: {
-        _29 = copy _23;
-        _28 = call const fn testing._collect_subtree_names_layered(copy _1, copy _29, copy _2, copy _3, copy _4, copy _5) -> [bb15];
+        _30 = copy _28;
+        _31 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _30) -> [bb15];
     }
 
     bb15: {
-        _30 = copy _28;
-        _31 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _30) -> [bb16];
+        _32 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _31) -> [bb16];
     }
 
     bb16: {
-        _32 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _31) -> [bb17];
+        _33 = is_type(copy _32, baml.iter.Done);
+        branch copy _33 -> [bb7, bb17];
     }
 
     bb17: {
-        _33 = is_type(copy _32, baml.iter.Done);
-        branch copy _33 -> [bb8, bb18];
-    }
-
-    bb18: {
         _34 = copy _32;
         fresh_cell(_35);
         _35 = copy _34;
         _37 = copy _35;
         _38 = load_type(string);
-        _36 = call const fn baml.Array.push<copy _38>(copy _6, copy _37) -> [bb16];
+        _36 = call const fn baml.Array.push<copy _38>(copy _6, copy _37) -> [bb15];
+    }
+
+    bb18: {
+        _0 = copy _6;
+        goto -> bb19;
     }
 
     bb19: {
-        _0 = copy _6;
-        goto -> bb20;
-    }
-
-    bb20: {
         return;
     }
 }
@@ -4092,14 +4048,14 @@ fn testing._count_leaves(results: (testing.TestReport | testing.TestSetReport)[]
     let _16: "error" | "fail" | "pass"
     let _17: testing.TestSetReport // tsr
     let _18: bool // ft
-    let _19: "error" | "fail" | "pass"
-    let _20: bool
-    let _21: int
-    let _22: ((testing.TestReport | testing.TestSetReport)[]) -> int throws never
-    let _23: (testing.TestReport | testing.TestSetReport)[]
-    let _24: bool
+    let _19: bool
+    let _20: "error" | "fail" | "pass"
+    let _21: bool
+    let _22: int
+    let _23: ((testing.TestReport | testing.TestSetReport)[]) -> int throws never
+    let _24: (testing.TestReport | testing.TestSetReport)[]
     let _25: bool
-    let _26: int
+    let _26: bool
     let _27: int
     let _28: int
     let _29: int
@@ -4113,6 +4069,7 @@ fn testing._count_leaves(results: (testing.TestReport | testing.TestSetReport)[]
     let _37: int
     let _38: int
     let _39: int
+    let _40: int
 
     bb0: {
         _3 = const 0_i64;
@@ -4141,50 +4098,51 @@ fn testing._count_leaves(results: (testing.TestReport | testing.TestSetReport)[]
 
     bb4: {
         _17 = copy _11;
-        _18 = short_circuit(||) copy _2 -> [eval: bb5, join: bb6];
+        _19 = short_circuit(||) copy _2 -> [eval: bb5, join: bb6];
     }
 
     bb5: {
-        _19 = copy _17.0;
-        _18 = call const fn baml.ops.equals_equals(copy _19, const "pass") -> [bb6];
+        _20 = copy _17.0;
+        _19 = call const fn baml.ops.equals_equals(copy _20, const "pass") -> [bb6];
     }
 
     bb6: {
-        _22 = copy _17.5;
-        _21 = len(_22);
+        _18 = copy _19;
+        _23 = copy _17.5;
+        _22 = len(_23);
         goto -> bb7;
     }
 
     bb7: {
-        _20 = copy _21 > const 0_i64;
-        branch copy _20 -> [bb11, bb8];
+        _21 = copy _22 > const 0_i64;
+        branch copy _21 -> [bb11, bb8];
     }
 
     bb8: {
-        _25 = copy _18;
-        branch copy _25 -> [bb10, bb9];
+        _26 = copy _18;
+        branch copy _26 -> [bb10, bb9];
     }
 
     bb9: {
-        _29 = copy _17.1;
-        _30 = copy _17.2;
-        _31 = copy _17.3;
-        _12 = testing._LeafCounts { copy _29, copy _30, const 0_i64, copy _31 };
+        _30 = copy _17.1;
+        _31 = copy _17.2;
+        _32 = copy _17.3;
+        _12 = testing._LeafCounts { copy _30, copy _31, const 0_i64, copy _32 };
         goto -> bb18;
     }
 
     bb10: {
-        _26 = copy _17.1;
-        _27 = copy _17.2;
-        _28 = copy _17.3;
-        _12 = testing._LeafCounts { copy _26, const 0_i64, copy _27, copy _28 };
+        _27 = copy _17.1;
+        _28 = copy _17.2;
+        _29 = copy _17.3;
+        _12 = testing._LeafCounts { copy _27, const 0_i64, copy _28, copy _29 };
         goto -> bb18;
     }
 
     bb11: {
-        _23 = copy _17.5;
-        _24 = copy _18;
-        _12 = call const fn testing._count_leaves(copy _23, copy _24) -> [bb18];
+        _24 = copy _17.5;
+        _25 = copy _18;
+        _12 = call const fn testing._count_leaves(copy _24, copy _25) -> [bb18];
     }
 
     bb12: {
@@ -4217,23 +4175,23 @@ fn testing._count_leaves(results: (testing.TestReport | testing.TestSetReport)[]
     }
 
     bb18: {
-        _32 = copy _12.0;
-        _3 = copy _3 + copy _32;
-        _33 = copy _12.1;
-        _4 = copy _4 + copy _33;
-        _34 = copy _12.2;
-        _5 = copy _5 + copy _34;
-        _35 = copy _12.3;
-        _6 = copy _6 + copy _35;
+        _33 = copy _12.0;
+        _3 = copy _3 + copy _33;
+        _34 = copy _12.1;
+        _4 = copy _4 + copy _34;
+        _35 = copy _12.2;
+        _5 = copy _5 + copy _35;
+        _36 = copy _12.3;
+        _6 = copy _6 + copy _36;
         goto -> bb1;
     }
 
     bb19: {
-        _36 = copy _3;
-        _37 = copy _4;
-        _38 = copy _5;
-        _39 = copy _6;
-        _0 = testing._LeafCounts { copy _36, copy _37, copy _38, copy _39 };
+        _37 = copy _3;
+        _38 = copy _4;
+        _39 = copy _5;
+        _40 = copy _6;
+        _0 = testing._LeafCounts { copy _37, copy _38, copy _39, copy _40 };
         goto -> bb20;
     }
 
@@ -4281,14 +4239,14 @@ fn testing._flatten_with_tolerated(report: testing.TestSetReport, selected_names
     let _34: testing._LeafIdentities
     let _35: testing._LeafIdentities // identities
     let _36: bool
-    let _37: bool
-    let _38: bool
+    let _37: int
+    let _38: (string[]) -> int throws never
     let _39: int
-    let _40: (string[]) -> int throws never
+    let _40: bool
     let _41: int
-    let _42: int
-    let _43: (string[]) -> int throws never
-    let _44: int
+    let _42: (string[]) -> int throws never
+    let _43: int
+    let _44: bool
     let _45: int
     let _46: (string[]) -> int throws never
     let _47: int
@@ -4386,61 +4344,53 @@ fn testing._flatten_with_tolerated(report: testing.TestSetReport, selected_names
     }
 
     bb10: {
-        _40 = copy _25.0;
-        _39 = len(_40);
+        _38 = copy _25.0;
+        _37 = len(_38);
         goto -> bb11;
     }
 
     bb11: {
-        _41 = copy _5.0;
-        _38 = copy _39 == copy _41;
-        _37 = short_circuit(&&) copy _38 -> [eval: bb12, join: bb14];
+        _39 = copy _5.0;
+        _36 = copy _37 == copy _39;
+        branch copy _36 -> [bb12, bb16];
     }
 
     bb12: {
-        _43 = copy _25.1;
-        _42 = len(_43);
+        _42 = copy _25.1;
+        _41 = len(_42);
         goto -> bb13;
     }
 
     bb13: {
-        _44 = copy _5.1;
-        _37 = copy _42 == copy _44;
-        goto -> bb14;
+        _43 = copy _5.1;
+        _40 = copy _41 == copy _43;
+        branch copy _40 -> [bb14, bb16];
     }
 
     bb14: {
-        _36 = short_circuit(&&) copy _37 -> [eval: bb15, join: bb17];
+        _46 = copy _25.2;
+        _45 = len(_46);
+        goto -> bb15;
     }
 
     bb15: {
-        _46 = copy _25.2;
-        _45 = len(_46);
-        goto -> bb16;
+        _47 = copy _5.2;
+        _44 = copy _45 == copy _47;
+        branch copy _44 -> [bb20, bb16];
     }
 
     bb16: {
-        _47 = copy _5.2;
-        _36 = copy _45 == copy _47;
+        _49 = len(_2);
         goto -> bb17;
     }
 
     bb17: {
-        branch copy _36 -> [bb22, bb18];
+        _50 = copy _5.3;
+        _48 = copy _49 == copy _50;
+        branch copy _48 -> [bb19, bb18];
     }
 
     bb18: {
-        _49 = len(_2);
-        goto -> bb19;
-    }
-
-    bb19: {
-        _50 = copy _5.3;
-        _48 = copy _49 == copy _50;
-        branch copy _48 -> [bb21, bb20];
-    }
-
-    bb20: {
         _53 = []: string[];
         _54 = []: string[];
         _55 = []: string[];
@@ -4448,21 +4398,21 @@ fn testing._flatten_with_tolerated(report: testing.TestSetReport, selected_names
         _57 = []: int[];
         _58 = []: int[];
         _35 = testing._LeafIdentities { copy _53, copy _54, copy _55, copy _56, copy _57, copy _58 };
-        goto -> bb23;
+        goto -> bb21;
+    }
+
+    bb19: {
+        _51 = copy _1.4;
+        _52 = copy _22;
+        _35 = call const fn testing._classify_selected_names(copy _2, copy _51, copy _52) -> [bb21];
+    }
+
+    bb20: {
+        _35 = copy _25;
+        goto -> bb21;
     }
 
     bb21: {
-        _51 = copy _1.4;
-        _52 = copy _22;
-        _35 = call const fn testing._classify_selected_names(copy _2, copy _51, copy _52) -> [bb23];
-    }
-
-    bb22: {
-        _35 = copy _25;
-        goto -> bb23;
-    }
-
-    bb23: {
         _59 = copy _1.0;
         _60 = copy _5.0;
         _61 = copy _5.1;
@@ -4476,10 +4426,10 @@ fn testing._flatten_with_tolerated(report: testing.TestSetReport, selected_names
         _69 = copy _35.5;
         _70 = copy _18;
         _0 = testing.FlatTestReport { copy _59, copy _60, copy _61, copy _62, copy _63, copy _64, copy _65, copy _66, copy _67, copy _68, copy _69, copy _70 };
-        goto -> bb24;
+        goto -> bb22;
     }
 
-    bb24: {
+    bb22: {
         return;
     }
 }
@@ -4645,21 +4595,19 @@ fn testing._failure_matches_selected(selected: string, failed_names: string[]) -
     let _1: string // selected // param
     let _2: string[] // failed_names // param
     let _3: bool
-    let _4: string // sentinel_suffix
-    let _5: bool
+    let _4: bool
+    let _5: string // prefix
     let _6: string
-    let _7: string // prefix
-    let _8: string
+    let _7: int
+    let _8: int
     let _9: int
-    let _10: int
-    let _11: int
-    let _12: baml.iter.Iterator<Error = never, Item = string>
-    let _13: unknown
-    let _14: bool
-    let _15: string
-    let _16: string // failed
-    let _17: bool
-    let _18: string
+    let _10: baml.iter.Iterator<Error = never, Item = string>
+    let _11: unknown
+    let _12: bool
+    let _13: string
+    let _14: string // failed
+    let _15: bool
+    let _16: string
 
     bb0: {
         _3 = call const fn testing._name_in(copy _1, copy _2) -> [bb1];
@@ -4670,52 +4618,50 @@ fn testing._failure_matches_selected(selected: string, failed_names: string[]) -
     }
 
     bb2: {
-        _4 = const "::(failed to expand)";
-        _6 = copy _4;
-        _5 = call const fn baml.String.ends_with(copy _1, copy _6) -> [bb3];
+        _4 = call const fn baml.String.ends_with(copy _1, const "::(failed to expand)") -> [bb3];
     }
 
     bb3: {
-        branch copy _5 -> [bb4, bb13];
+        branch copy _4 -> [bb4, bb13];
     }
 
     bb4: {
-        _10 = call const fn baml.String.length(copy _1) -> [bb5];
+        _8 = call const fn baml.String.length(copy _1) -> [bb5];
     }
 
     bb5: {
-        _11 = call const fn baml.String.length(copy _4) -> [bb6];
+        _9 = call const fn baml.String.length(const "::(failed to expand)") -> [bb6];
     }
 
     bb6: {
-        _9 = copy _10 - copy _11;
-        _8 = call const fn baml.String.slice(copy _1, const 0_i64, copy _9) -> [bb7];
+        _7 = copy _8 - copy _9;
+        _6 = call const fn baml.String.slice(copy _1, const 0_i64, copy _7) -> [bb7];
     }
 
     bb7: {
-        _7 = copy _8 + const "::";
-        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb8];
+        _5 = copy _6 + const "::";
+        _10 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb8];
     }
 
     bb8: {
-        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _12) -> [bb9];
+        _11 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _10) -> [bb9];
     }
 
     bb9: {
-        _14 = is_type(copy _13, baml.iter.Done);
-        branch copy _14 -> [bb13, bb10];
+        _12 = is_type(copy _11, baml.iter.Done);
+        branch copy _12 -> [bb13, bb10];
     }
 
     bb10: {
-        _15 = copy _13;
-        fresh_cell(_16);
-        _16 = copy _15;
-        _18 = copy _7;
-        _17 = call const fn baml.String.starts_with(copy _16, copy _18) -> [bb11];
+        _13 = copy _11;
+        fresh_cell(_14);
+        _14 = copy _13;
+        _16 = copy _5;
+        _15 = call const fn baml.String.starts_with(copy _14, copy _16) -> [bb11];
     }
 
     bb11: {
-        branch copy _17 -> [bb12, bb8];
+        branch copy _15 -> [bb12, bb8];
     }
 
     bb12: {
@@ -4799,43 +4745,44 @@ fn testing._collect_leaf_identities(report: testing.TestSetReport, tolerated_by_
     let _56: reflect.Type
     let _57: testing.TestSetReport // nested
     let _58: bool // nested_tolerated
-    let _59: "error" | "fail" | "pass"
-    let _60: bool
-    let _61: int
-    let _62: ((testing.TestReport | testing.TestSetReport)[]) -> int throws never
-    let _63: testing.TestSetReport
-    let _64: bool
+    let _59: bool
+    let _60: "error" | "fail" | "pass"
+    let _61: bool
+    let _62: int
+    let _63: ((testing.TestReport | testing.TestSetReport)[]) -> int throws never
+    let _64: testing.TestSetReport
     let _65: bool
-    let _66: int
-    let _67: string // sentinel
-    let _68: string
-    let _69: string // identity
-    let _70: bool
-    let _71: string
-    let _72: bool
-    let _73: int
-    let _74: (string[]) -> int throws never
-    let _75: string[]
-    let _76: 0
-    let _77: string
-    let _78: bool
-    let _79: int
-    let _80: (string[], string) -> int throws never
-    let _81: string
-    let _82: reflect.Type
-    let _83: (int[], int) -> int throws never
-    let _84: reflect.Type
-    let _85: int
-    let _86: (string[], string) -> int throws never
-    let _87: string
-    let _88: reflect.Type
-    let _89: (int[], int) -> int throws never
-    let _90: reflect.Type
+    let _66: bool
+    let _67: int
+    let _68: string // sentinel
+    let _69: string
+    let _70: string // identity
+    let _71: bool
+    let _72: string
+    let _73: bool
+    let _74: int
+    let _75: (string[]) -> int throws never
+    let _76: string[]
+    let _77: 0
+    let _78: string
+    let _79: bool
+    let _80: int
+    let _81: (string[], string) -> int throws never
+    let _82: string
+    let _83: reflect.Type
+    let _84: (int[], int) -> int throws never
+    let _85: reflect.Type
+    let _86: int
+    let _87: (string[], string) -> int throws never
+    let _88: string
+    let _89: reflect.Type
+    let _90: (int[], int) -> int throws never
+    let _91: reflect.Type
 
     bb0: {
         _5 = copy _1.6;
         _6 = copy _5 == const null;
-        branch copy _6 -> [bb43, bb1];
+        branch copy _6 -> [bb42, bb1];
     }
 
     bb1: {
@@ -4880,7 +4827,7 @@ fn testing._collect_leaf_identities(report: testing.TestSetReport, tolerated_by_
 
     bb8: {
         _0 = const null;
-        goto -> bb44;
+        goto -> bb43;
     }
 
     bb9: {
@@ -4891,209 +4838,205 @@ fn testing._collect_leaf_identities(report: testing.TestSetReport, tolerated_by_
         _24 = copy _14;
         _22 = copy _23[_24];
         _25 = copy _22;
-        _25 = narrow_bind copy _25 as Class(QualifiedTypeName { pkg: Dep("testing"), namespace: [], name: "TestReport" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb29, bb10];
+        _25 = narrow_bind copy _25 as Class(QualifiedTypeName { pkg: Dep("testing"), namespace: [], name: "TestReport" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb28, bb10];
     }
 
     bb10: {
         _57 = copy _22;
-        _58 = short_circuit(||) copy _2 -> [eval: bb11, join: bb12];
+        _59 = short_circuit(||) copy _2 -> [eval: bb11, join: bb12];
     }
 
     bb11: {
-        _59 = copy _57.0;
-        _58 = call const fn baml.ops.equals_equals(copy _59, const "pass") -> [bb12];
+        _60 = copy _57.0;
+        _59 = call const fn baml.ops.equals_equals(copy _60, const "pass") -> [bb12];
     }
 
     bb12: {
-        _62 = copy _57.5;
-        _61 = len(_62);
+        _58 = copy _59;
+        _63 = copy _57.5;
+        _62 = len(_63);
         goto -> bb13;
     }
 
     bb13: {
-        _60 = copy _61 > const 0_i64;
-        branch copy _60 -> [bb28, bb14];
+        _61 = copy _62 > const 0_i64;
+        branch copy _61 -> [bb27, bb14];
     }
 
     bb14: {
-        _66 = copy _57.2;
-        _65 = copy _66 > const 0_i64;
-        branch copy _65 -> [bb16, bb15];
+        _67 = copy _57.2;
+        _66 = copy _67 > const 0_i64;
+        branch copy _66 -> [bb15, bb41];
     }
 
     bb15: {
-        _18 = const null;
-        goto -> bb42;
+        _69 = copy _19;
+        _68 = copy _69 + const "::(failed to expand)";
+        _72 = copy _68;
+        _71 = call const fn testing._name_in(copy _72, copy _3) -> [bb16];
     }
 
     bb16: {
-        _68 = copy _19;
-        _67 = copy _68 + const "::(failed to expand)";
-        _71 = copy _67;
-        _70 = call const fn testing._name_in(copy _71, copy _3) -> [bb17];
+        branch copy _71 -> [bb21, bb17];
     }
 
     bb17: {
-        branch copy _70 -> [bb22, bb18];
+        _75 = copy _57.4;
+        _74 = len(_75);
+        goto -> bb18;
     }
 
     bb18: {
-        _74 = copy _57.4;
-        _73 = len(_74);
-        goto -> bb19;
+        _73 = copy _74 > const 0_i64;
+        branch copy _73 -> [bb20, bb19];
     }
 
     bb19: {
-        _72 = copy _73 > const 0_i64;
-        branch copy _72 -> [bb21, bb20];
+        _78 = copy _19;
+        _70 = copy _78 + const "::(testset error)";
+        goto -> bb22;
     }
 
     bb20: {
-        _77 = copy _19;
-        _69 = copy _77 + const "::(testset error)";
-        goto -> bb23;
+        _76 = copy _57.4;
+        _77 = const 0_i64;
+        _70 = copy _76[_77];
+        goto -> bb22;
     }
 
     bb21: {
-        _75 = copy _57.4;
-        _76 = const 0_i64;
-        _69 = copy _75[_76];
-        goto -> bb23;
+        _70 = copy _68;
+        goto -> bb22;
     }
 
     bb22: {
-        _69 = copy _67;
-        goto -> bb23;
+        _79 = copy _58;
+        branch copy _79 -> [bb25, bb23];
     }
 
     bb23: {
-        _78 = copy _58;
-        branch copy _78 -> [bb26, bb24];
+        _87 = copy _4.1;
+        _88 = copy _70;
+        _89 = load_type(string);
+        _86 = call const fn baml.Array.push<copy _89>(copy _87, copy _88) -> [bb24];
     }
 
     bb24: {
-        _86 = copy _4.1;
-        _87 = copy _69;
-        _88 = load_type(string);
-        _85 = call const fn baml.Array.push<copy _88>(copy _86, copy _87) -> [bb25];
+        _90 = copy _4.4;
+        _91 = load_type(int);
+        _18 = call const fn baml.Array.push<copy _91>(copy _90, const -1_i64) -> [bb41];
     }
 
     bb25: {
-        _89 = copy _4.4;
-        _90 = load_type(int);
-        _18 = call const fn baml.Array.push<copy _90>(copy _89, const -1_i64) -> [bb42];
+        _81 = copy _4.2;
+        _82 = copy _70;
+        _83 = load_type(string);
+        _80 = call const fn baml.Array.push<copy _83>(copy _81, copy _82) -> [bb26];
     }
 
     bb26: {
-        _80 = copy _4.2;
-        _81 = copy _69;
-        _82 = load_type(string);
-        _79 = call const fn baml.Array.push<copy _82>(copy _80, copy _81) -> [bb27];
+        _84 = copy _4.5;
+        _85 = load_type(int);
+        _18 = call const fn baml.Array.push<copy _85>(copy _84, const -1_i64) -> [bb41];
     }
 
     bb27: {
-        _83 = copy _4.5;
-        _84 = load_type(int);
-        _18 = call const fn baml.Array.push<copy _84>(copy _83, const -1_i64) -> [bb42];
+        _64 = copy _57;
+        _65 = copy _58;
+        _18 = call const fn testing._collect_leaf_identities(copy _64, copy _65, copy _3, copy _4) -> [bb41];
     }
 
     bb28: {
-        _63 = copy _57;
-        _64 = copy _58;
-        _18 = call const fn testing._collect_leaf_identities(copy _63, copy _64, copy _3, copy _4) -> [bb42];
-    }
-
-    bb29: {
         _26 = copy _25;
         _30 = copy _26.1;
         _29 = len(_30);
-        goto -> bb30;
+        goto -> bb29;
+    }
+
+    bb29: {
+        _28 = copy _29 > const 0_i64;
+        branch copy _28 -> [bb31, bb30];
     }
 
     bb30: {
-        _28 = copy _29 > const 0_i64;
-        branch copy _28 -> [bb32, bb31];
+        _27 = const -1_i64;
+        goto -> bb32;
     }
 
     bb31: {
-        _27 = const -1_i64;
-        goto -> bb33;
-    }
-
-    bb32: {
         _32 = copy _26.1;
         _33 = const 0_i64;
         _31 = copy _32[_33];
         _27 = copy _31.1;
-        goto -> bb33;
+        goto -> bb32;
+    }
+
+    bb32: {
+        _35 = copy _26.0;
+        _34 = call const fn baml.ops.equals_equals(copy _35, const "pass") -> [bb33];
     }
 
     bb33: {
-        _35 = copy _26.0;
-        _34 = call const fn baml.ops.equals_equals(copy _35, const "pass") -> [bb34];
+        branch copy _34 -> [bb39, bb34];
     }
 
     bb34: {
-        branch copy _34 -> [bb40, bb35];
+        branch copy _2 -> [bb37, bb35];
     }
 
     bb35: {
-        branch copy _2 -> [bb38, bb36];
-    }
-
-    bb36: {
         _51 = copy _4.1;
         _52 = copy _19;
         _53 = load_type(string);
-        _50 = call const fn baml.Array.push<copy _53>(copy _51, copy _52) -> [bb37];
+        _50 = call const fn baml.Array.push<copy _53>(copy _51, copy _52) -> [bb36];
     }
 
-    bb37: {
+    bb36: {
         _54 = copy _4.4;
         _55 = copy _27;
         _56 = load_type(int);
-        _18 = call const fn baml.Array.push<copy _56>(copy _54, copy _55) -> [bb42];
+        _18 = call const fn baml.Array.push<copy _56>(copy _54, copy _55) -> [bb41];
     }
 
-    bb38: {
+    bb37: {
         _44 = copy _4.2;
         _45 = copy _19;
         _46 = load_type(string);
-        _43 = call const fn baml.Array.push<copy _46>(copy _44, copy _45) -> [bb39];
+        _43 = call const fn baml.Array.push<copy _46>(copy _44, copy _45) -> [bb38];
     }
 
-    bb39: {
+    bb38: {
         _47 = copy _4.5;
         _48 = copy _27;
         _49 = load_type(int);
-        _18 = call const fn baml.Array.push<copy _49>(copy _47, copy _48) -> [bb42];
+        _18 = call const fn baml.Array.push<copy _49>(copy _47, copy _48) -> [bb41];
     }
 
-    bb40: {
+    bb39: {
         _37 = copy _4.0;
         _38 = copy _19;
         _39 = load_type(string);
-        _36 = call const fn baml.Array.push<copy _39>(copy _37, copy _38) -> [bb41];
+        _36 = call const fn baml.Array.push<copy _39>(copy _37, copy _38) -> [bb40];
     }
 
-    bb41: {
+    bb40: {
         _40 = copy _4.3;
         _41 = copy _27;
         _42 = load_type(int);
-        _18 = call const fn baml.Array.push<copy _42>(copy _40, copy _41) -> [bb42];
+        _18 = call const fn baml.Array.push<copy _42>(copy _40, copy _41) -> [bb41];
     }
 
-    bb42: {
+    bb41: {
         _14 = copy _14 + const 1_i64;
         goto -> bb7;
     }
 
-    bb43: {
+    bb42: {
         _0 = const null;
-        goto -> bb44;
+        goto -> bb43;
     }
 
-    bb44: {
+    bb43: {
         return;
     }
 }
@@ -5111,20 +5054,19 @@ fn testing._collect_all_failed_names(report: testing.TestSetReport, out: string[
     let _8: string // name
     let _9: void
     let _10: bool
-    let _11: bool
+    let _11: string
     let _12: string
-    let _13: string
-    let _14: reflect.Type
-    let _15: (testing.TestReport | testing.TestSetReport)[]
-    let _16: baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
-    let _17: unknown
-    let _18: bool
-    let _19: testing.TestReport | testing.TestSetReport
-    let _20: testing.TestReport | testing.TestSetReport // child
-    let _21: void
-    let _22: bool
-    let _23: testing.TestSetReport // nested
-    let _24: testing.TestSetReport
+    let _13: reflect.Type
+    let _14: (testing.TestReport | testing.TestSetReport)[]
+    let _15: baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
+    let _16: unknown
+    let _17: bool
+    let _18: testing.TestReport | testing.TestSetReport
+    let _19: testing.TestReport | testing.TestSetReport // child
+    let _20: void
+    let _21: bool
+    let _22: testing.TestSetReport // nested
+    let _23: testing.TestSetReport
 
     bb0: {
         _3 = copy _1.4;
@@ -5137,72 +5079,61 @@ fn testing._collect_all_failed_names(report: testing.TestSetReport, out: string[
 
     bb2: {
         _6 = is_type(copy _5, baml.iter.Done);
-        branch copy _6 -> [bb7, bb3];
+        branch copy _6 -> [bb6, bb3];
     }
 
     bb3: {
         _7 = copy _5;
         fresh_cell(_8);
         _8 = copy _7;
-        _12 = copy _8;
-        _11 = call const fn testing._name_in(copy _12, copy _2) -> [bb4];
+        _11 = copy _8;
+        _10 = call const fn testing._name_in(copy _11, copy _2) -> [bb4];
     }
 
     bb4: {
-        _10 = !copy _11;
-        branch copy _10 -> [bb6, bb5];
+        branch copy _10 -> [bb1, bb5];
     }
 
     bb5: {
-        _9 = const null;
-        goto -> bb1;
+        _12 = copy _8;
+        _13 = load_type(string);
+        _9 = call const fn baml.Array.push<copy _13>(copy _2, copy _12) -> [bb1];
     }
 
     bb6: {
-        _13 = copy _8;
-        _14 = load_type(string);
-        _9 = call const fn baml.Array.push<copy _14>(copy _2, copy _13) -> [bb1];
+        _14 = copy _1.5;
+        _15 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _14) -> [bb7];
     }
 
     bb7: {
-        _15 = copy _1.5;
-        _16 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _15) -> [bb8];
+        _16 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _15) -> [bb8];
     }
 
     bb8: {
-        _17 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _16) -> [bb9];
+        _17 = is_type(copy _16, baml.iter.Done);
+        branch copy _17 -> [bb11, bb9];
     }
 
     bb9: {
-        _18 = is_type(copy _17, baml.iter.Done);
-        branch copy _18 -> [bb13, bb10];
+        _18 = copy _16;
+        fresh_cell(_19);
+        _19 = copy _18;
+        _21 = is_type(copy _19, testing.TestReport);
+        branch copy _21 -> [bb7, bb10];
     }
 
     bb10: {
-        _19 = copy _17;
-        fresh_cell(_20);
-        _20 = copy _19;
-        _22 = is_type(copy _20, testing.TestReport);
-        branch copy _22 -> [bb12, bb11];
+        _22 = copy _19;
+        _23 = copy _22;
+        _20 = call const fn testing._collect_all_failed_names(copy _23, copy _2) -> [bb7];
     }
 
     bb11: {
-        _23 = copy _20;
-        _24 = copy _23;
-        _21 = call const fn testing._collect_all_failed_names(copy _24, copy _2) -> [bb8];
+        _0 = const null;
+        goto -> bb12;
     }
 
     bb12: {
-        _21 = const null;
-        goto -> bb8;
-    }
-
-    bb13: {
-        _0 = const null;
-        goto -> bb14;
-    }
-
-    bb14: {
         return;
     }
 }
@@ -5323,47 +5254,46 @@ fn testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws never) -> 
     let _2: int // m // param [captured]
     let _3: null
     let _4: bool
-    let _5: bool
+    let _5: int
     let _6: bool
+    let _7: int
+    let _8: bool
+    let _9: int
+    let _10: int
 
     bb0: {
-        _4 = copy _1 <= const 0_i64;
-        branch copy _4 -> [bb6, bb1];
+        _5 = copy _1;
+        _4 = copy _5 <= const 0_i64;
+        branch copy _4 -> [bb4, bb1];
     }
 
     bb1: {
-        _6 = copy _2 < const 0_i64;
-        _5 = short_circuit(||) copy _6 -> [eval: bb2, join: bb3];
+        _7 = copy _2;
+        _6 = copy _7 < const 0_i64;
+        branch copy _6 -> [bb3, bb2];
     }
 
     bb2: {
-        _5 = copy _2 > copy _1;
-        goto -> bb3;
+        _9 = copy _2;
+        _10 = copy _1;
+        _8 = copy _9 > copy _10;
+        branch copy _8 -> [bb3, bb5];
     }
 
     bb3: {
-        branch copy _5 -> [bb5, bb4];
+        _3 = call const fn baml.sys.panic(const "testing.Quorum requires 0 <= m <= n") -> [bb5];
     }
 
     bb4: {
-        _3 = const null;
-        goto -> bb7;
+        _3 = call const fn baml.sys.panic(const "testing.Quorum requires n > 0") -> [bb5];
     }
 
     bb5: {
-        _3 = call const fn baml.sys.panic(const "testing.Quorum requires 0 <= m <= n") -> [bb7];
+        _0 = make_closure lambda[0](copy _1, copy _2);
+        goto -> bb6;
     }
 
     bb6: {
-        _3 = call const fn baml.sys.panic(const "testing.Quorum requires n > 0") -> [bb7];
-    }
-
-    bb7: {
-        _0 = make_closure lambda[0](copy _1, copy _2);
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }
@@ -5510,27 +5440,24 @@ fn testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws never) -
     let _1: int // max_attempts // param [captured]
     let _2: null
     let _3: bool
+    let _4: int
 
     bb0: {
-        _3 = copy _1 <= const 0_i64;
-        branch copy _3 -> [bb2, bb1];
+        _4 = copy _1;
+        _3 = copy _4 <= const 0_i64;
+        branch copy _3 -> [bb1, bb2];
     }
 
     bb1: {
-        _2 = const null;
-        goto -> bb3;
+        _2 = call const fn baml.sys.panic(const "testing.Retry requires max_attempts > 0") -> [bb2];
     }
 
     bb2: {
-        _2 = call const fn baml.sys.panic(const "testing.Retry requires max_attempts > 0") -> [bb3];
+        _0 = make_closure lambda[0](copy _1);
+        goto -> bb3;
     }
 
     bb3: {
-        _0 = make_closure lambda[0](copy _1);
-        goto -> bb4;
-    }
-
-    bb4: {
         return;
     }
 }
@@ -5559,27 +5486,26 @@ fn .<lambda(<lambda(Retry, 0)>, 1)>() -> testing.TestReport {
     let _2: bool // passed
     let _3: int // attempts
     let _4: bool
-    let _5: bool
+    let _5: int
     let _6: int
-    let _7: int
-    let _8: bool
-    let _9: testing.TestReport // report
-    let _10: () -> testing.TestReport throws never
-    let _11: testing.RunReport[]
-    let _12: baml.iter.Iterator<Error = never, Item = testing.RunReport>
-    let _13: unknown
-    let _14: bool
-    let _15: testing.RunReport
-    let _16: testing.RunReport // run
-    let _17: void
-    let _18: testing.RunReport
-    let _19: reflect.Type
-    let _20: bool
-    let _21: "error" | "fail" | "pass"
-    let _22: "error" | "fail" | "pass" // outcome
-    let _23: bool
-    let _24: "error" | "fail" | "pass"
-    let _25: testing.RunReport[]
+    let _7: bool
+    let _8: testing.TestReport // report
+    let _9: () -> testing.TestReport throws never
+    let _10: testing.RunReport[]
+    let _11: baml.iter.Iterator<Error = never, Item = testing.RunReport>
+    let _12: unknown
+    let _13: bool
+    let _14: testing.RunReport
+    let _15: testing.RunReport // run
+    let _16: void
+    let _17: testing.RunReport
+    let _18: reflect.Type
+    let _19: bool
+    let _20: "error" | "fail" | "pass"
+    let _21: "error" | "fail" | "pass" // outcome
+    let _22: bool
+    let _23: "error" | "fail" | "pass"
+    let _24: testing.RunReport[]
 
     bb0: {
         _1 = []: testing.RunReport[];
@@ -5589,89 +5515,84 @@ fn .<lambda(<lambda(Retry, 0)>, 1)>() -> testing.TestReport {
     }
 
     bb1: {
-        _6 = copy _3;
-        _7 = copy capture[0];
-        _5 = copy _6 < copy _7;
-        _4 = short_circuit(&&) copy _5 -> [eval: bb2, join: bb3];
+        _5 = copy _3;
+        _6 = copy capture[0];
+        _4 = copy _5 < copy _6;
+        branch copy _4 -> [bb2, bb11];
     }
 
     bb2: {
-        _8 = copy _2;
-        _4 = !copy _8;
-        goto -> bb3;
+        _7 = copy _2;
+        branch copy _7 -> [bb11, bb3];
     }
 
     bb3: {
-        branch copy _4 -> [bb9, bb4];
+        _9 = copy capture[1];
+        _8 = call copy _9() -> [bb4];
     }
 
     bb4: {
-        _23 = copy _2;
-        branch copy _23 -> [bb6, bb5];
+        _3 = copy _3 + const 1_i64;
+        _10 = copy _8.1;
+        _11 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.RunReport>(copy _10) -> [bb5];
     }
 
     bb5: {
-        _22 = const "fail";
-        goto -> bb7;
+        _12 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.RunReport>(copy _11) -> [bb6];
     }
 
     bb6: {
-        _22 = const "pass";
-        goto -> bb7;
+        _13 = is_type(copy _12, baml.iter.Done);
+        branch copy _13 -> [bb8, bb7];
     }
 
     bb7: {
-        _24 = copy _22;
-        _25 = copy _1;
-        _0 = testing.TestReport { copy _24, copy _25 };
-        goto -> bb8;
+        _14 = copy _12;
+        fresh_cell(_15);
+        _15 = copy _14;
+        _17 = copy _15;
+        _18 = load_type(testing.RunReport);
+        _16 = call const fn baml.Array.push<copy _18>(copy _1, copy _17) -> [bb5];
     }
 
     bb8: {
-        return;
+        _20 = copy _8.0;
+        _19 = call const fn baml.ops.equals_equals(copy _20, const "pass") -> [bb9];
     }
 
     bb9: {
-        _10 = copy capture[1];
-        _9 = call copy _10() -> [bb10];
+        branch copy _19 -> [bb10, bb1];
     }
 
     bb10: {
-        _3 = copy _3 + const 1_i64;
-        _11 = copy _9.1;
-        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.RunReport>(copy _11) -> [bb11];
+        _2 = const true;
+        goto -> bb1;
     }
 
     bb11: {
-        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.RunReport>(copy _12) -> [bb12];
+        _22 = copy _2;
+        branch copy _22 -> [bb13, bb12];
     }
 
     bb12: {
-        _14 = is_type(copy _13, baml.iter.Done);
-        branch copy _14 -> [bb14, bb13];
+        _21 = const "fail";
+        goto -> bb14;
     }
 
     bb13: {
-        _15 = copy _13;
-        fresh_cell(_16);
-        _16 = copy _15;
-        _18 = copy _16;
-        _19 = load_type(testing.RunReport);
-        _17 = call const fn baml.Array.push<copy _19>(copy _1, copy _18) -> [bb11];
+        _21 = const "pass";
+        goto -> bb14;
     }
 
     bb14: {
-        _21 = copy _9.0;
-        _20 = call const fn baml.ops.equals_equals(copy _21, const "pass") -> [bb15];
+        _23 = copy _21;
+        _24 = copy _1;
+        _0 = testing.TestReport { copy _23, copy _24 };
+        goto -> bb15;
     }
 
     bb15: {
-        branch copy _20 -> [bb16, bb1];
-    }
-
-    bb16: {
-        _2 = const true;
-        goto -> bb1;
+        return;
     }
 }
 
@@ -5681,37 +5602,32 @@ fn testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testing.Tes
     let _1: float // threshold // param [captured]
     let _2: null
     let _3: bool
-    let _4: bool
+    let _4: float
+    let _5: bool
+    let _6: float
 
     bb0: {
-        _4 = copy _1 < const 0_f64;
-        _3 = short_circuit(||) copy _4 -> [eval: bb1, join: bb2];
+        _4 = copy _1;
+        _3 = copy _4 < const 0_f64;
+        branch copy _3 -> [bb2, bb1];
     }
 
     bb1: {
-        _3 = copy _1 > const 1_f64;
-        goto -> bb2;
+        _6 = copy _1;
+        _5 = copy _6 > const 1_f64;
+        branch copy _5 -> [bb2, bb3];
     }
 
     bb2: {
-        branch copy _3 -> [bb4, bb3];
+        _2 = call const fn baml.sys.panic(const "testing.PassRate requires 0.0 <= threshold <= 1.0") -> [bb3];
     }
 
     bb3: {
-        _2 = const null;
-        goto -> bb5;
+        _0 = make_closure lambda[0](copy _1);
+        goto -> bb4;
     }
 
     bb4: {
-        _2 = call const fn baml.sys.panic(const "testing.PassRate requires 0.0 <= threshold <= 1.0") -> [bb5];
-    }
-
-    bb5: {
-        _0 = make_closure lambda[0](copy _1);
-        goto -> bb6;
-    }
-
-    bb6: {
         return;
     }
 }
@@ -5895,7 +5811,7 @@ fn testing._run_children_sequential(children: testing.TestSetChild[], fail_fast:
 
     bb2: {
         _6 = is_type(copy _5, baml.iter.Done);
-        branch copy _6 -> [bb13, bb3];
+        branch copy _6 -> [bb12, bb3];
     }
 
     bb3: {
@@ -5932,7 +5848,7 @@ fn testing._run_children_sequential(children: testing.TestSetChild[], fail_fast:
     }
 
     bb8: {
-        _20 = short_circuit(&&) copy _2 -> [eval: bb9, join: bb11];
+        branch copy _2 -> [bb9, bb1];
     }
 
     bb9: {
@@ -5942,24 +5858,20 @@ fn testing._run_children_sequential(children: testing.TestSetChild[], fail_fast:
 
     bb10: {
         _20 = !copy _22;
-        goto -> bb11;
+        branch copy _20 -> [bb11, bb1];
     }
 
     bb11: {
-        branch copy _20 -> [bb12, bb1];
+        _23 = copy _3;
+        _0 = call const fn testing._aggregate_reports(copy _23) -> [bb13];
     }
 
     bb12: {
-        _23 = copy _3;
-        _0 = call const fn testing._aggregate_reports(copy _23) -> [bb14];
+        _24 = copy _3;
+        _0 = call const fn testing._aggregate_reports(copy _24) -> [bb13];
     }
 
     bb13: {
-        _24 = copy _3;
-        _0 = call const fn testing._aggregate_reports(copy _24) -> [bb14];
-    }
-
-    bb14: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__array_rest_binding_no_suffix_slices_to_len.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__array_rest_binding_no_suffix_slices_to_len.snap
@@ -10,13 +10,12 @@ fn user.f(xs: int[]) -> int {
     let _4: bool
     let _5: int
     let _6: int
-    let _7: int
-    let _8: int // a
-    let _9: int[]
-    let _10: int
-    let _11: int[] // r
+    let _7: int // a
+    let _8: int[]
+    let _9: int
+    let _10: int[] // r
+    let _11: int
     let _12: int
-    let _13: int
 
     bb0: {
         _2 = is_type_tag(copy _1, LIST);
@@ -31,35 +30,30 @@ fn user.f(xs: int[]) -> int {
 
     bb2: {
         _0 = const 0_i64;
-        goto -> bb7;
+        goto -> bb6;
     }
 
     bb3: {
         _5 = const 0_i64;
-        goto -> bb4;
+        _6 = copy _1[_5];
+        _7 = copy _6;
+        _9 = len(_1);
+        _8 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _9) -> [bb4];
     }
 
     bb4: {
-        _6 = const 0_i64;
-        _7 = copy _1[_6];
-        _8 = copy _7;
-        _10 = len(_1);
-        _9 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _10) -> [bb5];
+        _10 = copy _8;
+        _11 = len(_10);
+        goto -> bb5;
     }
 
     bb5: {
-        _11 = copy _9;
-        _12 = len(_11);
+        _12 = copy _7;
+        _0 = copy _11 + copy _12;
         goto -> bb6;
     }
 
     bb6: {
-        _13 = copy _8;
-        _0 = copy _12 + copy _13;
-        goto -> bb7;
-    }
-
-    bb7: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__array_rest_binding_with_suffix_slices_middle.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__array_rest_binding_with_suffix_slices_middle.snap
@@ -10,22 +10,19 @@ fn user.f(xs: int[]) -> int {
     let _4: bool
     let _5: int
     let _6: int
-    let _7: int
-    let _8: int
+    let _7: int // a
+    let _8: int[]
     let _9: int
-    let _10: int // a
-    let _11: int[]
+    let _10: int
+    let _11: int[] // r
     let _12: int
     let _13: int
-    let _14: int[] // r
-    let _15: int
+    let _14: int
+    let _15: int // z
     let _16: int
     let _17: int
-    let _18: int // z
+    let _18: int
     let _19: int
-    let _20: int
-    let _21: int
-    let _22: int
 
     bb0: {
         _2 = is_type_tag(copy _1, LIST);
@@ -40,48 +37,37 @@ fn user.f(xs: int[]) -> int {
 
     bb2: {
         _0 = const 0_i64;
-        goto -> bb8;
+        goto -> bb6;
     }
 
     bb3: {
         _5 = const 0_i64;
-        goto -> bb4;
+        _6 = copy _1[_5];
+        _7 = copy _6;
+        _9 = len(_1);
+        _10 = copy _9 - const 1_i64;
+        _8 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _10) -> [bb4];
     }
 
     bb4: {
-        _6 = len(_1);
-        _7 = copy _6 - const 1_i64;
+        _11 = copy _8;
+        _12 = len(_1);
+        _13 = copy _12 - const 1_i64;
+        _14 = copy _1[_13];
+        _15 = copy _14;
+        _17 = len(_11);
         goto -> bb5;
     }
 
     bb5: {
-        _8 = const 0_i64;
-        _9 = copy _1[_8];
-        _10 = copy _9;
-        _12 = len(_1);
-        _13 = copy _12 - const 1_i64;
-        _11 = call const fn baml.Array.slice(copy _1, const 1_i64, copy _13) -> [bb6];
+        _18 = copy _7;
+        _16 = copy _17 + copy _18;
+        _19 = copy _15;
+        _0 = copy _16 + copy _19;
+        goto -> bb6;
     }
 
     bb6: {
-        _14 = copy _11;
-        _15 = len(_1);
-        _16 = copy _15 - const 1_i64;
-        _17 = copy _1[_16];
-        _18 = copy _17;
-        _20 = len(_14);
-        goto -> bb7;
-    }
-
-    bb7: {
-        _21 = copy _10;
-        _19 = copy _20 + copy _21;
-        _22 = copy _18;
-        _0 = copy _19 + copy _22;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__nested_runtime_type_atoms_bind_slots_before_loading_templates.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__nested_runtime_type_atoms_bind_slots_before_loading_templates.snap
@@ -21,78 +21,66 @@ fn user.f(t: reflect.Type, value: unknown) -> bool {
     let _1: reflect.Type // t // param
     let _2: unknown // value // param
     let _3: reflect.Type
-    let _4: null | Wrapper<$unreflect$d7b1576f> // annotated
+    let _4: bool
     let _5: bool
     let _6: bool
     let _7: bool
-    let _8: string
-    let _9: reflect.Type
-    let _10: null | Wrapper<$unreflect$d7b1576f>
-    let _11: bool
+    let _8: bool
+    let _9: bool
+    let _10: string
+    let _11: reflect.Type
     let _12: bool
+    let _13: bool
 
     bb0: {
         bind_type(0, [Copy(Local(Local(1)))]);
         _3 = load_type(Wrapper<#0>);
         bind_type(5, [Copy(Local(Local(3)))]);
         bind_type(4, [Copy(Local(Local(1)))]);
-        _4 = const null;
         bind_type(1, [Copy(Local(Local(1)))]);
-        _9 = load_type(Wrapper<#1>);
-        _8 = call const fn user.erase<copy _9>(; runtime_type_check) -> [bb1];
+        _11 = load_type(Wrapper<#1>);
+        _10 = call const fn user.erase<copy _11>(; runtime_type_check) -> [bb1];
     }
 
     bb1: {
-        _7 = copy _8 == const "ok";
-        _6 = short_circuit(&&) copy _7 -> [eval: bb2, join: bb3];
+        _9 = copy _10 == const "ok";
+        _8 = short_circuit(&&) copy _9 -> [eval: bb2, join: bb3];
     }
 
     bb2: {
-        _10 = copy _4;
-        _6 = call const fn baml.ops.equals_equals(copy _10, const null) -> [bb3];
+        _8 = call const fn baml.ops.equals_equals(const null, const null) -> [bb3];
     }
 
     bb3: {
-        _5 = short_circuit(&&) copy _6 -> [eval: bb4, join: bb7];
+        _7 = copy _8;
+        _6 = short_circuit(&&) copy _7 -> [eval: bb4, join: bb5];
     }
 
     bb4: {
         bind_type(3, [Copy(Local(Local(1)))]);
-        _11 = is_type(copy _2, Wrapper<#3>);
-        branch copy _11 -> [bb6, bb5];
+        _12 = is_type(copy _2, Wrapper<#3>);
+        _6 = copy _12;
+        goto -> bb5;
     }
 
     bb5: {
-        _5 = const false;
-        goto -> bb7;
+        _5 = copy _6;
+        _4 = short_circuit(&&) copy _5 -> [eval: bb6, join: bb7];
     }
 
     bb6: {
-        _5 = const true;
+        bind_type(2, [Copy(Local(Local(1)))]);
+        _13 = is_type(copy _2, Wrapper<#2>);
+        _4 = copy _13;
         goto -> bb7;
     }
 
     bb7: {
-        _0 = short_circuit(&&) copy _5 -> [eval: bb8, join: bb11];
+        _0 = copy _4;
+        goto -> bb8;
     }
 
     bb8: {
-        bind_type(2, [Copy(Local(Local(1)))]);
-        _12 = is_type(copy _2, Wrapper<#2>);
-        branch copy _12 -> [bb10, bb9];
-    }
-
-    bb9: {
-        _0 = const false;
-        goto -> bb11;
-    }
-
-    bb10: {
-        _0 = const true;
-        goto -> bb11;
-    }
-
-    bb11: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__runtime_type_plan_operations_are_explicit.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiler2_mir/baml_tests__compiler2_mir__runtime_type_plan_operations_are_explicit.snap
@@ -25,6 +25,7 @@ fn user.f(t: reflect.Type, value: unknown) -> bool {
     let _4: bool
     let _5: bool
     let _6: bool
+    let _7: bool
 
     bb0: {
         bind_type(0, [Copy(Local(Local(1)))]);
@@ -32,40 +33,27 @@ fn user.f(t: reflect.Type, value: unknown) -> bool {
     }
 
     bb1: {
-        _5 = is_type(copy _3, #0);
-        branch copy _5 -> [bb3, bb2];
+        _6 = is_type(copy _3, #0);
+        _5 = copy _6;
+        goto -> bb2;
     }
 
     bb2: {
-        _4 = const false;
-        goto -> bb4;
+        _4 = short_circuit(&&) copy _5 -> [eval: bb3, join: bb4];
     }
 
     bb3: {
-        _4 = const true;
+        _7 = runtime_is_type(copy _3, copy _1);
+        _4 = copy _7;
         goto -> bb4;
     }
 
     bb4: {
-        _0 = short_circuit(&&) copy _4 -> [eval: bb5, join: bb8];
+        _0 = copy _4;
+        goto -> bb5;
     }
 
     bb5: {
-        _6 = runtime_is_type(copy _3, copy _1);
-        branch copy _6 -> [bb7, bb6];
-    }
-
-    bb6: {
-        _0 = const false;
-        goto -> bb8;
-    }
-
-    bb7: {
-        _0 = const true;
-        goto -> bb8;
-    }
-
-    bb8: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/src/compiler2_ppir.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_ppir.rs
@@ -105,7 +105,7 @@ mod tests {
             baml_artifact::decode::<PackageInterface>(ArtifactKind::PackageInterface, &legacy),
             Err(baml_artifact::Error::Incompatible {
                 artifact_format: 1,
-                runtime_format: 2,
+                runtime_format: baml_artifact::FORMAT_VERSION,
                 ..
             })
         ));

--- a/baml_language/crates/baml_tests/tests/exceptions.rs
+++ b/baml_language/crates/baml_tests/tests/exceptions.rs
@@ -63,15 +63,18 @@ async fn catch_stale_field_slot_invalid_field_access() {
         panic!("user.oob should be a function");
     };
 
-    func.bytecode.instructions = vec![
-        Instruction::AllocInstance {
-            class_obj: ObjectIndex::from_raw(class_idx),
-            ntypeargs: 0,
-        },
-        Instruction::LoadField(1),
-        Instruction::Return,
-    ];
-    func.bytecode.compact = None;
+    // Replacing the instruction stream also invalidates its PC-indexed metadata.
+    func.bytecode = bex_vm_types::Bytecode {
+        instructions: vec![
+            Instruction::AllocInstance {
+                class_obj: ObjectIndex::from_raw(class_idx),
+                ntypeargs: 0,
+            },
+            Instruction::LoadField(1),
+            Instruction::Return,
+        ],
+        ..Default::default()
+    };
 
     let engine = Arc::new(
         BexEngine::new(program, Arc::new(sys_ops::SysOps::native()), Vec::new()).expect("engine"),

--- a/baml_language/crates/baml_tests/tests/net.rs
+++ b/baml_language/crates/baml_tests/tests/net.rs
@@ -46,8 +46,6 @@ async fn net_connect_and_read() {
         load_type baml.io.Read
         load_const "read"
         virtual_call nargs=2 ntypeargs=0
-        store_var _0
-        load_var _0
         return
     }
     "#);
@@ -77,8 +75,6 @@ async fn net_connect_failure() {
         load_type baml.io.Read
         load_const "read"
         virtual_call nargs=2 ntypeargs=0
-        store_var _0
-        load_var _0
         return
     }
     "#);

--- a/baml_language/crates/baml_tests/tests/optimizer_binary_prefix.rs
+++ b/baml_language/crates/baml_tests/tests/optimizer_binary_prefix.rs
@@ -1,0 +1,92 @@
+use baml_tests::{
+    engine::{OptLevel, run_test},
+    stdlib_prefix::compile_source_with_opt,
+};
+use bex_external_types::BexExternalValue;
+use bex_vm_types::Object;
+use indexmap::IndexMap;
+
+const BACKTICKS: &str = include_str!("../baml_src/ns_backtick_strings/backtick_strings.baml");
+const SOURCE: &str = r#"
+class PrefixCounter { value: int }
+function prefix_number(value: int) -> int { value }
+function prefix_identity(value: int) -> int { value }
+function prefix_tick(counter: PrefixCounter) -> int {
+    counter.value = counter.value + 1
+    counter.value
+}
+function prefix_subtract() -> int { 20 - prefix_number(3) }
+function prefix_divide() -> int { 20 / prefix_number(4) }
+function prefix_nested() -> int { (20 - prefix_number(3)) * 2 }
+function prefix_call_arg() -> int { prefix_identity(20 - prefix_number(3)) }
+function prefix_order() -> int {
+    let counter = PrefixCounter { value: 0 }
+    prefix_tick(counter) - prefix_tick(counter)
+}
+function prefix_fail(counter: PrefixCounter, divisor: int) -> int {
+    prefix_tick(counter)
+    1 / divisor
+}
+function binary_prefix_unwind(divisor: int) -> int {
+    let counter = PrefixCounter { value: 0 }
+    { 20 - prefix_fail(counter, divisor) }
+        catch (e) { baml.panics.DivisionByZero => counter.value + 40 }
+}
+function binary_prefix_overflow() -> int {
+    { 4611686018427387903 + prefix_number(1) }
+        catch (e) { baml.panics.IntegerOverflow => 7 }
+}
+function verify_prefixes() -> string {
+    if (bt_case_h() != "!hi") { return "interpolation at end" }
+    if (bt_case_i() != "X Y Z") { return "nested concatenation" }
+    if (bt_case_n() != "Hello Ada!") { return "interpolation as call argument" }
+    if (prefix_subtract() != 17) { return "subtraction order" }
+    if (prefix_divide() != 5) { return "division order" }
+    if (prefix_nested() != 34) { return "nested arithmetic" }
+    if (prefix_call_arg() != 17) { return "arithmetic as call argument" }
+    if (prefix_order() != -1) { return "call evaluation order" }
+    if (binary_prefix_unwind(0) != 41) { return "call unwinding" }
+    if (binary_prefix_unwind(1) != 19) { return "non-failing call" }
+    if (binary_prefix_overflow() != 7) { return "operator unwinding" }
+    "ok"
+}
+"#;
+
+#[test]
+fn inlined_binary_prefixes_do_not_spill_call_results() {
+    let program = compile_source_with_opt(&format!("{BACKTICKS}\n{SOURCE}"), OptLevel::Two);
+    for (name, count) in [
+        ("bt_case_h", 6),
+        ("bt_case_i", 8),
+        ("bt_case_n", 7),
+        ("prefix_subtract", 5),
+        ("prefix_divide", 5),
+        ("prefix_nested", 7),
+        ("prefix_call_arg", 6),
+    ] {
+        let index = program.function_index(&format!("user.{name}")).unwrap();
+        let Some(Object::Function(function)) = program.objects.get(index) else {
+            panic!("expected function {name}");
+        };
+        assert_eq!(
+            function.bytecode.instructions.len(),
+            count,
+            "{name}: {:?}",
+            function.bytecode.instructions
+        );
+        assert_eq!(function.real_local_count, 0, "{name}");
+    }
+}
+
+#[tokio::test]
+async fn inlined_binary_prefixes_preserve_order_and_unwinding() {
+    let source = format!("{BACKTICKS}\n{SOURCE}");
+    for opt in [OptLevel::Zero, OptLevel::One, OptLevel::Two] {
+        let output = run_test(&source, "verify_prefixes", IndexMap::new(), opt).await;
+        assert_eq!(
+            output.result,
+            Ok(BexExternalValue::String("ok".into())),
+            "{opt:?}"
+        );
+    }
+}

--- a/baml_language/crates/baml_tests/tests/optimizer_effects.rs
+++ b/baml_language/crates/baml_tests/tests/optimizer_effects.rs
@@ -1,0 +1,273 @@
+use baml_tests::{
+    engine::{OptLevel, run_test},
+    stdlib_prefix::compile_source_with_opt,
+};
+use bex_external_types::BexExternalValue;
+use bex_vm_types::Object;
+use indexmap::IndexMap;
+
+const CLASSES: &str = include_str!("../baml_src/ns_classes/classes.baml");
+const PATTERNS: &str = include_str!("../baml_src/ns_array_rest_binding/array_rest_binding.baml");
+const GC: &str = include_str!("../baml_src/ns_gc/gc.baml");
+
+const SOURCE: &str = r#"
+class EffectsBox { value: int }
+class EffectsArrays { values: int[] }
+
+function bump(box: EffectsBox) -> int {
+    box.value = box.value + 1
+    box.value
+}
+function allocation_effects() -> int {
+    let box = EffectsBox { value: 0 }
+    let unused = EffectsBox { value: bump(box) }
+    box.value
+}
+function allocation_panic(divisor: int) -> int {
+    { let unused = [1 / divisor]; 42 }
+        catch (e) { baml.panics.DivisionByZero => 7 }
+}
+function index_initializer(xs: int[], index: int) -> int {
+    { let unused = EffectsBox { value: xs[index] }; 42 }
+        catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function guarded_read(xs: int[]) -> int {
+    if (xs.length() > 0) { let unused = xs[0] }
+    42
+}
+function guarded_negative_read(xs: int[]) -> int {
+    if (xs.length() > 0) { let unused = xs[-1] }
+    42
+}
+function guarded_suffix_read(xs: int[]) -> int {
+    if (xs.length() >= 2) { let unused = xs[xs.length() - 2] }
+    42
+}
+function projected_bounds(box: EffectsArrays) -> int {
+    if (box.values.length() > 0) { let unused = box.values[0] }
+    42
+}
+function projection_write_invalidates_bounds() -> int {
+    let box = EffectsArrays { values: [1] }
+    {
+        if (box.values.length() > 0) { box.values = []; let unused = box.values[0] }
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function repeated_read_after_mutation(xs: int[]) -> int {
+    {
+        let first = xs[0]
+        xs.pop()
+        let second = xs[0]
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function copied_predicate_after_reassignment(index: int) -> int {
+    {
+        let safe = index < 4611686018427387903
+        index = 4611686018427387903
+        if (safe) { let unused = index + 1 }
+        42
+    } catch (e) { baml.panics.IntegerOverflow => 7 }
+}
+function captured_index_changes() -> int {
+    let index = 0
+    let change = () => { index = 100 }
+    {
+        let xs = [1]
+        if (index == 0) { change(); let unused = xs[index] }
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function parameter_default(value: int = 1) -> int { value + 1 }
+function parameter_copy_before_write(value: int) -> int {
+    let values = [value, { value = 10; value }]
+    values[0]
+}
+function mutation_invalidates_bounds() -> int {
+    let xs = [1]
+    {
+        if (xs.length() > 0) {
+            let alias = xs
+            alias.pop()
+            let unused = xs[0]
+        }
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function reassignment_invalidates_bounds() -> int {
+    let xs = [1]
+    {
+        let nonempty = xs.length() > 0
+        xs = []
+        if (nonempty) { let unused = xs[0] }
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function index_reassignment_invalidates_bounds() -> int {
+    let xs = [1]
+    let index = 0
+    {
+        if (xs.length() > 0) { index = 100; let unused = xs[index] }
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function stale_length_is_not_a_bounds_proof() -> int {
+    let xs = [1]
+    {
+        let size = xs.length()
+        xs.pop()
+        if (size > 0) { let unused = xs[size - 1] }
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function unguarded_join(flag: bool) -> int {
+    let xs: int[] = []
+    {
+        if (flag) { if (xs.length() == 0) { return 42 } }
+        let unused = xs[0]
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function handler_invalidates_facts() -> int {
+    let xs = [1]
+    let index = 0
+    {
+        { index = 10; let unused = 1 / 0 }
+            catch (e) { baml.panics.DivisionByZero => null }
+        let unused = xs[index]
+        42
+    } catch (e) { baml.panics.IndexOutOfBounds => 7 }
+}
+function may_overflow(value: int) -> int {
+    { let unused = value + 1; 42 }
+        catch (e) { baml.panics.IntegerOverflow => 7 }
+}
+function bounded_arithmetic(value: int) -> int {
+    if (value < 4611686018427387903) { let unused = value + 1 }
+    42
+}
+function loop_bound(count: int) -> int {
+    let index = 0
+    while (index < count) {
+        if (index < 500) { let unused = [index, index + 1, index + 2] }
+        index = index + 1
+    }
+    index
+}
+// Compile-only convergence probe: never invoke this billion-iteration loop.
+function large_loop_analysis() -> int {
+    let index = 0
+    while (index < 1000000000) { let unused = [index, index + 1]; index = index + 1 }
+    index
+}
+function verify_effects() -> bool {
+    allocation_effects() == 1 && allocation_panic(0) == 7 && allocation_panic(1) == 42
+        && index_initializer([], 0) == 7 && index_initializer([1], 0) == 42
+        && guarded_read([]) == 42 && guarded_read([1]) == 42
+        && guarded_negative_read([]) == 42 && guarded_negative_read([1]) == 42
+        && guarded_suffix_read([1]) == 42 && guarded_suffix_read([1, 2]) == 42
+        && projected_bounds(EffectsArrays { values: [] }) == 42
+        && projected_bounds(EffectsArrays { values: [1] }) == 42
+        && projection_write_invalidates_bounds() == 7 && repeated_read_after_mutation([1]) == 7
+        && copied_predicate_after_reassignment(0) == 7 && captured_index_changes() == 7
+        && parameter_default() == 2 && parameter_default(value = 7) == 8
+        && parameter_copy_before_write(3) == 3
+        && mutation_invalidates_bounds() == 7 && reassignment_invalidates_bounds() == 7
+        && index_reassignment_invalidates_bounds() == 7 && stale_length_is_not_a_bounds_proof() == 7
+        && unguarded_join(false) == 7 && unguarded_join(true) == 42
+        && handler_invalidates_facts() == 7
+        && may_overflow(4611686018427387903) == 7 && may_overflow(0) == 42
+        && bounded_arithmetic(4611686018427387903) == 42 && bounded_arithmetic(0) == 42
+        && loop_bound(1000) == 1000
+}
+"#;
+
+#[tokio::test]
+async fn discardability_preserves_effects_and_invalidates_stale_proofs() {
+    for opt in [OptLevel::Zero, OptLevel::One, OptLevel::Two] {
+        let output = run_test(SOURCE, "verify_effects", IndexMap::new(), opt).await;
+        assert_eq!(output.result, Ok(BexExternalValue::Bool(true)), "{opt:?}");
+    }
+}
+
+#[tokio::test]
+async fn growing_parser_fixture_keeps_observable_panics() {
+    let source = format!(
+        "{}\n{}\n{}",
+        include_str!("../baml_src/ns_fixtures/ns_parser_expressions/field_access.baml"),
+        include_str!("../baml_src/ns_fixtures/ns_parser_expressions/index_access.baml"),
+        r#"
+        function field_case() -> string {
+            FieldAccess(User { name: "Ada", profile: Profile {
+                bio: "", settings: Settings { theme: "dark" }
+            }, tags: [] }) catch (e) { baml.panics.IndexOutOfBounds => "caught" }
+        }
+        function index_case(users: IndexUser[]) -> string {
+            IndexAccess(users) catch (e) { baml.panics.IndexOutOfBounds => "caught" }
+        }
+        function verify_parser_panics() -> bool {
+            let tagged = IndexUser { name: "Ada", age: 1, tags: ["tag"] }
+            let empty = IndexUser { name: "Ada", age: 1, tags: [] }
+            field_case() == "caught" && index_case([tagged]) == "caught"
+                && index_case([empty, tagged]) == "caught"
+                && index_case([tagged, empty]) == "Ada"
+        }
+        "#
+    );
+    for opt in [OptLevel::Zero, OptLevel::One, OptLevel::Two] {
+        let output = run_test(&source, "verify_parser_panics", IndexMap::new(), opt).await;
+        assert_eq!(output.result, Ok(BexExternalValue::Bool(true)), "{opt:?}");
+    }
+}
+
+#[test]
+fn dead_allocations_and_guarded_patterns_keep_their_old_instruction_budgets() {
+    let source = format!("{CLASSES}\n{PATTERNS}\n{GC}\n{SOURCE}");
+    let program = compile_source_with_opt(&source, OptLevel::Two);
+    for (name, budget) in [
+        ("nested_construction_dead_store_fn", 2),
+        ("spread_does_not_break_locals_fn", 4),
+        ("arb_tail_len", 21),
+        ("arb_grab", 30),
+        ("arb_pushing_to_rest_does_not_mutate_source", 43),
+        ("gc_map_survives_pressure", 17),
+        ("parameter_default", 10),
+    ] {
+        let index = program.function_index(&format!("user.{name}")).unwrap();
+        let Some(Object::Function(function)) = program.objects.get(index) else {
+            panic!("expected function");
+        };
+        assert!(
+            function.bytecode.instructions.len() <= budget,
+            "{name}: {:?}",
+            function.bytecode.instructions
+        );
+    }
+    for name in [
+        "guarded_read",
+        "guarded_negative_read",
+        "guarded_suffix_read",
+        "projected_bounds",
+        "bounded_arithmetic",
+    ] {
+        let index = program.function_index(&format!("user.{name}")).unwrap();
+        let Some(Object::Function(function)) = program.objects.get(index) else {
+            panic!("expected function");
+        };
+        assert!(
+            !function
+                .bytecode
+                .instructions
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    bex_vm_types::Instruction::LoadArrayElement
+                        | bex_vm_types::Instruction::AddInt
+                        | bex_vm_types::Instruction::BinOp(bex_vm_types::BinOp::Add)
+                )),
+            "{name}: {:?}",
+            function.bytecode.instructions
+        );
+    }
+}

--- a/baml_language/crates/baml_tests/tests/optimizer_stack.rs
+++ b/baml_language/crates/baml_tests/tests/optimizer_stack.rs
@@ -1,0 +1,56 @@
+use baml_tests::{
+    engine::{OptLevel, run_test},
+    stdlib_prefix::compile_source_with_opt,
+};
+use bex_external_types::BexExternalValue;
+use bex_vm_types::{Instruction, Object};
+use indexmap::IndexMap;
+
+const SOURCE: &str = include_str!("../baml_src/ns_optimizer_stack/optimizer_stack.baml");
+
+#[tokio::test]
+async fn optimizer_preserves_behavior_at_each_level() {
+    for opt in [OptLevel::Zero, OptLevel::One, OptLevel::Two] {
+        let output = run_test(SOURCE, "verify_all", IndexMap::new(), opt).await;
+        assert_eq!(output.result, Ok(BexExternalValue::Bool(true)), "{opt:?}");
+    }
+}
+
+#[test]
+fn optimized_instruction_and_local_counts() {
+    let program = compile_source_with_opt(SOURCE, OptLevel::Two);
+    for (name, instructions, locals) in [
+        ("and_value", 6, 0),
+        ("or_value", 6, 0),
+        ("coalesce", 4, 0),
+        ("array_mixed", 8, 0),
+        ("virtual_result", 5, 0),
+        ("constants", 2, 0),
+        ("overwritten", 6, 0),
+    ] {
+        let index = program.function_index(&format!("user.{name}")).unwrap();
+        let Some(Object::Function(function)) = program.objects.get(index) else {
+            panic!("expected function")
+        };
+        assert_eq!(
+            function.bytecode.instructions.len(),
+            instructions,
+            "{name}: {:?}",
+            function.bytecode.instructions
+        );
+        assert_eq!(function.real_local_count, locals, "{name}");
+    }
+    let index = program.function_index("user.and_value").unwrap();
+    let Some(Object::Function(function)) = program.objects.get(index) else {
+        panic!("expected function")
+    };
+    assert_eq!(
+        function
+            .bytecode
+            .instructions
+            .iter()
+            .filter(|instruction| matches!(instruction, Instruction::JumpIfFalseOrPop(_)))
+            .count(),
+        2
+    );
+}

--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -35,8 +35,6 @@ async fn shell_with_pipe() {
         load_type baml.ToString
         load_const "to_string"
         virtual_call nargs=1 ntypeargs=0
-        store_var _0
-        load_var _0
         return
     }
     "#);

--- a/baml_language/crates/bex_cache/src/lib.rs
+++ b/baml_language/crates/bex_cache/src/lib.rs
@@ -106,7 +106,10 @@ use sha2::{Digest, Sha256};
 /// as the `CompilationUnit`'s link-internal export/import key; compile
 /// boundaries read coordinates from the declaration-keyed placement
 /// registry, with a Pass-1 slot replay only at the stdlib-splice boundary.
-pub const FORMAT_VERSION: u32 = 11;
+///
+/// Version 12: appended `PopJumpIfTrue`, `JumpIfFalseOrPop`,
+/// `JumpIfTrueOrPop`, and `JumpIfNotNullOrPop` to the instruction/opcode sets.
+pub const FORMAT_VERSION: u32 = 12;
 
 const MAGIC: [u8; 4] = *b"BEXC";
 

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -178,6 +178,10 @@ pub(crate) fn display_instruction(
         }
         Instruction::Jump(offset)
         | Instruction::PopJumpIfFalse(offset)
+        | Instruction::PopJumpIfTrue(offset)
+        | Instruction::JumpIfFalseOrPop(offset)
+        | Instruction::JumpIfTrueOrPop(offset)
+        | Instruction::JumpIfNotNullOrPop(offset)
         | Instruction::JumpIfFalse(offset) => {
             format!("(to {})", instruction_ptr.wrapping_add_signed(*offset))
         }
@@ -414,6 +418,10 @@ fn instruction_style(instruction: &Instruction) -> Style {
         | Instruction::UnaryOp(_) => Style::new().blue().bright(),
         Instruction::Jump(_)
         | Instruction::PopJumpIfFalse(_)
+        | Instruction::PopJumpIfTrue(_)
+        | Instruction::JumpIfFalseOrPop(_)
+        | Instruction::JumpIfTrueOrPop(_)
+        | Instruction::JumpIfNotNullOrPop(_)
         | Instruction::JumpIfFalse(_)
         | Instruction::JumpTable { .. }
         | Instruction::DenseTag(_) => Style::new().yellow(),
@@ -660,6 +668,10 @@ fn display_bytecode_textual(function: &Function) -> String {
         match instruction {
             Instruction::Jump(offset)
             | Instruction::PopJumpIfFalse(offset)
+            | Instruction::PopJumpIfTrue(offset)
+            | Instruction::JumpIfFalseOrPop(offset)
+            | Instruction::JumpIfTrueOrPop(offset)
+            | Instruction::JumpIfNotNullOrPop(offset)
             | Instruction::JumpIfFalse(offset) => {
                 let target = ip.wrapping_add_signed(*offset);
                 jump_targets.insert(target);
@@ -810,6 +822,23 @@ fn display_instruction_textual(
                 .cloned()
                 .unwrap_or_else(|| format!("?{target}"));
             format!("jump_if_false {label}")
+        }
+        Instruction::PopJumpIfTrue(offset)
+        | Instruction::JumpIfFalseOrPop(offset)
+        | Instruction::JumpIfTrueOrPop(offset)
+        | Instruction::JumpIfNotNullOrPop(offset) => {
+            let name = match instruction {
+                Instruction::PopJumpIfTrue(_) => "pop_jump_if_true",
+                Instruction::JumpIfFalseOrPop(_) => "jump_if_false_or_pop",
+                Instruction::JumpIfTrueOrPop(_) => "jump_if_true_or_pop",
+                _ => "jump_if_not_null_or_pop",
+            };
+            let target = ip.wrapping_add_signed(*offset);
+            let label = label_map
+                .get(&target)
+                .cloned()
+                .unwrap_or_else(|| format!("?{target}"));
+            format!("{name} {label}")
         }
         Instruction::JumpTable(table_idx) => {
             let default_target =
@@ -1182,6 +1211,10 @@ fn display_expanded_metadata(ip: usize, instruction: &Instruction, function: &Fu
         // Jumps: show absolute target address.
         Instruction::Jump(offset)
         | Instruction::PopJumpIfFalse(offset)
+        | Instruction::PopJumpIfTrue(offset)
+        | Instruction::JumpIfFalseOrPop(offset)
+        | Instruction::JumpIfTrueOrPop(offset)
+        | Instruction::JumpIfNotNullOrPop(offset)
         | Instruction::JumpIfFalse(offset) => {
             let target = ip.wrapping_add_signed(*offset);
             format!("(to {target})")
@@ -1383,7 +1416,13 @@ pub fn display_compact_bytecode(
             }
 
             // Jump i32 operand: show relative offset and resolved absolute target
-            OpCode::Jump | OpCode::PopJumpIfFalse | OpCode::JumpIfFalse => {
+            OpCode::Jump
+            | OpCode::PopJumpIfFalse
+            | OpCode::JumpIfFalse
+            | OpCode::PopJumpIfTrue
+            | OpCode::JumpIfFalseOrPop
+            | OpCode::JumpIfTrueOrPop
+            | OpCode::JumpIfNotNullOrPop => {
                 let offset_val = read_i32(code, &mut pc);
                 let target = (pc as i64 + offset_val as i64) as usize;
                 writeln!(f, "{offset_val:+}  (-> {target:04})")?;

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -9077,10 +9077,10 @@ impl BexVm {
                     }
                 }
 
-                OpCode::PopJumpIfFalse => {
+                OpCode::PopJumpIfFalse | OpCode::PopJumpIfTrue => {
                     let offset = read_i32_unchecked(code, pc);
                     let cond = self.stack.ensure_pop();
-                    if cond == Value::bool(false) {
+                    if cond == Value::bool(op == OpCode::PopJumpIfTrue) {
                         *pc = (*pc as i64 + offset as i64) as usize;
                     }
                     if self.early_yield.should_early_yield() {
@@ -9094,6 +9094,25 @@ impl BexVm {
                     let cond = self.stack[top_slot];
                     if cond == Value::bool(false) {
                         *pc = (*pc as i64 + offset as i64) as usize;
+                    }
+                }
+
+                OpCode::JumpIfFalseOrPop | OpCode::JumpIfTrueOrPop | OpCode::JumpIfNotNullOrPop => {
+                    let offset = read_i32_unchecked(code, pc);
+                    let cond = self.stack[self.stack.ensure_stack_top()];
+                    let taken = match op {
+                        OpCode::JumpIfFalseOrPop => cond == Value::bool(false),
+                        OpCode::JumpIfTrueOrPop => cond == Value::bool(true),
+                        OpCode::JumpIfNotNullOrPop => !cond.is_null(),
+                        _ => unreachable!(),
+                    };
+                    if taken {
+                        *pc = (*pc as i64 + offset as i64) as usize;
+                    } else {
+                        self.stack.ensure_pop();
+                    }
+                    if self.early_yield.should_early_yield() {
+                        return Ok(Some(VmExecState::EarlyYield));
                     }
                 }
 

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -924,6 +924,15 @@ pub enum Instruction {
     /// constant-pool string naming the static package; a dynamic function's
     /// runtime owner takes precedence.
     LoadCurrentPackage(usize),
+
+    /// Pop the condition on both edges and branch when true.
+    PopJumpIfTrue(isize),
+    /// Keep a false value on the taken edge; pop on fallthrough.
+    JumpIfFalseOrPop(isize),
+    /// Keep a true value on the taken edge; pop on fallthrough.
+    JumpIfTrueOrPop(isize),
+    /// Keep a non-null value on the taken edge; pop on fallthrough.
+    JumpIfNotNullOrPop(isize),
 }
 
 /// Compact bytecode opcodes.
@@ -1125,6 +1134,12 @@ pub enum OpCode {
     // arg count; `Self` type, interface type, and method name come off the
     // stack and the resolved capture-less closure is pushed.
     MakeVirtualFunction,
+
+    // Conditional branches, appended to preserve serialized discriminants.
+    PopJumpIfTrue,
+    JumpIfFalseOrPop,
+    JumpIfTrueOrPop,
+    JumpIfNotNullOrPop,
 }
 
 impl OpCode {
@@ -1247,6 +1262,10 @@ impl OpCode {
             | Self::Jump
             | Self::PopJumpIfFalse
             | Self::JumpIfFalse
+            | Self::PopJumpIfTrue
+            | Self::JumpIfFalseOrPop
+            | Self::JumpIfTrueOrPop
+            | Self::JumpIfNotNullOrPop
             | Self::VirtualCall
             | Self::VirtualLoadField
             | Self::VirtualStoreField
@@ -1397,6 +1416,10 @@ impl TryFrom<u8> for OpCode {
             x if x == Self::Jump as u8 => Ok(Self::Jump),
             x if x == Self::PopJumpIfFalse as u8 => Ok(Self::PopJumpIfFalse),
             x if x == Self::JumpIfFalse as u8 => Ok(Self::JumpIfFalse),
+            x if x == Self::PopJumpIfTrue as u8 => Ok(Self::PopJumpIfTrue),
+            x if x == Self::JumpIfFalseOrPop as u8 => Ok(Self::JumpIfFalseOrPop),
+            x if x == Self::JumpIfTrueOrPop as u8 => Ok(Self::JumpIfTrueOrPop),
+            x if x == Self::JumpIfNotNullOrPop as u8 => Ok(Self::JumpIfNotNullOrPop),
             x if x == Self::JumpTable as u8 => Ok(Self::JumpTable),
             x if x == Self::MakeClosure as u8 => Ok(Self::MakeClosure),
             x if x == Self::MakeGenericFunction as u8 => Ok(Self::MakeGenericFunction),
@@ -1541,6 +1564,10 @@ impl std::fmt::Display for OpCode {
             Self::Jump => "JUMP",
             Self::PopJumpIfFalse => "POP_JUMP_IF_FALSE",
             Self::JumpIfFalse => "JUMP_IF_FALSE",
+            Self::PopJumpIfTrue => "POP_JUMP_IF_TRUE",
+            Self::JumpIfFalseOrPop => "JUMP_IF_FALSE_OR_POP",
+            Self::JumpIfTrueOrPop => "JUMP_IF_TRUE_OR_POP",
+            Self::JumpIfNotNullOrPop => "JUMP_IF_NOT_NULL_OR_POP",
             Self::JumpTable => "JUMP_TABLE",
             Self::MakeClosure => "MAKE_CLOSURE",
             Self::MakeGenericFunction => "MAKE_GENERIC_FUNCTION",
@@ -1678,6 +1705,10 @@ impl std::fmt::Display for Instruction {
             Instruction::Jump(o) => write!(f, "JUMP {o:+}"),
             Instruction::PopJumpIfFalse(o) => write!(f, "POP_JUMP_IF_FALSE {o:+}"),
             Instruction::JumpIfFalse(o) => write!(f, "JUMP_IF_FALSE {o:+}"),
+            Instruction::PopJumpIfTrue(o) => write!(f, "POP_JUMP_IF_TRUE {o:+}"),
+            Instruction::JumpIfFalseOrPop(o) => write!(f, "JUMP_IF_FALSE_OR_POP {o:+}"),
+            Instruction::JumpIfTrueOrPop(o) => write!(f, "JUMP_IF_TRUE_OR_POP {o:+}"),
+            Instruction::JumpIfNotNullOrPop(o) => write!(f, "JUMP_IF_NOT_NULL_OR_POP {o:+}"),
             Instruction::BinOp(op) => write!(f, "BIN_OP {op}"),
             Instruction::CmpOp(op) => write!(f, "CMP_OP {op}"),
             Instruction::AddInt => f.write_str("ADD_INT"),
@@ -2384,7 +2415,11 @@ impl Bytecode {
                 // ── Jump operands: translate to byte offsets ────────
                 Instruction::Jump(offset)
                 | Instruction::PopJumpIfFalse(offset)
-                | Instruction::JumpIfFalse(offset) => {
+                | Instruction::JumpIfFalse(offset)
+                | Instruction::PopJumpIfTrue(offset)
+                | Instruction::JumpIfFalseOrPop(offset)
+                | Instruction::JumpIfTrueOrPop(offset)
+                | Instruction::JumpIfNotNullOrPop(offset) => {
                     // In the old VM, offset is relative to the instruction
                     // itself (IP was pre-incremented before step() ran, and
                     // the jump uses instruction_ptr.checked_add_signed(offset)
@@ -2715,6 +2750,10 @@ impl Bytecode {
             Instruction::Jump(_) => OpCode::Jump,
             Instruction::PopJumpIfFalse(_) => OpCode::PopJumpIfFalse,
             Instruction::JumpIfFalse(_) => OpCode::JumpIfFalse,
+            Instruction::PopJumpIfTrue(_) => OpCode::PopJumpIfTrue,
+            Instruction::JumpIfFalseOrPop(_) => OpCode::JumpIfFalseOrPop,
+            Instruction::JumpIfTrueOrPop(_) => OpCode::JumpIfTrueOrPop,
+            Instruction::JumpIfNotNullOrPop(_) => OpCode::JumpIfNotNullOrPop,
 
             // Two-operand variants
             Instruction::JumpTable(_) => OpCode::JumpTable,
@@ -2775,6 +2814,41 @@ mod compact_tests {
         assert_eq!(compact.code[0], OpCode::LoadIntSmall as u8);
         assert_eq!(compact.code[1], 42u8);
         assert_eq!(compact.code[2], OpCode::Return as u8);
+    }
+
+    #[test]
+    fn conditional_branches_encode_both_directions_and_round_trip() {
+        let branches = [
+            (
+                Instruction::PopJumpIfTrue as fn(isize) -> Instruction,
+                OpCode::PopJumpIfTrue,
+            ),
+            (Instruction::JumpIfFalseOrPop, OpCode::JumpIfFalseOrPop),
+            (Instruction::JumpIfTrueOrPop, OpCode::JumpIfTrueOrPop),
+            (Instruction::JumpIfNotNullOrPop, OpCode::JumpIfNotNullOrPop),
+        ];
+        for (branch, opcode) in branches {
+            assert_eq!(opcode.encoded_size(), 5);
+            assert_eq!(OpCode::try_from(opcode as u8).unwrap(), opcode);
+            let bc = make_bytecode(
+                vec![
+                    branch(2),
+                    Instruction::LoadConst(0),
+                    branch(-2),
+                    Instruction::Return,
+                ],
+                vec![ConstValue::Int(42)],
+            );
+            let code = bc.lower_to_compact().code;
+            assert_eq!(code.len(), 13);
+            assert_eq!(code[0], opcode as u8);
+            assert_eq!(i32::from_le_bytes(code[1..5].try_into().unwrap()), 2);
+            assert_eq!(code[7], opcode as u8);
+            assert_eq!(i32::from_le_bytes(code[8..12].try_into().unwrap()), -12);
+            let encoded = borsh::to_vec(&bc.instructions).unwrap();
+            let decoded: Vec<Instruction> = borsh::from_slice(&encoded).unwrap();
+            assert_eq!(format!("{decoded:?}"), format!("{:?}", bc.instructions));
+        }
     }
 
     #[test]

--- a/baml_language/crates/bex_vm_types/src/relink.rs
+++ b/baml_language/crates/bex_vm_types/src/relink.rs
@@ -102,6 +102,10 @@ macro_rules! visit_bytecode_index_operands {
             | I::Jump(..)
             | I::PopJumpIfFalse(..)
             | I::JumpIfFalse(..)
+            | I::PopJumpIfTrue(..)
+            | I::JumpIfFalseOrPop(..)
+            | I::JumpIfTrueOrPop(..)
+            | I::JumpIfNotNullOrPop(..)
             | I::BinOp(..)
             | I::CmpOp(..)
             | I::AddInt


### PR DESCRIPTION
## Summary

Fix discarded-expression correctness first, then optimize MIR values and stackified bytecode.

This PR has three commits (the third is the requested follow-up for inlined binary prefixes):

1. `fix(compiler): preserve effects of discarded expressions`
2. `perf(compiler): optimize MIR values and stackified bytecode`
3. `perf(compiler): carry binary prefixes through inlined expressions`

The second commit:

- Gives short-circuit expressions their own MIR result, independent of mutable destination locals, and represents null coalescing explicitly.
- Lowers `&&`, `||`, and `!` in predicates directly to CFG branches, preserving non-boolean truthiness conversion.
- Adds O2 scalar constant propagation/folding and boolean-branch simplification, plus definition-level dead-store elimination with exception-handler liveness.
- Chooses branch polarity from emitted layout and threads identical value-preserving branches.
- Extends validated stack carry to virtual-call results, call arguments, binary operands, and mixed constant/call prefixes. Requires unique definitions and single-entry continuations, and revalidates the final carry plan.
- Preserves the existing phi-coverage checks and O0 named-scalar slot behavior. This is an incremental MIR improvement, not a wholesale SSA rewrite.

## Bug Repro

### Discarded short circuits dropped conditional RHS effects

```baml
class Box { value: int }

function and_inline(a: bool, box: Box) -> int {
    a && { box.value = box.value + 1; true }
    box.value
}

test "discarded result must not discard the mutation" {
    assert.equal(and_inline(true, Box { value: 0 }), 1)
    assert.equal(and_inline(false, Box { value: 0 }), 0)
}
```

Before this PR, the first call incorrectly returned **0** at O1 and O2. Dead-local elimination replaced the entire `ShortCircuit` with `Goto(join)` when its result was unused, deleting the conditional mutation. The emitted function was just:

```text
load_var box
load_field .value
return
```

The fix replaces the discarded logical result with an ordinary conditional branch, retaining RHS execution. After the PR:

```text
load_var a
pop_jump_if_false L0
load_var2 2 2
load_field .value
load_const 1
bin_op +
store_field .value
L0:
load_var box
load_field .value
return
```

Here both operands of `load_var2 2 2` refer to `box`. Regression tests cover AND/OR, field/index writes, and captured locals in `ns_optimizer_effects/optimizer_effects.baml`.

### Unused evaluations also dropped catchable panics

```baml
function unused_division(x: int) -> int {
    { let unused = 1 / x; 42 } catch (e) {
        baml.panics.DivisionByZero => 7
    }
}

test "unused evaluation must still panic" {
    assert.equal(unused_division(0), 7)
}
```

Previously this returned **42** because the division was deleted. The first commit adds conservative discardability checks and retains potentially failing evaluations. The regression now returns **7**; unused out-of-bounds indexing is covered too. This correction is a prerequisite for the broader dead-store optimization in the second commit.

## Seven Branch Instructions

The **seven-instruction ordinary branch family is inspired by Python's instruction set**, particularly its distinction between consuming predicate branches and historical value-preserving short-circuit branches. CPython 3.11 documents [`JUMP_IF_FALSE_OR_POP`](https://docs.python.org/3.11/library/dis.html#opcode-JUMP_IF_FALSE_OR_POP) and [`JUMP_IF_TRUE_OR_POP`](https://docs.python.org/3.11/library/dis.html#opcode-JUMP_IF_TRUE_OR_POP); contemporary Python documents consuming [`POP_JUMP_IF_TRUE`](https://docs.python.org/3.14/library/dis.html#opcode-POP_JUMP_IF_TRUE) branches. BAML adapts those ideas to its own CFG and stack VM; these are not seven opcodes copied verbatim from one Python release.

| BAML instruction | Taken edge | Fallthrough edge |
| --- | --- | --- |
| `Jump` | Jump; stack unchanged | Not applicable |
| `PopJumpIfFalse` | Pop false | Pop condition |
| `PopJumpIfTrue` | Pop true | Pop condition |
| `JumpIfFalse` | Keep false | Keep condition |
| `JumpIfFalseOrPop` | Keep false | Pop condition |
| `JumpIfTrueOrPop` | Keep true | Pop condition |
| `JumpIfNotNullOrPop` | Keep non-null value | Pop null |

MIR stays value/CFG-oriented; emission selects the fused, edge-dependent stack behavior after stack-carry validation. This count excludes switch/jump-table, exception, and async control flow. Four variants are appended without renumbering existing discriminants. Artifact ABI version is bumped **2 -> 3** and cache format **11 -> 12**.

## Before/After Bytecode

O2 examples below use the human-readable snapshot notation. Labels, temporary names, and helper namespaces are normalized where noted. Counts are static instructions, not runtime throughput claims.

<details>
<summary>Chained AND: 8 -> 6 instructions, with the first false edge going directly to the final join</summary>

Source: `function chained_and(a: bool, b: bool, c: bool) -> bool { a && b && c }`

Before (`ns_fixtures/ns_short_circuit_locals/bytecode.snap`):

```text
load_var a
jump_if_false L0
pop 1
load_var b
L0:
jump_if_false L1
pop 1
load_var c
L1:
return
```

After:

```text
load_var a
jump_if_false_or_pop L0
load_var b
jump_if_false_or_pop L0
load_var c
L0:
return
```

OR uses `jump_if_true_or_pop` and drops from 10 to 6 instructions. Predicate-only chains instead use popping branches and do not materialize an intermediate logical result.

</details>

<details>
<summary>Mutable destination: 14 -> 10 instructions without weakening phi coverage</summary>

```baml
function conditional_short_circuit(a: bool, b: bool, cond: bool) -> bool {
    let x = false
    if (cond) { x = a && b }
    x
}
```

Before (`ns_fixtures/ns_short_circuit_locals/bytecode.snap`):

```text
load_const false
store_var x
load_var cond
pop_jump_if_false L2
load_var a
jump_if_false L0
pop 1
jump L1
L0:
store_var x
jump L2
L1:
load_var b
store_var x
L2:
load_var x
return
```

After:

```text
load_const false
store_var x
load_var cond
pop_jump_if_false L1
load_var a
jump_if_false_or_pop L0
load_var b
L0:
store_var x
L1:
load_var x
return
```

The expression result can be stack-carried even though `x` must retain a real slot for the outer false edge. MIR now separates those two roles.

</details>

<details>
<summary>Null coalescing: 9 -> 4 instructions and no result slot</summary>

Source: `function nca_plain(n: int?, fallback: int) -> int { n ?? fallback }`

Before (`ns_null_coalesce_assign/bytecode.snap`):

```text
load_var n
store_var_load_var _3
load_const null
cmp_op ==
pop_jump_if_false L0
load_var fallback
store_var _3
L0:
load_var _3
return
```

After:

```text
load_var n
jump_if_not_null_or_pop L0
load_var fallback
L0:
return
```

The existing `x ?? y ?? z` snapshot similarly drops from 16 to 6 instructions.

</details>

<details>
<summary>Immediate virtual-call result: 7 -> 5 instructions</summary>

Source: `function ord_self_in_default(a: Tier, b: Tier) -> bool { a.precedes(b) }`

Before (`ns_operators/bytecode.snap`):

```text
load_var2 1 2
load_type operators.Ordered
load_const "precedes"
virtual_call nargs=2 ntypeargs=0
store_var _0
load_var _0
return
```

After:

```text
load_var2 1 2
load_type operators.Ordered
load_const "precedes"
virtual_call nargs=2 ntypeargs=0
return
```

Loop-header results are not blindly carried: one static use can execute repeatedly. Tests check that a backedge or another incoming edge forces materialization.

</details>

<details>
<summary>Mixed call/constant array prefix: 12 -> 8 instructions and 2 -> 0 temporary slots</summary>

```baml
function number(value: int) -> int { value }
function array_mixed() -> int[] { [number(1), 2, number(3)] }
```

Before (isolated compiler probe; temporary names normalized):

```text
load_const 1
call number
store_var t0
load_const 3
call number
store_var t1
load_var t0
load_const 2
load_var t1
load_type int
alloc_array 3
return
```

After (`ns_optimizer_stack/bytecode.snap`; helper namespace omitted):

```text
load_const 1
call number
load_const 2
load_const 3
call number
load_type int
alloc_array 3
return
```

Only the infallible constant moves before the next call. Effectful evaluations retain their order. Tests cover mutable receivers, noncommutative binary operations, indirect/generic/virtual calls, and unwinding while earlier operands remain on the stack.

</details>

<details>
<summary>Third commit: inlined string concatenation, 8 -> 6 instructions and 1 -> 0 result slots</summary>

```baml
function bt_case_h() -> string {
    let x = "hi"
    `!${x}`
}
```

The second commit moved the literal before `String.from` but retained the result's store/load pair. That particular hunk was reorder-only, not a size improvement:

```text
load_const "!"
load_type string
load_const "hi"
call baml.String.from
store_var _1
load_var _1
bin_op +
return
```

The third commit removes that pair:

```text
load_const "!"
load_type string
load_const "hi"
call baml.String.from
bin_op +
return
```

The existing binary-prefix proof now lives in the shared operand-prefix simulator, so it is used both at direct evaluations and when an expression is pulled through an inlined local into a return or call argument. No MIR or opcode changes, new candidate kinds, or relaxed safety guards are needed: both operands must already be stack-carried in source order, and existing definition, predecessor, depth, and final-plan checks remain intact.

`bt_case_i` similarly drops **10 -> 8** instructions; `bt_case_n` drops **9 -> 7**, both with zero result slots. Exact budgets use the actual backtick fixture source. Additional tests check subtraction/division order, nested expressions, call arguments, side-effect order, and unwinding from both calls and arithmetic at O0/O1/O2. A MIR-to-stack-classification unit test validates both operand depths and rejects reversed stack order.

Comparing this third commit against `045bffe6c` across all **248** snapshots: **22 snapshots shrink by 152 instructions total; no snapshot or individual existing function grows**. `ns_backtick_strings` drops **2,173 -> 2,137** instructions. The new regression tests are Rust integration tests, so they add no BAML corpus registration instructions.

</details>

Across the pre-existing snapshot inventory, displayed instructions decrease from **99,860 to 93,984** (about **5.9%**). This includes test/stdlib scaffolding and is not weighted by execution frequency. No throughput benchmark claim is made.

## Snapshot Regression Audit

Compared all **246 pre-existing bytecode snapshots** against the pre-PR base `048bf98ac`, including every file that grew in the first published revision. Counts below are actual instruction lines, not labels, temporary declarations, or diff churn.

| Snapshot | Pre-PR | Published PR | Revised PR |
| --- | ---: | ---: | ---: |
| `ns_patterns_new_runtime` | 3,772 | 4,329 | 3,570 |
| `ns_array_rest_binding` | 761 | 834 | 743 |
| `ns_classes` | 330 | 338 | 330 |
| `ns_gc` | 76 | 83 | 74 |
| `ns_fixtures/ns_type_annotation` | 23 | 30 | 23 |
| `ns_fixtures/ns_llm_parse_catchable_parse_error` | 110 | 113 | 107 |
| `ns_fixtures/ns_patterns_class_destructure_namespaces` | 110 | 112 | 106 |
| `ns_fixtures/ns_parser_expressions` | 33 | 45 | 38 |
| Root test registry | 649 | 655 | 655 |

The smaller original code in the first seven rows was sound: it omitted unused plain allocations/fields, array projections protected by shape/length guards, or arithmetic bounded by a loop predicate. The correction restores those optimizations through general MIR analysis, with no fixture names, snapshot-specific rules, or hand-restored bytecode:

- Discardability checks include every operand. An unused allocation can disappear, but a potentially failing initializer and initializer calls retain their evaluation.
- Forward CFG facts track integer ranges, container lengths, temporary aliases, and completed reads at each statement. Joins retain only shared facts; reassignment invalidates dependent proofs, heap writes/calls invalidate facts conservatively, and exception handlers start without assumptions from the try body.
- Loop widening bounds analysis time independently of the loop trip count. In-bounds negative and length-relative indices are supported.
- Dead-store/local elimination uses these evaluation-site proofs, not a whole-local purity classification. Temporary discards can be reconsidered when their producer is proven safe.
- Reassigned/defaulted parameter copies can propagate within a block until a source/destination write. Other temporary chains remain available to stackification.

For example, `nested_construction_dead_store_fn` in `ns_classes` regressed from 2 instructions to this 6-instruction sequence in the published PR:

```text
load_const 42
init_instance user.classes.CInner .value
init_instance user.classes.COuter .inner
pop 1
load_const 42
return
```

The revised compiler restores the original 2 instructions:

```text
load_const 42
return
```

The only remaining source-code snapshot increase is **`parser_expressions`: +5 instructions**, a correctness fix. Its old `FieldAccess` omitted `user.tags[0]`; its old `IndexAccess` omitted `users[1]` and `users[0].tags[0]`. Those accesses can panic even when their results are unused. Tests compile the actual fixture sources and check that an empty tags array, a one-element users array, and an empty nested tags array still raise catchable `IndexOutOfBounds` at O0/O1/O2. Non-failing inputs retain the original result.

The root registry's **+6** is test scaffolding: two new regression-test namespaces each add a load/call/pop registration sequence. It is not growth in an unchanged source function.

### Additional CI Coverage

The broader CI suite also exposed a copy-propagation bug: a single-use constant definition could be erased even when its consumer required a `Place`, such as `Len(local)`, where a constant substitution cannot be written. The collector now covers direct place reads as well as projection bases/indices. Existing runtime-session method tests cover the failure, and all 43 runtime-session tests pass.

MIR and inline virtual-call snapshots are refreshed, the artifact-compatibility test follows `FORMAT_VERSION`, and the VM fault-injection test replaces stale PC-indexed metadata along with its instruction stream.

Review also caught an O0 debugging regression: definition-level dead-store elimination now retains overwritten user-named stores at O0 while still optimizing unnamed temporaries. A MIR unit test checks both the individual pass and the full O0 cleanup pipeline, and verifies O1/O2 retain dead-store elimination. The reported virtual-field issue was withdrawn after checking the VM contract: missing interface field links are internal invariant violations, not BAML panics; potentially trapping receiver evaluation remains protected.

## Validation

- Full local nextest suite: **2,073 passed across 88 test binaries, 22 skipped**, on the final revision with snapshot updates disabled.
- [GitHub CI](https://github.com/BoundaryML/baml/actions/runs/33963565684) passed on final head `f793a6484`, including snapshot tests, native/WASM cargo tests, SDK tests, pre-commit, and the cross-platform size gate.
- [CodeRabbit approved](https://github.com/BoundaryML/baml/pull/4759#pullrequestreview-5121076647) final head `f793a6484`.
- Full native BAML corpus: **3,589 passed, 2 intentional tolerated failures, 3,591 total**; aggregate passed. Loopback/network tests were run outside the filesystem/network sandbox.
- `corpus_snapshots` regenerated and then passed with updates disabled.
- New optimizer behavior tests pass at **O0, O1, and O2**, with exact instruction/local-count assertions at O2.
- **58 emitter**, **10 MIR**, **58 VM-types**, **34 VM**, **5 artifact**, and **12 cache** unit tests passed.
- Deterministic emission (5), full/unit linking oracle (5), incremental relinking oracle (8), existing short-circuit regressions (4), loop-reassignment regressions (2), and optimization tests (9) passed.
- Scoped Clippy for the changed compiler/VM/artifact/cache crates, all targets, with `-D warnings`; Rust formatting and `git diff --check` passed.
- The second and third commits' normal pre-commit hooks, including `cargo fmt` and `cargo clippy`, passed.

Local tests used installed Rust **1.97.1** with locked/offline dependencies; initial formatting used installed rustfmt **1.93.0**, and the revised commits' normal formatting hooks used installed rustfmt **1.97.1**. The repository-pinned 1.98.0 toolchain was unavailable locally; GitHub CI supplied the broader platform, SDK, and WASM coverage linked above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for null-coalescing (`??`) expressions alongside `&&` and `||`.
  - Added value-preserving short-circuit evaluation and optimized conditional branching.

- **Performance**
  - Improved optimization through constant folding, dead-code elimination, and streamlined bytecode.
  - Reduced unnecessary temporary operations in generated bytecode.

- **Bug Fixes**
  - Preserved behavior for discarded expressions, panic paths, mutable values, virtual calls, and evaluation order.
  - Updated compiled artifact and cache formats to support new runtime instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



