### PR TITLE
feat(stdlib): add int div_euclid and rem_euclid

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/int.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/int.baml
@@ -125,10 +125,14 @@ class Int {
         $rust_function
     }
 
-    /// Returns `self` divided by `other`, rounded toward negative infinity —
-    /// the quotient paired with `rem_euclid` so that
-    /// `self == self.div_euclid(other) * other + self.rem_euclid(other)` and
-    /// the remainder is never negative.
+    /// Returns the unique `q` satisfying
+    /// `self == q * other + self.rem_euclid(other)` with the remainder never
+    /// negative — the quotient paired with `rem_euclid`.
+    ///
+    /// This equals floor division (rounding toward negative infinity) when
+    /// `other` is positive, but rounds toward *positive* infinity instead
+    /// when `other` is negative: `(7).div_euclid(-3)` is `-2`, not `-3`
+    /// (`floor(7 / -3)`).
     ///
     /// This differs from `/`, which truncates toward zero. `/` and
     /// `div_euclid` agree whenever `self` is non-negative or divides `other`
@@ -157,7 +161,7 @@ class Int {
     }
 
     /// Returns the remainder of dividing `self` by `other`, always in
-    /// `[0, other.abs())` regardless of either operand's sign. Paired with
+    /// `[0, |other|)` regardless of either operand's sign. Paired with
     /// `div_euclid`; see that method for the identity they satisfy together.
     ///
     /// This differs from `%`, which takes the sign of the dividend and can be
@@ -168,8 +172,8 @@ class Int {
     /// # Panics
     ///
     /// - `baml.panics.DivisionByZero` if `other` is zero. Never overflows
-    ///   otherwise: the result satisfies `0 <= r < other.abs()`, and
-    ///   `other.abs()` is at most `2^62`, so `r` always fits in `int` — even
+    ///   otherwise: the result satisfies `0 <= r < |other|`, and `|other|`
+    ///   is at most `2^62`, so `r` always fits in `int` — even
     ///   `int.min_value().rem_euclid(-1)`, which is `0` because dividing by
     ///   `1` or `-1` always leaves remainder `0`.
     ///

--- a/baml_language/crates/baml_builtins2/baml_std/baml/int.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/int.baml
@@ -125,6 +125,67 @@ class Int {
         $rust_function
     }
 
+    /// Returns `self` divided by `other`, rounded toward negative infinity —
+    /// the quotient paired with `rem_euclid` so that
+    /// `self == self.div_euclid(other) * other + self.rem_euclid(other)` and
+    /// the remainder is never negative.
+    ///
+    /// This differs from `/`, which truncates toward zero. `/` and
+    /// `div_euclid` agree whenever `self` is non-negative or divides `other`
+    /// evenly; they differ by exactly one only when `self` is negative and
+    /// `other` doesn't divide it evenly — the case where truncation and
+    /// flooring round to different integers.
+    ///
+    /// # Panics
+    ///
+    /// - `baml.panics.DivisionByZero` if `other` is zero.
+    /// - `baml.panics.IntegerOverflow` for `int.min_value().div_euclid(-1)`,
+    ///   whose mathematical result `2^62` is one past `int.max_value()` — the
+    ///   same single case `int.min_value() / -1` already panics on.
+    ///
+    /// # Examples
+    ///
+    /// ```baml
+    /// (7).div_euclid(3)     // 2   (same as 7 / 3)
+    /// (-7).div_euclid(3)    // -3  (7 / 3 truncates to -2)
+    /// (7).div_euclid(-3)    // -2
+    /// (-7).div_euclid(-3)   // 3   (-7 / -3 truncates to 2)
+    /// ```
+    //baml:fallible
+    function div_euclid(self, other: int) -> int throws never {
+        $rust_function
+    }
+
+    /// Returns the remainder of dividing `self` by `other`, always in
+    /// `[0, other.abs())` regardless of either operand's sign. Paired with
+    /// `div_euclid`; see that method for the identity they satisfy together.
+    ///
+    /// This differs from `%`, which takes the sign of the dividend and can be
+    /// negative: `(-7) % 3` is `-1`, but `(-7).rem_euclid(3)` is `2`. Use
+    /// `rem_euclid` for anything that treats the result as an index or an
+    /// offset into a cycle, where a negative remainder is a bug.
+    ///
+    /// # Panics
+    ///
+    /// - `baml.panics.DivisionByZero` if `other` is zero. Never overflows
+    ///   otherwise: the result satisfies `0 <= r < other.abs()`, and
+    ///   `other.abs()` is at most `2^62`, so `r` always fits in `int` — even
+    ///   `int.min_value().rem_euclid(-1)`, which is `0` because dividing by
+    ///   `1` or `-1` always leaves remainder `0`.
+    ///
+    /// # Examples
+    ///
+    /// ```baml
+    /// (7).rem_euclid(3)     // 1
+    /// (-7).rem_euclid(3)    // 2   ((-7) % 3 is -1; this is never negative)
+    /// (7).rem_euclid(-3)    // 1
+    /// (-7).rem_euclid(-3)   // 2
+    /// ```
+    //baml:fallible
+    function rem_euclid(self, other: int) -> int throws never {
+        $rust_function
+    }
+
     // ─── Bit operations ───────────────────────────────────────────────────────
     //
     // All bit operations interpret `int` as a 64-bit two's-complement value:

--- a/baml_language/crates/baml_tests/baml_src/ns_ints/ints.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_ints/ints.baml
@@ -573,6 +573,136 @@ test "int_ilog_base_negative_throws" {
     }
 }
 
+// ─── div_euclid / rem_euclid ────────────────────────────────────────────────────
+//
+// `div_euclid`/`rem_euclid` satisfy `a == a.div_euclid(b) * b + a.rem_euclid(b)`
+// with `0 <= a.rem_euclid(b) < b.abs()` always — unlike `/`/`%`, which truncate
+// toward zero and can leave a negative remainder.
+
+// The classic footgun this pair exists to fix: truncating `%` gives a negative
+// remainder for a negative dividend, which is wrong for anything treating the
+// result as an index or a position in a cycle.
+test "int_rem_euclid_negative_dividend_is_never_negative" {
+    assert.equal((-7) % 3, -1);              // truncating `%`: negative
+    assert.equal((-7).rem_euclid(3), 2)      // rem_euclid: never negative
+}
+
+test "int_div_euclid_positive_divides_evenly" {
+    assert.equal((7).div_euclid(3), 2);
+    assert.equal((7).rem_euclid(3), 1)
+}
+
+test "int_div_euclid_negative_dividend" {
+    assert.equal((-7).div_euclid(3), -3);
+    assert.equal((-7).rem_euclid(3), 2)
+}
+
+test "int_div_euclid_negative_divisor" {
+    assert.equal((7).div_euclid(-3), -2);
+    assert.equal((7).rem_euclid(-3), 1)
+}
+
+test "int_div_euclid_both_negative" {
+    assert.equal((-7).div_euclid(-3), 3);
+    assert.equal((-7).rem_euclid(-3), 2)
+}
+
+test "int_div_euclid_exact_division" {
+    assert.equal((8).div_euclid(4), 2);
+    assert.equal((-8).div_euclid(4), -2);
+    assert.equal((8).div_euclid(-4), -2);
+    assert.equal((-8).div_euclid(-4), 2);
+    // Exact division always has zero remainder, regardless of sign.
+    assert.equal((8).rem_euclid(4), 0);
+    assert.equal((-8).rem_euclid(4), 0);
+    assert.equal((8).rem_euclid(-4), 0);
+    assert.equal((-8).rem_euclid(-4), 0)
+}
+
+test "int_div_euclid_zero_dividend" {
+    assert.equal((0).div_euclid(5), 0);
+    assert.equal((0).rem_euclid(5), 0);
+    assert.equal((0).div_euclid(-5), 0);
+    assert.equal((0).rem_euclid(-5), 0)
+}
+
+test "int_div_euclid_by_one_and_negative_one" {
+    assert.equal((1).div_euclid(-1), -1);
+    assert.equal((1).rem_euclid(-1), 0);
+    assert.equal((-1).div_euclid(-1), 1);
+    assert.equal((-1).rem_euclid(-1), 0)
+}
+
+test "int_div_euclid_zero_divisor_panics" {
+    {
+        (10).div_euclid(0);
+        baml.sys.panic("expected (10).div_euclid(0) to panic")
+    } catch (e) {
+        baml.panics.DivisionByZero => null
+    }
+}
+
+test "int_rem_euclid_zero_divisor_panics" {
+    {
+        (10).rem_euclid(0);
+        baml.sys.panic("expected (10).rem_euclid(0) to panic")
+    } catch (e) {
+        baml.panics.DivisionByZero => null
+    }
+}
+
+// int.min_value() / -1 already panics (2^62 overflows int.max_value()) --
+// div_euclid must panic the same way rather than let a raw Rust panic escape.
+test "int_div_euclid_min_value_by_negative_one_panics" {
+    {
+        int.min_value().div_euclid(-1);
+        baml.sys.panic("expected int.min_value().div_euclid(-1) to panic")
+    } catch (e) {
+        baml.panics.IntegerOverflow => null
+    }
+}
+
+// rem_euclid has no equivalent overflow case: dividing by +-1 always leaves
+// remainder 0, so int.min_value().rem_euclid(-1) is fine.
+test "int_rem_euclid_min_value_by_negative_one_succeeds" {
+    assert.equal(int.min_value().rem_euclid(-1), 0)
+}
+
+test "int_div_euclid_min_value_by_one_succeeds" {
+    assert.equal(int.min_value().div_euclid(1), -4611686018427387904);
+    assert.equal(int.min_value().rem_euclid(1), 0)
+}
+
+test "int_div_euclid_max_value_by_negative_one_succeeds" {
+    // Unlike min_value(), max_value() / -1 fits (it's -max_value()).
+    assert.equal(int.max_value().div_euclid(-1), -4611686018427387903);
+    assert.equal(int.max_value().rem_euclid(-1), 0)
+}
+
+test "int_rem_euclid_bound_near_widest_divisor" {
+    // The widest possible dividend magnitude (int.min_value(), 2^62), divided
+    // by the largest positive divisor (int.max_value()): rem_euclid must
+    // still land in [0, int.max_value()), never overflowing int.
+    assert.equal(int.min_value().div_euclid(int.max_value()), -2);
+    assert.equal(int.min_value().rem_euclid(int.max_value()), 4611686018427387902)
+}
+
+// Two cases with int.min_value() as the *divisor* (2^62 in magnitude, the
+// widest possible divisor). Both are kept: the first is a trivial sanity
+// check (|5| < |int.min_value()|, so the remainder is just 5 and no sign
+// adjustment ever fires); the second, with a negative dividend, is the one
+// that actually exercises the euclidean sign-adjustment against the widest
+// possible divisor magnitude.
+test "int_div_euclid_divisor_is_min_value_trivial" {
+    assert.equal((5).div_euclid(int.min_value()), 0);
+    assert.equal((5).rem_euclid(int.min_value()), 5)
+}
+
+test "int_div_euclid_divisor_is_min_value_with_adjustment" {
+    assert.equal((-5).div_euclid(int.min_value()), 1);
+    assert.equal((-5).rem_euclid(int.min_value()), 4611686018427387899)
+}
+
 // ─── Bit operations ───────────────────────────────────────────────────────────
 
 test "int_leading_zeros_zero" {

--- a/baml_language/crates/baml_tests/baml_src/ns_ints/ints.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_ints/ints.baml
@@ -652,7 +652,9 @@ test "int_rem_euclid_zero_divisor_panics" {
 }
 
 // int.min_value() / -1 already panics (2^62 overflows int.max_value()) --
-// div_euclid must panic the same way rather than let a raw Rust panic escape.
+// div_euclid must panic the same way. The underlying i64 computation itself
+// succeeds fine (2^62 fits i64); it's BAML's tighter i63 range that requires
+// the guard, not an i64-level overflow.
 test "int_div_euclid_min_value_by_negative_one_panics" {
     {
         int.min_value().div_euclid(-1);

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_ints/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_ints/bytecode.snap
@@ -536,281 +536,400 @@ function ints.$init_test_ns_ints_ints(registry: testing.TestCollector) -> null {
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_leading_zeros_zero"
+    load_const "int_rem_euclid_negative_dividend_is_never_negative"
     make_closure .<lambda($init_test_ns_ints_ints, 76)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_leading_zeros_one"
+    load_const "int_div_euclid_positive_divides_evenly"
     make_closure .<lambda($init_test_ns_ints_ints, 77)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_leading_zeros_negative_one_is_zero"
+    load_const "int_div_euclid_negative_dividend"
     make_closure .<lambda($init_test_ns_ints_ints, 78)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_leading_zeros_large_power_of_two"
+    load_const "int_div_euclid_negative_divisor"
     make_closure .<lambda($init_test_ns_ints_ints, 79)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_leading_ones_zero"
+    load_const "int_div_euclid_both_negative"
     make_closure .<lambda($init_test_ns_ints_ints, 80)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_leading_ones_negative_one"
+    load_const "int_div_euclid_exact_division"
     make_closure .<lambda($init_test_ns_ints_ints, 81)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_zeros_zero"
+    load_const "int_div_euclid_zero_dividend"
     make_closure .<lambda($init_test_ns_ints_ints, 82)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_zeros_one"
+    load_const "int_div_euclid_by_one_and_negative_one"
     make_closure .<lambda($init_test_ns_ints_ints, 83)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_zeros_eight"
+    load_const "int_div_euclid_zero_divisor_panics"
     make_closure .<lambda($init_test_ns_ints_ints, 84)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_ones_zero"
+    load_const "int_rem_euclid_zero_divisor_panics"
     make_closure .<lambda($init_test_ns_ints_ints, 85)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_ones_seven"
+    load_const "int_div_euclid_min_value_by_negative_one_panics"
     make_closure .<lambda($init_test_ns_ints_ints, 86)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_ones_negative_one"
+    load_const "int_rem_euclid_min_value_by_negative_one_succeeds"
     make_closure .<lambda($init_test_ns_ints_ints, 87)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_count_zeros_of_zero"
+    load_const "int_div_euclid_min_value_by_one_succeeds"
     make_closure .<lambda($init_test_ns_ints_ints, 88)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_count_zeros_of_negative_one"
+    load_const "int_div_euclid_max_value_by_negative_one_succeeds"
     make_closure .<lambda($init_test_ns_ints_ints, 89)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_count_ones_of_zero"
+    load_const "int_rem_euclid_bound_near_widest_divisor"
     make_closure .<lambda($init_test_ns_ints_ints, 90)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_count_ones_of_seven"
+    load_const "int_div_euclid_divisor_is_min_value_trivial"
     make_closure .<lambda($init_test_ns_ints_ints, 91)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_count_ones_of_negative_one"
+    load_const "int_div_euclid_divisor_is_min_value_with_adjustment"
     make_closure .<lambda($init_test_ns_ints_ints, 92)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_count_zeros_plus_count_ones_equals_64"
+    load_const "int_leading_zeros_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 93)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_add_at_max_boundary_no_overflow"
+    load_const "int_leading_zeros_one"
     make_closure .<lambda($init_test_ns_ints_ints, 94)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_sub_at_min_boundary_no_overflow"
+    load_const "int_leading_zeros_negative_one_is_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 95)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_mul_max_by_one_no_overflow"
+    load_const "int_leading_zeros_large_power_of_two"
     make_closure .<lambda($init_test_ns_ints_ints, 96)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_mul_min_by_one_no_overflow"
+    load_const "int_leading_ones_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 97)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_abs_bare_literal"
+    load_const "int_leading_ones_negative_one"
     make_closure .<lambda($init_test_ns_ints_ints, 98)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_to_string_bare_literal"
+    load_const "int_trailing_zeros_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 99)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_literal"
+    load_const "int_trailing_zeros_one"
     make_closure .<lambda($init_test_ns_ints_ints, 100)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_lowercase_digits"
+    load_const "int_trailing_zeros_eight"
     make_closure .<lambda($init_test_ns_ints_ints, 101)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_mixed_case_digits"
+    load_const "int_trailing_ones_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 102)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_octal_literal"
+    load_const "int_trailing_ones_seven"
     make_closure .<lambda($init_test_ns_ints_ints, 103)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_binary_literal"
+    load_const "int_trailing_ones_negative_one"
     make_closure .<lambda($init_test_ns_ints_ints, 104)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_prefixed_zero"
+    load_const "int_count_zeros_of_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 105)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_negative_prefixed"
+    load_const "int_count_zeros_of_negative_one"
     make_closure .<lambda($init_test_ns_ints_ints, 106)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_underscore_separators"
+    load_const "int_count_ones_of_zero"
     make_closure .<lambda($init_test_ns_ints_ints, 107)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_trailing_underscore"
+    load_const "int_count_ones_of_seven"
     make_closure .<lambda($init_test_ns_ints_ints, 108)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_underscores"
+    load_const "int_count_ones_of_negative_one"
     make_closure .<lambda($init_test_ns_ints_ints, 109)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_binary_underscores"
+    load_const "int_count_zeros_plus_count_ones_equals_64"
     make_closure .<lambda($init_test_ns_ints_ints, 110)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_octal_underscores"
+    load_const "int_add_at_max_boundary_no_overflow"
     make_closure .<lambda($init_test_ns_ints_ints, 111)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_underscore_after_prefix"
+    load_const "int_sub_at_min_boundary_no_overflow"
     make_closure .<lambda($init_test_ns_ints_ints, 112)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_max_value"
+    load_const "int_mul_max_by_one_no_overflow"
     make_closure .<lambda($init_test_ns_ints_ints, 113)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_bitwise"
+    load_const "int_mul_min_by_one_no_overflow"
     make_closure .<lambda($init_test_ns_ints_ints, 114)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.ints"
-    load_const "int_hex_bare_literal_method"
+    load_const "int_abs_bare_literal"
     make_closure .<lambda($init_test_ns_ints_ints, 115)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_to_string_bare_literal"
+    make_closure .<lambda($init_test_ns_ints_ints, 116)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_literal"
+    make_closure .<lambda($init_test_ns_ints_ints, 117)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_lowercase_digits"
+    make_closure .<lambda($init_test_ns_ints_ints, 118)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_mixed_case_digits"
+    make_closure .<lambda($init_test_ns_ints_ints, 119)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_octal_literal"
+    make_closure .<lambda($init_test_ns_ints_ints, 120)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_binary_literal"
+    make_closure .<lambda($init_test_ns_ints_ints, 121)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_prefixed_zero"
+    make_closure .<lambda($init_test_ns_ints_ints, 122)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_negative_prefixed"
+    make_closure .<lambda($init_test_ns_ints_ints, 123)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_underscore_separators"
+    make_closure .<lambda($init_test_ns_ints_ints, 124)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_trailing_underscore"
+    make_closure .<lambda($init_test_ns_ints_ints, 125)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_underscores"
+    make_closure .<lambda($init_test_ns_ints_ints, 126)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_binary_underscores"
+    make_closure .<lambda($init_test_ns_ints_ints, 127)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_octal_underscores"
+    make_closure .<lambda($init_test_ns_ints_ints, 128)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_underscore_after_prefix"
+    make_closure .<lambda($init_test_ns_ints_ints, 129)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_max_value"
+    make_closure .<lambda($init_test_ns_ints_ints, 130)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_bitwise"
+    make_closure .<lambda($init_test_ns_ints_ints, 131)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.ints"
+    load_const "int_hex_bare_literal_method"
+    make_closure .<lambda($init_test_ns_ints_ints, 132)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -823,6 +823,9 @@ function baml.Int.count_ones(self: int) -> int {
 function baml.Int.count_zeros(self: int) -> int {
 }
 
+function baml.Int.div_euclid(self: int, other: int) -> int {
+}
+
 function baml.Int.ilog(self: int, base: int) -> int {
 }
 
@@ -908,6 +911,9 @@ function baml.Int.random(lower: int, upper: int, rng: baml.random.Rng) -> int {
     bin_op +
     init_instance baml.errors.InvalidArgument .message
     throw
+}
+
+function baml.Int.rem_euclid(self: int, other: int) -> int {
 }
 
 function baml.Int.trailing_ones(self: int) -> int {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -1251,6 +1251,10 @@ fn baml.Int.pow = builtin(vm)
 
 fn baml.Int.ilog = builtin(vm)
 
+fn baml.Int.div_euclid = builtin(vm)
+
+fn baml.Int.rem_euclid = builtin(vm)
+
 fn baml.Int.leading_zeros = builtin(vm)
 
 fn baml.Int.leading_ones = builtin(vm)

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
@@ -219,6 +219,7 @@ function baml._random_in_range(draw: int, lower: int, upper: int) -> int  [built
 function baml.abs(self: ?) -> int  [builtin]
 function baml.count_ones(self: ?) -> int  [builtin]
 function baml.count_zeros(self: ?) -> int  [builtin]
+function baml.div_euclid(self: ?, other: int) -> int  [builtin]
 function baml.ilog(self: ?, base: int) -> int  [builtin]
 function baml.isqrt(self: ?) -> int  [builtin]
 function baml.leading_ones(self: ?) -> int  [builtin]
@@ -234,6 +235,7 @@ function baml.pow(self: ?, exp: int) -> int  [builtin]
 function baml.random(lower: int, upper: int, rng: root.random.Rng = root.random.SystemRandom.get()) -> int  [expr] {
   { if (lower Ge upper) { throw root.errors.InvalidArgument { message: `...` } }; let r = int._random_in_range(rng.random_int(), lower, upper); while r Eq upper { r = int._random_in_range(rng.random_int(), lower, upper) } } r
 }
+function baml.rem_euclid(self: ?, other: int) -> int  [builtin]
 function baml.trailing_ones(self: ?) -> int  [builtin]
 function baml.trailing_zeros(self: ?) -> int  [builtin]
 

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -10,7 +10,7 @@ namespace baml:
   class Float { methods: [is_nan, is_infinite, is_finite, abs, signum, floor, ceil, round, trunc, fract, ifloor, iceil, iround, itrunc, sqrt, pow, log, exp, ln, log2, log10, cbrt, hypot, sin, cos, tan, asin, acos, atan, atan2, sinh, cosh, tanh, asinh, acosh, atanh, to_radians, to_degrees, parse, random, _unit_from_draw, pi, e, golden_ratio, nan, inf, max_finite, min_finite, epsilon] }
   type FloatStats
   type FromJson
-  class Int { methods: [abs, isqrt, pow, ilog, leading_zeros, leading_ones, trailing_zeros, trailing_ones, count_zeros, count_ones, parse, random, _random_in_range, max_value, min_value] }
+  class Int { methods: [abs, isqrt, pow, ilog, div_euclid, rem_euclid, leading_zeros, leading_ones, trailing_zeros, trailing_ones, count_zeros, count_ones, parse, random, _random_in_range, max_value, min_value] }
   class Map<K, V> { methods: [length, has, keys, values, set, get, delete, get_or_insert, clear] }
   class Null { methods: [] }
   type Sortable

--- a/baml_language/crates/bex_vm/src/package_baml/int.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/int.rs
@@ -131,6 +131,43 @@ impl BamlClassInt for PackageBamlImpl {
         })))
     }
 
+    fn div_euclid(int: i64, other: i64) -> Result<i64, VmRustFnError> {
+        if other == 0 {
+            return Err(VmPanic::DivisionByZero {
+                left: Value::int(int),
+                right: Value::int(other),
+            }
+            .into());
+        }
+        // `i64::div_euclid` panics on exactly these two conditions: a zero
+        // divisor (checked above), or `Value::INT_MIN.div_euclid(-1)` (Rust's
+        // own documented overflow case, identical to plain `/`'s
+        // `INT_MIN / -1`). Precheck both so a raw Rust panic never reaches the
+        // VM; only a `VmPanic` should.
+        if int == Value::INT_MIN && other == -1 {
+            return Err(VmPanic::IntegerOverflow {
+                message: format!("{int}.div_euclid({other}) overflows int"),
+            }
+            .into());
+        }
+        Ok(int.div_euclid(other))
+    }
+
+    fn rem_euclid(int: i64, other: i64) -> Result<i64, VmRustFnError> {
+        if other == 0 {
+            return Err(VmPanic::DivisionByZero {
+                left: Value::int(int),
+                right: Value::int(other),
+            }
+            .into());
+        }
+        // Never overflows once the zero-divisor case is out of the way: the
+        // result satisfies 0 <= r < |other|, and |other| <= 2^62, so r always
+        // fits i63 — including `Value::INT_MIN.rem_euclid(-1)` (`0`, since
+        // dividing by ±1 always leaves remainder 0).
+        Ok(int.rem_euclid(other))
+    }
+
     // ── Bit operations ────────────────────────────────────────────────────────
 
     fn leading_zeros(int: i64) -> i64 {

--- a/baml_language/crates/bex_vm/src/package_baml/int.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/int.rs
@@ -139,11 +139,13 @@ impl BamlClassInt for PackageBamlImpl {
             }
             .into());
         }
-        // `i64::div_euclid` panics on exactly these two conditions: a zero
-        // divisor (checked above), or `Value::INT_MIN.div_euclid(-1)` (Rust's
-        // own documented overflow case, identical to plain `/`'s
-        // `INT_MIN / -1`). Precheck both so a raw Rust panic never reaches the
-        // VM; only a `VmPanic` should.
+        // `Value::INT_MIN` is `-2^62`, not `i64::MIN` (`-2^63`), so
+        // `Value::INT_MIN.div_euclid(-1)` fits comfortably in `i64` — the
+        // underlying primitive does not panic here. The guard exists because
+        // its result, `2^62`, is one past `Value::INT_MAX` and therefore not
+        // representable as a BAML `int` — the same i63 reason `abs()`'s
+        // guard above exists, not an i64-level overflow. Matches plain `/`'s
+        // existing `INT_MIN / -1` panic for the same underlying reason.
         if int == Value::INT_MIN && other == -1 {
             return Err(VmPanic::IntegerOverflow {
                 message: format!("{int}.div_euclid({other}) overflows int"),


### PR DESCRIPTION
## What's added

Two `int` methods, native (`$rust_function`), matching this file's existing convention for arithmetic (`abs`, `isqrt`, `pow`, `ilog` are all native — unlike `float.baml`, `int.baml` has no pure-BAML preference to honor):

| Method | Signature | Panics |
|---|---|---|
| `div_euclid` | `(self, other: int) -> int` | `DivisionByZero`; `IntegerOverflow` only for `int.min_value().div_euclid(-1)` |
| `rem_euclid` | `(self, other: int) -> int` | `DivisionByZero` only — never overflows |

## Why these two, not the other 25 from the audit

From the earlier stdlib gap audit (27 unblocked int candidates), `div_euclid`/`rem_euclid` fix a real footgun: BAML's `%` truncates toward the dividend's sign, so `(-7) % 3` is `-1` — wrong for anything treating the result as an index or a position in a cycle. `rem_euclid` is always in `[0, |other|)`.

`abs_diff` was also recommended `keep` in that audit, but is left out of this PR: on inspection, BAML's `int` has no unsigned companion type to widen into (unlike Rust's `i64::abs_diff() -> u64`), so a dedicated `abs_diff` fails in exactly the same cases a hand-written `(a - b).abs()` would — it adds call-site convenience, not capability. Filing separately if there's appetite for it on those narrower terms.

Everything else in the batch was `cut` or `unsure`: the `checked_*`/`saturating_*`/`wrapping_*` families are redundant with BAML's existing typed-panic-on-overflow model (and `wrapping_*` would be outright wrong here — BAML's `int` wraps at 2^62, not the 2^32/2^64 boundaries every real wrapping-arithmetic use case, e.g. hashing, actually wants); the bit-manipulation family (`rotate_*`, `reverse_bits`, `swap_bytes`) belongs to `baml.crypto`/`uint8array` territory that already has native coverage; `signum`/`is_positive`/`is_negative` are one-line comparisons; `gcd`/`lcm`/`ilog2`/`ilog10`/`is_power_of_two`/`next_power_of_two`/`midpoint` had no concrete BAML caller and, for the `ilog2`/`ilog10` case specifically, no precision argument either — `ilog(2)`/`ilog(10)` are already exact.

## Correctness notes worth a reviewer's eye

**`div_euclid`'s overflow precondition is checked explicitly**, but not because the underlying `i64::div_euclid` panics for that input — it doesn't. `Value::INT_MIN` is `-2^62`, not `i64::MIN` (`-2^63`), so `Value::INT_MIN.div_euclid(-1)` computes cleanly to `2^62` at the `i64` level (verified by compiling and running it directly). The guard exists because `2^62` is one past `Value::INT_MAX` and doesn't fit BAML's i63 `int` — the same reason `abs()`'s existing guard exists in this file, not an i64-level overflow. The Rust implementation prechecks `int == Value::INT_MIN && other == -1` before calling the stdlib method, matching that existing `abs`/`/` pattern.

**`rem_euclid` never overflows**, by construction: the result satisfies `0 <= r < |other|`, and `|other|` is at most `2^62`, so `r` always fits `int` — including the widest possible divisor, `int.min_value()`.

## Test coverage

17 new BAML-level tests in `ns_ints/ints.baml` (`root.ints`), covering the classic `-7 % 3` footgun case explicitly contrasted with `rem_euclid`, all four sign combinations, exact division, zero dividend, division by `±1`, both panic conditions (`DivisionByZero`, and `min_value().div_euclid(-1)` specifically), the widest-dividend case (`int.min_value()` against `int.max_value()`), and two widest-*divisor* cases (`other = int.min_value()`) — one trivial (`|5| < |int.min_value()|`, no sign adjustment fires) and one that actually exercises the euclidean sign-adjustment against the widest possible divisor magnitude (a negative dividend, where the adjustment shifts the quotient and produces a remainder just under `2^62`).

Test values were computed independently in Python — using two structurally different derivations for the boundary cases, cross-checked against each other — and checked against Rust's own documented `div_euclid`/`rem_euclid` semantics before being written into assertions, not hand-derived in place.

```
root.ints (BAML-level):                     133 passed, 0 failed
Full BAML corpus:                           3606 passed, 0 real failures (2 pre-existing unrelated tolerated fixtures)
cargo test -p baml_builtins2_codegen --lib:  31 passed, 0 failed
cargo test -p baml_bridge --lib:             33 passed, 0 failed
cargo test -p baml_cli --lib (snapshot):      1 passed, 0 failed
cargo test -p baml_tests --lib (2 snapshots): 2 passed, 0 failed
cargo fmt --check:                           clean
```

4 insta snapshots regenerated (`ppir.snap`, `mir.snap`, `stdlib/bytecode.snap`, `ns_ints/bytecode.snap`) — the two new methods change the rendered stdlib listing, same drift pattern as the earlier float stdlib PR (#4751).

Investigated and implemented with AI-assisted tooling, reviewed and verified by me before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmU8doXq5VDwN9WrVrDjGv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Euclidean integer division with `div_euclid`.
  * Added non-negative Euclidean remainder calculation with `rem_euclid`.
  * Division by zero and supported overflow cases now produce explicit panics.

* **Documentation**
  * Clarified quotient, remainder, rounding behavior, and valid result ranges for Euclidean operations.

* **Tests**
  * Added coverage for positive and negative operands, boundary values, exact division, zero, unit divisors, and exceptional cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
