### PR TITLE
Improve generated developer reference discovery and readability

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1804,8 +1804,9 @@ jobs:
     name: Promote verified release channel manifest
     # Keep the mutable canary/nightly pointer on the preceding known-good
     # release until every publisher completes and the public Go and Swift
-    # packages execute their native runtimes successfully.
-    needs: [plan, publish-pkg-boundaryml-com, release-complete, smoke-go-release, smoke-swift-release]
+    # packages execute their native runtimes successfully, and until the
+    # matching developer reference is published and live.
+    needs: [plan, publish-pkg-boundaryml-com, release-complete, smoke-go-release, smoke-swift-release, deploy-developer-docs]
     if: >-
       ${{
         !cancelled() &&
@@ -1814,6 +1815,7 @@ jobs:
         needs.release-complete.result == 'success' &&
         needs.smoke-go-release.result == 'success' &&
         needs.smoke-swift-release.result == 'success' &&
+        needs.deploy-developer-docs.result == 'success' &&
         needs.plan.outputs.dry_run == 'false' &&
         needs.plan.outputs.source_branch == 'canary'
       }}
@@ -1847,12 +1849,15 @@ jobs:
     # every release smoke test. The publication is transactional and
     # idempotent: reruns verify immutable rows before touching the channel
     # pointer.
-    needs: [plan, publish-pkg-channel]
+    needs: [plan, publish-pkg-boundaryml-com, release-complete, smoke-go-release, smoke-swift-release]
     if: >-
       ${{
         !cancelled() &&
         needs.plan.result == 'success' &&
-        needs.publish-pkg-channel.result == 'success' &&
+        needs.publish-pkg-boundaryml-com.result == 'success' &&
+        needs.release-complete.result == 'success' &&
+        needs.smoke-go-release.result == 'success' &&
+        needs.smoke-swift-release.result == 'success' &&
         needs.plan.outputs.dry_run == 'false' &&
         needs.plan.outputs.source_branch == 'canary'
       }}
@@ -2306,5 +2311,5 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
           VERSION: ${{ needs.plan.outputs.version }}
           CHANNEL: ${{ needs.plan.outputs.channel }}
-          RELEASE_SUCCEEDED: ${{ needs.deploy-developer-docs.result == 'success' }}
+          RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}
         run: uv run --script tools/notify-release-failure.py

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1841,6 +1841,138 @@ jobs:
             --content-type application/json \
             --cache-control "public, max-age=60, must-revalidate"
 
+  publish-developer-docs:
+    name: Publish generated developer documentation
+    # Generate documentation from the exact wrapper + toolchain that survived
+    # every release smoke test. The publication is transactional and
+    # idempotent: reruns verify immutable rows before touching the channel
+    # pointer.
+    needs: [plan, publish-pkg-channel]
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.publish-pkg-channel.result == 'success' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
+    runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.plan.outputs.source_sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node2
+      - name: Require the generated-content writer credential
+        env:
+          GENERATED_CONTENT_DATABASE_URL: ${{ secrets.GENERATED_CONTENT_DATABASE_WRITE_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GENERATED_CONTENT_DATABASE_URL" ]]; then
+            echo "::error::GENERATED_CONTENT_DATABASE_WRITE_URL is not configured"
+            exit 1
+          fi
+      - name: Install the exact published BAML toolchain
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          export BAML_HOME="$RUNNER_TEMP/developer-docs-baml"
+          scripts/install.sh --version "$VERSION" --no-modify-path
+          baml_binary="$BAML_HOME/bin/baml"
+          actual_version="$("$baml_binary" --version | sed -n 's/^baml toolchain \([^ ]*\).*/\1/p')"
+          if [[ "$actual_version" != "$VERSION" ]]; then
+            echo "::error::installed BAML toolchain is $actual_version, expected $VERSION"
+            exit 1
+          fi
+          echo "BAML_BINARY=$baml_binary" >> "$GITHUB_ENV"
+          echo "BAML_HOME=$BAML_HOME" >> "$GITHUB_ENV"
+      - name: Publish and verify the immutable documentation snapshot
+        working-directory: typescript2/app-developer-docs
+        env:
+          CHANNEL: ${{ needs.plan.outputs.channel }}
+          DEVELOPER_DOCS_DATABASE_CONTEXT: production
+          GENERATED_CONTENT_DATABASE_URL: ${{ secrets.GENERATED_CONTENT_DATABASE_WRITE_URL }}
+          RELEASED_AT: ${{ needs.plan.outputs.released_at }}
+          SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          pnpm exec tsx scripts/populate-generated-content.ts \
+            --baml-bin "$BAML_BINARY" \
+            --source-commit "$SOURCE_SHA" \
+            --released-at "$RELEASED_AT" \
+            --channel "$CHANNEL" \
+            --organization boundaryml \
+            --database developer-docs \
+            --branch main \
+            --production
+          pnpm exec tsx scripts/verify-generated-content.ts \
+            --version "$VERSION"
+
+  deploy-developer-docs:
+    name: Rebuild developer.boundaryml.com
+    # The site is a static export. Rebuild the current production deployment
+    # after the database transaction commits so package, CLI, search, and
+    # sitemap outputs all observe the same snapshot. Redeploying the existing
+    # production deployment also decouples site code from this release checkout.
+    needs: [plan, publish-developer-docs]
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.plan.result == 'success' &&
+        needs.publish-developer-docs.result == 'success' &&
+        needs.plan.outputs.dry_run == 'false' &&
+        needs.plan.outputs.source_branch == 'canary'
+      }}
+    runs-on: ubuntu-latest
+    environment: infisical-github-baml-language-release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - name: Redeploy the production developer site
+        env:
+          VERCEL_ORG_ID: ${{ vars.DEVELOPER_DOCS_VERCEL_ORG_ID }}
+          VERCEL_TELEMETRY_DISABLED: "1"
+          VERCEL_TOKEN: ${{ secrets.DEVELOPER_DOCS_VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$VERCEL_ORG_ID" ]]; then
+            echo "::error::DEVELOPER_DOCS_VERCEL_ORG_ID is not configured"
+            exit 1
+          fi
+          if [[ -z "$VERCEL_TOKEN" ]]; then
+            echo "::error::DEVELOPER_DOCS_VERCEL_TOKEN is not configured"
+            exit 1
+          fi
+          npx --yes vercel@59.11.2 redeploy developer.boundaryml.com \
+            --target production \
+            --scope "$VERCEL_ORG_ID" \
+            --token "$VERCEL_TOKEN"
+      - name: Verify the released reference is live
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          url="https://developer.boundaryml.com/baml/packages/$VERSION"
+          for attempt in $(seq 1 12); do
+            if curl --fail --silent --show-error --location "$url" >/dev/null; then
+              echo "Published developer reference is live: $url"
+              exit 0
+            fi
+            if [[ "$attempt" -lt 12 ]]; then
+              sleep 5
+            fi
+          done
+          echo "::error::released developer reference did not become available: $url"
+          exit 1
+
   publish-homebrew:
     name: Publish Homebrew wrapper formula
     needs: [plan, all-builds, publish-wrapper-release]
@@ -2142,6 +2274,8 @@ jobs:
       - release-prerequisites-complete
       - release-complete
       - publish-pkg-channel
+      - publish-developer-docs
+      - deploy-developer-docs
       - smoke-swift-release
       - verify-release
     # Use the dispatch input so a failure in plan itself is still reportable.
@@ -2172,5 +2306,5 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
           VERSION: ${{ needs.plan.outputs.version }}
           CHANNEL: ${{ needs.plan.outputs.channel }}
-          RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}
+          RELEASE_SUCCEEDED: ${{ needs.deploy-developer-docs.result == 'success' }}
         run: uv run --script tools/notify-release-failure.py

--- a/typescript2/app-developer-docs/app/baml/packages/[version]/[...fqn]/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/[version]/[...fqn]/page.tsx
@@ -3,12 +3,18 @@ import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import {
   GeneratedReferenceContent,
+  type ReferenceChildLink,
   referencePageTableOfContents,
 } from '@/components/generated-reference';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { directRouteChildren } from '@/lib/generated-content/routes';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
@@ -32,7 +38,20 @@ async function loadPage(version: string, fqn: readonly string[]) {
   const page = snapshot?.pages.find(
     (candidate) => candidate.route_path === routePath,
   );
-  return page ?? null;
+  return page && snapshot ? { page, snapshot } : null;
+}
+
+function directNamespacedChildren(
+  routePath: string,
+  pages: NonNullable<
+    Awaited<ReturnType<typeof loadGeneratedReleaseSnapshot>>
+  >['pages'],
+): ReferenceChildLink[] {
+  return directRouteChildren(routePath, pages).map((candidate) => ({
+    page_kind: candidate.page_kind,
+    qualified_name: candidate.qualified_name,
+    route_path: candidate.route_path,
+  }));
 }
 
 export async function generateMetadata({
@@ -41,14 +60,18 @@ export async function generateMetadata({
   params: Promise<{ fqn: string[]; version: string }>;
 }): Promise<Metadata> {
   const { fqn, version } = await params;
-  const page = await loadPage(version, fqn);
-  if (!page) return {};
-  return {
-    description:
-      page.page_data.summary ??
-      `${page.page_kind} reference for ${page.qualified_name}.`,
+  const loaded = await loadPage(version, fqn);
+  if (!loaded) return {};
+  const { page, snapshot } = loaded;
+  const description =
+    page.page_data.summary ??
+    `${page.page_kind} reference for ${page.qualified_name}.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/baml/packages/${version}/${fqn.join('/')}`,
     title: `${page.qualified_name} — ${version}`,
-  };
+  });
 }
 
 export default async function ReferencePage({
@@ -57,8 +80,17 @@ export default async function ReferencePage({
   params: Promise<{ fqn: string[]; version: string }>;
 }) {
   const { fqn, version } = await params;
-  const page = await loadPage(version, fqn);
-  if (!page) notFound();
+  const loaded = await loadPage(version, fqn);
+  if (!loaded) notFound();
+  const { page, snapshot } = loaded;
+  const namespacedChildren =
+    page.page_kind === 'package' || page.page_kind === 'namespace'
+      ? []
+      : directNamespacedChildren(page.route_path, snapshot.pages);
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'package',
+    routePath: page.route_path,
+  });
   const qualifiedParts = page.qualified_name.split('.');
   const breadcrumbs = [
     { href: '/baml', label: 'BAML' },
@@ -83,9 +115,14 @@ export default async function ReferencePage({
         `${page.page_kind} in the ${page.page_data.package_name} package.`
       }
       title={page.qualified_name}
-      toc={referencePageTableOfContents(page.page_data)}
+      toc={referencePageTableOfContents(page.page_data, namespacedChildren)}
     >
-      <GeneratedReferenceContent page={page.page_data} routeVersion={version} />
+      <GeneratedVersionSwitcher options={versionOptions} />
+      <GeneratedReferenceContent
+        namespacedChildren={namespacedChildren}
+        page={page.page_data}
+        routeVersion={version}
+      />
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/app/baml/packages/[version]/[...fqn]/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/[version]/[...fqn]/page.tsx
@@ -12,7 +12,10 @@ import {
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
-import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import {
+  generatedDeclarationTypeReferences,
+  listGeneratedVersionOptions,
+} from '@/lib/generated-content/discovery';
 import { directRouteChildren } from '@/lib/generated-content/routes';
 import { documentationMetadata } from '@/lib/metadata';
 
@@ -91,6 +94,7 @@ export default async function ReferencePage({
     kind: 'package',
     routePath: page.route_path,
   });
+  const typeReferences = generatedDeclarationTypeReferences(snapshot.pages);
   const qualifiedParts = page.qualified_name.split('.');
   const breadcrumbs = [
     { href: '/baml', label: 'BAML' },
@@ -114,14 +118,16 @@ export default async function ReferencePage({
         page.page_data.summary ??
         `${page.page_kind} in the ${page.page_data.package_name} package.`
       }
+      headerControls={<GeneratedVersionSwitcher options={versionOptions} />}
       title={page.qualified_name}
       toc={referencePageTableOfContents(page.page_data, namespacedChildren)}
+      wideContent
     >
-      <GeneratedVersionSwitcher options={versionOptions} />
       <GeneratedReferenceContent
         namespacedChildren={namespacedChildren}
         page={page.page_data}
         routeVersion={version}
+        typeReferences={typeReferences}
       />
     </DocsShell>
   );

--- a/typescript2/app-developer-docs/app/baml/packages/[version]/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/[version]/page.tsx
@@ -2,16 +2,40 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { DocsShell } from '@/components/docs-shell';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const versions = await listGeneratedReleaseRouteVersions();
   return versions.map((version) => ({ version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ version: string }>;
+}) {
+  const { version } = await params;
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  if (!snapshot) return {};
+  const channelLabel = snapshot.channels.length
+    ? ` (${snapshot.channels.join(', ')})`
+    : '';
+  const description = `Immutable package reference generated from BAML ${snapshot.release.version}${channelLabel}.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/baml/packages/${version}`,
+    title: `Standard packages ${version}`,
+  });
 }
 
 export default async function PackageVersionPage({
@@ -28,6 +52,9 @@ export default async function PackageVersionPage({
   const channelLabel = snapshot.channels.length
     ? ` (${snapshot.channels.join(', ')})`
     : '';
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'package',
+  });
 
   return (
     <DocsShell
@@ -43,6 +70,7 @@ export default async function PackageVersionPage({
         { href: '#release', label: 'Release provenance' },
       ]}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="packages">Packages</h2>
       <ul>
         {packagePages.map((page) => (

--- a/typescript2/app-developer-docs/app/baml/packages/[version]/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/[version]/page.tsx
@@ -64,13 +64,13 @@ export default async function PackageVersionPage({
         { label: version },
       ]}
       description={`Immutable package reference generated from BAML ${snapshot.release.version}${channelLabel}.`}
+      headerControls={<GeneratedVersionSwitcher options={versionOptions} />}
       title={`Standard packages ${version}`}
       toc={[
         { href: '#packages', label: 'Packages' },
         { href: '#release', label: 'Release provenance' },
       ]}
     >
-      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="packages">Packages</h2>
       <ul>
         {packagePages.map((page) => (

--- a/typescript2/app-developer-docs/app/baml/packages/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/page.tsx
@@ -1,27 +1,27 @@
+import Link from 'next/link';
+
 import { DocsShell } from '@/components/docs-shell';
+import { GeneratedReleaseCatalog } from '@/components/generated-release-catalog';
+import {
+  listGeneratedReleaseSummaries,
+  loadGeneratedReleaseSnapshot,
+  selectFeaturedGeneratedRelease,
+} from '@/lib/generated-content/build-content';
+import { documentationMetadata } from '@/lib/metadata';
 
-export const metadata = {
+export const metadata = documentationMetadata({
   description: 'Versioned reference for BAML standard packages.',
+  path: '/baml/packages',
   title: 'Standard packages',
-};
+});
 
-const packages = [
-  'baml',
-  'reflect',
-  'boundary',
-  'testing',
-  'assert',
-  'log',
-  'ai',
-  'openai',
-  'anthropic',
-  'google',
-  'aws',
-  'vercel',
-  'claude_code',
-];
+export default async function PackagesPage() {
+  const releases = await listGeneratedReleaseSummaries();
+  const featuredRelease = selectFeaturedGeneratedRelease(releases);
+  const featured = featuredRelease
+    ? await loadGeneratedReleaseSnapshot(featuredRelease.routeVersion)
+    : null;
 
-export default function PackagesPage() {
   return (
     <DocsShell
       breadcrumbs={[
@@ -30,26 +30,23 @@ export default function PackagesPage() {
       ]}
       description="Versioned package reference generated from the exact compiled BAML toolchain."
       title="Standard packages"
-      toc={[
-        { href: '#published', label: 'Published versions' },
-        { href: '#packages', label: 'Package catalog' },
-      ]}
+      toc={[{ href: '#published', label: 'Published reference' }]}
     >
-      <h2 id="published">Published versions</h2>
+      <h2 id="published">Published reference</h2>
       <p>
-        Exact-version pages will appear after their complete immutable package
-        and CLI records are published. Canary and nightly snapshots will be
-        labeled explicitly and will never be presented as stable.
+        Choose a published release to browse reference generated from that exact
+        BAML toolchain. Exact-version URLs never move or silently fall forward
+        to another release.
       </p>
-      <h2 id="packages">Package catalog</h2>
-      <p>The initial publication allowlist contains:</p>
-      <ul className="columns-2 sm:columns-3">
-        {packages.map((packageName) => (
-          <li key={packageName}>
-            <code>{packageName}</code>
-          </li>
-        ))}
-      </ul>
+      <GeneratedReleaseCatalog
+        featured={featured}
+        product="packages"
+        releases={releases}
+      />
+      <p>
+        Use the <Link href="/changelog">changelog</Link> to review language,
+        toolchain, and package changes between releases.
+      </p>
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/app/baml/packages/page.tsx
+++ b/typescript2/app-developer-docs/app/baml/packages/page.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 import { DocsShell } from '@/components/docs-shell';
 import { GeneratedReleaseCatalog } from '@/components/generated-release-catalog';
 import {
@@ -43,10 +41,6 @@ export default async function PackagesPage() {
         product="packages"
         releases={releases}
       />
-      <p>
-        Use the <Link href="/changelog">changelog</Link> to review language,
-        toolchain, and package changes between releases.
-      </p>
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/app/cli/[version]/commands/[...command]/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/commands/[...command]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import { CliCommandContent } from '@/components/generated-cli';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
@@ -10,6 +12,8 @@ import {
   findCliCommand,
   flattenCliCommands,
 } from '@/lib/generated-content/cli-routes';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
@@ -43,11 +47,15 @@ export async function generateMetadata({
   const { command, version } = await params;
   const commandNode = await loadCommand(version, command);
   if (!commandNode) return {};
-  return {
-    description:
-      commandNode.description ?? `Reference for baml ${command.join(' ')}.`,
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  const description =
+    commandNode.description ?? `Reference for baml ${command.join(' ')}.`;
+  return documentationMetadata({
+    description,
+    index: snapshot !== null && !isPrereleaseVersion(snapshot.release.version),
+    path: `/cli/${version}/commands/${command.join('/')}`,
     title: `baml ${command.join(' ')} — ${version}`,
-  };
+  });
 }
 
 export default async function CliCommandPage({
@@ -58,6 +66,10 @@ export default async function CliCommandPage({
   const { command, version } = await params;
   const commandNode = await loadCommand(version, command);
   if (!commandNode) notFound();
+  const versionOptions = await listGeneratedVersionOptions({
+    commandPath: command,
+    kind: 'cli-command',
+  });
   const breadcrumbs = [
     { href: '/cli', label: 'BAML CLI' },
     { href: `/cli/${version}`, label: version },
@@ -92,6 +104,7 @@ export default async function CliCommandPage({
       title={`baml ${command.join(' ')}`}
       toc={toc}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <CliCommandContent command={commandNode} routeVersion={version} />
     </DocsShell>
   );

--- a/typescript2/app-developer-docs/app/cli/[version]/commands/[...command]/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/commands/[...command]/page.tsx
@@ -101,10 +101,10 @@ export default async function CliCommandPage({
       description={
         commandNode.description ?? 'Exact-version generated command reference.'
       }
+      headerControls={<GeneratedVersionSwitcher options={versionOptions} />}
       title={`baml ${command.join(' ')}`}
       toc={toc}
     >
-      <GeneratedVersionSwitcher options={versionOptions} />
       <CliCommandContent command={commandNode} routeVersion={version} />
     </DocsShell>
   );

--- a/typescript2/app-developer-docs/app/cli/[version]/commands/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/commands/page.tsx
@@ -1,16 +1,37 @@
 import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import { CliCommandTree } from '@/components/generated-cli';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const versions = await listGeneratedReleaseRouteVersions();
   return versions.map((version) => ({ version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ version: string }>;
+}) {
+  const { version } = await params;
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  if (!snapshot) return {};
+  const description = `Every public command captured from the exact BAML ${snapshot.release.version} executable.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/cli/${version}/commands`,
+    title: `Command index — ${version}`,
+  });
 }
 
 export default async function CliCommandsPage({
@@ -21,6 +42,9 @@ export default async function CliCommandsPage({
   const { version } = await params;
   const snapshot = await loadGeneratedReleaseSnapshot(version);
   if (!snapshot) notFound();
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'cli-command-index',
+  });
 
   return (
     <DocsShell
@@ -33,6 +57,7 @@ export default async function CliCommandsPage({
       title="Command index"
       toc={[{ href: '#commands', label: 'Commands' }]}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="commands">Commands</h2>
       <CliCommandTree
         commands={snapshot.cli.payload.root.subcommands}

--- a/typescript2/app-developer-docs/app/cli/[version]/commands/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/commands/page.tsx
@@ -54,10 +54,10 @@ export default async function CliCommandsPage({
         { label: 'Commands' },
       ]}
       description={`Every public command captured from the exact BAML ${snapshot.release.version} executable.`}
+      headerControls={<GeneratedVersionSwitcher options={versionOptions} />}
       title="Command index"
       toc={[{ href: '#commands', label: 'Commands' }]}
     >
-      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="commands">Commands</h2>
       <CliCommandTree
         commands={snapshot.cli.payload.root.subcommands}

--- a/typescript2/app-developer-docs/app/cli/[version]/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/page.tsx
@@ -2,16 +2,39 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { DocsShell } from '@/components/docs-shell';
 import { CliCommandTree } from '@/components/generated-cli';
+import { GeneratedVersionSwitcher } from '@/components/generated-version-switcher';
 import {
+  isPrereleaseVersion,
   listGeneratedReleaseRouteVersions,
   loadGeneratedReleaseSnapshot,
 } from '@/lib/generated-content/build-content';
+import { listGeneratedVersionOptions } from '@/lib/generated-content/discovery';
+import { documentationMetadata } from '@/lib/metadata';
 
 export const dynamicParams = false;
 
 export async function generateStaticParams() {
   const versions = await listGeneratedReleaseRouteVersions();
   return versions.map((version) => ({ version }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ version: string }>;
+}) {
+  const { version } = await params;
+  const snapshot = await loadGeneratedReleaseSnapshot(version);
+  if (!snapshot) return {};
+  const description =
+    snapshot.cli.payload.root.description ??
+    `Exact command reference for BAML ${snapshot.release.version}.`;
+  return documentationMetadata({
+    description,
+    index: !isPrereleaseVersion(snapshot.release.version),
+    path: `/cli/${version}`,
+    title: `BAML CLI ${version}`,
+  });
 }
 
 export default async function CliVersionPage({
@@ -23,6 +46,9 @@ export default async function CliVersionPage({
   const snapshot = await loadGeneratedReleaseSnapshot(version);
   if (!snapshot) notFound();
   const root = snapshot.cli.payload.root;
+  const versionOptions = await listGeneratedVersionOptions({
+    kind: 'cli-overview',
+  });
 
   return (
     <DocsShell
@@ -38,6 +64,7 @@ export default async function CliVersionPage({
         { href: '#release', label: 'Release provenance' },
       ]}
     >
+      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="usage">Usage</h2>
       <pre>
         <code>{root.usage}</code>

--- a/typescript2/app-developer-docs/app/cli/[version]/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/[version]/page.tsx
@@ -57,6 +57,7 @@ export default async function CliVersionPage({
         root.description ??
         `Exact command reference for BAML ${snapshot.release.version}.`
       }
+      headerControls={<GeneratedVersionSwitcher options={versionOptions} />}
       title={`BAML CLI ${version}`}
       toc={[
         { href: '#usage', label: 'Usage' },
@@ -64,7 +65,6 @@ export default async function CliVersionPage({
         { href: '#release', label: 'Release provenance' },
       ]}
     >
-      <GeneratedVersionSwitcher options={versionOptions} />
       <h2 id="usage">Usage</h2>
       <pre>
         <code>{root.usage}</code>

--- a/typescript2/app-developer-docs/app/cli/page.tsx
+++ b/typescript2/app-developer-docs/app/cli/page.tsx
@@ -1,5 +1,32 @@
 import { AuthoredPage, authoredMetadata } from '@/components/authored-page';
+import { GeneratedReleaseCatalog } from '@/components/generated-release-catalog';
+import {
+  listGeneratedReleaseSummaries,
+  loadGeneratedReleaseSnapshot,
+  selectFeaturedGeneratedRelease,
+} from '@/lib/generated-content/build-content';
+
 export const metadata = authoredMetadata('/cli');
-export default function CliPage() {
-  return <AuthoredPage path="/cli" />;
+
+export default async function CliPage() {
+  const releases = await listGeneratedReleaseSummaries();
+  const featuredRelease = selectFeaturedGeneratedRelease(releases);
+  const featured = featuredRelease
+    ? await loadGeneratedReleaseSnapshot(featuredRelease.routeVersion)
+    : null;
+
+  return (
+    <AuthoredPage
+      components={{
+        GeneratedReleaseCatalog: () => (
+          <GeneratedReleaseCatalog
+            featured={featured}
+            product="cli"
+            releases={releases}
+          />
+        ),
+      }}
+      path="/cli"
+    />
+  );
 }

--- a/typescript2/app-developer-docs/app/page.tsx
+++ b/typescript2/app-developer-docs/app/page.tsx
@@ -10,6 +10,7 @@ import {
 import Link from 'next/link';
 
 import { PageHeader } from '@/components/page-header';
+import { documentationMetadata } from '@/lib/metadata';
 
 const sections = [
   {
@@ -57,9 +58,12 @@ const sections = [
 ];
 
 export const dynamic = 'force-static';
-export const metadata = {
+export const metadata = documentationMetadata({
+  description:
+    'Technical documentation for BAML, the BAML CLI, and Boundary Cloud Services.',
+  path: '/',
   title: 'BAML Developer Documentation',
-};
+});
 
 export default function HomePage() {
   return (

--- a/typescript2/app-developer-docs/app/search-index.json/route.ts
+++ b/typescript2/app-developer-docs/app/search-index.json/route.ts
@@ -1,0 +1,7 @@
+import { buildGeneratedSearchIndex } from '@/lib/generated-content/discovery';
+
+export const dynamic = 'force-static';
+
+export async function GET() {
+  return Response.json(await buildGeneratedSearchIndex());
+}

--- a/typescript2/app-developer-docs/app/sitemap.ts
+++ b/typescript2/app-developer-docs/app/sitemap.ts
@@ -1,18 +1,28 @@
 import type { MetadataRoute } from 'next';
 
+import { listGeneratedSitemapRoutes } from '@/lib/generated-content/discovery';
 import { documentationPages } from '@/lib/navigation';
 import { siteConfig } from '@/lib/site-config';
 
 export const dynamic = 'force-static';
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const paths = documentationPages.map((page) =>
     page.href === '/' ? '' : page.href,
   );
+  const generatedRoutes = await listGeneratedSitemapRoutes();
 
-  return paths.map((path, index) => ({
-    changeFrequency: 'weekly',
-    priority: index === 0 ? 1 : 0.8,
-    url: `${siteConfig.url}${path}`,
-  }));
+  return [
+    ...paths.map((path, index) => ({
+      changeFrequency: 'weekly' as const,
+      priority: index === 0 ? 1 : 0.8,
+      url: `${siteConfig.url}${path}`,
+    })),
+    ...generatedRoutes.map((route) => ({
+      changeFrequency: 'never' as const,
+      lastModified: route.lastModified,
+      priority: 0.6,
+      url: `${siteConfig.url}${route.path}`,
+    })),
+  ];
 }

--- a/typescript2/app-developer-docs/components/authored-page.tsx
+++ b/typescript2/app-developer-docs/components/authored-page.tsx
@@ -1,8 +1,10 @@
+import type { MDXComponents } from 'mdx/types';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { DocsShell } from '@/components/docs-shell';
 import { authoredSource } from '@/lib/content/source';
+import { documentationMetadata } from '@/lib/metadata';
 import { useMDXComponents } from '@/mdx-components';
 
 function pageFromPath(path: string) {
@@ -13,13 +15,20 @@ function pageFromPath(path: string) {
 export function authoredMetadata(path: string): Metadata {
   const page = pageFromPath(path);
   if (!page) return {};
-  return {
+  return documentationMetadata({
     description: page.data.description,
+    path,
     title: page.data.title,
-  };
+  });
 }
 
-export function AuthoredPage({ path }: { path: string }) {
+export function AuthoredPage({
+  components = {},
+  path,
+}: {
+  components?: MDXComponents;
+  path: string;
+}) {
   const page = pageFromPath(path);
   if (!page) notFound();
   const Content = page.data.body;
@@ -33,7 +42,7 @@ export function AuthoredPage({ path }: { path: string }) {
         label: item.title,
       }))}
     >
-      <Content components={useMDXComponents({})} />
+      <Content components={useMDXComponents(components)} />
     </DocsShell>
   );
 }

--- a/typescript2/app-developer-docs/components/docs-page-actions.tsx
+++ b/typescript2/app-developer-docs/components/docs-page-actions.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
+import { useCopyFeedback } from '@/components/use-copy-feedback';
 import { documentationPages } from '@/lib/navigation';
 import { siteConfig } from '@/lib/site-config';
 
@@ -25,9 +26,9 @@ Help me understand how to use it. Be ready to explain concepts, give examples, o
 
 export function DocsPageActions() {
   const pathname = usePathname();
-  const [copied, setCopied] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const { copiedAction, copy } = useCopyFeedback<'page'>();
   const pageIndex = documentationPages.findIndex(
     (page) => page.href === pathname,
   );
@@ -41,9 +42,7 @@ export function DocsPageActions() {
   const copyPage = async () => {
     const content = document.querySelector<HTMLElement>('[data-docs-content]');
     if (!content) return;
-    await navigator.clipboard.writeText(content.innerText);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1600);
+    await copy('page', content.innerText);
   };
 
   useEffect(() => {
@@ -74,12 +73,12 @@ export function DocsPageActions() {
           onClick={copyPage}
           type="button"
         >
-          {copied ? (
+          {copiedAction === 'page' ? (
             <Check aria-hidden="true" className="size-4" />
           ) : (
             <Copy aria-hidden="true" className="size-4" />
           )}
-          {copied ? 'Copied' : 'Copy Page'}
+          {copiedAction === 'page' ? 'Copied' : 'Copy Page'}
         </button>
         <button
           aria-expanded={menuOpen}

--- a/typescript2/app-developer-docs/components/docs-shell.tsx
+++ b/typescript2/app-developer-docs/components/docs-shell.tsx
@@ -21,14 +21,18 @@ export function DocsShell({
   breadcrumbs,
   children,
   description,
+  headerControls,
   title,
   toc = [],
+  wideContent = false,
 }: {
   breadcrumbs: BreadcrumbItem[];
   children: React.ReactNode;
   description: string;
+  headerControls?: React.ReactNode;
   title: string;
   toc?: TocItem[];
+  wideContent?: boolean;
 }) {
   return (
     <div className="container-wrapper flex flex-1 flex-col px-2">
@@ -43,7 +47,7 @@ export function DocsShell({
               <div className="h-[var(--top-spacing)] shrink-0" />
               <article
                 aria-label={breadcrumbs.map((item) => item.label).join(' / ')}
-                className="mx-auto flex w-full max-w-160 min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-foreground md:px-0 lg:py-8 dark:text-foreground"
+                className={`mx-auto flex w-full min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-foreground md:px-0 lg:py-8 dark:text-foreground ${wideContent ? 'max-w-4xl' : 'max-w-160'}`}
               >
                 <header className="flex flex-col gap-2">
                   {breadcrumbs.length > 1 ? (
@@ -81,15 +85,22 @@ export function DocsShell({
                       ))}
                     </nav>
                   ) : null}
-                  <div className="flex items-center justify-between md:items-start">
-                    <h1 className="scroll-m-24 text-3xl font-semibold tracking-tight sm:text-3xl">
+                  <div className="flex items-start justify-between gap-4">
+                    <h1 className="min-w-0 scroll-m-24 text-3xl font-semibold tracking-tight sm:text-3xl">
                       {title}
                     </h1>
-                    <DocsPageActions />
+                    <div className="shrink-0">
+                      <DocsPageActions />
+                    </div>
                   </div>
                   <p className="text-[1.05rem] text-muted-foreground sm:max-w-[80%] sm:text-balance sm:text-base">
                     {description}
                   </p>
+                  {headerControls ? (
+                    <div className="mt-2 flex items-center">
+                      {headerControls}
+                    </div>
+                  ) : null}
                 </header>
                 <div
                   className="typeset w-full flex-1 pb-16 sm:pb-0"

--- a/typescript2/app-developer-docs/components/generated-member-actions.tsx
+++ b/typescript2/app-developer-docs/components/generated-member-actions.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Check, Copy, Link2 } from 'lucide-react';
+import { useCopyFeedback } from '@/components/use-copy-feedback';
+
+type CopyAction = 'declaration' | 'link';
+
+export function GeneratedMemberActions({
+  anchor,
+  declaration,
+  label,
+}: {
+  anchor: string;
+  declaration: string;
+  label: string;
+}) {
+  const { copiedAction, copy } = useCopyFeedback<CopyAction>();
+
+  const copyLink = () => {
+    const url = new URL(window.location.href);
+    url.hash = anchor;
+    void copy('link', url.toString());
+  };
+
+  const buttonClass =
+    'docs-focus-ring inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground';
+
+  return (
+    <div className="absolute top-2 right-2 flex items-center rounded-md border bg-background/95 p-0.5 opacity-100 shadow-sm transition-opacity sm:opacity-0 sm:group-hover/member:opacity-100 sm:group-focus-within/member:opacity-100">
+      <button
+        aria-label={`Copy link to ${label}`}
+        className={buttonClass}
+        onClick={copyLink}
+        title="Copy link"
+        type="button"
+      >
+        {copiedAction === 'link' ? (
+          <Check aria-hidden="true" className="size-3.5" />
+        ) : (
+          <Link2 aria-hidden="true" className="size-3.5" />
+        )}
+      </button>
+      <button
+        aria-label={`Copy declaration for ${label}`}
+        className={buttonClass}
+        onClick={() => void copy('declaration', declaration)}
+        title="Copy declaration"
+        type="button"
+      >
+        {copiedAction === 'declaration' ? (
+          <Check aria-hidden="true" className="size-3.5" />
+        ) : (
+          <Copy aria-hidden="true" className="size-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/typescript2/app-developer-docs/components/generated-reference.tsx
+++ b/typescript2/app-developer-docs/components/generated-reference.tsx
@@ -76,6 +76,12 @@ const implementationSchema = z
 type ExportedMember = z.output<typeof memberSchema>;
 type ExportedSignature = z.output<typeof signatureSchema>;
 
+export interface ReferenceChildLink {
+  page_kind: ReferencePageData['page_kind'];
+  qualified_name: string;
+  route_path: string;
+}
+
 function Docstring({ value }: { value: string }) {
   return <ReactMarkdown>{value}</ReactMarkdown>;
 }
@@ -147,10 +153,7 @@ function ChildLinks({
   items,
   routeVersion,
 }: {
-  items: Extract<
-    ReferencePageData,
-    { page_kind: 'package' | 'namespace' }
-  >['children'];
+  items: ReferenceChildLink[];
   routeVersion: string;
 }) {
   return (
@@ -169,6 +172,7 @@ function ChildLinks({
 
 export function referencePageTableOfContents(
   page: ReferencePageData,
+  namespacedChildren: readonly ReferenceChildLink[] = [],
 ): { href: string; label: string }[] {
   if (page.page_kind === 'package' || page.page_kind === 'namespace') {
     return [{ href: '#contents', label: 'Contents' }];
@@ -184,13 +188,18 @@ export function referencePageTableOfContents(
     ...(page.cross_references.length > 0
       ? [{ href: '#related', label: 'Related definitions' }]
       : []),
+    ...(namespacedChildren.length > 0
+      ? [{ href: '#namespaced-definitions', label: 'Namespaced definitions' }]
+      : []),
   ];
 }
 
 export function GeneratedReferenceContent({
+  namespacedChildren = [],
   page,
   routeVersion,
 }: {
+  namespacedChildren?: ReferenceChildLink[];
   page: ReferencePageData;
   routeVersion: string;
 }) {
@@ -331,6 +340,16 @@ export function GeneratedReferenceContent({
               </li>
             ))}
           </ul>
+        </section>
+      ) : null}
+      {namespacedChildren.length > 0 ? (
+        <section>
+          <h2 id="namespaced-definitions">Namespaced definitions</h2>
+          <p>
+            These definitions use this declaration name as their namespace
+            prefix.
+          </p>
+          <ChildLinks items={namespacedChildren} routeVersion={routeVersion} />
         </section>
       ) : null}
     </>

--- a/typescript2/app-developer-docs/components/generated-reference.tsx
+++ b/typescript2/app-developer-docs/components/generated-reference.tsx
@@ -1,80 +1,29 @@
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
-import { z } from 'zod';
 
+import { GeneratedMemberActions } from '@/components/generated-member-actions';
+import {
+  type ExportedGeneric,
+  type ExportedMember,
+  type ExportedParameter,
+  type ExportedSignature,
+  type ExportedSource,
+  exportedImplementationSchema,
+  exportedItemSchema,
+} from '@/lib/generated-content/package-export';
+import {
+  createTypeReferenceIndex,
+  declarationMemberGroups,
+  type MemberKind,
+  memberDeclarationText,
+  type ReferenceTypeLink,
+  referenceHref,
+  shouldUseMultilineSignature,
+  splitMethods,
+  type TypeReferenceIndex,
+  typeDisplaySegments,
+} from '@/lib/generated-content/reference-rendering';
 import type { ReferencePageData } from '@/lib/generated-content/schemas';
-
-const typeDisplaySchema = z
-  .object({ display: z.string().min(1) })
-  .passthrough();
-const sourceSchema = z
-  .object({
-    end: z.number().int(),
-    file: z.string().min(1),
-    start: z.number().int(),
-  })
-  .passthrough();
-const parameterSchema = z
-  .object({
-    name: z.string().min(1),
-    optional: z.boolean().optional(),
-    ty: typeDisplaySchema,
-  })
-  .passthrough();
-const signatureSchema = z
-  .object({
-    params: z.array(parameterSchema),
-    returns: typeDisplaySchema,
-    throws: typeDisplaySchema.optional(),
-  })
-  .passthrough();
-const genericSchema = z.object({ name: z.string().min(1) }).passthrough();
-const memberSchema = z
-  .object({
-    docstring: z.string().optional(),
-    id: z.string().min(1),
-    name: z.string().min(1),
-    signature: signatureSchema.optional(),
-    ty: typeDisplaySchema.optional(),
-  })
-  .passthrough();
-const declarationSchema = z
-  .object({
-    assoc_types: z.array(memberSchema).optional(),
-    default_methods: z.array(memberSchema).optional(),
-    detail: z.string().optional(),
-    docstring: z.string().optional(),
-    fields: z.array(memberSchema).optional(),
-    generics: z.array(genericSchema).optional(),
-    methods: z.array(memberSchema).optional(),
-    name: z.string().min(1),
-    required_methods: z.array(memberSchema).optional(),
-    resolved: typeDisplaySchema.optional(),
-    signature: signatureSchema.optional(),
-    source: sourceSchema.optional(),
-    variants: z.array(memberSchema).optional(),
-  })
-  .passthrough();
-const implementationSchema = z
-  .object({
-    assoc_bindings: z
-      .array(
-        z
-          .object({ name: z.string().min(1), ty: typeDisplaySchema })
-          .passthrough(),
-      )
-      .optional(),
-    docstring: z.string().optional(),
-    for_ty: typeDisplaySchema.optional(),
-    id: z.string().min(1),
-    interface: z.string().optional(),
-    methods: z.array(memberSchema).optional(),
-    source: sourceSchema.optional(),
-  })
-  .passthrough();
-
-type ExportedMember = z.output<typeof memberSchema>;
-type ExportedSignature = z.output<typeof signatureSchema>;
 
 export interface ReferenceChildLink {
   page_kind: ReferencePageData['page_kind'];
@@ -86,66 +35,348 @@ function Docstring({ value }: { value: string }) {
   return <ReactMarkdown>{value}</ReactMarkdown>;
 }
 
-function signatureText(name: string, signature: ExportedSignature): string {
-  const parameters = signature.params
-    .map(
-      (parameter) =>
-        `${parameter.name}${parameter.optional ? '?' : ''}: ${parameter.ty.display}`,
-    )
-    .join(', ');
-  const throws =
-    signature.throws && signature.throws.display !== 'never'
-      ? ` throws ${signature.throws.display}`
-      : '';
-  return `${name}(${parameters}) -> ${signature.returns.display}${throws}`;
+interface TypeLinkContext {
+  references: TypeReferenceIndex;
+  routeVersion: string;
 }
 
-function SourceLocation({ source }: { source: z.output<typeof sourceSchema> }) {
+function TypeDisplay({
+  links,
+  value,
+}: {
+  links: TypeLinkContext;
+  value: string;
+}) {
+  return typeDisplaySegments(value, links.references).map((segment) => {
+    if (!segment.reference) return segment.text;
+    return (
+      <Link
+        className="font-medium text-foreground underline decoration-border underline-offset-2 transition-colors hover:decoration-foreground"
+        href={referenceHref(links.routeVersion, segment.reference)}
+        key={`${segment.reference.exported_id}-${segment.start}`}
+      >
+        {segment.text}
+      </Link>
+    );
+  });
+}
+
+function GenericParameters({
+  generics,
+  links,
+}: {
+  generics: readonly ExportedGeneric[] | undefined;
+  links: TypeLinkContext;
+}) {
+  if (!generics?.length) return null;
   return (
-    <p className="text-sm text-muted-foreground">
-      Source: <code>{source.file}</code>, bytes {source.start}–{source.end}
+    <>
+      {'<'}
+      {generics.map((generic, genericIndex) => (
+        <span key={generic.name}>
+          {genericIndex > 0 ? ', ' : null}
+          {generic.name}
+          {generic.bounds.length > 0 ? ' extends ' : null}
+          {generic.bounds.map((bound, boundIndex) => (
+            <span key={bound}>
+              {boundIndex > 0 ? ' & ' : null}
+              <TypeDisplay links={links} value={bound} />
+            </span>
+          ))}
+        </span>
+      ))}
+      {'>'}
+    </>
+  );
+}
+
+function ParameterDisplay({
+  links,
+  parameter,
+}: {
+  links: TypeLinkContext;
+  parameter: ExportedParameter;
+}) {
+  if (parameter.name === 'self') return 'self';
+  return (
+    <>
+      {parameter.name}:{' '}
+      <TypeDisplay links={links} value={parameter.ty.display} />
+      {parameter.optional ? ' = …' : null}
+    </>
+  );
+}
+
+function FunctionSignature({
+  headingLevel,
+  links,
+  name,
+  signature,
+}: {
+  headingLevel?: 'h3' | 'h4';
+  links: TypeLinkContext;
+  name: string;
+  signature: ExportedSignature;
+}) {
+  const Name = headingLevel ?? 'span';
+  const thrownType =
+    signature.throws?.display === 'never' ? null : signature.throws?.display;
+  const multiline = shouldUseMultilineSignature(name, signature);
+  const nameElement = (
+    <Name className="inline font-mono text-[0.82rem] leading-5 font-semibold text-foreground">
+      {name}
+    </Name>
+  );
+
+  if (!multiline) {
+    return (
+      <div className="min-w-0 font-mono text-[0.82rem] leading-5 break-words whitespace-pre-wrap">
+        <span className="font-medium text-[var(--docs-purple)]">function </span>
+        {nameElement}
+        <span className="text-muted-foreground">
+          <GenericParameters generics={signature.generics} links={links} />(
+        </span>
+        {signature.params.map((parameter, index) => (
+          <span className="text-muted-foreground" key={parameter.name}>
+            {index > 0 ? ', ' : null}
+            <ParameterDisplay links={links} parameter={parameter} />
+          </span>
+        ))}
+        <span className="text-muted-foreground">) -&gt; </span>
+        <span className="text-muted-foreground">
+          <TypeDisplay links={links} value={signature.returns.display} />
+        </span>
+        {thrownType ? (
+          <>
+            {' '}
+            <span className="font-medium text-[var(--docs-purple)]">
+              throws
+            </span>{' '}
+            <span className="text-muted-foreground">
+              <TypeDisplay links={links} value={thrownType} />
+            </span>
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0 font-mono text-[0.82rem] leading-5 break-words">
+      <div>
+        <span className="font-medium text-[var(--docs-purple)]">function </span>
+        {nameElement}
+        <span className="text-muted-foreground">
+          <GenericParameters generics={signature.generics} links={links} />(
+        </span>
+      </div>
+      <div className="pl-4 text-muted-foreground">
+        {signature.params.map((parameter, index) => (
+          <div key={parameter.name}>
+            <ParameterDisplay links={links} parameter={parameter} />
+            {index < signature.params.length - 1 ? ',' : null}
+          </div>
+        ))}
+      </div>
+      <div className="text-muted-foreground">
+        ) -&gt; <TypeDisplay links={links} value={signature.returns.display} />
+        {thrownType ? (
+          <>
+            {' '}
+            <span className="font-medium text-[var(--docs-purple)]">
+              throws
+            </span>{' '}
+            <TypeDisplay links={links} value={thrownType} />
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SourceLocation({ source }: { source: ExportedSource }) {
+  return (
+    <p className="flex flex-wrap items-baseline gap-x-1 text-sm text-muted-foreground">
+      <span>Source:</span>
+      <code>{source.file}</code>
+      <span>
+        bytes {source.start}–{source.end}
+      </span>
     </p>
   );
 }
 
+function CompactDocstring({ value }: { value: string }) {
+  return (
+    <div className="mt-2 text-sm leading-6 text-muted-foreground [&_a]:underline [&_li]:mt-1 [&_ol]:mt-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:m-0 [&_ul]:mt-2 [&_ul]:list-disc [&_ul]:pl-5">
+      <ReactMarkdown>{value}</ReactMarkdown>
+    </div>
+  );
+}
+
+function MemberRow({
+  anchor,
+  headingLevel = 'h3',
+  kind,
+  links,
+  member,
+}: {
+  anchor?: string;
+  headingLevel?: 'h3' | 'h4';
+  kind: MemberKind;
+  links: TypeLinkContext;
+  member: ExportedMember;
+}) {
+  const Heading = headingLevel;
+
+  const declaration = memberDeclarationText(member, kind);
+  if (member.signature) {
+    return (
+      <article
+        className="group/member relative scroll-mt-24 min-w-0 px-4 py-3 pr-20 transition-colors hover:bg-muted/25"
+        id={anchor}
+      >
+        <FunctionSignature
+          headingLevel={headingLevel}
+          links={links}
+          name={member.name}
+          signature={member.signature}
+        />
+        {anchor ? (
+          <GeneratedMemberActions
+            anchor={anchor}
+            declaration={declaration}
+            label={member.name}
+          />
+        ) : null}
+        {member.docstring ? (
+          <CompactDocstring value={member.docstring} />
+        ) : null}
+      </article>
+    );
+  }
+
+  const displayedType = member.ty ?? member.default;
+  return (
+    <article
+      className="group/member relative scroll-mt-24 grid min-w-0 gap-1.5 px-4 py-3 pr-20 transition-colors hover:bg-muted/25 sm:grid-cols-[minmax(12rem,0.65fr)_minmax(0,1fr)] sm:gap-4"
+      id={anchor}
+    >
+      <Heading className="min-w-0 font-mono text-sm leading-5 font-medium text-foreground">
+        {kind === 'associated-type' ? (
+          <span className="text-[var(--docs-purple)]">type </span>
+        ) : null}
+        {member.name}
+      </Heading>
+      <div className="min-w-0">
+        {displayedType ? (
+          <code className="font-mono text-xs leading-5 text-muted-foreground">
+            {kind === 'associated-type' ? '= ' : null}
+            <TypeDisplay links={links} value={displayedType.display} />
+          </code>
+        ) : null}
+        {member.docstring ? (
+          <CompactDocstring value={member.docstring} />
+        ) : null}
+      </div>
+      {anchor ? (
+        <GeneratedMemberActions
+          anchor={anchor}
+          declaration={declaration}
+          label={member.name}
+        />
+      ) : null}
+    </article>
+  );
+}
+
+function MemberRows({
+  anchors,
+  headingLevel,
+  kind,
+  links,
+  members,
+}: {
+  anchors: Map<string, string>;
+  headingLevel?: 'h3' | 'h4';
+  kind: MemberKind;
+  links: TypeLinkContext;
+  members: ExportedMember[];
+}) {
+  return members.map((member) => (
+    <MemberRow
+      anchor={anchors.get(member.id)}
+      headingLevel={headingLevel}
+      key={member.id}
+      kind={kind}
+      links={links}
+      member={member}
+    />
+  ));
+}
+
 function MemberGroup({
   anchors,
+  id,
+  kind,
+  links,
   members,
   title,
 }: {
   anchors: Map<string, string>;
+  id: string;
+  kind: MemberKind;
+  links: TypeLinkContext;
+  members: ExportedMember[];
+  title: string;
+}) {
+  return (
+    <section className="mt-8" data-not-typeset="">
+      <h2
+        className="scroll-mt-24 text-xl leading-7 font-semibold tracking-tight"
+        id={id}
+      >
+        {title}
+      </h2>
+      <div className="mt-3 divide-y overflow-hidden rounded-lg border bg-background">
+        <MemberRows
+          anchors={anchors}
+          kind={kind}
+          links={links}
+          members={members}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ImplementationMethodRows({
+  anchors,
+  links,
+  members,
+  title,
+}: {
+  anchors: Map<string, string>;
+  links: TypeLinkContext;
   members: ExportedMember[];
   title: string;
 }) {
   if (members.length === 0) return null;
   return (
-    <section>
-      <h2>{title}</h2>
-      {members.map((member) => (
-        <article
-          className="scroll-mt-24 border-t py-5 first:border-t-0"
-          id={anchors.get(member.id)}
-          key={member.id}
-        >
-          <h3>
-            <code>{member.name}</code>
-          </h3>
-          {member.signature ? (
-            <pre>
-              <code>{signatureText(member.name, member.signature)}</code>
-            </pre>
-          ) : null}
-          {member.ty ? (
-            <pre>
-              <code>
-                {member.name}: {member.ty.display}
-              </code>
-            </pre>
-          ) : null}
-          {member.docstring ? <Docstring value={member.docstring} /> : null}
-        </article>
-      ))}
-    </section>
+    <div className="border-t">
+      <p className="bg-muted/15 px-4 py-2 text-[0.7rem] font-medium tracking-wider text-muted-foreground uppercase">
+        {title}
+      </p>
+      <div className="divide-y border-t">
+        <MemberRows
+          anchors={anchors}
+          headingLevel="h4"
+          kind="method"
+          links={links}
+          members={members}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -177,11 +408,14 @@ export function referencePageTableOfContents(
   if (page.page_kind === 'package' || page.page_kind === 'namespace') {
     return [{ href: '#contents', label: 'Contents' }];
   }
+  const declaration = exportedItemSchema.parse(page.declaration);
+  const memberGroups = declarationMemberGroups(declaration);
   return [
     { href: '#signature', label: 'Signature' },
-    ...(page.member_anchors.length > 0
-      ? [{ href: '#members', label: 'Members' }]
-      : []),
+    ...memberGroups.map((group) => ({
+      href: `#${group.id}`,
+      label: group.title,
+    })),
     ...(page.implementations.length > 0
       ? [{ href: '#implementations', label: 'Implementations' }]
       : []),
@@ -198,10 +432,12 @@ export function GeneratedReferenceContent({
   namespacedChildren = [],
   page,
   routeVersion,
+  typeReferences = [],
 }: {
   namespacedChildren?: ReferenceChildLink[];
   page: ReferencePageData;
   routeVersion: string;
+  typeReferences?: readonly ReferenceTypeLink[];
 }) {
   if (page.page_kind === 'package' || page.page_kind === 'namespace') {
     return (
@@ -216,37 +452,63 @@ export function GeneratedReferenceContent({
     );
   }
 
-  const declaration = declarationSchema.parse(page.declaration);
-  const implementations = implementationSchema
+  const declaration = exportedItemSchema.parse(page.declaration);
+  const implementations = exportedImplementationSchema
     .array()
     .parse(page.implementations);
   const anchors = new Map(
     page.member_anchors.map((anchor) => [anchor.exported_id, anchor.anchor]),
   );
-  const genericSuffix = declaration.generics?.length
-    ? `<${declaration.generics.map((generic) => generic.name).join(', ')}>`
-    : '';
-  const declarationSignature = declaration.signature
-    ? signatureText(page.qualified_name, declaration.signature)
-    : declaration.resolved
-      ? `type ${page.qualified_name}${genericSuffix} = ${declaration.resolved.display}`
-      : `${page.page_kind} ${page.qualified_name}${genericSuffix}`;
-  const memberGroups: [string, ExportedMember[]][] = [
-    ['Fields', declaration.fields ?? []],
-    ['Variants', declaration.variants ?? []],
-    ['Associated types', declaration.assoc_types ?? []],
-    ['Required methods', declaration.required_methods ?? []],
-    ['Default methods', declaration.default_methods ?? []],
-    ['Methods', declaration.methods ?? []],
-  ];
+  const memberGroups = declarationMemberGroups(declaration);
+  const links: TypeLinkContext = {
+    references: createTypeReferenceIndex(
+      [...page.cross_references, ...typeReferences],
+      page.qualified_name,
+    ),
+    routeVersion,
+  };
 
   return (
     <>
       <section>
         <h2 id="signature">Signature</h2>
-        <pre>
-          <code>{declarationSignature}</code>
-        </pre>
+        <div
+          className="overflow-x-auto rounded-lg bg-muted/40 px-4 py-3"
+          data-not-typeset=""
+        >
+          {declaration.signature ? (
+            <FunctionSignature
+              links={links}
+              name={page.qualified_name}
+              signature={declaration.signature}
+            />
+          ) : (
+            <code className="font-mono text-[0.82rem] leading-5 text-muted-foreground">
+              {declaration.resolved ? (
+                <>
+                  type {page.qualified_name}
+                  <GenericParameters
+                    generics={declaration.generics}
+                    links={links}
+                  />{' '}
+                  ={' '}
+                  <TypeDisplay
+                    links={links}
+                    value={declaration.resolved.display}
+                  />
+                </>
+              ) : (
+                <>
+                  {page.page_kind} {page.qualified_name}
+                  <GenericParameters
+                    generics={declaration.generics}
+                    links={links}
+                  />
+                </>
+              )}
+            </code>
+          )}
+        </div>
         {declaration.docstring ? (
           <Docstring value={declaration.docstring} />
         ) : null}
@@ -254,76 +516,102 @@ export function GeneratedReferenceContent({
           <SourceLocation source={declaration.source} />
         ) : null}
       </section>
-      {page.member_anchors.length > 0 ? (
+      {memberGroups.length > 0 ? (
         <div id="members">
-          {memberGroups.map(([title, members]) => (
+          {memberGroups.map((group) => (
             <MemberGroup
               anchors={anchors}
-              key={title}
-              members={members}
-              title={title}
+              id={group.id}
+              key={group.id}
+              kind={group.kind}
+              links={links}
+              members={group.members}
+              title={group.title}
             />
           ))}
         </div>
       ) : null}
       {implementations.length > 0 ? (
-        <section>
-          <h2 id="implementations">Implementations</h2>
-          {implementations.map((implementation) => {
-            const label = [
-              implementation.interface,
-              implementation.for_ty
-                ? `for ${implementation.for_ty.display}`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(' ');
-            return (
-              <article
-                className="scroll-mt-24 border-t py-5 first:border-t-0"
-                id={anchors.get(implementation.id)}
-                key={implementation.id}
-              >
-                <h3>{label || 'Implementation'}</h3>
-                {implementation.assoc_bindings?.length ? (
-                  <p>
-                    {implementation.assoc_bindings.map((binding) => (
-                      <code key={binding.name}>
-                        {binding.name} = {binding.ty.display}{' '}
-                      </code>
-                    ))}
-                  </p>
-                ) : null}
-                {implementation.docstring ? (
-                  <Docstring value={implementation.docstring} />
-                ) : null}
-                {implementation.methods?.map((method) => (
-                  <article
-                    className="scroll-mt-24 border-t py-4"
-                    id={anchors.get(method.id)}
-                    key={method.id}
-                  >
-                    <h4>
-                      <code>{method.name}</code>
-                    </h4>
-                    {method.signature ? (
-                      <pre>
-                        <code>
-                          {signatureText(method.name, method.signature)}
-                        </code>
-                      </pre>
+        <section className="mt-8" data-not-typeset="">
+          <h2
+            className="text-xl leading-7 font-semibold tracking-tight"
+            id="implementations"
+          >
+            Implementations
+          </h2>
+          <div className="mt-3 space-y-3">
+            {implementations.map((implementation) => {
+              const implementationMethods = splitMethods(
+                implementation.methods ?? [],
+              );
+              return (
+                <article
+                  className="scroll-mt-24 overflow-hidden rounded-lg border bg-background"
+                  id={anchors.get(implementation.id)}
+                  key={implementation.id}
+                >
+                  <header className="bg-muted/35 px-4 py-3">
+                    <h3 className="text-sm leading-5 font-semibold break-words">
+                      {implementation.interface ? (
+                        <TypeDisplay
+                          links={links}
+                          value={implementation.interface}
+                        />
+                      ) : (
+                        'Implementation'
+                      )}
+                      {implementation.for_ty ? (
+                        <>
+                          {' '}
+                          for{' '}
+                          <TypeDisplay
+                            links={links}
+                            value={implementation.for_ty.display}
+                          />
+                        </>
+                      ) : null}
+                    </h3>
+                    {implementation.assoc_bindings?.length ? (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {implementation.assoc_bindings.map((binding) => (
+                          <code
+                            className="rounded-md bg-muted px-2 py-1 font-mono text-xs"
+                            key={binding.name}
+                          >
+                            {binding.name} ={' '}
+                            <TypeDisplay
+                              links={links}
+                              value={binding.ty.display}
+                            />
+                          </code>
+                        ))}
+                      </div>
                     ) : null}
-                    {method.docstring ? (
-                      <Docstring value={method.docstring} />
+                    {implementation.docstring ? (
+                      <CompactDocstring value={implementation.docstring} />
                     ) : null}
-                  </article>
-                ))}
-                {implementation.source ? (
-                  <SourceLocation source={implementation.source} />
-                ) : null}
-              </article>
-            );
-          })}
+                  </header>
+                  <ImplementationMethodRows
+                    anchors={anchors}
+                    links={links}
+                    members={implementationMethods.staticMethods}
+                    title="Static methods"
+                  />
+                  <ImplementationMethodRows
+                    anchors={anchors}
+                    links={links}
+                    members={implementationMethods.instanceMethods}
+                    title="Instance methods"
+                  />
+                  {implementation.source ? (
+                    <div className="border-t px-4 py-2.5">
+                      <SourceLocation source={implementation.source} />
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
         </section>
       ) : null}
       {page.cross_references.length > 0 ? (
@@ -332,9 +620,7 @@ export function GeneratedReferenceContent({
           <ul>
             {page.cross_references.map((reference) => (
               <li key={reference.exported_id}>
-                <Link
-                  href={`/baml/packages/${routeVersion}/${reference.route_path}${reference.anchor ? `#${reference.anchor}` : ''}`}
-                >
+                <Link href={referenceHref(routeVersion, reference)}>
                   <code>{reference.qualified_name}</code>
                 </Link>
               </li>

--- a/typescript2/app-developer-docs/components/generated-release-catalog.tsx
+++ b/typescript2/app-developer-docs/components/generated-release-catalog.tsx
@@ -1,0 +1,151 @@
+import Link from 'next/link';
+
+import type {
+  GeneratedReleaseSnapshot,
+  GeneratedReleaseSummary,
+} from '@/lib/generated-content/build-content';
+
+type GeneratedProduct = 'cli' | 'packages';
+
+function productRoot(product: GeneratedProduct): string {
+  return product === 'packages' ? '/baml/packages' : '/cli';
+}
+
+function productLabel(product: GeneratedProduct): string {
+  return product === 'packages' ? 'standard packages' : 'CLI reference';
+}
+
+function formatReleaseDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function channelText(release: GeneratedReleaseSummary): string {
+  return release.channels.length > 0
+    ? release.channels.join(', ')
+    : 'historical';
+}
+
+function ReleaseLink({
+  product,
+  release,
+}: {
+  product: GeneratedProduct;
+  release: GeneratedReleaseSummary;
+}) {
+  const href = `${productRoot(product)}/${release.routeVersion}`;
+  return (
+    <li>
+      <Link href={href}>
+        <code>{release.routeVersion}</code>
+      </Link>{' '}
+      <span className="text-muted-foreground">
+        {channelText(release)} · published{' '}
+        <time dateTime={release.release.released_at.toISOString()}>
+          {formatReleaseDate(release.release.released_at)}
+        </time>
+      </span>
+    </li>
+  );
+}
+
+export function GeneratedReleaseCatalog({
+  featured,
+  product,
+  releases,
+}: {
+  featured: GeneratedReleaseSnapshot | null;
+  product: GeneratedProduct;
+  releases: GeneratedReleaseSummary[];
+}) {
+  if (releases.length === 0) {
+    return (
+      <p>
+        No complete generated releases are published yet. This page will list a
+        release only after both its package and CLI records are available.
+      </p>
+    );
+  }
+
+  const currentReleases = releases.filter(
+    (release) => release.channels.length > 0,
+  );
+  const displayedCurrentReleases =
+    currentReleases.length > 0 ? currentReleases : releases.slice(0, 1);
+  const hasStable = currentReleases.some((release) =>
+    release.channels.includes('stable'),
+  );
+
+  return (
+    <>
+      <h3>{hasStable ? 'Current stable release' : 'Current snapshots'}</h3>
+      {!hasStable ? (
+        <p>
+          No stable release has been published in this catalog. Canary and
+          nightly entries are labeled explicitly and are not stable releases.
+        </p>
+      ) : null}
+      <ul>
+        {displayedCurrentReleases.map((release) => (
+          <ReleaseLink
+            key={release.routeVersion}
+            product={product}
+            release={release}
+          />
+        ))}
+      </ul>
+
+      {featured && product === 'packages' ? (
+        <>
+          <h3>
+            Package catalog for <code>{featured.routeVersion}</code>
+          </h3>
+          <ul className="columns-2 sm:columns-3">
+            {featured.pages
+              .filter((page) => page.page_kind === 'package')
+              .map((page) => (
+                <li key={page.route_path}>
+                  <Link
+                    href={`/baml/packages/${featured.routeVersion}/${page.route_path}`}
+                  >
+                    <code>{page.qualified_name}</code>
+                  </Link>
+                </li>
+              ))}
+          </ul>
+        </>
+      ) : null}
+
+      {featured && product === 'cli' ? (
+        <p>
+          Browse the{' '}
+          <Link href={`/cli/${featured.routeVersion}`}>
+            {featured.routeVersion} CLI overview
+          </Link>{' '}
+          or open its{' '}
+          <Link href={`/cli/${featured.routeVersion}/commands`}>
+            complete command index
+          </Link>
+          .
+        </p>
+      ) : null}
+
+      <h3>All published versions</h3>
+      <p>
+        Every link below opens immutable {productLabel(product)} generated from
+        that exact BAML toolchain release.
+      </p>
+      <ul>
+        {releases.map((release) => (
+          <ReleaseLink
+            key={release.routeVersion}
+            product={product}
+            release={release}
+          />
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/typescript2/app-developer-docs/components/generated-version-switcher.tsx
+++ b/typescript2/app-developer-docs/components/generated-version-switcher.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import type { GeneratedVersionOption } from '@/lib/generated-content/discovery';
+
+export function GeneratedVersionSwitcher({
+  options,
+}: {
+  options: GeneratedVersionOption[];
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const current = options.find((option) => option.href === pathname);
+
+  if (options.length === 0) return null;
+
+  return (
+    <label className="flex max-w-md items-center gap-3 rounded-lg border bg-muted/40 px-3 py-2 text-sm">
+      <span className="font-medium">Reference version</span>
+      <select
+        aria-label="Reference version"
+        className="ml-auto min-w-0 rounded border border-input bg-background px-2 py-1 font-mono text-xs text-foreground"
+        onChange={(event) => router.push(event.target.value)}
+        value={current?.href ?? options[0]?.href}
+      >
+        {options.map((option) => (
+          <option key={option.href} value={option.href}>
+            {option.routeVersion}
+            {option.channels.length ? ` (${option.channels.join(', ')})` : ''}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/typescript2/app-developer-docs/components/generated-version-switcher.tsx
+++ b/typescript2/app-developer-docs/components/generated-version-switcher.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Check, ChevronDown } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 
 import type { GeneratedVersionOption } from '@/lib/generated-content/discovery';
 
@@ -12,25 +14,76 @@ export function GeneratedVersionSwitcher({
   const pathname = usePathname();
   const router = useRouter();
   const current = options.find((option) => option.href === pathname);
+  const selected = current ?? options[0];
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
-  if (options.length === 0) return null;
+  useEffect(() => {
+    if (!menuOpen) return;
+    const closeMenu = (event: MouseEvent) => {
+      const menu = menuRef.current;
+      if (menu && !event.composedPath().includes(menu)) setMenuOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', closeMenu);
+    document.addEventListener('keydown', closeOnEscape);
+    return () => {
+      document.removeEventListener('mousedown', closeMenu);
+      document.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [menuOpen]);
+
+  if (!selected) return null;
 
   return (
-    <label className="flex max-w-md items-center gap-3 rounded-lg border bg-muted/40 px-3 py-2 text-sm">
-      <span className="font-medium">Reference version</span>
-      <select
-        aria-label="Reference version"
-        className="ml-auto min-w-0 rounded border border-input bg-background px-2 py-1 font-mono text-xs text-foreground"
-        onChange={(event) => router.push(event.target.value)}
-        value={current?.href ?? options[0]?.href}
-      >
-        {options.map((option) => (
-          <option key={option.href} value={option.href}>
-            {option.routeVersion}
-            {option.channels.length ? ` (${option.channels.join(', ')})` : ''}
-          </option>
-        ))}
-      </select>
-    </label>
+    <div className="inline-flex min-w-0 max-w-full items-center gap-2 text-sm">
+      <span className="shrink-0 font-medium text-foreground">
+        Reference version
+      </span>
+      <div className="relative min-w-0" ref={menuRef}>
+        <button
+          aria-expanded={menuOpen}
+          aria-haspopup="menu"
+          className="docs-focus-ring inline-flex h-8 max-w-[min(18rem,60vw)] items-center gap-2 rounded-lg bg-secondary px-3 font-mono text-xs font-medium text-secondary-foreground shadow-none hover:bg-accent md:h-7"
+          onClick={() => setMenuOpen((open) => !open)}
+          type="button"
+        >
+          <span className="truncate">{selected.routeVersion}</span>
+          <ChevronDown aria-hidden="true" className="size-4 shrink-0" />
+        </button>
+        {menuOpen ? (
+          <div
+            className="absolute top-[calc(100%+0.35rem)] left-0 z-50 min-w-full rounded-lg border bg-background/90 p-1 text-sm shadow-lg backdrop-blur-sm"
+            role="menu"
+          >
+            {options.map((option) => (
+              <button
+                aria-checked={option.href === selected.href}
+                className="docs-focus-ring flex h-9 w-full items-center justify-between gap-3 rounded-md px-2 text-left font-mono text-xs whitespace-nowrap hover:bg-accent"
+                key={option.href}
+                onClick={() => {
+                  setMenuOpen(false);
+                  if (option.href !== pathname) router.push(option.href);
+                }}
+                role="menuitemradio"
+                type="button"
+              >
+                {option.routeVersion}
+                <Check
+                  aria-hidden="true"
+                  className={
+                    option.href === selected.href
+                      ? 'size-4'
+                      : 'size-4 opacity-0'
+                  }
+                />
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/typescript2/app-developer-docs/components/search-menu.tsx
+++ b/typescript2/app-developer-docs/components/search-menu.tsx
@@ -11,6 +11,17 @@ import {
 } from 'react';
 
 import { searchablePages } from '@/lib/navigation';
+import {
+  type GeneratedSearchIndex,
+  generatedSearchIndexSchema,
+  type SearchEntry,
+} from '@/lib/search';
+
+const authoredEntries: SearchEntry[] = searchablePages.map((page) => ({
+  ...page,
+  current: true,
+}));
+const MAX_RESULTS = 100;
 
 function isEditableTarget(target: EventTarget | null) {
   return (
@@ -25,18 +36,32 @@ export function SearchMenu() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [generatedIndex, setGeneratedIndex] =
+    useState<GeneratedSearchIndex | null>(null);
+  const [generatedIndexError, setGeneratedIndexError] = useState(false);
+  const [versionFilter, setVersionFilter] = useState('current');
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
-  const results = useMemo(() => {
+  const matchingResults = useMemo(() => {
+    const entries = [
+      ...authoredEntries,
+      ...(generatedIndex?.entries ?? []),
+    ].filter((page) => {
+      if (!page.version) return true;
+      if (versionFilter === 'all') return true;
+      if (versionFilter === 'current') return page.current;
+      return page.version === versionFilter;
+    });
     const normalized = query.trim().toLowerCase();
-    if (!normalized) return searchablePages;
-    return searchablePages.filter((page) =>
-      `${page.label} ${page.group} ${page.href}`
+    if (!normalized) return entries;
+    return entries.filter((page) =>
+      `${page.label} ${page.group} ${page.href} ${page.keywords ?? ''}`
         .toLowerCase()
         .includes(normalized),
     );
-  }, [query]);
+  }, [generatedIndex, query, versionFilter]);
+  const results = matchingResults.slice(0, MAX_RESULTS);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -60,6 +85,17 @@ export function SearchMenu() {
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(frame);
   }, [open]);
+
+  useEffect(() => {
+    if (!open || generatedIndex || generatedIndexError) return;
+    void fetch('/search-index.json')
+      .then(async (response) => {
+        if (!response.ok) throw new Error('Unable to load search index.');
+        return generatedSearchIndexSchema.parse(await response.json());
+      })
+      .then(setGeneratedIndex)
+      .catch(() => setGeneratedIndexError(true));
+  }, [generatedIndex, generatedIndexError, open]);
 
   const visit = (href: string) => {
     setOpen(false);
@@ -134,30 +170,68 @@ export function SearchMenu() {
               className="scrollbar-none min-h-80 max-h-[22rem] overflow-y-auto scroll-py-1.5 py-1.5"
               id="search-results"
             >
-              {results.length ? (
-                results.map((page, index) => (
-                  <button
-                    className="flex h-9 w-full items-center gap-3 rounded-md border border-transparent px-3 text-left text-sm font-medium outline-none data-[selected=true]:border-input data-[selected=true]:bg-input/50 hover:bg-input/40"
-                    data-selected={index === selectedIndex}
-                    id={`search-result-${index}`}
-                    key={page.href}
-                    onClick={() => visit(page.href)}
-                    onMouseEnter={() => setSelectedIndex(index)}
-                    type="button"
+              {generatedIndex?.versions.length ? (
+                <label className="mb-1 flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground">
+                  Reference version
+                  <select
+                    className="ml-auto rounded border border-input bg-background px-2 py-1 text-foreground"
+                    onChange={(event) => {
+                      setVersionFilter(event.target.value);
+                      setSelectedIndex(0);
+                    }}
+                    value={versionFilter}
                   >
-                    <ArrowRight
-                      aria-hidden="true"
-                      className="size-4 text-muted-foreground"
-                    />
-                    <span>{page.label}</span>
-                    <span className="ml-auto text-xs font-normal text-muted-foreground">
-                      {page.group}
-                    </span>
-                  </button>
-                ))
+                    <option value="current">Current channels</option>
+                    {generatedIndex.versions.map((version) => (
+                      <option
+                        key={version.routeVersion}
+                        value={version.routeVersion}
+                      >
+                        {version.routeVersion}
+                        {version.channels.length
+                          ? ` (${version.channels.join(', ')})`
+                          : ''}
+                      </option>
+                    ))}
+                    <option value="all">All versions</option>
+                  </select>
+                </label>
+              ) : null}
+              {results.length ? (
+                <>
+                  {results.map((page, index) => (
+                    <button
+                      className="flex min-h-9 w-full items-center gap-3 rounded-md border border-transparent px-3 py-2 text-left text-sm font-medium outline-none data-[selected=true]:border-input data-[selected=true]:bg-input/50 hover:bg-input/40"
+                      data-selected={index === selectedIndex}
+                      id={`search-result-${index}`}
+                      key={`${page.href}-${page.label}`}
+                      onClick={() => visit(page.href)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                      type="button"
+                    >
+                      <ArrowRight
+                        aria-hidden="true"
+                        className="size-4 shrink-0 text-muted-foreground"
+                      />
+                      <span className="min-w-0 truncate">{page.label}</span>
+                      <span className="ml-auto max-w-44 shrink-0 truncate text-xs font-normal text-muted-foreground">
+                        {page.group}
+                      </span>
+                    </button>
+                  ))}
+                  {matchingResults.length > MAX_RESULTS ? (
+                    <p className="px-3 py-2 text-xs text-muted-foreground">
+                      Showing the first {MAX_RESULTS} of{' '}
+                      {matchingResults.length} results. Refine your search to
+                      narrow the list.
+                    </p>
+                  ) : null}
+                </>
               ) : (
                 <p className="py-12 text-center text-sm text-muted-foreground">
-                  No results found.
+                  {generatedIndexError
+                    ? 'Generated reference search is unavailable. Authored pages remain searchable.'
+                    : 'No results found.'}
                 </p>
               )}
             </div>

--- a/typescript2/app-developer-docs/components/use-copy-feedback.ts
+++ b/typescript2/app-developer-docs/components/use-copy-feedback.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const COPY_FEEDBACK_DURATION_MS = 1600;
+
+export function useCopyFeedback<Action extends string>() {
+  const [copiedAction, setCopiedAction] = useState<Action | null>(null);
+  const resetTimer = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== null) {
+        window.clearTimeout(resetTimer.current);
+      }
+    },
+    [],
+  );
+
+  const copy = async (action: Action, value: string): Promise<boolean> => {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      return false;
+    }
+
+    setCopiedAction(action);
+    if (resetTimer.current !== null) {
+      window.clearTimeout(resetTimer.current);
+    }
+    resetTimer.current = window.setTimeout(
+      () => setCopiedAction(null),
+      COPY_FEEDBACK_DURATION_MS,
+    );
+    return true;
+  };
+
+  return { copiedAction, copy };
+}

--- a/typescript2/app-developer-docs/content/cli/index.mdx
+++ b/typescript2/app-developer-docs/content/cli/index.mdx
@@ -1,17 +1,19 @@
 ---
 title: BAML CLI
-description: Install, configure, and use the exact BAML toolchain version that matches your project.
+description: Browse exact-version command reference generated from the BAML toolchain that matches your project.
 breadcrumbs:
   - label: BAML CLI
 ---
 
 ## Overview
 
-The CLI documentation covers installation, public commands, configuration, environment variables, and exit behavior. Command nesting mirrors the tokens accepted by the executable.
+The initial CLI reference covers the public command tree, arguments, flags, defaults, and allowed values exposed by the selected executable. Command nesting mirrors the tokens accepted by that exact toolchain version.
 
 ## Versioned reference
 
 Exact command pages are generated from the noncolored help emitted by the corresponding compiled wrapper and toolchain binaries. Unknown versions remain real 404s rather than silently falling forward.
+
+<GeneratedReleaseCatalog />
 
 <div className="docs-card-grid">
   <DocsCard description="Create a normal BAML project and check it with the toolchain." href="/baml/get-started" title="Get started with BAML" />

--- a/typescript2/app-developer-docs/lib/deployment.ts
+++ b/typescript2/app-developer-docs/lib/deployment.ts
@@ -3,3 +3,9 @@ export function shouldIndexDeployment(
 ): boolean {
   return vercelEnvironment !== 'preview' && vercelEnvironment !== 'development';
 }
+
+export function robotsDisallowEntireSite(robots: string): boolean {
+  return robots
+    .split(/\r?\n/)
+    .some((line) => line.trim().toLowerCase() === 'disallow: /');
+}

--- a/typescript2/app-developer-docs/lib/generated-content/build-content.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/build-content.ts
@@ -17,10 +17,17 @@ export interface GeneratedReleaseSnapshot {
   routeVersion: string;
 }
 
+export interface GeneratedReleaseSummary {
+  channels: ChannelPointerRow['channel'][];
+  release: ReleaseRow;
+  routeVersion: string;
+}
+
 const snapshotPromises = new Map<
   string,
   Promise<GeneratedReleaseSnapshot | null>
 >();
+let releaseSummariesPromise: Promise<GeneratedReleaseSummary[]> | undefined;
 
 export function canonicalVersionToRouteVersion(version: string): string {
   return `v${version}`;
@@ -35,16 +42,52 @@ export function routeVersionToCanonicalVersion(
   return routeVersion.slice(1);
 }
 
-export async function listGeneratedReleaseRouteVersions(): Promise<string[]> {
+async function readReleaseSummaries(): Promise<GeneratedReleaseSummary[]> {
   const reader = createGeneratedContentReader();
   try {
-    const releases = await reader.listReleases();
-    return releases.map((release) =>
-      canonicalVersionToRouteVersion(release.version),
-    );
+    const [releases, channels] = await Promise.all([
+      reader.listReleases(),
+      reader.listChannels(),
+    ]);
+    return releases.map((release) => ({
+      channels: channels
+        .filter((pointer) => pointer.release_version === release.version)
+        .map((pointer) => pointer.channel),
+      release,
+      routeVersion: canonicalVersionToRouteVersion(release.version),
+    }));
   } finally {
     await reader.close();
   }
+}
+
+export function listGeneratedReleaseSummaries(): Promise<
+  GeneratedReleaseSummary[]
+> {
+  releaseSummariesPromise ??= readReleaseSummaries();
+  return releaseSummariesPromise;
+}
+
+export async function listGeneratedReleaseRouteVersions(): Promise<string[]> {
+  return (await listGeneratedReleaseSummaries()).map(
+    (release) => release.routeVersion,
+  );
+}
+
+export function selectFeaturedGeneratedRelease(
+  releases: readonly GeneratedReleaseSummary[],
+): GeneratedReleaseSummary | null {
+  for (const channel of ['stable', 'canary', 'nightly'] as const) {
+    const release = releases.find((candidate) =>
+      candidate.channels.includes(channel),
+    );
+    if (release) return release;
+  }
+  return releases[0] ?? null;
+}
+
+export function isPrereleaseVersion(version: string): boolean {
+  return version.includes('-');
 }
 
 async function readSnapshot(
@@ -53,26 +96,26 @@ async function readSnapshot(
   const version = routeVersionToCanonicalVersion(routeVersion);
   if (!version) return null;
 
+  const releaseSummary = (await listGeneratedReleaseSummaries()).find(
+    (candidate) => candidate.release.version === version,
+  );
+  if (!releaseSummary) return null;
+
   const reader = createGeneratedContentReader();
   try {
-    const [releases, channels, packages, pages, cli] = await Promise.all([
-      reader.listReleases(),
-      reader.listChannels(),
+    const [packages, pages, cli] = await Promise.all([
       reader.listPackageExports(version),
       reader.listReferencePages(version),
       reader.getCliArtifact(version),
     ]);
-    const release = releases.find((candidate) => candidate.version === version);
-    if (!release || !cli) return null;
+    if (!cli) return null;
 
     return {
-      channels: channels
-        .filter((pointer) => pointer.release_version === version)
-        .map((pointer) => pointer.channel),
+      channels: releaseSummary.channels,
       cli,
       packages,
       pages,
-      release,
+      release: releaseSummary.release,
       routeVersion,
     };
   } finally {

--- a/typescript2/app-developer-docs/lib/generated-content/discovery.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/discovery.ts
@@ -1,0 +1,198 @@
+import {
+  type GeneratedReleaseSnapshot,
+  type GeneratedReleaseSummary,
+  isPrereleaseVersion,
+  listGeneratedReleaseSummaries,
+  loadGeneratedReleaseSnapshot,
+} from '@/lib/generated-content/build-content';
+import {
+  findCliCommand,
+  flattenCliCommands,
+} from '@/lib/generated-content/cli-routes';
+import type { GeneratedSearchIndex, SearchEntry } from '@/lib/search';
+
+function channelSuffix(channels: readonly string[]): string {
+  return channels.length > 0 ? ` · ${channels.join(', ')}` : '';
+}
+
+export interface GeneratedVersionOption {
+  channels: string[];
+  href: string;
+  routeVersion: string;
+}
+
+type VersionDestination =
+  | { kind: 'cli-command'; commandPath: readonly string[] }
+  | { kind: 'cli-command-index' }
+  | { kind: 'cli-overview' }
+  | { kind: 'package'; routePath?: string };
+
+export async function listGeneratedVersionOptions(
+  destination: VersionDestination,
+): Promise<GeneratedVersionOption[]> {
+  const releases = await listGeneratedReleaseSummaries();
+  const options: GeneratedVersionOption[] = [];
+
+  for (const release of releases) {
+    const snapshot = await loadGeneratedReleaseSnapshot(release.routeVersion);
+    if (!snapshot) continue;
+    let suffix = '';
+    if (destination.kind === 'package') {
+      if (
+        destination.routePath &&
+        !snapshot.pages.some(
+          (page) => page.route_path === destination.routePath,
+        )
+      ) {
+        continue;
+      }
+      suffix = destination.routePath ? `/${destination.routePath}` : '';
+    } else if (destination.kind === 'cli-command') {
+      if (!findCliCommand(snapshot.cli.payload.root, destination.commandPath)) {
+        continue;
+      }
+      suffix = `/commands/${destination.commandPath.join('/')}`;
+    } else if (destination.kind === 'cli-command-index') {
+      suffix = '/commands';
+    }
+    const root = destination.kind === 'package' ? '/baml/packages' : '/cli';
+    options.push({
+      channels: release.channels,
+      href: `${root}/${release.routeVersion}${suffix}`,
+      routeVersion: release.routeVersion,
+    });
+  }
+
+  return options;
+}
+
+export function generatedRoutePaths(
+  snapshot: GeneratedReleaseSnapshot,
+): string[] {
+  const packageRoot = `/baml/packages/${snapshot.routeVersion}`;
+  const cliRoot = `/cli/${snapshot.routeVersion}`;
+  return [
+    packageRoot,
+    ...snapshot.pages.map((page) => `${packageRoot}/${page.route_path}`),
+    cliRoot,
+    `${cliRoot}/commands`,
+    ...flattenCliCommands(snapshot.cli.payload.root).map(
+      (command) => `${cliRoot}/commands/${command.command_path.join('/')}`,
+    ),
+  ];
+}
+
+export function generatedSearchEntries(
+  release: GeneratedReleaseSummary,
+  snapshot: GeneratedReleaseSnapshot,
+): SearchEntry[] {
+  const entries: SearchEntry[] = [];
+  const current = release.channels.length > 0;
+  const version = release.routeVersion;
+  const packageGroup = `Standard packages · ${version}${channelSuffix(release.channels)}`;
+  const cliGroup = `CLI · ${version}${channelSuffix(release.channels)}`;
+  const packageRoot = `/baml/packages/${version}`;
+  const cliRoot = `/cli/${version}`;
+
+  entries.push(
+    {
+      current,
+      group: packageGroup,
+      href: packageRoot,
+      label: `Standard packages ${version}`,
+      version,
+    },
+    {
+      current,
+      group: cliGroup,
+      href: cliRoot,
+      label: `BAML CLI ${version}`,
+      version,
+    },
+    {
+      current,
+      group: cliGroup,
+      href: `${cliRoot}/commands`,
+      label: `Command index ${version}`,
+      version,
+    },
+  );
+
+  for (const page of snapshot.pages) {
+    const href = `${packageRoot}/${page.route_path}`;
+    entries.push({
+      current,
+      group: packageGroup,
+      href,
+      keywords: `${page.page_kind} ${page.page_data.summary ?? ''}`,
+      label: page.qualified_name,
+      version,
+    });
+    if ('member_anchors' in page.page_data) {
+      for (const member of page.page_data.member_anchors) {
+        entries.push({
+          current,
+          group: packageGroup,
+          href: `${href}#${member.anchor}`,
+          keywords: member.member_kind,
+          label: `${page.qualified_name}.${member.label}`,
+          version,
+        });
+      }
+    }
+  }
+
+  for (const command of flattenCliCommands(snapshot.cli.payload.root)) {
+    entries.push({
+      current,
+      group: cliGroup,
+      href: `${cliRoot}/commands/${command.command_path.join('/')}`,
+      keywords: command.description ?? '',
+      label: `baml ${command.command_path.join(' ')}`,
+      version,
+    });
+  }
+
+  return entries;
+}
+
+export async function listGeneratedSitemapRoutes(): Promise<
+  { lastModified: Date; path: string }[]
+> {
+  const releases = await listGeneratedReleaseSummaries();
+  const routes: { lastModified: Date; path: string }[] = [];
+
+  for (const release of releases) {
+    if (isPrereleaseVersion(release.release.version)) continue;
+    const snapshot = await loadGeneratedReleaseSnapshot(release.routeVersion);
+    if (!snapshot) continue;
+    routes.push(
+      ...generatedRoutePaths(snapshot).map((path) => ({
+        lastModified: release.release.released_at,
+        path,
+      })),
+    );
+  }
+
+  return routes;
+}
+
+export async function buildGeneratedSearchIndex(): Promise<GeneratedSearchIndex> {
+  const releases = await listGeneratedReleaseSummaries();
+  const entries: SearchEntry[] = [];
+
+  for (const release of releases) {
+    const snapshot = await loadGeneratedReleaseSnapshot(release.routeVersion);
+    if (!snapshot) continue;
+    entries.push(...generatedSearchEntries(release, snapshot));
+  }
+
+  return {
+    entries,
+    versions: releases.map((release) => ({
+      channels: release.channels,
+      current: release.channels.length > 0,
+      routeVersion: release.routeVersion,
+    })),
+  };
+}

--- a/typescript2/app-developer-docs/lib/generated-content/discovery.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/discovery.ts
@@ -9,7 +9,16 @@ import {
   findCliCommand,
   flattenCliCommands,
 } from '@/lib/generated-content/cli-routes';
+import type {
+  CrossReference,
+  ReferencePageRow,
+} from '@/lib/generated-content/schemas';
 import type { GeneratedSearchIndex, SearchEntry } from '@/lib/search';
+
+const declarationReferencesByPages = new WeakMap<
+  ReferencePageRow[],
+  CrossReference[]
+>();
 
 function channelSuffix(channels: readonly string[]): string {
   return channels.length > 0 ? ` · ${channels.join(', ')}` : '';
@@ -19,6 +28,26 @@ export interface GeneratedVersionOption {
   channels: string[];
   href: string;
   routeVersion: string;
+}
+
+export function generatedDeclarationTypeReferences(
+  pages: ReferencePageRow[],
+): readonly CrossReference[] {
+  const cached = declarationReferencesByPages.get(pages);
+  if (cached) return cached;
+
+  const references: CrossReference[] = [];
+  for (const page of pages) {
+    if (!('exported_id' in page.page_data)) continue;
+    references.push({
+      anchor: null,
+      exported_id: page.page_data.exported_id,
+      qualified_name: page.qualified_name,
+      route_path: page.route_path,
+    });
+  }
+  declarationReferencesByPages.set(pages, references);
+  return references;
 }
 
 type VersionDestination =

--- a/typescript2/app-developer-docs/lib/generated-content/package-export.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/package-export.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+
+import { declarationPageKindSchema } from '@/lib/generated-content/schemas';
+
+export const exportedTypeDisplaySchema = z
+  .object({ display: z.string().min(1) })
+  .passthrough();
+
+export const exportedSourceSchema = z
+  .object({
+    end: z.number().int(),
+    file: z.string().min(1),
+    start: z.number().int(),
+  })
+  .passthrough();
+
+export const exportedParameterSchema = z
+  .object({
+    name: z.string().min(1),
+    optional: z.boolean().optional(),
+    ty: exportedTypeDisplaySchema,
+  })
+  .passthrough();
+
+const exportedGenericSchema = z
+  .object({
+    bounds: z.array(z.string().min(1)),
+    name: z.string().min(1),
+  })
+  .passthrough();
+
+export const exportedSignatureSchema = z
+  .object({
+    generics: z.array(exportedGenericSchema).optional(),
+    params: z.array(exportedParameterSchema),
+    returns: exportedTypeDisplaySchema,
+    throws: exportedTypeDisplaySchema.optional(),
+  })
+  .passthrough();
+
+export const exportedMemberSchema = z
+  .object({
+    default: exportedTypeDisplaySchema.optional(),
+    docstring: z.string().optional(),
+    id: z.string().min(1),
+    name: z.string().min(1),
+    signature: exportedSignatureSchema.optional(),
+    ty: exportedTypeDisplaySchema.optional(),
+  })
+  .passthrough();
+
+export const exportedItemSchema = z
+  .object({
+    assoc_types: z.array(exportedMemberSchema).optional(),
+    default_methods: z.array(exportedMemberSchema).optional(),
+    detail: z.string().optional(),
+    docstring: z.string().optional(),
+    fields: z.array(exportedMemberSchema).optional(),
+    generics: z.array(exportedGenericSchema).optional(),
+    id: z.string().min(1),
+    impls: z.array(z.string().min(1)).optional(),
+    kind: declarationPageKindSchema,
+    methods: z.array(exportedMemberSchema).optional(),
+    name: z.string().min(1),
+    namespace: z.array(z.string().min(1)).optional(),
+    required_methods: z.array(exportedMemberSchema).optional(),
+    resolved: exportedTypeDisplaySchema.optional(),
+    signature: exportedSignatureSchema.optional(),
+    source: exportedSourceSchema.optional(),
+    variants: z.array(exportedMemberSchema).optional(),
+  })
+  .passthrough();
+
+export const exportedImplementationSchema = z
+  .object({
+    assoc_bindings: z
+      .array(
+        z
+          .object({
+            name: z.string().min(1),
+            ty: exportedTypeDisplaySchema,
+          })
+          .passthrough(),
+      )
+      .optional(),
+    docstring: z.string().optional(),
+    for_ty: exportedTypeDisplaySchema.optional(),
+    id: z.string().min(1),
+    interface: z.string().optional(),
+    methods: z.array(exportedMemberSchema).optional(),
+    source: exportedSourceSchema.optional(),
+  })
+  .passthrough();
+
+export type ExportedImplementation = z.output<
+  typeof exportedImplementationSchema
+>;
+export type ExportedGeneric = z.output<typeof exportedGenericSchema>;
+export type ExportedItem = z.output<typeof exportedItemSchema>;
+export type ExportedMember = z.output<typeof exportedMemberSchema>;
+export type ExportedParameter = z.output<typeof exportedParameterSchema>;
+export type ExportedSignature = z.output<typeof exportedSignatureSchema>;
+export type ExportedSource = z.output<typeof exportedSourceSchema>;

--- a/typescript2/app-developer-docs/lib/generated-content/package-generator.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/package-generator.ts
@@ -8,60 +8,21 @@ import {
   sha256,
 } from '@/lib/generated-content/json';
 import {
+  type ExportedImplementation,
+  type ExportedItem,
+  exportedImplementationSchema,
+  exportedItemSchema,
+} from '@/lib/generated-content/package-export';
+import {
   createMemberAnchors,
   qualifiedNameToRoutePath,
   qualifyExportedName,
 } from '@/lib/generated-content/routes';
 import {
-  declarationPageKindSchema,
   packageDescribeExportSchema,
   type ReferencePageData,
   referencePageDataSchema,
 } from '@/lib/generated-content/schemas';
-
-const exportedMemberSchema = z
-  .object({
-    id: z.string().min(1),
-    name: z.string().min(1),
-  })
-  .passthrough();
-
-const exportedItemSchema = z
-  .object({
-    assoc_types: z.array(exportedMemberSchema).optional(),
-    default_methods: z.array(exportedMemberSchema).optional(),
-    docstring: z.string().optional(),
-    fields: z.array(exportedMemberSchema).optional(),
-    id: z.string().min(1),
-    impls: z.array(z.string().min(1)).optional(),
-    kind: declarationPageKindSchema,
-    methods: z.array(exportedMemberSchema).optional(),
-    name: z.string().min(1),
-    namespace: z.array(z.string().min(1)).optional(),
-    required_methods: z.array(exportedMemberSchema).optional(),
-    variants: z.array(exportedMemberSchema).optional(),
-  })
-  .passthrough();
-
-const exportedImplementationSchema = z
-  .object({
-    docstring: z.string().optional(),
-    id: z.string().min(1),
-    methods: z
-      .array(
-        z
-          .object({
-            id: z.string().min(1),
-            name: z.string().min(1),
-          })
-          .passthrough(),
-      )
-      .optional(),
-  })
-  .passthrough();
-
-type ExportedItem = z.output<typeof exportedItemSchema>;
-type ExportedImplementation = z.output<typeof exportedImplementationSchema>;
 
 export interface ReferencePageProjection {
   pageData: ReferencePageData;

--- a/typescript2/app-developer-docs/lib/generated-content/reference-rendering.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/reference-rendering.ts
@@ -1,0 +1,214 @@
+import type {
+  ExportedGeneric,
+  ExportedItem,
+  ExportedMember,
+  ExportedParameter,
+  ExportedSignature,
+} from '@/lib/generated-content/package-export';
+import type { CrossReference } from '@/lib/generated-content/schemas';
+
+export type ReferenceTypeLink = CrossReference;
+
+export interface MemberGroupData {
+  id: string;
+  kind: MemberKind;
+  members: ExportedMember[];
+  title: string;
+}
+
+export type MemberKind = 'associated-type' | 'field' | 'method' | 'variant';
+
+export interface TypeDisplaySegment {
+  reference?: ReferenceTypeLink;
+  start: number;
+  text: string;
+}
+
+export type TypeReferenceIndex = ReadonlyMap<string, ReferenceTypeLink>;
+
+const TYPE_NAME_PATTERN =
+  /[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*/g;
+
+function parameterText(parameter: ExportedParameter): string {
+  if (parameter.name === 'self') return 'self';
+  return `${parameter.name}: ${parameter.ty.display}${parameter.optional ? ' = …' : ''}`;
+}
+
+function genericText(generic: ExportedGeneric): string {
+  const bounds =
+    generic.bounds.length > 0 ? ` extends ${generic.bounds.join(' & ')}` : '';
+  return `${generic.name}${bounds}`;
+}
+
+export function genericParametersText(
+  generics: readonly ExportedGeneric[] | undefined,
+): string {
+  return generics?.length ? `<${generics.map(genericText).join(', ')}>` : '';
+}
+
+export function signatureText(
+  name: string,
+  signature: ExportedSignature,
+): string {
+  const generics = genericParametersText(signature.generics);
+  const parameters = signature.params.map(parameterText).join(', ');
+  const throws =
+    signature.throws && signature.throws.display !== 'never'
+      ? ` throws ${signature.throws.display}`
+      : '';
+  return `${name}${generics}(${parameters}) -> ${signature.returns.display}${throws}`;
+}
+
+export function shouldUseMultilineSignature(
+  name: string,
+  signature: ExportedSignature,
+): boolean {
+  return (
+    signature.params.length > 3 || signatureText(name, signature).length > 96
+  );
+}
+
+export function splitMethods(members: ExportedMember[]) {
+  const staticMethods: ExportedMember[] = [];
+  const instanceMethods: ExportedMember[] = [];
+  for (const member of members) {
+    if (member.signature?.params[0]?.name === 'self') {
+      instanceMethods.push(member);
+    } else {
+      staticMethods.push(member);
+    }
+  }
+  return { instanceMethods, staticMethods };
+}
+
+export function declarationMemberGroups(
+  declaration: ExportedItem,
+): MemberGroupData[] {
+  const declaredMethods = splitMethods(declaration.methods ?? []);
+  const requiredMethods = splitMethods(declaration.required_methods ?? []);
+  const defaultMethods = splitMethods(declaration.default_methods ?? []);
+  return [
+    {
+      id: 'fields',
+      kind: 'field' as const,
+      members: declaration.fields ?? [],
+      title: 'Fields',
+    },
+    {
+      id: 'variants',
+      kind: 'variant' as const,
+      members: declaration.variants ?? [],
+      title: 'Variants',
+    },
+    {
+      id: 'associated-types',
+      kind: 'associated-type' as const,
+      members: declaration.assoc_types ?? [],
+      title: 'Associated types',
+    },
+    {
+      id: 'static-methods',
+      kind: 'method' as const,
+      members: declaredMethods.staticMethods,
+      title: 'Static methods',
+    },
+    {
+      id: 'required-static-methods',
+      kind: 'method' as const,
+      members: requiredMethods.staticMethods,
+      title: 'Required static methods',
+    },
+    {
+      id: 'default-static-methods',
+      kind: 'method' as const,
+      members: defaultMethods.staticMethods,
+      title: 'Default static methods',
+    },
+    {
+      id: 'instance-methods',
+      kind: 'method' as const,
+      members: declaredMethods.instanceMethods,
+      title: 'Instance methods',
+    },
+    {
+      id: 'required-instance-methods',
+      kind: 'method' as const,
+      members: requiredMethods.instanceMethods,
+      title: 'Required instance methods',
+    },
+    {
+      id: 'default-instance-methods',
+      kind: 'method' as const,
+      members: defaultMethods.instanceMethods,
+      title: 'Default instance methods',
+    },
+  ].filter((group) => group.members.length > 0);
+}
+
+export function memberDeclarationText(
+  member: ExportedMember,
+  kind: MemberKind,
+): string {
+  if (member.signature) {
+    return `function ${signatureText(member.name, member.signature)}`;
+  }
+  if (kind === 'associated-type') {
+    const defaultType = member.default ? ` = ${member.default.display}` : '';
+    return `type ${member.name}${defaultType}`;
+  }
+  return member.ty ? `${member.name}: ${member.ty.display}` : member.name;
+}
+
+export function createTypeReferenceIndex(
+  references: readonly ReferenceTypeLink[],
+  excludedQualifiedName?: string,
+): TypeReferenceIndex {
+  const index = new Map<string, ReferenceTypeLink>();
+  for (const reference of references) {
+    if (reference.qualified_name === excludedQualifiedName) continue;
+    const existing = index.get(reference.qualified_name);
+    if (!existing || (existing.anchor !== null && reference.anchor === null)) {
+      index.set(reference.qualified_name, reference);
+    }
+  }
+  return index;
+}
+
+export function typeDisplaySegments(
+  display: string,
+  references: TypeReferenceIndex,
+): TypeDisplaySegment[] {
+  const segments: TypeDisplaySegment[] = [];
+  let plainTextStart = 0;
+
+  for (const match of display.matchAll(TYPE_NAME_PATTERN)) {
+    const reference = references.get(match[0]);
+    if (!reference) continue;
+    const start = match.index;
+    if (plainTextStart < start) {
+      segments.push({
+        start: plainTextStart,
+        text: display.slice(plainTextStart, start),
+      });
+    }
+    segments.push({ reference, start, text: match[0] });
+    plainTextStart = start + match[0].length;
+  }
+
+  if (plainTextStart < display.length) {
+    segments.push({
+      start: plainTextStart,
+      text: display.slice(plainTextStart),
+    });
+  }
+
+  return segments.length > 0 ? segments : [{ start: 0, text: display }];
+}
+
+export function referenceHref(
+  routeVersion: string,
+  reference: ReferenceTypeLink,
+): string {
+  const anchor = reference.anchor ? `#${reference.anchor}` : '';
+  return `/baml/packages/${routeVersion}/${reference.route_path}${anchor}`;
+}

--- a/typescript2/app-developer-docs/lib/generated-content/routes.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/routes.ts
@@ -47,6 +47,17 @@ export function deriveParentQualifiedName(
   return segments.length === 1 ? null : segments.slice(0, -1).join('.');
 }
 
+export function directRouteChildren<T extends { route_path: string }>(
+  routePath: string,
+  pages: readonly T[],
+): T[] {
+  const prefix = `${routePath}/`;
+  return pages.filter((candidate) => {
+    if (!candidate.route_path.startsWith(prefix)) return false;
+    return !candidate.route_path.slice(prefix.length).includes('/');
+  });
+}
+
 export function qualifyExportedName(
   packageName: string,
   namespace: readonly string[],

--- a/typescript2/app-developer-docs/lib/generated-content/schemas.ts
+++ b/typescript2/app-developer-docs/lib/generated-content/schemas.ts
@@ -271,6 +271,7 @@ export const cliArtifactRowSchema = z
 export type ReleaseRow = z.output<typeof releaseRowSchema>;
 export type ChannelPointerRow = z.output<typeof channelPointerRowSchema>;
 export type PackageExportRow = z.output<typeof packageExportRowSchema>;
+export type CrossReference = z.output<typeof crossReferenceSchema>;
 export type ReferencePageData = z.output<typeof referencePageDataSchema>;
 export type ReferencePageRow = z.output<typeof referencePageRowSchema>;
 export type CliArtifactPayload = z.output<typeof cliArtifactPayloadSchema>;

--- a/typescript2/app-developer-docs/lib/metadata.ts
+++ b/typescript2/app-developer-docs/lib/metadata.ts
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+
+import { shouldIndexDeployment } from '@/lib/deployment';
+
+export function documentationMetadata({
+  description,
+  index = true,
+  path,
+  title,
+}: {
+  description: string;
+  index?: boolean;
+  path: string;
+  title: string;
+}): Metadata {
+  const deploymentIsPublic = shouldIndexDeployment();
+  return {
+    alternates: { canonical: path },
+    description,
+    openGraph: {
+      description,
+      title,
+      url: path,
+    },
+    robots: {
+      follow: deploymentIsPublic,
+      index: deploymentIsPublic && index,
+    },
+    title,
+  };
+}

--- a/typescript2/app-developer-docs/lib/search.ts
+++ b/typescript2/app-developer-docs/lib/search.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const searchEntrySchema = z
+  .object({
+    current: z.boolean(),
+    group: z.string(),
+    href: z.string().startsWith('/'),
+    keywords: z.string().optional(),
+    label: z.string(),
+    version: z.string().optional(),
+  })
+  .strict();
+
+const searchVersionSchema = z
+  .object({
+    channels: z.array(z.string()),
+    current: z.boolean(),
+    routeVersion: z.string(),
+  })
+  .strict();
+
+export const generatedSearchIndexSchema = z
+  .object({
+    entries: z.array(searchEntrySchema),
+    versions: z.array(searchVersionSchema),
+  })
+  .strict();
+
+export type SearchEntry = z.output<typeof searchEntrySchema>;
+export type SearchVersion = z.output<typeof searchVersionSchema>;
+export type GeneratedSearchIndex = z.output<typeof generatedSearchIndexSchema>;

--- a/typescript2/app-developer-docs/scripts/check-static-links.ts
+++ b/typescript2/app-developer-docs/scripts/check-static-links.ts
@@ -4,6 +4,7 @@ import { extname, relative, resolve, sep } from 'node:path';
 const outputRoot = resolve(import.meta.dirname, '..', 'out');
 const hrefPattern = /\shref=(?:"([^"]+)"|'([^']+)')/g;
 const idPattern = /\sid=(?:"([^"]+)"|'([^']+)')/g;
+const sitemapLocationPattern = /<loc>([^<]+)<\/loc>/g;
 
 async function collectHtmlFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -79,7 +80,10 @@ async function resolveTarget(route: string) {
 }
 
 const failures = new Set<string>();
+const routeLinks = new Map<string, Set<string>>();
 for (const [currentRoute, page] of pages) {
+  const links = new Set<string>();
+  routeLinks.set(currentRoute, links);
   for (const match of page.html.matchAll(hrefPattern)) {
     const href = match[1] ?? match[2];
     const target = internalTarget(href, currentRoute);
@@ -89,6 +93,7 @@ for (const [currentRoute, page] of pages) {
       failures.add(`${relative(outputRoot, page.file)}: missing route ${href}`);
       continue;
     }
+    if (pages.has(target.route)) links.add(target.route);
     if (
       target.fragment &&
       !targetPage.anchors.has(decodeURIComponent(target.fragment))
@@ -100,10 +105,61 @@ for (const [currentRoute, page] of pages) {
   }
 }
 
+const reachableRoutes = new Set(['/']);
+const pendingRoutes = ['/'];
+while (pendingRoutes.length > 0) {
+  const route = pendingRoutes.shift();
+  if (!route) continue;
+  for (const target of routeLinks.get(route) ?? []) {
+    if (reachableRoutes.has(target)) continue;
+    reachableRoutes.add(target);
+    pendingRoutes.push(target);
+  }
+}
+for (const route of pages.keys()) {
+  if (route === '/404' || route === '/_not-found') continue;
+  if (!reachableRoutes.has(route)) {
+    failures.add(`${route}: static page is unreachable from /`);
+  }
+}
+
+const sitemapSource = await readFile(
+  resolve(outputRoot, 'sitemap.xml'),
+  'utf8',
+);
+const sitemapRoutes = new Set(
+  [...sitemapSource.matchAll(sitemapLocationPattern)].flatMap((match) => {
+    const location = match[1];
+    if (!location) return [];
+    const route = new URL(location).pathname;
+    return [route === '/' ? '/' : route.replace(/\/$/, '')];
+  }),
+);
+const excludedFromSitemap = new Set(['/404', '/_not-found']);
+for (const [route, page] of pages) {
+  if (excludedFromSitemap.has(route)) continue;
+  const noindex = /<meta[^>]+name="robots"[^>]+content="[^"]*noindex/i.test(
+    page.html,
+  );
+  if (!noindex && !sitemapRoutes.has(route)) {
+    failures.add(`${route}: indexable page is missing from sitemap.xml`);
+  }
+  if (noindex && sitemapRoutes.has(route)) {
+    failures.add(`${route}: noindex page is present in sitemap.xml`);
+  }
+}
+for (const route of sitemapRoutes) {
+  if (!pages.has(route)) {
+    failures.add(`sitemap.xml: missing static page ${route}`);
+  }
+}
+
 if (failures.size > 0) {
   throw new Error(
     `Static internal-link validation failed:\n${[...failures].join('\n')}`,
   );
 }
 
-console.log(`Validated internal links across ${pages.size} static HTML pages.`);
+console.log(
+  `Validated links, reachability, and sitemap coverage across ${pages.size} static HTML pages.`,
+);

--- a/typescript2/app-developer-docs/scripts/check-static-links.ts
+++ b/typescript2/app-developer-docs/scripts/check-static-links.ts
@@ -1,6 +1,8 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { extname, relative, resolve, sep } from 'node:path';
 
+import { robotsDisallowEntireSite } from '@/lib/deployment';
+
 const outputRoot = resolve(import.meta.dirname, '..', 'out');
 const hrefPattern = /\shref=(?:"([^"]+)"|'([^']+)')/g;
 const idPattern = /\sid=(?:"([^"]+)"|'([^']+)')/g;
@@ -127,6 +129,8 @@ const sitemapSource = await readFile(
   resolve(outputRoot, 'sitemap.xml'),
   'utf8',
 );
+const robotsSource = await readFile(resolve(outputRoot, 'robots.txt'), 'utf8');
+const deploymentWideNoindex = robotsDisallowEntireSite(robotsSource);
 const sitemapRoutes = new Set(
   [...sitemapSource.matchAll(sitemapLocationPattern)].flatMap((match) => {
     const location = match[1];
@@ -144,7 +148,7 @@ for (const [route, page] of pages) {
   if (!noindex && !sitemapRoutes.has(route)) {
     failures.add(`${route}: indexable page is missing from sitemap.xml`);
   }
-  if (noindex && sitemapRoutes.has(route)) {
+  if (noindex && sitemapRoutes.has(route) && !deploymentWideNoindex) {
     failures.add(`${route}: noindex page is present in sitemap.xml`);
   }
 }

--- a/typescript2/app-developer-docs/tests/deployment.test.ts
+++ b/typescript2/app-developer-docs/tests/deployment.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { shouldIndexDeployment } from '../lib/deployment.ts';
+import {
+  robotsDisallowEntireSite,
+  shouldIndexDeployment,
+} from '../lib/deployment.ts';
 
 test('Vercel previews and development deployments are noindex', () => {
   assert.equal(shouldIndexDeployment('preview'), false);
@@ -11,4 +14,12 @@ test('Vercel previews and development deployments are noindex', () => {
 test('production and ordinary static builds are indexable', () => {
   assert.equal(shouldIndexDeployment('production'), true);
   assert.equal(shouldIndexDeployment(undefined), true);
+});
+
+test('deployment-wide robots exclusions are detected independently of sitemap intent', () => {
+  assert.equal(robotsDisallowEntireSite('User-agent: *\nDisallow: /\n'), true);
+  assert.equal(
+    robotsDisallowEntireSite('User-agent: *\nDisallow: /private\n'),
+    false,
+  );
 });

--- a/typescript2/app-developer-docs/tests/generated-reference-rendering.test.ts
+++ b/typescript2/app-developer-docs/tests/generated-reference-rendering.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { referencePageTableOfContents } from '../components/generated-reference.tsx';
+import {
+  createTypeReferenceIndex,
+  genericParametersText,
+  memberDeclarationText,
+  shouldUseMultilineSignature,
+  signatureText,
+  typeDisplaySegments,
+} from '../lib/generated-content/reference-rendering.ts';
+import { referencePageDataSchema } from '../lib/generated-content/schemas.ts';
+
+test('reference page table of contents lists each non-empty member group', () => {
+  const page = referencePageDataSchema.parse({
+    cross_references: [],
+    declaration: {
+      fields: [{ id: 'field:model', name: 'model', ty: { display: 'string' } }],
+      id: 'interface:example.Client',
+      kind: 'interface',
+      name: 'Client',
+      required_methods: [
+        {
+          id: 'method:create',
+          name: 'create',
+          signature: { params: [], returns: { display: 'example.Client' } },
+        },
+        {
+          id: 'method:run',
+          name: 'run',
+          signature: {
+            params: [{ name: 'self', ty: { display: 'example.Client' } }],
+            returns: { display: 'string' },
+          },
+        },
+      ],
+    },
+    display_name: 'Client',
+    exported_id: 'interface:example.Client',
+    implementations: [{ id: 'impl:Client', methods: [] }],
+    member_anchors: [
+      {
+        anchor: 'model',
+        exported_id: 'field:model',
+        label: 'model',
+        member_kind: 'field',
+      },
+    ],
+    namespace_path: [],
+    package_name: 'example',
+    page_kind: 'interface',
+    qualified_name: 'example.Client',
+    schema_version: 1,
+    summary: null,
+  });
+
+  assert.deepEqual(referencePageTableOfContents(page), [
+    { href: '#signature', label: 'Signature' },
+    { href: '#fields', label: 'Fields' },
+    { href: '#required-static-methods', label: 'Required static methods' },
+    {
+      href: '#required-instance-methods',
+      label: 'Required instance methods',
+    },
+    { href: '#implementations', label: 'Implementations' },
+  ]);
+});
+
+test('signatures preserve generics and defaults and wrap only when dense', () => {
+  const shortSignature = {
+    generics: [{ bounds: [], name: 'Out' }],
+    params: [
+      { name: 'self', ty: { display: 'ai.Runner' } },
+      {
+        name: 'spec',
+        optional: true,
+        ty: { display: 'ai.FunctionSpec<Out>' },
+      },
+    ],
+    returns: { display: 'ai.RunResult<Out>' },
+  };
+
+  assert.equal(
+    signatureText('run', shortSignature),
+    'run<Out>(self, spec: ai.FunctionSpec<Out> = …) -> ai.RunResult<Out>',
+  );
+  assert.equal(shouldUseMultilineSignature('run', shortSignature), false);
+  assert.equal(
+    shouldUseMultilineSignature('new', {
+      params: [
+        { name: 'one', ty: { display: 'string' } },
+        { name: 'two', ty: { display: 'string' } },
+        { name: 'three', ty: { display: 'string' } },
+        { name: 'four', ty: { display: 'string' } },
+      ],
+      returns: { display: 'example.Client' },
+    }),
+    true,
+  );
+
+  const boundedSignature = {
+    generics: [
+      {
+        bounds: ['baml.Named', 'baml.Sized'],
+        name: 'T',
+      },
+    ],
+    params: [{ name: 'value', ty: { display: 'T' } }],
+    returns: { display: 'string' },
+  };
+  assert.equal(
+    genericParametersText(boundedSignature.generics),
+    '<T extends baml.Named & baml.Sized>',
+  );
+  assert.equal(
+    signatureText('describe', boundedSignature),
+    'describe<T extends baml.Named & baml.Sized>(value: T) -> string',
+  );
+});
+
+test('associated type declarations include the type keyword and defaults', () => {
+  assert.equal(
+    memberDeclarationText(
+      { id: 'assoc:Error', name: 'Error' },
+      'associated-type',
+    ),
+    'type Error',
+  );
+  assert.equal(
+    memberDeclarationText(
+      {
+        default: { display: 'baml.errors.InvalidArgument' },
+        id: 'assoc:Error',
+        name: 'Error',
+      },
+      'associated-type',
+    ),
+    'type Error = baml.errors.InvalidArgument',
+  );
+});
+
+test('type displays link exact qualified names without partial identifiers', () => {
+  const references = [
+    {
+      anchor: null,
+      exported_id: 'class:ai.Client',
+      qualified_name: 'ai.Client',
+      route_path: 'ai/Client',
+    },
+    {
+      anchor: null,
+      exported_id: 'class:ai.Client.Result',
+      qualified_name: 'ai.Client.Result',
+      route_path: 'ai/Client/Result',
+    },
+  ];
+
+  const segments = typeDisplaySegments(
+    'map<ai.Client, ai.Client.Result> | notai.Client',
+    createTypeReferenceIndex(references),
+  );
+  assert.deepEqual(
+    segments.map((segment) => ({
+      reference: segment.reference?.qualified_name,
+      text: segment.text,
+    })),
+    [
+      { reference: undefined, text: 'map<' },
+      { reference: 'ai.Client', text: 'ai.Client' },
+      { reference: undefined, text: ', ' },
+      { reference: 'ai.Client.Result', text: 'ai.Client.Result' },
+      { reference: undefined, text: '> | notai.Client' },
+    ],
+  );
+});
+
+test('type reference indexing prefers declaration routes and excludes the current page', () => {
+  const index = createTypeReferenceIndex(
+    [
+      {
+        anchor: 'run',
+        exported_id: 'method:ai.Runner.run',
+        qualified_name: 'ai.Runner',
+        route_path: 'ai/Runner',
+      },
+      {
+        anchor: null,
+        exported_id: 'class:ai.Runner',
+        qualified_name: 'ai.Runner',
+        route_path: 'ai/Runner',
+      },
+      {
+        anchor: null,
+        exported_id: 'class:ai.Client',
+        qualified_name: 'ai.Client',
+        route_path: 'ai/Client',
+      },
+    ],
+    'ai.Client',
+  );
+
+  assert.equal(index.get('ai.Runner')?.anchor, null);
+  assert.equal(index.has('ai.Client'), false);
+});

--- a/typescript2/app-developer-docs/tests/generated-routes.test.ts
+++ b/typescript2/app-developer-docs/tests/generated-routes.test.ts
@@ -3,12 +3,21 @@ import test from 'node:test';
 
 import {
   canonicalVersionToRouteVersion,
+  type GeneratedReleaseSnapshot,
+  type GeneratedReleaseSummary,
+  isPrereleaseVersion,
   routeVersionToCanonicalVersion,
+  selectFeaturedGeneratedRelease,
 } from '../lib/generated-content/build-content.ts';
 import {
   findCliCommand,
   flattenCliCommands,
 } from '../lib/generated-content/cli-routes.ts';
+import {
+  generatedRoutePaths,
+  generatedSearchEntries,
+} from '../lib/generated-content/discovery.ts';
+import { directRouteChildren } from '../lib/generated-content/routes.ts';
 import type { CliCommandNodeInput } from '../lib/generated-content/schemas.ts';
 
 const leaf: CliCommandNodeInput = {
@@ -55,4 +64,139 @@ test('CLI routes mirror command tokens and reject unknown paths', () => {
   );
   assert.equal(findCliCommand(root, ['generate', 'add']), leaf);
   assert.equal(findCliCommand(root, ['generate', 'remove']), null);
+});
+
+function releaseSummary(
+  version: string,
+  channels: GeneratedReleaseSummary['channels'],
+): GeneratedReleaseSummary {
+  return {
+    channels,
+    release: {
+      created_at: new Date('2026-09-01T00:00:00Z'),
+      generated_at: new Date('2026-09-01T00:00:00Z'),
+      generator_version: '2b85a0ae8a258b7dbe21c346ffe05b051d62a08d',
+      released_at: new Date('2026-09-01T00:00:00Z'),
+      source_commit: '5a29ca428e3a964d262506ed90d889b3ab4d01a7',
+      version,
+    },
+    routeVersion: `v${version}`,
+  };
+}
+
+test('release discovery prefers stable and keeps prereleases explicit', () => {
+  const nightly = releaseSummary('0.18.1-nightly.20260901.a', ['nightly']);
+  const canary = releaseSummary('0.18.1-canary.1', ['canary']);
+  const stable = releaseSummary('0.18.0', ['stable']);
+
+  assert.equal(
+    selectFeaturedGeneratedRelease([nightly, canary, stable]),
+    stable,
+  );
+  assert.equal(selectFeaturedGeneratedRelease([nightly, canary]), canary);
+  assert.equal(isPrereleaseVersion(nightly.release.version), true);
+  assert.equal(isPrereleaseVersion(stable.release.version), false);
+});
+
+test('direct route children make hidden namespace descendants discoverable', () => {
+  const pages = [
+    { route_path: 'boundary/id' },
+    { route_path: 'boundary/id/current' },
+    { route_path: 'boundary/id/nested/value' },
+    { route_path: 'boundary/other' },
+  ];
+  assert.deepEqual(directRouteChildren('boundary/id', pages), [pages[1]]);
+});
+
+test('generated discovery covers exact routes and member search anchors', () => {
+  const summary = releaseSummary('0.18.1-nightly.20260901.a', ['nightly']);
+  const hash = '0'.repeat(64);
+  const snapshot: GeneratedReleaseSnapshot = {
+    channels: summary.channels,
+    cli: {
+      payload: {
+        artifact_schema_version: 1,
+        product_version: summary.release.version,
+        raw_help: [
+          {
+            command_path: [],
+            invocation: ['help'],
+            sha256: hash,
+            text: 'BAML help',
+          },
+        ],
+        root,
+        wrapper_version: '0.2.4',
+      },
+      row: {
+        artifact_schema_version: 1,
+        generated_at: new Date('2026-09-01T00:00:00Z'),
+        payload_json: '{}',
+        payload_sha256: hash,
+        release_version: summary.release.version,
+        source_sha256: hash,
+        wrapper_version: '0.2.4',
+      },
+    },
+    packages: [],
+    pages: [
+      {
+        generated_at: new Date('2026-09-01T00:00:00Z'),
+        package_export_id: 1,
+        page_data: {
+          cross_references: [],
+          declaration: {
+            id: 'V:boundary.id.current',
+            kind: 'function',
+            name: 'current',
+          },
+          display_name: 'current',
+          exported_id: 'V:boundary.id.current',
+          implementations: [],
+          member_anchors: [
+            {
+              anchor: 'value',
+              exported_id: 'F:boundary.id.current.value',
+              label: 'value',
+              member_kind: 'field',
+            },
+          ],
+          namespace_path: ['id'],
+          package_name: 'boundary',
+          page_kind: 'function',
+          qualified_name: 'boundary.id.current',
+          schema_version: 1,
+          summary: 'Returns the current identifier.',
+        },
+        page_kind: 'function',
+        page_schema_version: 1,
+        qualified_name: 'boundary.id.current',
+        route_path: 'boundary/id/current',
+      },
+    ],
+    release: summary.release,
+    routeVersion: summary.routeVersion,
+  };
+
+  const paths = generatedRoutePaths(snapshot);
+  assert.ok(paths.includes(`/baml/packages/${summary.routeVersion}`));
+  assert.ok(
+    paths.includes(
+      `/baml/packages/${summary.routeVersion}/boundary/id/current`,
+    ),
+  );
+  assert.ok(
+    paths.includes(`/cli/${summary.routeVersion}/commands/generate/add`),
+  );
+
+  const search = generatedSearchEntries(summary, snapshot);
+  assert.ok(
+    search.some(
+      (entry) =>
+        entry.label === 'boundary.id.current.value' &&
+        entry.href.endsWith('/boundary/id/current#value') &&
+        entry.current,
+    ),
+  );
+  assert.ok(search.some((entry) => entry.label === 'baml generate add'));
 });

--- a/typescript2/app-developer-docs/tests/navigation.test.ts
+++ b/typescript2/app-developer-docs/tests/navigation.test.ts
@@ -106,3 +106,26 @@ test('the docs shell preserves the measured shadcn geometry', async () => {
   assert.doesNotMatch(headerSource, /border-b/);
   assert.doesNotMatch(globalStyles, /fumadocs-ui\/css/);
 });
+
+test('generated reference hubs, search, and sitemap share published release data', async () => {
+  const [packageHub, cliHub, cliContent, searchMenu, searchRoute, sitemap] =
+    await Promise.all([
+      readFile(resolve(process.cwd(), 'app/baml/packages/page.tsx'), 'utf8'),
+      readFile(resolve(process.cwd(), 'app/cli/page.tsx'), 'utf8'),
+      readFile(resolve(process.cwd(), 'content/cli/index.mdx'), 'utf8'),
+      readFile(resolve(process.cwd(), 'components/search-menu.tsx'), 'utf8'),
+      readFile(
+        resolve(process.cwd(), 'app/search-index.json/route.ts'),
+        'utf8',
+      ),
+      readFile(resolve(process.cwd(), 'app/sitemap.ts'), 'utf8'),
+    ]);
+
+  assert.match(packageHub, /listGeneratedReleaseSummaries/);
+  assert.doesNotMatch(packageHub, /const packages =/);
+  assert.match(cliHub, /listGeneratedReleaseSummaries/);
+  assert.match(cliContent, /<GeneratedReleaseCatalog \/>/);
+  assert.match(searchMenu, /fetch\('\/search-index\.json'/);
+  assert.match(searchRoute, /buildGeneratedSearchIndex/);
+  assert.match(sitemap, /listGeneratedSitemapRoutes/);
+});


### PR DESCRIPTION
## What developers see

Before this change, the generated package and CLI references existed as static pages but were difficult to discover, search, or navigate between versions. Dense declarations were plain text, member kinds were mixed together, type names were not linked, and associated types and generic bounds lost compiler detail.

After this change:

- `/baml/packages` and `/cli` expose published versions, channel snapshots, direct package/command links, and version-preserving navigation.
- Generated declarations and members are included in search, sitemap coverage, and reachability validation.
- Reference pages use a wider reading column, granular table of contents, and predictable field/static/instance grouping.
- Types in fields, parameters, returns, throws clauses, generic bounds, and implementations link to the same release.
- Every member has copy-link and copy-declaration actions.
- Compiler declarations retain their meaningful syntax. For example:

```baml
// Before
Error
interface baml.ops.Add<Rhs>

// After
type Error = never
interface baml.ops.Add<Rhs extends baml.Concrete>
```

- Release CI publishes the immutable generated snapshot after the exact toolchain passes its smoke tests, then rebuilds `developer.boundaryml.com` and verifies the released route is live.

## Implementation notes

Visual declarations and clipboard text share one rendering model, and compiler-export schemas are centralized rather than repeated in the React renderer. Release declaration references are cached once per version during static generation.

The compiler-only `boundary.id` namespace collision remains narrowly hidden while its declaration and routable descendants stay available. Symbolic projection linking such as `(Self as ai.Runner).Error` is intentionally deferred to the compiler `describe` work.

This branch includes the discovery commit previously proposed in #4749 because that PR was closed without merging and the readability work depends on it. It is rebased directly onto current `canary` and preserves upstream's removal of the authored changelog route.

No private planning or status Markdown files are included.

## Validation

- `pnpm lint`
- `pnpm test` — 37 passing
- `pnpm typecheck`
- Seeded production build — 1,561 static routes
- Static link, reachability, and sitemap validation — 1,546 HTML pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added versioned release catalogs for BAML packages and CLI documentation.
  - Added version switchers for browsing documentation across published releases.
  - Enhanced API references with linked types, organized member sections, namespaced definitions, and copyable declarations and URLs.
  - Expanded search with generated reference content, version filtering, and richer results.
  - Added generated search indexing and sitemap coverage.
- **Documentation**
  - Added exact-version reference URLs and improved metadata, canonical links, and prerelease indexing behavior.
- **Bug Fixes**
  - Improved copy feedback and handling when generated search content is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->