### PR TITLE
Isolate the feedback runner and authenticate Infisical at boot

### DIFF
--- a/.github/workflows/atb2-deploy.yml
+++ b/.github/workflows/atb2-deploy.yml
@@ -47,9 +47,21 @@ jobs:
         run: python3 tools/atb2/deploy/test_launch_runtime.py
       - name: Verify builder cannot read the runtime login
         run: >-
-          docker run --rm --network none --entrypoint bash
+          docker run --rm --network none --privileged --entrypoint bash
           --mount type=bind,src="${{ github.workspace }}/tools/atb2/deploy/test_build_isolation.sh",dst=/test-build-isolation.sh,readonly
           atb2-runner:ci /test-build-isolation.sh
+
+      # Disposable, network-disabled fixtures need namespaces inside Docker.
+      # No credentials or host runtime directories are mounted.
+      - name: Verify agent boundary and trusted pushes
+        run: |
+          docker run --rm --network none --privileged \
+            -e FAKE_APP_SECRET=private-fixture \
+            --mount type=bind,src="${{ github.workspace }}/tools/atb2/deploy",dst=/tests,readonly \
+            --entrypoint bash atb2-runner:ci -c '
+              mkdir -p /data/home /data/worktrees /data/agent-cache /data/repo
+              chown -R 1000:1000 /data
+              exec setpriv --reuid=1000 --regid=1000 --clear-groups --no-new-privs --bounding-set=-all python3 /tests/test_sandbox.py'
 
   # On canary only: deploy. A manual run from any other ref is refused, so
   # the deploy token never runs against unreviewed code.

--- a/tools/atb2/.dockerignore
+++ b/tools/atb2/.dockerignore
@@ -6,3 +6,6 @@
 !deploy/bootstrap.sh
 !deploy/build-cli.sh
 !deploy/launch-runtime.py
+
+!deploy/sandbox.py
+!deploy/push.py

--- a/tools/atb2/.dockerignore
+++ b/tools/atb2/.dockerignore
@@ -9,3 +9,7 @@
 
 !deploy/sandbox.py
 !deploy/push.py
+
+!deploy/cache-cli.py
+!deploy/cli-cache-service.py
+!deploy/build-version.py

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -105,8 +105,8 @@ literal strings, with shell parameter expansion disabled.
 
 Existing volumes keep their login and runtime state. The first boot after
 this change builds a fresh compiler in the isolated cache, even if the old
-runtime cache already contains one. This isolates startup builds; it does
-not isolate the runtime agent's Bash from the runtime user's files.
+runtime cache already contains one. Runtime checkout commands also use a Linux mount/process boundary with an isolated HOME.
+Claude authentication is handled by a messages-only broker outside that boundary.
 
 Set `ATB2_CANARY_REV` to a commit SHA to pin the runner's compiler. If the
 cached executable's recorded revision matches that pin, startup skips the
@@ -159,3 +159,11 @@ rows, and `dataset=eq.live` in a dashboard filter hides them.
 The eval dataset itself (`eval/supabase`, tables `triage_issues` /
 `triage_feedback`) is separate: reference issues and synthetic reports,
 eval-only by construction.
+
+### Universal Auth and agent isolation
+
+The root launcher accepts `INFISICAL_CLIENT_ID` and `INFISICAL_CLIENT_SECRET`
+from the Fly machine identity, or the existing `INFISICAL_TOKEN` fallback.
+Neither reaches the runtime. Agent commands require Linux namespaces; startup
+fails closed if they are unavailable. Trusted pushes export Git objects into
+fresh controller-owned metadata and use a fixed repository and exact branch lease.

--- a/tools/atb2/baml_src/handle_issue.baml
+++ b/tools/atb2/baml_src/handle_issue.baml
@@ -235,21 +235,25 @@ function still_broken(issue: Issue) -> bool {
 /// The `baml-cli` to check repros with: canary's own build when the cache
 /// has been built, else whatever `baml` resolves to.
 function check_cli() -> string {
-    let built = target_dir() + "/debug/baml-cli";
+    let built = atb2_home() + "/agent-cache/repo/target/debug/baml-cli";
     if (baml.fs.exists(built)) {
         built
     } else {
-        "baml"
+        atb2_home() + "/target/debug/baml-cli"
     }
 }
 
 /// Write the repro to a scratch project and run it with check_cli().
 function check_on_canary(r: Repro, n: int) -> Verdict {
     //# write the repro to a scratch project
-    let dir = atb2_home() + "/repro-check/" + baml.id.new();
+    let repro_id = baml.id.new();
+    let dir = atb2_home() + "/repro-check/" + repro_id;
     baml.fs.mkdir(dir + "/baml_src", baml.fs.MkdirOptions { recursive: true });
     defer {
         baml.fs.remove_dir_all(dir) catch (_) {
+            _ => null,
+        };
+        baml.fs.remove_dir_all(atb2_home() + "/agent-cache/repro-check/" + repro_id) catch (_) {
             _ => null,
         };
     }
@@ -424,7 +428,7 @@ function cache_repo() -> string {
 }
 
 function target_dir() -> string {
-    atb2_home() + "/target"
+    atb2_home() + "/agent-cache/target"
 }
 
 function repo_url() -> string {
@@ -609,7 +613,17 @@ function keep_awake(program: string, args: string[]) -> Cmd {
 
 function run_with(c: Cmd, env: map<string, string>) -> CmdResult {
     let label = c.program + " " + c.args.join(" ");
-    let awake = keep_awake(c.program, c.args);
+    let untrusted = c.cwd.starts_with(atb2_home() + "/worktrees/")
+        || c.cwd.starts_with(atb2_home() + "/repro-check/")
+        || (c.cwd == cache_repo() + "/baml_language");
+    let awake = if (untrusted) {
+        keep_awake(
+            "/usr/bin/python3",
+            ["-I", "/usr/local/lib/atb2/sandbox.py", c.cwd, c.program].concat(c.args),
+        )
+    } else {
+        keep_awake(c.program, c.args)
+    };
     let out = baml.sys.exec(
         awake.program,
         awake.args,
@@ -675,6 +689,7 @@ class Sandbox {
     worktree: string,
     run_dir: string,
     reused_branch: bool,
+    base_head: string?,
 }
 
 /// One cached clone, fetched each run. Safe to call from parallel tests:
@@ -685,7 +700,7 @@ function ensure_cache() -> null {
     //# mkdir the atb2 home
     baml.fs.mkdir(atb2_home(), baml.fs.MkdirOptions { recursive: true });
     //# mkdir the target dir
-    baml.fs.mkdir(target_dir(), baml.fs.MkdirOptions { recursive: true });
+    baml.fs.mkdir(atb2_home() + "/agent-cache", baml.fs.MkdirOptions { recursive: true });
     //# if the repo does not exist
     if (!baml.fs.exists(repo + "/.git")) {
         let clone = run(
@@ -700,8 +715,6 @@ function ensure_cache() -> null {
             baml.sys.panic("clone failed: " + tail(clone.stderr, 5));
         };
     };
-    //# worktree config must be on or the --worktree pushurl guard is a no-op
-    git(repo, ["config", "extensions.worktreeConfig", "true"]);
     //# fetch canary (retried: parallel tests share the cache)
     let tries = 0;
     //# while the tries are less than 3
@@ -725,10 +738,6 @@ function ensure_cache() -> null {
     baml.sys.panic("git fetch failed three times")
 }
 
-function branch_exists_locally(branch: string) -> bool {
-    git(cache_repo(), ["rev-parse", "--verify", "--quiet", "refs/heads/" + branch]).ok
-}
-
 function branch_exists_on_origin(branch: string) -> bool {
     git(cache_repo(), ["ls-remote", "--exit-code", "--heads", "origin", branch]).ok
 }
@@ -740,112 +749,81 @@ function open_sandbox(issue: Issue, update: bool) -> Sandbox {
 /// The sandbox for any branch: a fresh one off origin/canary, or (`update`)
 /// the branch as it is on origin. merge_issue opens PR branches this way.
 function open_branch_sandbox(branch: string, update: bool) -> Sandbox {
-    //# get the repo
-    let repo = cache_repo();
-    //# get the worktree
     let wt = worktree_for(branch);
-    //# get the run dir
     let rd = run_dir_for(branch);
-    //# if the worktree exists
     if (baml.fs.exists(wt)) {
-        //# remove the worktree
-        git(repo, ["worktree", "remove", "--force", wt]);
-        //# if the worktree still exists, remove the dir all
-        if (baml.fs.exists(wt)) {
-            baml.fs.remove_dir_all(wt);
-        };
+        baml.fs.remove_dir_all(wt);
     };
-    //# prune the worktree
-    git(repo, ["worktree", "prune"]);
-    //# remove the run dir
-    baml.fs.remove_dir_all(rd);
+    if (baml.fs.exists(rd)) {
+        baml.fs.remove_dir_all(rd);
+    };
     baml.fs.mkdir(rd, baml.fs.MkdirOptions { recursive: true });
-    //# mkdir the worktrees dir
     baml.fs.mkdir(atb2_home() + "/worktrees", baml.fs.MkdirOptions { recursive: true });
-    //# set reused to false
-    let reused = false;
-    //# if the branch exists locally and update is true
-    let add = if (branch_exists_locally(branch) && update) {
-        //# set reused to true
-        reused = true;
-        //# add the worktree
-        git(repo, ["worktree", "add", wt, branch])
-    } else {
-        //# if the branch exists locally
-        if (branch_exists_locally(branch)) {
-            git(repo, ["branch", "-D", branch]);
+    // Independent object storage and metadata: never mount the controller's
+    // linked-worktree .git directory into an agent sandbox.
+    let clone = git(cache_repo(), ["clone", "--no-local", "--no-hardlinks", "--no-checkout", cache_repo(), wt]);
+    if (!clone.ok) {
+        baml.sys.panic("isolated clone failed");
+    };
+    let reused = branch_exists_on_origin(branch);
+    if (reused && !update) {
+        baml.sys.panic("branch already exists; explicit update required");
+    };
+    if (reused) {
+        if (!git(wt, ["fetch", repo_url(), "refs/heads/" + branch]).ok) {
+            baml.sys.panic("isolated branch fetch failed");
         };
-        if (branch_exists_on_origin(branch)) {
-            reused = true;
-            git(repo, ["fetch", "origin", branch]);
-            git(repo, ["worktree", "add", "--track", "-b", branch, wt, "origin/" + branch])
-        } else {
-            git(repo, ["worktree", "add", "-b", branch, wt, "origin/canary"])
-        }
     };
-    //# if the add is not ok, panic
-    if (!add.ok) {
-        baml.sys.panic("worktree add failed: " + tail(add.stderr, 5));
+    let base = if (reused) {
+        "FETCH_HEAD"
+    } else {
+        "origin/canary"
     };
-    //# config the worktree
-    git(wt, ["config", "--worktree", "remote.origin.pushurl", "no_push://atb2"]);
-    //# config the user name
-    git(wt, ["config", "--worktree", "user.name", "atb2"]);
-    git(wt, ["config", "--worktree", "user.email", "atb2@boundaryml.com"]);
-
-    log.info({ "sandbox": wt, "branch": branch, "reused_branch": reused });
-    Sandbox { branch: branch, worktree: wt, run_dir: rd, reused_branch: reused }
+    if (!git(wt, ["checkout", "-b", branch, base]).ok) {
+        baml.sys.panic("isolated checkout failed");
+    };
+    git(wt, ["config", "remote.origin.pushurl", "no_push://atb2"]);
+    git(wt, ["config", "user.name", "atb2"]);
+    git(wt, ["config", "user.email", "atb2@boundaryml.com"]);
+    let base_head = if (reused) {
+        git(wt, ["rev-parse", "HEAD"]).stdout.trim()
+    } else {
+        null
+    };
+    Sandbox {
+        branch: branch,
+        worktree: wt,
+        run_dir: rd,
+        reused_branch: reused,
+        base_head: base_head,
+    }
 }
 
 /// Runs from `defer`: never throws. Removes the worktree (and the local
 /// branch unless kept for a human), then checks the cache is untouched.
 function close_sandbox(sb: Sandbox, keep_branch: bool) -> null {
-    let repo = cache_repo();
-    //# remove the worktree
-    let removed = git(repo, ["worktree", "remove", "--force", sb.worktree]);
-    git(repo, ["worktree", "prune"]);
-    if (baml.fs.exists(sb.worktree)) {
-        // git refused (or the tree was already unregistered): delete it outright
-        let rm = run(Cmd { program: "rm", args: ["-rf", sb.worktree], cwd: atb2_home(), timeout_ms: 600000 });
-        if (baml.fs.exists(sb.worktree)) {
-            log.warn(
-                {
-                    "sandbox": sb.worktree,
-                    "warning": "worktree not removed",
-                    "git": tail(removed.stderr, 2),
-                    "rm": tail(rm.stderr, 2),
-                },
-            );
-        };
+    // Build output is private to this invocation and can be large. Keep the
+    // conversation checkout if needed, but reclaim its completed build cache.
+    let cache = atb2_home()
+        + "/agent-cache/worktrees/"
+        + sb.worktree.replace_all(atb2_home() + "/worktrees/", "");
+    if (baml.fs.exists(cache)) {
+        baml.fs.remove_dir_all(cache);
     };
-    //# delete the local branch unless a human should pick it up
-    if (!keep_branch) {
-        git(repo, ["branch", "-D", sb.branch]);
+    if (!keep_branch && baml.fs.exists(sb.worktree)) {
+        baml.fs.remove_dir_all(sb.worktree);
     };
-    //# keep the run dir as the audit trail (ATB2_KEEP_RUNS=0 deletes it)
     if ((baml.env.get("ATB2_KEEP_RUNS") ?? "1") == "0") {
         baml.fs.remove_dir_all(sb.run_dir) catch (_) {
-            _ => null,
+            _ => null
         };
-    };
-    //# verify the cache repo is untouched
-    if (!cache_is_clean(sb)) {
-        log.warn(
-            { "sandbox": sb.worktree, "warning": "cache repo is not clean after close_sandbox" },
-        );
     };
     null
 }
 
-function cache_is_clean(sb: Sandbox) -> bool {
-    let status = git(cache_repo(), ["status", "--porcelain"]);
-    let list = git(cache_repo(), ["worktree", "list", "--porcelain"]);
-    status.ok && status.stdout.trim().length() == 0 && !list.stdout.includes(sb.worktree)
-}
-
 /// canary's own baml-cli, rebuilt from the cache checkout after each fetch,
 /// so the repro pre-check and the gate both speak for canary HEAD. Seconds
-/// when the shared target is warm.
+/// when the private baseline target is warm.
 function build_canary_cli() -> null {
     let b = run(
         Cmd {
@@ -926,6 +904,14 @@ function claude_args(prompt: string, tools: string[]) -> string[] {
         // env is an allowlist, so this is the sandbox, not the prompt.
         "--permission-mode",
         "bypassPermissions",
+        "--safe-mode",
+        "--setting-sources",
+        "",
+        "--strict-mcp-config",
+        "--mcp-config",
+        "{\"mcpServers\":{}}",
+        "--settings",
+        "{\"disableAllHooks\":true}",
         "--no-session-persistence",
         "--tools",
         tools.join(","),
@@ -950,10 +936,8 @@ function run_claude(
     env.set("ATB2_TRANSCRIPT", transcript_path);
     let r = run_with(
         Cmd {
-            program: "sh",
-            args: ["-c", "exec \"$@\" > \"$ATB2_TRANSCRIPT\" 2>&1", "atb2", "claude"].concat(
-                claude_args(prompt, tools),
-            ),
+            program: "claude",
+            args: claude_args(prompt, tools),
             cwd: cwd,
             timeout_ms: timeout_s * 1000,
         },
@@ -1337,31 +1321,6 @@ function changed_crates(worktree: string) -> string[] {
     changed_crates_from(git(worktree, ["diff", "--name-only", "origin/canary...HEAD"]).stdout)
 }
 
-/// Tests known to fail on canary itself; a gate failure that is only these
-/// is not the agent's. ATB2_FLAKY_TESTS overrides (comma-separated names).
-function flaky_tests() -> string[] {
-    (baml.env.get("ATB2_FLAKY_TESTS") ?? "claude_code_client_preserves_process_wait_timeout").split(
-        ",",
-    )
-}
-
-/// `FAIL [...] crate::module test_name` lines of nextest output, minus the
-/// known-flaky names.
-function unexpected_failures(output: string, flaky: string[]) -> string[] {
-    let out: string[] = [];
-    for (let line in output.lines()) {
-        let l = line.trim();
-        if (l.starts_with("FAIL [")) {
-            let parts = l.split(" ");
-            let name = parts.at(parts.length() - 1) ?? "";
-            if (!flaky.includes(name) && !out.includes(name)) {
-                out.push(name);
-            };
-        };
-    }
-    out
-}
-
 function gate_step(name: string, c: Cmd) -> GateStep {
     let started = baml.time.Instant.now();
     let r = run(c);
@@ -1423,72 +1382,28 @@ function run_gate(worktree: string) -> GateResult {
         };
     }
     if (ok) {
-        //## nextest on baml_tests (known-flaky failures subtracted)
-        // --no-fail-fast, then subtract the known-flaky tests: one flaky test
-        // must not sink a gate that canary itself would not pass
-        let s = gate_step(
-            "nextest baml_tests",
-            Cmd {
-                program: "cargo",
-                args: ["nextest", "run", "-p", "baml_tests", "--no-fail-fast"],
-                cwd: wd,
-                timeout_ms: 1800000,
-            },
-        );
-        let real = unexpected_failures(s.tail, flaky_tests());
-        // nextest exits 100 only when it compiled and ran and some tests
-        // failed; a compile error / timeout (124) exits otherwise. Gate the
-        // known-flaky pass on that code, not on captured stdout, so a
-        // non-completed run cannot be waved through with injected output.
-        let ran_tests = s.exit_code == 100;
-        let step = GateStep {
-            name: s.name,
-            ok: s.ok || (ran_tests && real.length() == 0),
-            seconds: s.seconds,
-            tail: if (s.ok || !ran_tests || real.length() > 0) {
-                s.tail
-            } else {
-                "only known-flaky failures: " + s.tail
-            },
-            exit_code: s.exit_code,
-        };
-        steps.push(step);
-        ok = step.ok;
+        // Every nonzero exit fails closed. Log tails are display-only and
+        // cannot establish that a failed run contained only known failures.
+        ok
+            = cargo(
+                "nextest baml_tests",
+                ["nextest", "run", "-p", "baml_tests", "--no-fail-fast"],
+                1800000,
+            );
     };
     if (ok) {
-        //## insta: snapshots must be settled
-        // insta re-runs the crate to refresh snapshots; test verdicts were
-        // already taken by the nextest step above, so this step gates on
-        // snapshot state only (the tree-clean check below catches churn)
-        let s = gate_step(
-            "insta baml_tests",
-            Cmd {
-                program: "cargo",
-                args: ["insta", "test", "--test-runner=nextest", "--accept", "-p", "baml_tests"],
-                cwd: wd,
-                timeout_ms: 1800000,
-            },
-        );
-        // settled = the run completed (exit 0, or 100 = test failures only, e.g.
-        // the known-flaky test); a compile error / timeout does not count. The
-        // tree-clean check below catches any real snapshot churn.
-        let snapshots_settled = s.ok || s.exit_code == 100;
-        steps.push(
-            GateStep {
-                name: s.name,
-                ok: snapshots_settled,
-                seconds: s.seconds,
-                tail: s.tail,
-                exit_code: s.exit_code,
-            },
-        );
-        ok = snapshots_settled;
+        ok
+            = cargo(
+                "insta baml_tests",
+                ["insta", "test", "--test-runner=nextest", "--accept", "-p", "baml_tests"],
+                1800000,
+            );
     };
     if (ok) {
         //## the tree must be clean after --accept
         // --accept must not have produced unreviewed snapshot churn
         let status = git(worktree, ["status", "--porcelain"]);
-        let clean = status.stdout.trim().length() == 0;
+        let clean = status.ok && status.stdout.trim().length() == 0;
         steps.push(
             GateStep {
                 name: "insta clean",
@@ -1676,32 +1591,24 @@ function head_sha(sb: Sandbox) -> string {
 
 /// Live only. Lifts the worktree's push guard for this one push. The
 /// guard is set by open_sandbox and is what keeps the agent from pushing.
-function push_branch(sb: Sandbox) -> null {
-    //# lift the push guard for this one push
-    // pushurl is multi-valued, so it cannot be overridden with -c; the
-    // no_push guard is removed here, and only here, for this one push
-    git(sb.worktree, ["config", "--worktree", "--unset-all", "remote.origin.pushurl"]);
-    //# push with the host's credentials, hooks off
+function push_branch(sb: Sandbox, expected_head: string? = null) -> null {
     let push = run_with(
         Cmd {
-            program: "git",
+            program: "/usr/bin/python3",
             args: [
-                "-c",
-                "core.hooksPath=/dev/null",
-                "push",
-                "--force-with-lease",
-                "-u",
-                "origin",
+                "-I",
+                "/usr/local/lib/atb2/push.py",
+                sb.worktree,
                 sb.branch,
+                expected_head ?? sb.base_head ?? "",
             ],
-            cwd: sb.worktree,
+            cwd: atb2_home(),
             timeout_ms: 600000,
         },
         sandbox_env(true),
     );
     if (!push.ok) {
-        //## stop: the push was rejected
-        baml.sys.panic("push failed: " + tail(push.stderr, 5));
+        baml.sys.panic("trusted push failed");
     };
     null
 }
@@ -1742,7 +1649,7 @@ function comment_on_pr(sb: Sandbox, pr: string, body: string) -> null {
 /// Live only. Pushes the branch and opens a draft PR — or updates the
 /// existing PR for the branch.
 function push_and_open_pr(sb: Sandbox, draft: PrDraft) -> string {
-    //# lift the push guard and push the branch
+    //# push through trusted metadata
     let env = sandbox_env(true);
     push_branch(sb);
     //# update the existing PR for this branch, if there is one
@@ -1751,7 +1658,7 @@ function push_and_open_pr(sb: Sandbox, draft: PrDraft) -> string {
         Cmd {
             program: "gh",
             args: ["pr", "view", sb.branch, "--repo", repo_slug(), "--json", "url", "--jq", ".url"],
-            cwd: sb.worktree,
+            cwd: atb2_home(),
             timeout_ms: 120000,
         },
         env,
@@ -1771,7 +1678,7 @@ function push_and_open_pr(sb: Sandbox, draft: PrDraft) -> string {
                     "--body-file",
                     body_path,
                 ],
-                cwd: sb.worktree,
+                cwd: atb2_home(),
                 timeout_ms: 120000,
             },
             env,
@@ -1797,7 +1704,7 @@ function push_and_open_pr(sb: Sandbox, draft: PrDraft) -> string {
                 "--body-file",
                 body_path,
             ],
-            cwd: sb.worktree,
+            cwd: atb2_home(),
             timeout_ms: 120000,
         },
         env,
@@ -2250,18 +2157,22 @@ testset "handle_issue" {
         assert.is_true(settled.includes("no snapshots to review"));
     }
 
-    test "known-flaky nextest failures are subtracted" {
-        let out = "        PASS [   0.9s] (1/3) baml_tests::shell exec_with_cwd\n        FAIL [   1.1s] (2/3) baml_tests::shell claude_code_client_preserves_process_wait_timeout\n        FAIL [   0.2s] (3/3) baml_tests::foo real_regression\n";
-        assert.equal(
-            unexpected_failures(out, ["claude_code_client_preserves_process_wait_timeout"]),
-            ["real_regression"],
+    test "failed gate output cannot become a pass when truncated" {
+        let step = gate_step(
+            "failure",
+            Cmd {
+                program: "/bin/sh",
+                args: [
+                    "-c",
+                    "echo 'FAIL [0.1s] unexpected_regression'; i=0; while [ $i -lt 65 ]; do echo ordinary-output; i=$((i+1)); done; exit 100",
+                ],
+                cwd: "/tmp",
+                timeout_ms: 10000,
+            },
         );
-        assert.equal(
-            unexpected_failures(out, ["claude_code_client_preserves_process_wait_timeout", "real_regression"])
-                .length(),
-            0,
-        );
-        assert.is_true(claude_args("x", fix_tools()).includes("bypassPermissions"));
+        assert.equal(step.exit_code, 100);
+        assert.is_true(!step.ok);
+        assert.is_true(!step.tail.includes("unexpected_regression"));
     }
 
     test "time budgets" {

--- a/tools/atb2/deploy/Dockerfile
+++ b/tools/atb2/deploy/Dockerfile
@@ -11,13 +11,22 @@
 # Build context is tools/atb2 (the repo root's .dockerignore keeps everything
 # out): `docker build -f tools/atb2/deploy/Dockerfile tools/atb2`.
 
-FROM rust:1-bookworm
+FROM node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS node
+FROM rust:1.98.0-bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl git jq openssh-client pkg-config libssl-dev \
-      python3 clang lld cmake util-linux \
+      python3 clang lld cmake util-linux bubblewrap \
     && rm -rf /var/lib/apt/lists/*
+
+# Immutable gate executables and the toolchain required by canary. Workspace
+# caches are private; they cannot install replacements into this trusted PATH.
+RUN rustup component add clippy rustfmt rust-analyzer \
+    && rustup target add wasm32-unknown-unknown \
+    && cargo install --locked --version 0.9.143 cargo-nextest \
+    && cargo install --locked --version 1.48.0 cargo-insta \
+    && rm -rf /usr/local/cargo/registry /usr/local/cargo/git
 
 # gh
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -27,12 +36,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# node (Debian's package, no third-party install script), the Claude Code CLI
-# the agent runs as, and the Infisical CLI the entrypoint pulls secrets with.
-# Both from the npm registry, the Infisical one pinned.
-RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install -g @anthropic-ai/claude-code @infisical/cli@0.43.128
+# Claude Code requires Node >=22. Copy a digest-pinned runtime, without an installer script.
+COPY --from=node --chown=root:root /usr/local/bin/node /usr/local/bin/node
+COPY --from=node --chown=root:root /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && npm install -g @anthropic-ai/claude-code@2.1.261 @infisical/cli@0.43.128
 
 RUN useradd -m -u 1000 -s /bin/bash atb2 \
     && useradd -m -u 1001 -s /bin/bash builder \
@@ -48,6 +57,7 @@ ENV ATB2_HOME=/data \
 WORKDIR /app
 COPY baml.toml ./
 COPY baml_src ./baml_src
+COPY deploy/sandbox.py deploy/push.py /usr/local/lib/atb2/
 COPY deploy/entrypoint.sh /usr/local/bin/atb2-entrypoint
 COPY deploy/build-cli.sh /usr/local/bin/atb2-build-cli
 COPY deploy/bootstrap.sh /usr/local/bin/atb2-bootstrap

--- a/tools/atb2/deploy/Dockerfile
+++ b/tools/atb2/deploy/Dockerfile
@@ -57,6 +57,7 @@ ENV ATB2_HOME=/data \
 WORKDIR /app
 COPY baml.toml ./
 COPY baml_src ./baml_src
+COPY deploy/cache-cli.py deploy/cli-cache-service.py deploy/build-version.py /usr/local/lib/atb2/
 COPY deploy/sandbox.py deploy/push.py /usr/local/lib/atb2/
 COPY deploy/entrypoint.sh /usr/local/bin/atb2-entrypoint
 COPY deploy/build-cli.sh /usr/local/bin/atb2-build-cli

--- a/tools/atb2/deploy/bootstrap.sh
+++ b/tools/atb2/deploy/bootstrap.sh
@@ -12,7 +12,7 @@ fi
 # runtime directories retain their contents, including the persistent CLI login.
 chown root:root /data
 chmod 711 /data
-for name in home repo target cargo rustup worktrees runs merge repro-check agent-cache bootstrap; do
+for name in home repo target cargo rustup worktrees runs merge repro-check agent-cache agent-sessions bootstrap; do
   dir="/data/$name"
   if [ -L "$dir" ]; then
     echo "atb2: refusing symlink at $dir" >&2
@@ -92,5 +92,7 @@ with os.fdopen(fd, "w") as out:
     out.write(revision + "\n")
 os.replace(tmp, "/data/target/.baml-cli-rev")
 '
+# Start the credential-free cache service; it builds nothing until an issue asks.
+env -i PATH="$PATH" /usr/bin/python3 -I /usr/local/lib/atb2/cli-cache-service.py &
 # Fetch secrets while still root, then replace the environment before setpriv.
 exec /usr/bin/python3 -I /usr/local/bin/atb2-launch-runtime.py "$@"

--- a/tools/atb2/deploy/bootstrap.sh
+++ b/tools/atb2/deploy/bootstrap.sh
@@ -12,7 +12,7 @@ fi
 # runtime directories retain their contents, including the persistent CLI login.
 chown root:root /data
 chmod 711 /data
-for name in home repo target cargo rustup worktrees runs merge repro-check bootstrap; do
+for name in home repo target cargo rustup worktrees runs merge repro-check agent-cache bootstrap; do
   dir="/data/$name"
   if [ -L "$dir" ]; then
     echo "atb2: refusing symlink at $dir" >&2
@@ -78,5 +78,19 @@ if [ -n "$artifact" ]; then
   echo 'atb2: compiler installation failed; previous runtime binary preserved' >&2
   exit 1
 fi
+# Publish the compiler revision with the same UID boundary as the executable.
+# Play runs use this marker to report exactly which canary build they exercised.
+"${as_builder[@]}" cat /data/bootstrap/target/.baml-cli-rev |
+  "${as_runtime[@]}" /usr/bin/python3 -I -c '
+import os, re, sys, tempfile
+from pathlib import Path
+revision = sys.stdin.read(128).strip()
+if not re.fullmatch("[0-9a-f]{40}", revision):
+    raise SystemExit("atb2: invalid compiler revision")
+fd, tmp = tempfile.mkstemp(dir="/data/target", prefix=".revision-")
+with os.fdopen(fd, "w") as out:
+    out.write(revision + "\n")
+os.replace(tmp, "/data/target/.baml-cli-rev")
+'
 # Fetch secrets while still root, then replace the environment before setpriv.
 exec /usr/bin/python3 -I /usr/local/bin/atb2-launch-runtime.py "$@"

--- a/tools/atb2/deploy/build-version.py
+++ b/tools/atb2/deploy/build-version.py
@@ -1,0 +1,43 @@
+"""Credential-free builder child. Stdout is only the requested CLI executable."""
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+version = sys.argv[1]
+if not re.fullmatch(r'[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?', version):
+    raise SystemExit('invalid version')
+if os.geteuid() != 1001:
+    raise SystemExit('builder UID required')
+root = Path('/data/bootstrap')
+pinned = root / 'target/debug/baml-cli'
+def run(args, **kwargs):
+    return subprocess.run(args, check=True, stdout=subprocess.PIPE, stderr=sys.stderr, **kwargs)
+# Reuse the bootstrap compiler when it is exactly the requested version.
+actual = run([str(pinned), '--version']).stdout.decode().strip().split()[-1] if pinned.exists() else ''
+if actual == version:
+    revision = (root / 'target/.baml-cli-rev').read_text().strip()
+    binary = pinned
+else:
+    repo = root / 'version-repo'
+    if not repo.exists():
+        run(['git', 'clone', '--no-checkout', 'https://github.com/BoundaryML/baml.git', str(repo)])
+    tag = 'refs/tags/baml-language-' + version
+    run(['git', '-C', str(repo), 'fetch', '--no-tags', 'origin', tag])
+    revision = run(['git', '-C', str(repo), 'rev-parse', 'FETCH_HEAD^{commit}']).stdout.decode().strip()
+    run(['git', '-C', str(repo), 'checkout', '--detach', revision])
+    env = dict(os.environ, CARGO_TARGET_DIR=str(root / 'version-target' / revision))
+    # Build diagnostics are sent to stderr; stdout remains a framed artifact.
+    subprocess.run(['cargo', 'build', '-p', 'baml_cli', '--bin', 'baml-cli'],
+                   cwd=repo/'baml_language', env=env, stdout=sys.stderr, check=True)
+    binary = Path(env['CARGO_TARGET_DIR']) / 'debug/baml-cli'
+    actual = run([str(binary), '--version']).stdout.decode().strip().split()[-1]
+    if actual != version:
+        raise SystemExit('built CLI version does not match request')
+if not re.fullmatch('[0-9a-f]{40}', revision):
+    raise SystemExit('invalid source revision')
+sys.stdout.buffer.write((revision + '\n').encode())
+with binary.open('rb') as source:
+    shutil.copyfileobj(source, sys.stdout.buffer)

--- a/tools/atb2/deploy/cache-cli.py
+++ b/tools/atb2/deploy/cache-cli.py
@@ -1,0 +1,84 @@
+"""Publish builder-produced CLIs to an immutable, version/revision-keyed cache.
+
+Only bootstrap invokes this as root, with executable bytes supplied by the
+unprivileged builder. Agents only receive a read-only mount of the cache.
+"""
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+
+VERSION = re.compile(r'(?:baml(?:-cli)?\s+)?([0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?(?:\+[A-Za-z0-9.-]+)?)\Z')
+REVISION = re.compile(r'[0-9a-f]{40}\Z')
+
+
+def directory(path):
+    if path.is_symlink():
+        raise ValueError('cache directory is a symlink')
+    path.mkdir(exist_ok=True)
+    if not path.is_dir() or path.stat().st_uid != os.geteuid():
+        raise ValueError('cache directory has unexpected owner')
+    path.chmod(0o755)
+
+
+def publish(root, version, revision, stream):
+    match = VERSION.fullmatch(version.strip())
+    if not match or not REVISION.fullmatch(revision):
+        raise ValueError('invalid CLI version or source revision')
+    version = match.group(1)
+    directory(root)
+    folder = root / version
+    directory(folder)
+    folder = folder / revision
+    directory(folder)
+    binary = folder / 'baml-cli'
+    fd, temporary = tempfile.mkstemp(dir=folder, prefix='.publish-')
+    try:
+        digest = hashlib.sha256()
+        size = 0
+        with os.fdopen(fd, 'wb') as output:
+            while chunk := stream.read(1024 * 1024):
+                size += len(chunk)
+                if size > 2 * 1024**3:
+                    raise ValueError('CLI artifact too large')
+                digest.update(chunk)
+                output.write(chunk)
+        if size == 0:
+            raise ValueError('empty CLI artifact')
+        if binary.is_symlink():
+            raise ValueError('cached CLI is a symlink')
+        if binary.exists():
+            # Never replace an already-published version/revision pair.
+            with binary.open('rb') as existing:
+                old = hashlib.file_digest(existing, 'sha256').hexdigest()
+            if old != digest.hexdigest():
+                raise ValueError('CLI version/revision already contains a different artifact')
+        else:
+            os.chmod(temporary, 0o555)
+            os.replace(temporary, binary)
+        entries = []
+        for path in sorted(root.glob('*/*/baml-cli')):
+            if path.is_symlink() or not path.is_file():
+                raise ValueError('unsafe cached artifact')
+            entries.append({'version': path.parent.parent.name, 'revision': path.parent.name,
+                            'path': str(path.relative_to(root))})
+        index_fd, index_tmp = tempfile.mkstemp(dir=root, prefix='.index-')
+        try:
+            with os.fdopen(index_fd, 'w') as out:
+                json.dump(entries, out)
+            os.chmod(index_tmp, 0o444)
+            os.replace(index_tmp, root / 'index.json')
+        finally:
+            Path(index_tmp).unlink(missing_ok=True)
+        return binary
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+
+
+if __name__ == '__main__':
+    if os.geteuid() != 0:
+        raise SystemExit('only bootstrap may publish shared CLIs')
+    publish(Path('/data/cli-cache'), sys.argv[1], sys.argv[2], sys.stdin.buffer)

--- a/tools/atb2/deploy/cli-cache-service.py
+++ b/tools/atb2/deploy/cli-cache-service.py
@@ -1,0 +1,113 @@
+"""Root-owned lazy CLI cache. Builder children never inherit runtime credentials."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import socket
+import socketserver
+import struct
+import subprocess
+import sys
+import tempfile
+
+SOCKET = '/data/cli-build/request.sock'
+ROOT = Path('/data/cli-cache')
+VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.-]+)?\Z')
+spec = importlib.util.spec_from_file_location('cache_cli', Path(__file__).with_name('cache-cli.py'))
+cache = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cache)
+
+
+def cached(version):
+    if not VERSION.fullmatch(version):
+        raise ValueError('invalid CLI version')
+    paths = sorted((ROOT/version).glob('*/baml-cli'))
+    if len(paths) > 1:
+        raise ValueError('ambiguous CLI version; source revision must be resolved by an operator')
+    if paths:
+        path = paths[0]
+        if path.is_symlink() or path.resolve() != path or path.stat().st_uid != 0 or path.stat().st_mode & 0o222:
+            raise ValueError('unsafe cached CLI')
+        return str(path)
+    return None
+
+
+def ensure(version):
+    found = cached(version)
+    if found:
+        return found
+    env = {'PATH': '/usr/local/cargo/bin:/usr/local/bin:/usr/bin:/bin',
+           'HOME': '/data/bootstrap/home', 'USER': 'builder', 'LOGNAME': 'builder',
+           'LANG': 'C.UTF-8', 'CARGO_HOME': '/data/bootstrap/cargo',
+           'RUSTUP_HOME': '/data/bootstrap/rustup', 'CARGO_INCREMENTAL': '0'}
+    command = ['setpriv', '--reuid=1001', '--regid=1001', '--clear-groups',
+               '--no-new-privs', '--bounding-set=-all', '/usr/bin/python3', '-I',
+               '/usr/local/lib/atb2/build-version.py', version]
+    # Wait for a complete, successful build before publishing any artifact.
+    with tempfile.TemporaryFile() as artifact:
+        child = subprocess.Popen(command, env=env, cwd='/', stdout=artifact,
+                                 stderr=subprocess.DEVNULL, start_new_session=True)
+        try:
+            status = child.wait(timeout=2400)
+            if status:
+                raise subprocess.CalledProcessError(status, command)
+        finally:
+            # Cargo/build scripts must not survive a timeout and race the next miss.
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            child.wait()
+        artifact.seek(0)
+        revision = artifact.readline(128).decode().strip()
+        return str(cache.publish(ROOT, version, revision, artifact))
+
+
+class Handler(socketserver.StreamRequestHandler):
+    def handle(self):
+        uid = struct.unpack('3i', self.request.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12))[1]
+        if uid != 1000:
+            return
+        self.request.settimeout(5)
+        version = self.rfile.readline(128).decode().strip()
+        self.request.settimeout(None)
+        try:
+            response = {'path': ensure(version)}
+        except Exception:
+            response = {'error': 'requested CLI version could not be built or verified'}
+        self.wfile.write((json.dumps(response)+'\n').encode())
+
+
+def request(version):
+    if not VERSION.fullmatch(version):
+        raise ValueError('invalid CLI version')
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
+        connection.settimeout(2500)
+        connection.connect(SOCKET)
+        connection.sendall((version+'\n').encode())
+        response = json.loads(connection.makefile('rb').readline(4096))
+        path = response.get('path')
+        if not path or not Path(path).is_relative_to(ROOT/version):
+            raise ValueError(response.get('error', 'invalid cache response'))
+        return path
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 2:
+        print(request(sys.argv[1]))
+    else:
+        if os.geteuid() != 0:
+            raise SystemExit('cache service must be started by bootstrap')
+        cache.directory(ROOT)
+        directory = Path(SOCKET).parent
+        cache.directory(directory)
+        if Path(SOCKET).is_symlink():
+            raise SystemExit('unsafe cache service socket')
+        Path(SOCKET).unlink(missing_ok=True)
+        # Serialized requests mean simultaneous misses build each version only once.
+        with socketserver.UnixStreamServer(SOCKET, Handler) as server:
+            os.chown(SOCKET, 0, 1000)
+            os.chmod(SOCKET, 0o660)
+            server.serve_forever()

--- a/tools/atb2/deploy/entrypoint.sh
+++ b/tools/atb2/deploy/entrypoint.sh
@@ -20,6 +20,11 @@ if [ -n "${GH_TOKEN:-}" ]; then
   git config --global user.email "${ATB2_GIT_EMAIL:-atb2@boundaryml.com}"
 fi
 
+# Refuse deployment when the host cannot provide the required namespace boundary.
+mkdir -p /data/repro-check/preflight
+/usr/bin/python3 -I /usr/local/lib/atb2/sandbox.py /data/repro-check/preflight /usr/bin/true
+rmdir /data/repro-check/preflight
+
 expr="${1:-runner_loop()}"
 echo "atb2: $expr"
 cd /app

--- a/tools/atb2/deploy/launch-runtime.py
+++ b/tools/atb2/deploy/launch-runtime.py
@@ -3,6 +3,8 @@
 import json
 import os
 import resource
+from urllib.parse import urlsplit
+import stat
 import subprocess
 import sys
 
@@ -28,9 +30,20 @@ FIXED_ENV = {
 
 def runtime_environment(source):
     env = {key: source[key] for key in RUNTIME_KEYS if key in source}
+    auth = source.get("ATB2_INFISICAL_AUTH", "machine")
+    if auth not in ("machine", "user"):
+        raise ValueError("invalid Infisical authentication mode")
+    if auth == "user":
+        # Only explicitly selected demo logins may replace machine authentication.
+        # Reject symlinks and writable parents before trusting persisted CLI state.
+        for path in ("/data", "/data/infisical-home"):
+            info = os.lstat(path)
+            forbidden = 0o077 if path.endswith("infisical-home") else 0o022
+            if not stat.S_ISDIR(info.st_mode) or info.st_uid != 0 or info.st_mode & forbidden:
+                raise ValueError("Infisical login directory must be private to root")
     client_id = source.get("INFISICAL_CLIENT_ID")
     client_secret = source.get("INFISICAL_CLIENT_SECRET")
-    if client_id or client_secret or source.get("INFISICAL_TOKEN"):
+    if auth == "user" or client_id or client_secret or source.get("INFISICAL_TOKEN"):
         project = source.get("INFISICAL_PROJECT_ID")
         if not project:
             raise ValueError("INFISICAL_PROJECT_ID is required")
@@ -40,10 +53,17 @@ def runtime_environment(source):
             "PATH": FIXED_ENV["PATH"], "HOME": "/root", "LANG": "C.UTF-8",
             "INFISICAL_DISABLE_UPDATE_CHECK": "true",
         }
+        if auth == "user":
+            export_env["HOME"] = "/data/infisical-home"
         for key in ("INFISICAL_API_URL", "INFISICAL_DOMAIN"):
             if key in source:
+                url = urlsplit(source[key])
+                if url.scheme != 'https' or not url.hostname or url.username or url.password or url.fragment:
+                    raise ValueError('Infisical endpoint must use HTTPS without embedded credentials')
                 export_env[key] = source[key]
-        if client_id or client_secret:
+        if auth == "user":
+            pass  # The root exporter uses its saved CLI session, never inherited tokens.
+        elif client_id or client_secret:
             if not client_id or not client_secret:
                 raise ValueError("both Infisical Universal Auth credentials are required")
             login_env = {

--- a/tools/atb2/deploy/launch-runtime.py
+++ b/tools/atb2/deploy/launch-runtime.py
@@ -8,10 +8,11 @@ import sys
 
 
 RUNTIME_KEYS = frozenset("""
-ATB2_DATASET ATB2_FLAKY_TESTS ATB2_GIT_EMAIL ATB2_GIT_USER ATB2_ISSUES
+ATB2_DATASET ATB2_GIT_EMAIL ATB2_GIT_USER ATB2_ISSUES
 ATB2_KEEP_RUNS ATB2_MAX_WAIT_S ATB2_MODEL ATB2_POLL_S ATB2_REPO ATB2_REPO_URL
-ATB2_REVIEWERS ATB2_UI_URL ATB2_SLACK_BOT_TOKEN ATB2_SLACK_CHANNEL
+ATB2_REVIEWERS ATB2_SHEPHERDS ATB2_UI_URL ATB2_SLACK_BOT_TOKEN ATB2_SLACK_CHANNEL
 ATB2_SLACK_INTAKE_CHANNEL ATB_SLACK_BOT_TOKEN ATB_SLACK_FIX_CHANNEL
+ATB2_SLACK_SIGNING_SECRET ATB_SLACK_SIGNING_SECRET
 ATB2_POSTHOG_API_KEY ATB2_POSTHOG_PROJECT_ID ATB2_POSTHOG_HOST
 ATB_POSTHOG_API_KEY ATB_POSTHOG_PROJECT_ID ATB_POSTHOG_HOST
 ATB_GITHUB_TOKEN GH_TOKEN GITHUB_TOKEN FEEDBACK_SUPABASE_KEY FEEDBACK_SUPABASE_URL
@@ -27,7 +28,9 @@ FIXED_ENV = {
 
 def runtime_environment(source):
     env = {key: source[key] for key in RUNTIME_KEYS if key in source}
-    if source.get("INFISICAL_TOKEN"):
+    client_id = source.get("INFISICAL_CLIENT_ID")
+    client_secret = source.get("INFISICAL_CLIENT_SECRET")
+    if client_id or client_secret or source.get("INFISICAL_TOKEN"):
         project = source.get("INFISICAL_PROJECT_ID")
         if not project:
             raise ValueError("INFISICAL_PROJECT_ID is required")
@@ -35,12 +38,33 @@ def runtime_environment(source):
         # exported shell code or place credentials in command arguments/files.
         export_env = {
             "PATH": FIXED_ENV["PATH"], "HOME": "/root", "LANG": "C.UTF-8",
-            "INFISICAL_TOKEN": source["INFISICAL_TOKEN"],
             "INFISICAL_DISABLE_UPDATE_CHECK": "true",
         }
         for key in ("INFISICAL_API_URL", "INFISICAL_DOMAIN"):
             if key in source:
                 export_env[key] = source[key]
+        if client_id or client_secret:
+            if not client_id or not client_secret:
+                raise ValueError("both Infisical Universal Auth credentials are required")
+            login_env = {
+                **export_env,
+                "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID": client_id,
+                "INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET": client_secret,
+            }
+            login = subprocess.run(
+                ["/usr/local/bin/infisical", "login", "--method=universal-auth",
+                 "--plain", "--silent", "--telemetry=false"],
+                env=login_env, cwd="/", stdin=subprocess.DEVNULL,
+                capture_output=True, text=True, timeout=120,
+            )
+            token = login.stdout.strip()
+            if login.returncode or not token or any(c.isspace() or c == "\0" for c in token):
+                raise ValueError("Infisical login failed")
+            # Only the exporter receives the fresh access token. It never
+            # receives the client secret or the host's application credentials.
+            export_env["INFISICAL_TOKEN"] = token
+        else:
+            export_env["INFISICAL_TOKEN"] = source["INFISICAL_TOKEN"]
         result = subprocess.run(
             ["/usr/local/bin/infisical", "export", "--format=json", "--silent",
              "--telemetry=false", "--expand=false", "--projectId=" + project,

--- a/tools/atb2/deploy/push.py
+++ b/tools/atb2/deploy/push.py
@@ -1,0 +1,85 @@
+"""Export objects without credentials, then push from fresh trusted Git metadata."""
+import importlib.util
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+spec = importlib.util.spec_from_file_location('atb2_sandbox', Path(__file__).with_name('sandbox.py'))
+sandbox = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sandbox)
+REPOSITORY = 'https://github.com/BoundaryML/baml.git'
+
+
+def trusted_env(home, token):
+    # No ambient Git configuration, askpass, SSH agent, executable PATH, or
+    # repository-provided credential helper is used by the credential process.
+    return {'PATH': '/usr/bin:/bin', 'HOME': str(home), 'LANG': 'C.UTF-8',
+            'GIT_CONFIG_GLOBAL': '/dev/null', 'GIT_CONFIG_SYSTEM': '/dev/null',
+            'GIT_CONFIG_NOSYSTEM': '1', 'GIT_TERMINAL_PROMPT': '0',
+            'GH_TOKEN': token, 'GIT_CONFIG_COUNT': '4',
+            'GIT_CONFIG_KEY_0': 'core.hooksPath', 'GIT_CONFIG_VALUE_0': '/dev/null',
+            'GIT_CONFIG_KEY_1': 'credential.helper', 'GIT_CONFIG_VALUE_1': '',
+            'GIT_CONFIG_KEY_2': 'credential.helper',
+            'GIT_CONFIG_VALUE_2': '!/usr/bin/python3 -I /usr/local/lib/atb2/push.py credential',
+            'GIT_CONFIG_KEY_3': 'protocol.allow', 'GIT_CONFIG_VALUE_3': 'never'}
+
+
+def main():
+    if sys.argv[1:] == ['credential']:
+        # git appends get/store/erase, handled below by the shared entry check.
+        return 1
+    if len(sys.argv) >= 2 and sys.argv[1] == 'credential':
+        fields = dict(line.rstrip('\n').split('=', 1) for line in sys.stdin if '=' in line)
+        if (sys.argv[2:] == ['get'] and fields.get('protocol') == 'https'
+            and fields.get('host') == 'github.com'):
+            sys.stdout.write('username=x-access-token\npassword=' + os.environ['GH_TOKEN'] + '\n\n')
+        return 0
+    cwd, branch, expected = sys.argv[1:]
+    root, readonly = sandbox.workspace(cwd)
+    if readonly or root != Path(cwd) or root.parent != Path('/data/worktrees'):
+        raise ValueError('push requires an isolated checkout')
+    if not re.fullmatch(r'[0-9a-f]{40}|', expected): raise ValueError('invalid expected head')
+    token = os.environ.get('GH_TOKEN') or os.environ.get('ATB_GITHUB_TOKEN') or os.environ.get('GITHUB_TOKEN')
+    if not token: raise ValueError('GitHub credential missing')
+    with tempfile.TemporaryDirectory(prefix='atb2-push-') as tmp:
+        folder = Path(tmp)
+        env = trusted_env(folder, token)
+        def git(*args, **kwargs):
+            return subprocess.run(['/usr/bin/git', *args], cwd=folder, env=env,
+                                  check=True, stderr=subprocess.PIPE, timeout=600, **kwargs)
+        git('check-ref-format', 'refs/heads/' + branch, stdout=subprocess.DEVNULL)
+        # No controller command loads the checkout's .git/config. Both object
+        # export operations run behind the same isolation boundary as the agent.
+        def export(*args, **kwargs):
+            return subprocess.run(sandbox.command(cwd, ['/usr/bin/git', '-c', 'core.hooksPath=/dev/null',
+                '-c', 'core.fsmonitor=false', *args]), env={'PATH': sandbox.SAFE_PATH},
+                check=True, stderr=subprocess.PIPE, timeout=600, **kwargs)
+        commit = export('rev-parse', '--verify', 'HEAD^{commit}', stdout=subprocess.PIPE).stdout.decode().strip()
+        if not re.fullmatch('[0-9a-f]{40}', commit): raise ValueError('invalid proposed commit')
+        # Import object data only. Never copy configuration, hooks, refs, or
+        # alternates from the agent checkout to the credential-bearing process.
+        with (folder / 'objects.pack').open('w+b') as pack:
+            export('pack-objects', '--stdout', '--revs', input=(commit + '\n').encode(), stdout=pack)
+            pack.seek(0)
+            git('init', '--bare', 'trusted.git', stdout=subprocess.DEVNULL)
+            git('--git-dir=trusted.git', 'index-pack', '--stdin', '--strict', stdin=pack, stdout=subprocess.DEVNULL)
+        git('--git-dir=trusted.git', 'cat-file', '-e', commit + '^{commit}', stdout=subprocess.DEVNULL)
+        if expected:
+            git('--git-dir=trusted.git', 'merge-base', '--is-ancestor', expected, commit, stdout=subprocess.DEVNULL)
+        # Exact source SHA, fixed URL and exact destination ref. No origin or
+        # URL rewrites from the checkout; an empty lease only permits creation.
+        git('--git-dir=trusted.git', '-c', 'protocol.https.allow=always', 'push',
+            '--force-with-lease=refs/heads/' + branch + ':' + expected,
+            REPOSITORY, commit + ':refs/heads/' + branch, stdout=subprocess.DEVNULL)
+        print(commit)
+    return 0
+
+
+if __name__ == '__main__':
+    try: sys.exit(main())
+    except Exception:
+        print('atb2: trusted push failed; no credential diagnostics are shown', file=sys.stderr)
+        sys.exit(1)

--- a/tools/atb2/deploy/sandbox.py
+++ b/tools/atb2/deploy/sandbox.py
@@ -70,6 +70,12 @@ def command(cwd, argv, extra=None):
     baseline = DATA / 'agent-cache/repo/target/debug/baml-cli'
     if root != DATA / 'repo' and baseline.is_file():
         args += ['--ro-bind', str(baseline), str(baseline)]
+    # Shared versioned executables are root-published and read-only in every sandbox.
+    cli_cache = DATA / 'cli-cache'
+    if cli_cache.exists():
+        if cli_cache.is_symlink() or cli_cache.stat().st_uid != 0 or cli_cache.stat().st_mode & 0o022:
+            raise ValueError('unsafe shared CLI cache')
+        args += ['--ro-bind', str(cli_cache), str(cli_cache)]
     # The installed compiler is safe to expose read-only to repro checks.
     if Path('/data/target/debug/baml-cli').is_file():
         args += ['--ro-bind', '/data/target/debug/baml-cli', '/data/target/debug/baml-cli']
@@ -88,7 +94,7 @@ class CredentialStore:
     def token(self):
         # Different conversations have separate broker processes. Serialize
         # refreshes across them as well as across this server's threads.
-        with self.lock, self.path.with_name('.atb2-oauth.lock').open('a', opener=lambda path, flags: os.open(path, flags, 0o600)) as lock:
+        with self.lock, open(self.path.with_name('.atb2-oauth.lock'), 'a', opener=lambda path, flags: os.open(path, flags | os.O_NOFOLLOW, 0o600)) as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
             data = json.loads(self.path.read_text())
             auth = data['claudeAiOauth']
@@ -126,6 +132,7 @@ class BrokerHandler(http.server.BaseHTTPRequestHandler):
         if (self.path not in ('/v1/messages', '/v1/messages?beta=true', '/v1/messages/count_tokens', '/v1/messages/count_tokens?beta=true')
             or self.headers.get('Authorization') != 'Bearer ' + self.server.client_token):
             self.send_error(403); return
+        started = False
         try:
             size = int(self.headers.get('Content-Length', '-1'))
             if size < 0 or size > 8 * 1024 * 1024 or self.headers.get('Transfer-Encoding'):
@@ -148,6 +155,7 @@ class BrokerHandler(http.server.BaseHTTPRequestHandler):
                 self.send_response(200)
                 self.send_header('Content-Type', response.getheader('Content-Type', 'application/json'))
                 self.end_headers()
+                started = True
                 while True:
                     chunk = response.read1(65536)
                     if not chunk: break
@@ -155,7 +163,10 @@ class BrokerHandler(http.server.BaseHTTPRequestHandler):
             finally: conn.close()
         except Exception:
             # Never log request bodies, tokens, upstream diagnostics or errors.
-            with contextlib.suppress(Exception): self.send_error(502, 'Claude broker unavailable')
+            if started:
+                self.close_connection = True
+            else:
+                with contextlib.suppress(Exception): self.send_error(502, 'Claude broker unavailable')
 
 
 @contextlib.contextmanager

--- a/tools/atb2/deploy/sandbox.py
+++ b/tools/atb2/deploy/sandbox.py
@@ -1,0 +1,203 @@
+"""Linux process/filesystem boundary and Claude-only credential broker.
+
+The controller runs this root-owned file with python -I. No host HOME, process
+namespace, application environment, or controller Git metadata enters bwrap.
+"""
+import contextlib
+import fcntl
+import http.client
+import http.server
+import json
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import sys
+import threading
+import time
+
+DATA = Path('/data')
+SAFE_PATH = '/usr/local/cargo/bin:/usr/local/bin:/usr/bin:/bin'
+CREDENTIALS = DATA / 'home/.claude/.credentials.json'
+
+
+def clean_env():
+    return {'PATH': SAFE_PATH, 'HOME': '/home/agent', 'LANG': 'C.UTF-8',
+            'USER': 'atb2', 'LOGNAME': 'atb2', 'TERM': 'dumb',
+            'GIT_CONFIG_GLOBAL': '/dev/null', 'GIT_CONFIG_SYSTEM': '/dev/null',
+            'GIT_CONFIG_NOSYSTEM': '1', 'GIT_TERMINAL_PROMPT': '0',
+            'CARGO_HOME': '/data/agent-cache/cargo', 'RUSTUP_HOME': '/usr/local/rustup',
+            'CARGO_TARGET_DIR': '/data/agent-cache/target', 'CARGO_INCREMENTAL': '0',
+            'CARGO_PROFILE_DEV_OPT_LEVEL': '1', 'CARGO_PROFILE_TEST_OPT_LEVEL': '1',
+            'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC': '1', 'DISABLE_AUTOUPDATER': '1'}
+
+
+def workspace(cwd):
+    """Only individually mounted checkouts/scratch projects are exposed."""
+    path = Path(cwd)
+    real = path.resolve(strict=True)
+    if real != path or not real.is_relative_to(DATA):
+        raise ValueError('unsafe sandbox working directory')
+    relative = real.relative_to(DATA).parts
+    if len(relative) >= 2 and relative[0] in ('worktrees', 'repro-check'):
+        root = DATA / relative[0] / relative[1]
+        # A linked worktree exposes controller Git metadata; refuse it.
+        if (root / '.git').is_symlink() or ((root / '.git').exists() and not (root / '.git').is_dir()):
+            raise ValueError('sandbox needs an independent clone')
+        return root, False
+    if real == DATA / 'repo/baml_language':
+        return DATA / 'repo', True
+    raise ValueError('working directory is outside sandbox roots')
+
+
+def command(cwd, argv, extra=None):
+    root, readonly = workspace(cwd)
+    args = ['/usr/bin/bwrap', '--unshare-user', '--unshare-pid', '--unshare-ipc',
+            '--unshare-uts', '--die-with-parent', '--new-session', '--cap-drop', 'ALL',
+            '--clearenv', '--proc', '/proc', '--dev', '/dev', '--tmpfs', '/tmp',
+            '--dir', '/home/agent']
+    for item in ('/usr', '/bin', '/lib', '/lib64', '/etc/ssl', '/etc/resolv.conf',
+                 '/etc/hosts', '/etc/alternatives', '/etc/passwd', '/etc/group', '/etc/ld.so.cache'):
+        if Path(item).exists(): args += ['--ro-bind', item, item]
+    # Each workspace gets a separate writable cache. Never share executable
+    # build output or Cargo configuration between unrelated agent sessions.
+    cache = DATA / 'agent-cache' / root.relative_to(DATA)
+    cache.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if cache.resolve() != cache:
+        raise ValueError('unsafe workspace cache')
+    args += ['--ro-bind' if readonly else '--bind', str(root), str(root),
+             '--bind', str(cache), '/data/agent-cache']
+    baseline = DATA / 'agent-cache/repo/target/debug/baml-cli'
+    if root != DATA / 'repo' and baseline.is_file():
+        args += ['--ro-bind', str(baseline), str(baseline)]
+    # The installed compiler is safe to expose read-only to repro checks.
+    if Path('/data/target/debug/baml-cli').is_file():
+        args += ['--ro-bind', '/data/target/debug/baml-cli', '/data/target/debug/baml-cli']
+    env = clean_env()
+    env.update(extra or {})
+    for key, value in env.items(): args += ['--setenv', key, value]
+    return args + ['--chdir', str(cwd), '--', *argv]
+
+
+class CredentialStore:
+    """Reads the machine's Claude login outside the agent mount namespace."""
+    def __init__(self, path=CREDENTIALS):
+        self.path = path
+        self.lock = threading.Lock()
+
+    def token(self):
+        # Different conversations have separate broker processes. Serialize
+        # refreshes across them as well as across this server's threads.
+        with self.lock, self.path.with_name('.atb2-oauth.lock').open('a', opener=lambda path, flags: os.open(path, flags, 0o600)) as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            data = json.loads(self.path.read_text())
+            auth = data['claudeAiOauth']
+            if auth.get('expiresAt', 0) < (time.time() + 90) * 1000:
+                # Refresh stays outside the sandbox, using Claude Code's public
+                # OAuth client. Neither refresh nor access token reaches it.
+                conn = http.client.HTTPSConnection('platform.claude.com', timeout=30)
+                try:
+                    conn.request('POST', '/v1/oauth/token', json.dumps({
+                        'grant_type': 'refresh_token', 'refresh_token': auth['refreshToken'],
+                        'client_id': '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+                    }), {'Content-Type': 'application/json'})
+                    response = conn.getresponse()
+                    raw = response.read(65536)
+                    if response.status != 200: raise ValueError('Claude refresh failed')
+                    result = json.loads(raw)
+                    auth['accessToken'] = result['access_token']
+                    auth['refreshToken'] = result.get('refresh_token', auth['refreshToken'])
+                    auth['expiresAt'] = (time.time() + result['expires_in']) * 1000
+                    tmp = self.path.with_name('.atb2-credentials-' + secrets.token_hex(12))
+                    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                    with os.fdopen(fd, 'w') as f: json.dump(data, f)
+                    os.replace(tmp, self.path)
+                finally: conn.close()
+            token = auth['accessToken']
+            if not isinstance(token, str) or not token: raise ValueError('Claude login unavailable')
+            return token
+
+
+class BrokerHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.0'
+    def log_message(self, *_): pass
+    def do_POST(self):
+        # Never a general proxy: fixed origin, paths, headers and body bound.
+        if (self.path not in ('/v1/messages', '/v1/messages?beta=true', '/v1/messages/count_tokens', '/v1/messages/count_tokens?beta=true')
+            or self.headers.get('Authorization') != 'Bearer ' + self.server.client_token):
+            self.send_error(403); return
+        try:
+            size = int(self.headers.get('Content-Length', '-1'))
+            if size < 0 or size > 8 * 1024 * 1024 or self.headers.get('Transfer-Encoding'):
+                self.send_error(413); return
+            self.connection.settimeout(30)
+            body = self.rfile.read(size)
+            if len(body) != size: raise ValueError('incomplete body')
+            headers = {'Authorization': 'Bearer ' + self.server.credentials.token(),
+                       'Content-Type': 'application/json', 'anthropic-version': '2023-06-01'}
+            for name in ('anthropic-beta', 'anthropic-dangerous-direct-browser-access', 'x-app', 'user-agent'):
+                value = self.headers.get(name)
+                if value: headers[name] = value
+            conn = self.server.connect()
+            try:
+                conn.request('POST', self.path, body, headers)
+                response = conn.getresponse()
+                if response.status != 200:
+                    # Authentication diagnostics must not reflect real credentials.
+                    self.send_error(502, 'Claude upstream rejected request'); return
+                self.send_response(200)
+                self.send_header('Content-Type', response.getheader('Content-Type', 'application/json'))
+                self.end_headers()
+                while True:
+                    chunk = response.read1(65536)
+                    if not chunk: break
+                    self.wfile.write(chunk); self.wfile.flush()
+            finally: conn.close()
+        except Exception:
+            # Never log request bodies, tokens, upstream diagnostics or errors.
+            with contextlib.suppress(Exception): self.send_error(502, 'Claude broker unavailable')
+
+
+@contextlib.contextmanager
+def broker(credentials=None):
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), BrokerHandler)
+    server.daemon_threads = True
+    server.client_token = 'sk-ant-oat01-' + secrets.token_urlsafe(32)
+    server.credentials = credentials or CredentialStore()
+    server.connect = lambda: http.client.HTTPSConnection('api.anthropic.com', timeout=300)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try: yield server
+    finally: server.shutdown(); server.server_close(); thread.join()
+
+
+def main():
+    if sys.platform != 'linux' or not Path('/usr/bin/bwrap').is_file():
+        raise ValueError('Linux bubblewrap isolation is required')
+    cwd, *argv = sys.argv[1:]
+    if not argv: raise ValueError('missing sandbox command')
+    transcript = os.environ.get('ATB2_TRANSCRIPT')
+    with contextlib.ExitStack() as stack:
+        output = None
+        extra = {}
+        if argv[0] == 'claude':
+            proxy = stack.enter_context(broker())
+            extra = {'ANTHROPIC_BASE_URL': 'http://127.0.0.1:' + str(proxy.server_port),
+                     'CLAUDE_CODE_OAUTH_TOKEN': proxy.client_token,
+                     'CLAUDE_CODE_SAFE_MODE': '1'}
+            if transcript:
+                path = Path(transcript)
+                if not path.parent.resolve().is_relative_to(DATA / 'runs') or path.is_symlink():
+                    raise ValueError('unsafe transcript path')
+                fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+                output = stack.enter_context(os.fdopen(fd, 'wb'))
+        result = subprocess.run(command(cwd, argv, extra), env={'PATH': SAFE_PATH},
+                                stdout=output, stderr=subprocess.STDOUT if output else None)
+        return result.returncode
+
+
+if __name__ == '__main__':
+    try: sys.exit(main())
+    except Exception:
+        print('atb2: isolated command could not start', file=sys.stderr)
+        sys.exit(126)

--- a/tools/atb2/deploy/test_build_isolation.sh
+++ b/tools/atb2/deploy/test_build_isolation.sh
@@ -42,6 +42,11 @@ EOF
 cat > /data/bootstrap/repo/baml_language/src/main.rs <<'EOF'
 use std::{env, fs, process::Command};
 fn main() {
+    if env::args().any(|a| a == "--version") {
+        assert_eq!(Command::new("id").arg("-u").output().unwrap().stdout, b"1001\n");
+        println!("baml 0.0.0");
+        return;
+    }
     assert_eq!(Command::new("id").arg("-u").output().unwrap().stdout, b"1000\n");
     assert_eq!(env::var("HOME").unwrap(), "/data/home");
     assert_eq!(env::var("FEEDBACK_SUPABASE_KEY").unwrap(), "exported-app-placeholder");
@@ -52,6 +57,10 @@ fn main() {
     assert!(!String::from_utf8_lossy(&raw_env).contains("machine-placeholder"));
     assert_eq!(fs::read_to_string("/data/home/.credentials.json").unwrap(), "test-login-placeholder");
     assert!(fs::read("/data/bootstrap/isolation-passed").is_err());
+    // Session persistence must work beneath the root-owned volume directory.
+    fs::create_dir_all("/data/agent-sessions/test-session").unwrap();
+    fs::write("/data/agent-sessions/test-session/turn.lock", "fixture").unwrap();
+    assert!(fs::create_dir("/data/unprepared-directory").is_err());
     assert!(!Command::new("setpriv").args(["--reuid=0", "id"]).status().unwrap().success());
     println!("runtime isolation passed");
 }
@@ -91,6 +100,28 @@ mv -fT /tmp/fake-infisical /usr/local/bin/infisical
 /usr/local/bin/atb2-bootstrap
 test "$(cat /data/bootstrap/isolation-passed)" = ok
 test "$(stat -c %a /data/home)" = 700
+
+# Starting the service must not publish any version. The first request does.
+python3 - <<'PYTEST'
+import pathlib, subprocess, time
+for _ in range(100):
+    if pathlib.Path('/data/cli-build/request.sock').exists(): break
+    time.sleep(.05)
+assert not list(pathlib.Path('/data/cli-cache').glob('*/*/baml-cli'))
+command = ['setpriv', '--reuid=1000', '--regid=1000', '--clear-groups',
+           'python3', '-I', '/usr/local/lib/atb2/cli-cache-service.py', '0.0.0']
+path = pathlib.Path(subprocess.check_output(command, text=True).strip())
+assert path.is_file() and path.stat().st_uid == 0 and path.stat().st_mode & 0o222 == 0
+# Even deleting the builder source artifact cannot cause a build on a cache hit.
+original = pathlib.Path('/data/bootstrap/target/debug/baml-cli')
+saved = original.with_name('saved-cli')
+original.rename(saved)
+try:
+    assert subprocess.check_output(command, text=True).strip() == str(path)
+finally:
+    saved.rename(original)
+print('PASS: lazy publication and build-free cache hit through runtime socket')
+PYTEST
 
 # A pinned cache remains usable even with no git remote and no network.
 setpriv --reuid=1001 --regid=1001 --clear-groups git -C /data/bootstrap/repo remote remove origin

--- a/tools/atb2/deploy/test_cache_cli.py
+++ b/tools/atb2/deploy/test_cache_cli.py
@@ -1,0 +1,42 @@
+"""Offline versioned CLI publication and cache-integrity checks."""
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location('cache_cli', Path(__file__).with_name('cache-cli.py'))
+cache = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cache)
+
+
+class CacheTests(unittest.TestCase):
+    def test_versions_and_revisions_are_retained_and_indexed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'cache'
+            first = cache.publish(root, 'baml 0.18.0', 'a'*40, io.BytesIO(b'first'))
+            second = cache.publish(root, '0.18.0', 'b'*40, io.BytesIO(b'second'))
+            third = cache.publish(root, 'baml-cli 0.19.0-beta.1', 'c'*40, io.BytesIO(b'third'))
+            self.assertEqual(first.read_bytes(), b'first')
+            self.assertNotEqual(first, second)
+            self.assertEqual(third.stat().st_mode & 0o777, 0o555)
+            self.assertEqual(len(json.loads((root / 'index.json').read_text())), 3)
+            cache.publish(root, '0.18.0', 'a'*40, io.BytesIO(b'first'))
+            with self.assertRaises(ValueError):
+                cache.publish(root, '0.18.0', 'a'*40, io.BytesIO(b'poison'))
+            self.assertEqual(first.read_bytes(), b'first')
+
+    def test_invalid_keys_empty_artifacts_and_symlinks_are_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'cache'
+            for version, revision in [('../escape','a'*40), ('0.18.0','../escape')]:
+                with self.assertRaises(ValueError):
+                    cache.publish(root, version, revision, io.BytesIO(b'cli'))
+            with self.assertRaises(ValueError):
+                cache.publish(root, '0.18.0', 'a'*40, io.BytesIO(b''))
+            (root/'0.19.0').symlink_to(Path(tmp))
+            with self.assertRaises(ValueError):
+                cache.publish(root, '0.19.0', 'b'*40, io.BytesIO(b'cli'))
+
+if __name__ == '__main__': unittest.main()

--- a/tools/atb2/deploy/test_cli_cache_service.py
+++ b/tools/atb2/deploy/test_cli_cache_service.py
@@ -1,0 +1,46 @@
+import importlib.util
+import io
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch, Mock
+
+spec=importlib.util.spec_from_file_location('service',Path(__file__).with_name('cli-cache-service.py'))
+service=importlib.util.module_from_spec(spec);spec.loader.exec_module(service)
+
+class LazyCacheTests(unittest.TestCase):
+    def test_cache_hit_never_builds_or_fetches(self):
+        with patch.object(service,'cached',return_value='/cache/0.18.0/cli'), patch.object(service.subprocess,'Popen') as run:
+            self.assertEqual(service.ensure('0.18.0'),'/cache/0.18.0/cli')
+            run.assert_not_called()
+
+    def test_miss_builds_without_credentials_and_only_publishes_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            def build(command,**kwargs):
+                self.assertIn('--reuid=1001',command)
+                self.assertNotIn('GH_TOKEN',kwargs['env'])
+                self.assertNotIn('INFISICAL_TOKEN',kwargs['env'])
+                self.assertEqual(kwargs['env']['HOME'],'/data/bootstrap/home')
+                kwargs['stdout'].write(b'a'*40+b'\nexecutable')
+                return Mock(pid=123, wait=Mock(return_value=0))
+            with patch.object(service,'ROOT',Path(tmp)/'cache'), patch.object(service,'cached',return_value=None), patch.object(service.subprocess,'Popen',side_effect=build), patch.object(service.os,'killpg'):
+                path=service.ensure('0.18.0')
+                self.assertEqual(Path(path).read_bytes(),b'executable')
+            with patch.object(service,'cached',return_value=None), patch.object(service.subprocess,'Popen',return_value=Mock(pid=123, wait=Mock(return_value=1))), patch.object(service.os,'killpg'), patch.object(service.cache,'publish') as publish:
+                with self.assertRaises(subprocess.CalledProcessError):service.ensure('0.19.0')
+                publish.assert_not_called()
+
+    def test_timeout_kills_the_build_process_group_without_publication(self):
+        child = Mock(pid=123, wait=Mock(side_effect=[subprocess.TimeoutExpired('build', 2400), 0]))
+        with patch.object(service, 'cached', return_value=None), patch.object(service.subprocess, 'Popen', return_value=child), patch.object(service.os, 'killpg') as kill, patch.object(service.cache, 'publish') as publish:
+            with self.assertRaises(subprocess.TimeoutExpired):
+                service.ensure('0.18.0')
+            kill.assert_called_once_with(123, service.signal.SIGKILL)
+            publish.assert_not_called()
+
+    def test_untrusted_version_is_not_a_command_or_path(self):
+        for v in ['../bad','canary;id','0.18.0\ncommand','--help']:
+            with self.assertRaises(ValueError):service.cached(v)
+
+if __name__=='__main__':unittest.main()

--- a/tools/atb2/deploy/test_launch_runtime.py
+++ b/tools/atb2/deploy/test_launch_runtime.py
@@ -20,6 +20,50 @@ class LauncherTests(unittest.TestCase):
     def export(self, rows, returncode=0):
         return subprocess.CompletedProcess([], returncode, json.dumps(rows), "private diagnostic")
 
+    identity = {"INFISICAL_CLIENT_ID": "identity-fixture", "INFISICAL_CLIENT_SECRET": "secret-fixture",
+                "INFISICAL_PROJECT_ID": "test-project"}
+
+    def test_universal_auth_keeps_credentials_in_root_children_only(self):
+        login = subprocess.CompletedProcess([], 0, "fresh-token\n", "private diagnostic")
+        rows = [{"key": "GH_TOKEN", "value": "app-fixture"},
+                {"key": "INFISICAL_CLIENT_SECRET", "value": "must-not-pass"}]
+        with patch.object(launcher.subprocess, "run", side_effect=[login, self.export(rows)]) as run:
+            env = launcher.runtime_environment({**self.identity, "INFISICAL_TOKEN": "stale-token"})
+        auth, export = run.call_args_list
+        self.assertIn("--method=universal-auth", auth.args[0])
+        self.assertEqual(auth.kwargs["env"]["INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET"], "secret-fixture")
+        self.assertEqual(export.kwargs["env"]["INFISICAL_TOKEN"], "fresh-token")
+        self.assertNotIn("INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET", export.kwargs["env"])
+        self.assertNotIn("INFISICAL_TOKEN", auth.kwargs["env"])
+        for call in run.call_args_list:
+            for secret in ("secret-fixture", "identity-fixture", "fresh-token", "stale-token"):
+                self.assertNotIn(secret, str(call.args))
+        self.assertEqual(env["GH_TOKEN"], "app-fixture")
+        self.assertFalse(any(key.startswith("INFISICAL_") for key in env))
+
+    def test_incomplete_identity_refuses_fallback(self):
+        for missing in ("INFISICAL_CLIENT_ID", "INFISICAL_CLIENT_SECRET"):
+            source = {key: value for key, value in self.identity.items() if key != missing}
+            with patch.object(launcher.subprocess, "run") as run:
+                with self.assertRaises(ValueError):
+                    launcher.runtime_environment({**source, "INFISICAL_TOKEN": "old-token"})
+                run.assert_not_called()
+
+    def test_failed_or_malformed_login_never_exports(self):
+        for code, output in ((1, "private output"), (0, ""), (0, "banner\ntoken"), (0, "bad\0token")):
+            with self.subTest(code=code, output=output), patch.object(launcher.subprocess, "run",
+                    return_value=subprocess.CompletedProcess([], code, output, "private diagnostic")) as run:
+                with self.assertRaisesRegex(ValueError, "^Infisical login failed$"):
+                    launcher.runtime_environment(self.identity)
+                self.assertEqual(run.call_count, 1)
+
+    def test_slack_intake_and_shepherd_config_survive_filtering(self):
+        source = {"ATB_SLACK_SIGNING_SECRET": "fixture", "ATB2_SHEPHERDS": "owner:U1"}
+        env = launcher.runtime_environment(source)
+        self.assertEqual(env["ATB_SLACK_SIGNING_SECRET"], "fixture")
+        self.assertEqual(env["ATB2_SHEPHERDS"], "owner:U1")
+        self.assertNotIn("INFISICAL_TOKEN", env)
+
     def test_only_named_values_cross_boundary(self):
         value = "quotes'\" newline\n$(never-run); literal"
         rows = [{"key": key, "value": val} for key, val in {

--- a/tools/atb2/deploy/test_launch_runtime.py
+++ b/tools/atb2/deploy/test_launch_runtime.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+import stat
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -22,6 +24,49 @@ class LauncherTests(unittest.TestCase):
 
     identity = {"INFISICAL_CLIENT_ID": "identity-fixture", "INFISICAL_CLIENT_SECRET": "secret-fixture",
                 "INFISICAL_PROJECT_ID": "test-project"}
+
+    def test_user_login_ignores_machine_credentials_and_stays_outside_runtime(self):
+        source = {**self.identity, "INFISICAL_TOKEN": "stale-token", "ATB2_INFISICAL_AUTH": "user"}
+        with patch.object(launcher.os, "lstat", return_value=SimpleNamespace(st_uid=0, st_mode=stat.S_IFDIR | 0o700)), \
+             patch.object(launcher.subprocess, "run", return_value=self.export([
+                 {"key": "GH_TOKEN", "value": "app-fixture"},
+                 {"key": "INFISICAL_TOKEN", "value": "excluded"}])) as run:
+            env = launcher.runtime_environment(source)
+        run.assert_called_once()
+        self.assertIn("export", run.call_args.args[0])
+        exporter = run.call_args.kwargs["env"]
+        self.assertEqual(exporter["HOME"], "/data/infisical-home")
+        for key in ("INFISICAL_TOKEN", "INFISICAL_CLIENT_ID", "INFISICAL_CLIENT_SECRET"):
+            self.assertNotIn(key, exporter)
+            self.assertNotIn(key, env)
+        self.assertEqual(env["HOME"], "/data/home")
+        self.assertEqual(env["GH_TOKEN"], "app-fixture")
+        self.assertNotIn("ATB2_INFISICAL_AUTH", env)
+
+    def test_user_login_rejects_unsafe_storage_before_export(self):
+        safe = SimpleNamespace(st_uid=0, st_mode=stat.S_IFDIR | 0o711)
+        unsafe = [SimpleNamespace(st_uid=1000, st_mode=stat.S_IFDIR | 0o700),
+                  SimpleNamespace(st_uid=0, st_mode=stat.S_IFLNK | 0o700),
+                  SimpleNamespace(st_uid=0, st_mode=stat.S_IFDIR | 0o755)]
+        for info in unsafe:
+            with self.subTest(info=info), patch.object(launcher.os, "lstat", side_effect=[safe, info]), \
+                 patch.object(launcher.subprocess, "run") as run:
+                with self.assertRaises(ValueError):
+                    launcher.runtime_environment({**self.identity, "ATB2_INFISICAL_AUTH": "user"})
+                run.assert_not_called()
+
+    def test_unsafe_endpoint_is_rejected_before_credentials_are_sent(self):
+        for endpoint in ('http://example.invalid', 'https://user:pass@example.invalid', 'https://example.invalid/#fragment'):
+            with self.subTest(endpoint=endpoint), patch.object(launcher.subprocess, "run") as run:
+                with self.assertRaises(ValueError):
+                    launcher.runtime_environment({**self.identity, "INFISICAL_API_URL": endpoint})
+                run.assert_not_called()
+
+    def test_invalid_auth_mode_fails_closed(self):
+        with patch.object(launcher.subprocess, "run") as run:
+            with self.assertRaises(ValueError):
+                launcher.runtime_environment({"ATB2_INFISICAL_AUTH": "typo"})
+            run.assert_not_called()
 
     def test_universal_auth_keeps_credentials_in_root_children_only(self):
         login = subprocess.CompletedProcess([], 0, "fresh-token\n", "private diagnostic")

--- a/tools/atb2/deploy/test_sandbox.py
+++ b/tools/atb2/deploy/test_sandbox.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 import urllib.error
 import urllib.request
@@ -22,6 +23,23 @@ push = importlib.util.module_from_spec(spec); spec.loader.exec_module(push)
 
 
 class BrokerTests(unittest.TestCase):
+    def test_saved_login_uses_private_lock_and_returns_cached_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / '.credentials.json'
+            path.write_text(json.dumps({'claudeAiOauth': {
+                'accessToken': 'private-fixture', 'expiresAt': (time.time() + 3600) * 1000}}))
+            with patch.object(sandbox.http.client, 'HTTPSConnection') as connection:
+                self.assertEqual(sandbox.CredentialStore(path).token(), 'private-fixture')
+                connection.assert_not_called()
+            self.assertEqual((path.parent / '.atb2-oauth.lock').stat().st_mode & 0o777, 0o600)
+
+    def test_login_lock_refuses_symlinks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / '.credentials.json'
+            (path.parent / '.atb2-oauth.lock').symlink_to(path.parent / 'other')
+            with self.assertRaises(OSError):
+                sandbox.CredentialStore(path).token()
+
     def test_broker_replaces_auth_and_refuses_other_destinations(self):
         seen = []
         class Credentials:
@@ -46,6 +64,25 @@ class BrokerTests(unittest.TestCase):
             self.assertEqual(send('/v1/messages',broker.client_token),(200,b'{"ok":true}'))
         self.assertEqual(len(seen),1)
         self.assertEqual(seen[0][2]['Authorization'],'Bearer private-fixture')
+
+    def test_upstream_failure_after_headers_does_not_append_an_http_error(self):
+        class Credentials:
+            def token(self): return 'private-fixture'
+        class Response:
+            status = 200
+            def getheader(self, *_): return 'text/event-stream'
+            def read1(self, _): raise OSError('private-upstream-diagnostic')
+        class Connection:
+            def request(self, *_): pass
+            def getresponse(self): return Response()
+            def close(self): pass
+        with sandbox.broker(Credentials()) as broker:
+            broker.connect = Connection
+            req = urllib.request.Request('http://127.0.0.1:'+str(broker.server_port)+'/v1/messages',
+                data=b'{}', headers={'Authorization':'Bearer '+broker.client_token})
+            with urllib.request.urlopen(req) as response:
+                self.assertEqual(response.status, 200)
+                self.assertEqual(response.read(), b'')
 
     def test_broker_errors_never_echo_credentials(self):
         class Credentials:
@@ -141,6 +178,25 @@ print('isolated')'''
     def test_linked_worktrees_are_refused(self):
         (self.work/'.git').write_text('gitdir: /data/repo/.git/worktrees/unsafe')
         with self.assertRaises(ValueError): sandbox.workspace(str(self.work))
+
+    def test_shared_cli_is_readable_but_not_writable_from_sandbox(self):
+        cache = Path('/data/cli-cache')
+        cache.mkdir(exist_ok=True)
+        cache.chmod(0o755)
+        fixture = cache / 'test-readonly'
+        fixture.write_text('cached fixture')
+        fixture.chmod(0o444)
+        self.addCleanup(fixture.unlink)
+        code = """from pathlib import Path
+p = Path('/data/cli-cache/test-readonly')
+assert p.read_text() == 'cached fixture'
+assert not Path('/data/cli-build/request.sock').exists()
+try: p.write_text('poison')
+except OSError: pass
+else: raise AssertionError('shared cache was writable')
+"""
+        result = self.isolated('/usr/bin/python3', '-c', code)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_workspace_caches_cannot_poison_other_sessions(self):
         with tempfile.TemporaryDirectory(dir='/data/worktrees') as other:

--- a/tools/atb2/deploy/test_sandbox.py
+++ b/tools/atb2/deploy/test_sandbox.py
@@ -1,0 +1,204 @@
+"""Offline security regression tests. Run in the runner image with user namespaces.
+No network access, real credentials, or model requests are needed.
+"""
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from unittest.mock import patch
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location('sandbox', Path(__file__).with_name('sandbox.py'))
+sandbox = importlib.util.module_from_spec(spec); spec.loader.exec_module(sandbox)
+spec = importlib.util.spec_from_file_location('push', Path(__file__).with_name('push.py'))
+push = importlib.util.module_from_spec(spec); spec.loader.exec_module(push)
+
+
+class BrokerTests(unittest.TestCase):
+    def test_broker_replaces_auth_and_refuses_other_destinations(self):
+        seen = []
+        class Credentials:
+            def token(self): return 'private-fixture'
+        class Connection:
+            def request(self, method, path, body, headers): seen.append((method,path,headers))
+            def getresponse(self):
+                r = io.BytesIO(b'{"ok":true}'); r.status = 200
+                r.getheader = lambda *_: 'application/json'
+                return r
+            def close(self): pass
+        with sandbox.broker(Credentials()) as broker:
+            broker.connect = Connection
+            def send(path, token):
+                req = urllib.request.Request('http://127.0.0.1:'+str(broker.server_port)+path,
+                    data=b'{}', headers={'Authorization':'Bearer '+token})
+                try:
+                    with urllib.request.urlopen(req) as r: return r.status, r.read()
+                except urllib.error.HTTPError as r: return r.code, r.read()
+            self.assertEqual(send('/v1/messages', 'wrong')[0],403)
+            self.assertEqual(send('/api/oauth/token',broker.client_token)[0],403)
+            self.assertEqual(send('/v1/messages',broker.client_token),(200,b'{"ok":true}'))
+        self.assertEqual(len(seen),1)
+        self.assertEqual(seen[0][2]['Authorization'],'Bearer private-fixture')
+
+    def test_broker_errors_never_echo_credentials(self):
+        class Credentials:
+            def token(self): raise ValueError('private-fixture')
+        with sandbox.broker(Credentials()) as broker:
+            req=urllib.request.Request('http://127.0.0.1:'+str(broker.server_port)+'/v1/messages',
+                data=b'{}',headers={'Authorization':'Bearer '+broker.client_token})
+            with self.assertRaises(urllib.error.HTTPError) as error: urllib.request.urlopen(req)
+            self.assertNotIn(b'private-fixture',error.exception.read())
+
+
+@unittest.skipUnless(sys.platform=='linux' and Path('/usr/bin/bwrap').exists(), 'Linux bubblewrap required')
+class BoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.work = Path(tempfile.mkdtemp(dir='/data/worktrees',prefix='security-'))
+        self.addCleanup(lambda: __import__('shutil').rmtree(self.work))
+        Path('/data/home/security-fixture').write_text('private-fixture')
+        self.addCleanup(lambda: Path('/data/home/security-fixture').unlink())
+
+    def isolated(self,*argv):
+        return subprocess.run(sandbox.command(str(self.work),list(argv)),env={'PATH':sandbox.SAFE_PATH},
+            capture_output=True,text=True,timeout=30)
+
+    def test_files_processes_and_controller_git_are_not_visible(self):
+        (self.work/'escape').symlink_to('/data/home/security-fixture')
+        code='''import os,pathlib
+assert os.environ['HOME']=='/home/agent'
+assert not pathlib.Path('/data/home').exists()
+assert not pathlib.Path('/data/repo').exists()
+assert not pathlib.Path('escape').exists()
+for p in pathlib.Path('/proc').glob('[0-9]*/environ'):
+ try: assert b'FAKE_APP_SECRET' not in p.read_bytes()
+ except PermissionError: pass
+pathlib.Path('allowed-write').write_text('ok')
+print('isolated')'''
+        with patch.dict(os.environ,{'FAKE_APP_SECRET':'private-fixture'}):
+            result=self.isolated('/usr/bin/python3','-c',code)
+        self.assertEqual(result.returncode,0,result.stderr)
+        self.assertEqual((self.work/'allowed-write').read_text(),'ok')
+
+    def test_project_hook_does_not_run_with_planner_flags(self):
+        (self.work/'.claude').mkdir()
+        marker=self.work/'hook-ran'
+        (self.work/'.claude/settings.json').write_text(json.dumps({'hooks':{'SessionStart':[{'hooks':[
+            {'type':'command','command':'touch '+str(marker)}]}]}}))
+        result=self.isolated('claude','-p','Return OK','--output-format','stream-json','--verbose',
+            '--permission-mode','bypassPermissions','--safe-mode','--setting-sources','',
+            '--strict-mcp-config','--mcp-config','{"mcpServers":{}}','--settings','{"disableAllHooks":true}',
+            '--no-session-persistence','--tools','Read,Glob,Grep')
+        self.assertFalse(marker.exists(),result.stdout+result.stderr)
+        self.assertNotIn('unknown option',result.stderr)
+        self.assertNotIn('bwrap:',result.stderr)
+
+    def test_claude_uses_broker_without_real_login(self):
+        seen = []
+        class Credentials:
+            def token(self): return 'private-fixture'
+        class Connection:
+            def request(self, method, path, body, headers):
+                seen.append((path, headers))
+            def getresponse(self):
+                events = [
+                    ('message_start', {'type':'message_start','message':{'id':'msg_fixture','type':'message','role':'assistant','content':[], 'model':'claude-sonnet-4-6','stop_reason':None,'stop_sequence':None,'usage':{'input_tokens':1,'output_tokens':0}}}),
+                    ('content_block_start', {'type':'content_block_start','index':0,'content_block':{'type':'text','text':''}}),
+                    ('content_block_delta', {'type':'content_block_delta','index':0,'delta':{'type':'text_delta','text':'OK'}}),
+                    ('content_block_stop', {'type':'content_block_stop','index':0}),
+                    ('message_delta', {'type':'message_delta','delta':{'stop_reason':'end_turn','stop_sequence':None},'usage':{'output_tokens':1}}),
+                    ('message_stop', {'type':'message_stop'}),
+                ]
+                raw = ''.join('event: '+name+'\ndata: '+json.dumps(value)+'\n\n' for name,value in events)
+                r=io.BytesIO(raw.encode()); r.status=200
+                r.getheader=lambda *_:'text/event-stream'
+                return r
+            def close(self): pass
+        with sandbox.broker(Credentials()) as broker:
+            broker.connect=Connection
+            args=sandbox.command(str(self.work), ['claude','-p','Return OK','--model','claude-sonnet-4-6',
+                '--safe-mode','--setting-sources','','--strict-mcp-config','--mcp-config','{"mcpServers":{}}',
+                '--settings','{"disableAllHooks":true}','--no-session-persistence','--tools','Read,Glob,Grep'],
+                {'ANTHROPIC_BASE_URL':'http://127.0.0.1:'+str(broker.server_port),
+                 'CLAUDE_CODE_OAUTH_TOKEN':broker.client_token,'CLAUDE_CODE_SAFE_MODE':'1'})
+            result=subprocess.run(args,env={'PATH':sandbox.SAFE_PATH},capture_output=True,text=True,timeout=30)
+        self.assertEqual(result.returncode,0,result.stdout+result.stderr)
+        self.assertIn('OK',result.stdout)
+        self.assertTrue(seen)
+        self.assertTrue(all(h['Authorization']=='Bearer private-fixture' for _,h in seen))
+        self.assertNotIn('private-fixture',result.stdout+result.stderr)
+
+    def test_symlinked_git_metadata_is_refused(self):
+        (self.work/'.git').symlink_to('/data/repo',target_is_directory=True)
+        with self.assertRaises(ValueError): sandbox.workspace(str(self.work))
+
+    def test_linked_worktrees_are_refused(self):
+        (self.work/'.git').write_text('gitdir: /data/repo/.git/worktrees/unsafe')
+        with self.assertRaises(ValueError): sandbox.workspace(str(self.work))
+
+    def test_workspace_caches_cannot_poison_other_sessions(self):
+        with tempfile.TemporaryDirectory(dir='/data/worktrees') as other:
+            poison = """import os
+from pathlib import Path
+cache=Path(os.environ['CARGO_HOME']);cache.mkdir(parents=True,exist_ok=True)
+(cache/'config.toml').write_text('[build]\\nrustc = "/data/agent-cache/poison"\\n')
+p=Path('/data/agent-cache/poison');p.write_text('#!/bin/sh\\necho POISONED\\n');p.chmod(0o755)
+try: Path(os.environ['RUSTUP_HOME'],'settings.toml').write_text('poison')
+except OSError: pass
+else: raise AssertionError('shared toolchain was writable')
+"""
+            result=self.isolated('python3','-c',poison)
+            self.assertEqual(result.returncode,0,result.stderr)
+            result=subprocess.run(sandbox.command(other,['bash','-c',
+                'test ! -e "$CARGO_HOME/config.toml" && test ! -e /data/agent-cache/poison && cargo --version && rustc --version']),
+                capture_output=True,text=True,timeout=30)
+            self.assertEqual(result.returncode,0,result.stderr)
+            self.assertNotIn('POISONED',result.stdout)
+
+    def test_gate_tools_and_compiled_binary_are_available_in_private_target(self):
+        (self.work/'src').mkdir()
+        (self.work/'Cargo.toml').write_text('[package]\nname="gate_fixture"\nversion="0.0.0"\nedition="2021"\n')
+        (self.work/'src/main.rs').write_text('fn main() { println!("patched-fixture"); }')
+        result=self.isolated('bash','-c',
+            'cargo nextest --version && cargo insta --version && cargo build --offline && "$CARGO_TARGET_DIR/debug/gate_fixture"')
+        self.assertEqual(result.returncode,0,result.stderr)
+        self.assertIn('patched-fixture',result.stdout)
+
+    def test_push_ignores_agent_origin_and_credential_helper(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            folder=Path(tmp)
+            def git(cwd,*args):
+                return subprocess.check_output(['/usr/bin/git',*args],cwd=cwd,stderr=subprocess.DEVNULL).decode().strip()
+            for name in ['intended.git','attacker.git']:git(folder,'init','--bare',name)
+            git(self.work,'init','-b','fix');git(self.work,'config','user.name','fixture');git(self.work,'config','user.email','fixture@example.invalid')
+            (self.work/'file').write_text('base');git(self.work,'add','.');git(self.work,'commit','-m','base')
+            base=git(self.work,'rev-parse','HEAD')
+            for name in ['intended.git','attacker.git']:git(self.work,'push',str(folder/name),'fix')
+            git(self.work,'remote','add','origin',str(folder/'attacker.git'))
+            git(self.work,'config','credential.helper','!touch '+str(folder/'token-helper-ran'))
+            git(self.work,'config','url.'+str(folder/'attacker.git')+'.insteadOf',push.REPOSITORY)
+            (self.work/'file').write_text('fix');git(self.work,'commit','-am','fix')
+            commit=git(self.work,'rev-parse','HEAD')
+            real_run=subprocess.run
+            def intercept(args,**kwargs):
+                if args[0]=='/usr/bin/git' and 'push' in args:
+                    self.assertIn(push.REPOSITORY,args)
+                    self.assertEqual(args[-1],commit+':refs/heads/fix')
+                    # Replace only the network transport in this offline test.
+                    args=[str(folder/'intended.git') if a==push.REPOSITORY else
+                          'protocol.file.allow=always' if a=='protocol.https.allow=always' else a for a in args]
+                return real_run(args,**kwargs)
+            with patch.object(sys,'argv',['push.py',str(self.work),'fix',base]), patch.dict(os.environ,{'GH_TOKEN':'fixture'}), patch.object(subprocess,'run',side_effect=intercept):
+                self.assertEqual(push.main(),0)
+            self.assertEqual(git(folder/'intended.git','rev-parse','fix'),commit)
+            self.assertEqual(git(folder/'attacker.git','rev-parse','fix'),base)
+            self.assertFalse((folder/'token-helper-ran').exists())
+
+
+if __name__=='__main__': unittest.main()


### PR DESCRIPTION
Compiler builds now run under a builder UID that cannot read the persistent Claude login. Root authenticates with Infisical Universal Auth and exports only an explicit application environment to the runtime. Agent commands use an isolated HOME and filesystem/process boundary; a fixed-origin broker supplies Claude authentication outside that boundary. Trusted pushes use fresh Git metadata, a fixed repository and an expected-head lease.

Writable Cargo caches and build output are isolated per workspace, and completed fix caches are removed. Rust, nextest, and insta are installed in the image with pinned versions. The gate requires successful exit codes for every step; truncated logs cannot waive a failure. Baseline repro checks use a separate compiler build, and the installed compiler revision is recorded for play runs. Node 22 is included at this layer.

Validation: 86 BAML tests, 9 launcher tests, 6 entrypoint/cache tests, the runner image build, and 10 offline container boundary tests at this layer. A real Rust fixture compiles and executes inside its private cache. Cross-workspace cache poisoning is rejected; builder isolation and credential-broker forwarding are tested offline.

Setup: retain the Fly volume and stage INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET on atb2-runner. INFISICAL_PROJECT_ID is configured in fly.toml. This layer requires no SQL. Do not deploy this layer alone with live intake enabled. Keep automatic canary deployments paused while demoing the final unmerged stack, so an early layer merge cannot replace it. Live Fly namespaces and OAuth must still be verified after deployment.

Stack position 1/7. Base: canary.

<details>
<summary>Changed files (12)</summary>

- `.github/workflows/atb2-deploy.yml`
- `tools/atb2/.dockerignore`
- `tools/atb2/README.md`
- `tools/atb2/baml_src/handle_issue.baml`
- `tools/atb2/deploy/Dockerfile`
- `tools/atb2/deploy/bootstrap.sh`
- `tools/atb2/deploy/entrypoint.sh`
- `tools/atb2/deploy/launch-runtime.py`
- `tools/atb2/deploy/push.py`
- `tools/atb2/deploy/sandbox.py`
- `tools/atb2/deploy/test_launch_runtime.py`
- `tools/atb2/deploy/test_sandbox.py`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added isolated execution for agent tasks with protected workspaces, private caches, and restricted credential access.
  - Added secure trusted-push handling with commit validation and protected branch updates.
  - Added authenticated CLI artifact caching and controlled versioned builds.
  - Added Infisical authentication options and expanded runtime secret support.
  - Added deployment preflight checks and improved runtime setup.

- **Bug Fixes**
  - Agent verification now enforces stronger process and filesystem boundaries.
  - Test gates no longer allow known failures or incomplete test runs to pass.

- **Documentation**
  - Documented authentication, isolation, and trusted-push behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->