### PR TITLE
Add signed Slack intake and shepherd approval from Slack or the website

### DIFF
--- a/.github/workflows/atb2-deploy.yml
+++ b/.github/workflows/atb2-deploy.yml
@@ -88,4 +88,4 @@ jobs:
         if: env.FLY_API_TOKEN != ''
         run: |
           flyctl apps list --json | grep -q '"atb2-runner"' || { echo "the Fly app atb2-runner does not exist yet; see tools/atb2/README.md"; exit 1; }
-          flyctl deploy tools/atb2 --config tools/atb2/deploy/fly.toml --remote-only --ha=false
+          flyctl deploy tools/atb2 --config deploy/fly.toml --remote-only --ha=false

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -167,3 +167,19 @@ from the Fly machine identity, or the existing `INFISICAL_TOKEN` fallback.
 Neither reaches the runtime. Agent commands require Linux namespaces; startup
 fails closed if they are unavailable. Trusted pushes export Git objects into
 fresh controller-owned metadata and use a fixed repository and exact branch lease.
+
+## Slack intake and issue approval
+
+The runner serves signed Slack events at `/slack/events` and health at `/health`
+on port 8080. Subscribe to `app_mention` and `reaction_added`, with
+`chat:write`, `app_mentions:read`, and `reactions:read`.
+Set `ATB2_SHEPHERDS` to a comma-separated GitHub-login:Slack-user-ID map.
+New issues announce their shepherd and wait for approval before implementation.
+
+On the website the assigned shepherd can sign in with GitHub and click
+**Approve issue**. Configure `FEEDBACK_SITE_URL`, `FEEDBACK_GITHUB_CLIENT_ID`,
+`FEEDBACK_GITHUB_CLIENT_SECRET`, `FEEDBACK_APPROVAL_SESSION_KEY` (64 hex digits),
+and server-only `FEEDBACK_APPROVAL_SUPABASE_KEY`. The OAuth callback is
+`/auth/github/callback`. Slack and website approvals update the same pending row;
+only the winning conditional write succeeds. The runner narrates website approvals
+in the issue thread before starting the fix.

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -52,6 +52,7 @@ PostHog trio; `dev` does not). `run_tests.sh` and any live run go through
 | `FEEDBACK_SUPABASE_URL`, `FEEDBACK_SUPABASE_KEY` | store, evals | service key; the tables below exist in the project |
 | `ATB2_SLACK_BOT_TOKEN`, `ATB2_SLACK_CHANNEL` | notifications | `chat:write`; one thread per issue; fall back to the old bot's `ATB_SLACK_BOT_TOKEN`, `ATB_SLACK_FIX_CHANNEL` |
 | `ATB2_SLACK_INTAKE_CHANNEL` | Slack intake | `channels:history`; unset = no Slack intake |
+| `ATB2_SLACK_SIGNING_SECRET` | `/slack/events` | verifies Slack's request signature; falls back to the old app's `ATB_SLACK_SIGNING_SECRET` |
 | `ATB2_POSTHOG_API_KEY`, `ATB2_POSTHOG_PROJECT_ID`, `ATB2_POSTHOG_HOST` | PostHog intake | fall back to `ATB_POSTHOG_*`; personal key with `events:read`; host defaults to `https://us.posthog.com` |
 | `ATB2_UI_URL` | notifications | links issues to `typescript2/app-feedback` |
 | `ATB2_REVIEWERS`, `ATB2_POLL_S`, `ATB2_MAX_WAIT_S` | merge_issue | see `merge_issue.baml`; fork PRs are refused |
@@ -171,8 +172,12 @@ fresh controller-owned metadata and use a fixed repository and exact branch leas
 ## Slack intake and issue approval
 
 The runner serves signed Slack events at `/slack/events` and health at `/health`
-on port 8080. Subscribe to `app_mention` and `reaction_added`, with
-`chat:write`, `app_mentions:read`, and `reactions:read`.
+on port 8080. Requests are verified against `ATB2_SLACK_SIGNING_SECRET`
+(falling back to the old app's `ATB_SLACK_SIGNING_SECRET`), from Infisical
+like the rest of the Wiring table. Subscribe to `app_mention` and
+`reaction_added`, with `chat:write`, `app_mentions:read`, and `reactions:read`;
+polling intake through `ATB2_SLACK_INTAKE_CHANNEL` reads
+`conversations.history`, which also needs `channels:history`.
 Set `ATB2_SHEPHERDS` to a comma-separated GitHub-login:Slack-user-ID map.
 New issues announce their shepherd and wait for approval before implementation.
 

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -137,7 +137,7 @@ By hand, from the repo root:
 fly apps create atb2-runner                                            # once (exists)
 fly volumes create atb2_data --size 80 --region sjc -a atb2-runner     # once
 fly secrets set -a atb2-runner INFISICAL_TOKEN=...                     # once
-fly deploy tools/atb2 --config tools/atb2/deploy/fly.toml
+fly deploy tools/atb2 --config deploy/fly.toml
 ```
 
 ## Tests

--- a/tools/atb2/baml_src/create_issue.baml
+++ b/tools/atb2/baml_src/create_issue.baml
@@ -37,6 +37,8 @@ function create_issue(fb: Feedback) -> Issue? {
         resolution_plan: draft.resolution_plan,
         difficulty: null,
         design_doc: null,
+        slack_ts: null,
+        slack_channel: null,
     }
 }
 
@@ -644,6 +646,8 @@ function reference_as_issue(number: int, r: ReferenceIssue) -> Issue {
         resolution_plan: r.resolution_plan,
         difficulty: null,
         design_doc: null,
+        slack_ts: null,
+        slack_channel: null,
     }
 }
 

--- a/tools/atb2/baml_src/gauge_issue.baml
+++ b/tools/atb2/baml_src/gauge_issue.baml
@@ -100,6 +100,8 @@ function with_difficulty(issue: Issue, difficulty: Difficulty) -> Issue {
         resolution_plan: issue.resolution_plan,
         difficulty: difficulty,
         design_doc: issue.design_doc,
+        slack_ts: issue.slack_ts,
+        slack_channel: issue.slack_channel,
     }
 }
 

--- a/tools/atb2/baml_src/handle_issue.baml
+++ b/tools/atb2/baml_src/handle_issue.baml
@@ -205,6 +205,7 @@ function handle_ready(issue: Issue, update: bool) -> string? {
     };
     match (issue.status) {
         let s: Open => null,
+        let s: Approved => null,
         _ => "not open",
     }
 }
@@ -382,6 +383,11 @@ function verdict_from_check(
 }
 
 function with_status(issue: Issue, status: IssueStatus) -> Issue {
+    let reset_anchor = match (status) {
+        let s: AwaitingApproval => true,
+        let s: Open => true,
+        _ => false,
+    };
     Issue {
         id: issue.id,
         title: issue.title,
@@ -396,6 +402,16 @@ function with_status(issue: Issue, status: IssueStatus) -> Issue {
         resolution_plan: issue.resolution_plan,
         difficulty: issue.difficulty,
         design_doc: issue.design_doc,
+        slack_ts: if (reset_anchor) {
+            null
+        } else {
+            issue.slack_ts
+        },
+        slack_channel: if (reset_anchor) {
+            null
+        } else {
+            issue.slack_channel
+        },
     }
 }
 
@@ -414,6 +430,8 @@ function with_design_doc(issue: Issue, doc: string) -> Issue {
         resolution_plan: issue.resolution_plan,
         difficulty: issue.difficulty,
         design_doc: doc,
+        slack_ts: issue.slack_ts,
+        slack_channel: issue.slack_channel,
     }
 }
 
@@ -1957,6 +1975,8 @@ function gh_issue(number: int, difficulty: Difficulty?) -> Issue {
         resolution_plan: null,
         difficulty: difficulty,
         design_doc: null,
+        slack_ts: null,
+        slack_channel: null,
     }
 }
 
@@ -2016,6 +2036,8 @@ testset "handle_issue" {
             resolution_plan: null,
             difficulty: Difficulty.Easy,
             design_doc: null,
+            slack_ts: null,
+            slack_channel: null,
         };
         assert.is_true(branch_for(piped).starts_with("agent/issue-01j9x7ab-"));
         assert.equal(github_number(piped) == null, true);
@@ -2210,6 +2232,8 @@ testset "handle_issue" {
             resolution_plan: null,
             difficulty: Difficulty.Easy,
             design_doc: null,
+            slack_ts: null,
+            slack_channel: null,
         };
         assert.contains(test_route(with_repro), "diagnostic_errors");
         assert.contains(test_route(base), "Rust test");

--- a/tools/atb2/baml_src/intake.baml
+++ b/tools/atb2/baml_src/intake.baml
@@ -6,7 +6,7 @@
 //   PostHog   `baml feedback` posts a `baml_feedback` event; posthog_feedback
 //             turns new events into Feedback (run_pipeline's ingest stage)
 //   Slack     @bammy mentions and reactions arrive at the HTTP server here
-//             (next PR): babysit <PR> -> merge_issue, a report -> triage,
+//             babysit <PR> -> the approval queue, a report -> triage,
 //             a reaction -> approval
 //   by hand   `baml run -e 'request_merge("<PR url>")'`, `run_pipeline()`
 //
@@ -257,5 +257,342 @@ testset "intake" {
         assert.equal(slack_feedback(null).ran, false);
         assert.equal(slack_feedback(null).feedback.length(), 0);
         assert.equal(slack_feedback(null).resume == null, true);
+    }
+}
+
+// ==================== Slack Events HTTP server ====================
+
+/// One process owns the HTTP listener, pipeline and merge queue.
+function main_ingress(
+    port: int = 8080,
+    every_s: int = 300,
+    mode: HandleMode = HandleMode.Live,
+) -> never {
+    spawn { runner_loop(every_s = every_s, mode = mode) };
+    serve_slack(port = port)
+}
+
+/// Also callable alone for local HTTP verification, without starting agents.
+function serve_slack(port: int = 8080) -> never {
+    let server = baml.http.Server.bind("0.0.0.0:" + port.to_string()) catch (_) {
+        _ => baml.sys.panic("cannot bind Slack listener"),
+    };
+    server.serve(
+        slack_http,
+        max_body_size = 131072,
+        max_connections = 64,
+        header_read_timeout = baml.time.Duration.from_seconds(5),
+    ) catch (_) {
+        _ => baml.sys.panic("Slack listener stopped"),
+    }
+}
+
+function intake_response(status: int, body: json) -> baml.http.Response {
+    baml.http.Response.new(
+        status,
+        { "content-type": "application/json" },
+        baml.json.stringify(body).to_utf8(),
+    )
+}
+
+function slack_http(req: baml.http.Request) -> baml.http.Response throws never {
+    slack_http_inner(req) catch_all (_) {
+        _ => baml.http.Response.new(503, { "content-type": "application/json" }, "{}".to_utf8()),
+    }
+}
+
+function slack_http_inner(req: baml.http.Request) -> baml.http.Response {
+    let path = req.url.split("?").at(0) ?? req.url;
+    if (path == "/health" && req.method == "GET") {
+        return intake_response(200, { "ok": true }.to_json());
+    };
+    if (path != "/slack/events") {
+        return intake_response(404, baml.json.parse("{}"));
+    };
+    if (req.method != "POST") {
+        return intake_response(405, baml.json.parse("{}"));
+    };
+    slack_events(
+        req,
+        baml.env.get("ATB2_SLACK_SIGNING_SECRET") ?? baml.env.get("ATB_SLACK_SIGNING_SECRET") ?? "",
+        baml.time.Instant.now().to_timestamp_seconds(),
+    )
+}
+
+function slack_events(req: baml.http.Request, secret: string, now: bigint) -> baml.http.Response {
+    if (req.body.to_utf8().length() > 131072) {
+        return intake_response(413, baml.json.parse("{}"));
+    };
+    if (!slack_signature_ok(req, secret, now)) {
+        return intake_response(403, baml.json.parse("{}"));
+    };
+    let envelope = baml.json.parse(req.body) catch (_) {
+        _ => {
+            return intake_response(400, baml.json.parse("{}"));
+        },
+    };
+    let kind = baml.json.path_or<string>(envelope, ".type", "");
+    if (kind == "url_verification") {
+        let challenge = baml.json.path_or<string?>(envelope, ".challenge", null);
+        if (challenge == null) {
+            return intake_response(400, baml.json.parse("{}"));
+        };
+        return intake_response(200, { "challenge": challenge }.to_json());
+    };
+    if (kind != "event_callback") {
+        return intake_response(200, baml.json.parse("{}"));
+    };
+    let event = baml.json.path_or<json>(envelope, ".event", baml.json.parse("{}"));
+    if (baml.json.path_or<string>(event, ".type", "") == "reaction_added") {
+        accept_approval(event);
+        return intake_response(200, baml.json.parse("{}"));
+    };
+    if (baml.json.path_or<string>(event, ".type", "") != "app_mention") {
+        return intake_response(200, baml.json.parse("{}"));
+    };
+    let mention = slack_mention(envelope);
+    if (mention == null) {
+        return intake_response(200, baml.json.parse("{}"));
+    };
+    let m = mention ?? baml.sys.panic("checked mention");
+    // Save before ACK: a failed insert returns 503 so Slack retries. The
+    // single insert has a two-second timeout; Slack replies run after ACK.
+    let inserted = persist_mention(m);
+    if (inserted) {
+        spawn {
+            slack_post(mention_ack(m), m.thread) catch_all (_) {
+                _ => {
+                    log.warn({ "slack": "intake acknowledgement failed" });
+                    null
+                },
+            };
+        };
+    };
+    intake_response(200, baml.json.parse("{}"))
+}
+
+class SlackMention {
+    event_id: string,
+    team: string,
+    user: string,
+    ts: string,
+    thread: SlackRef,
+    route: MentionRoute,
+}
+
+function slack_id(s: string) -> bool {
+    s.length() > 0
+        && s.length() <= 80
+        && s.chars().every((c: string) -> bool {
+            (c >= "A" && c <= "Z") || (c >= "a" && c <= "z") || (c >= "0" && c <= "9")
+        })
+}
+
+function slack_ts(s: string) -> bool {
+    s.length() > 0
+        && s.length() <= 32
+        && s.chars().every((c: string) -> bool {
+            (c >= "0" && c <= "9") || c == "."
+        })
+}
+
+function slack_mention(envelope: json) -> SlackMention? {
+    let event = baml.json.path_or<json>(envelope, ".event", baml.json.parse("{}"));
+    if (
+        baml.json.path_or<string?>(event, ".bot_id", null) != null
+            || baml.json.path_or<string?>(event, ".subtype", null) != null
+    ) {
+        return null;
+    };
+    let event_id = baml.json.path_or<string>(envelope, ".event_id", "");
+    let team = baml.json.path_or<string>(envelope, ".team_id", "");
+    let channel = baml.json.path_or<string>(event, ".channel", "");
+    let user = baml.json.path_or<string>(event, ".user", "");
+    let ts = baml.json.path_or<string>(event, ".ts", "");
+    let anchor = baml.json.path_or<string>(event, ".thread_ts", ts);
+    if (
+        !slack_id(event_id)
+            || !slack_id(team)
+            || !slack_id(channel)
+            || !slack_id(user)
+            || !slack_ts(ts)
+            || !slack_ts(anchor)
+    ) {
+        return null;
+    };
+    let route = parse_mention(baml.json.path_or<string>(event, ".text", ""));
+    if (route.text.length() == 0) {
+        return null;
+    };
+    SlackMention {
+        event_id: event_id,
+        team: team,
+        user: user,
+        ts: ts,
+        thread: SlackRef { channel: channel, ts: anchor },
+        route: route,
+    }
+}
+
+function mention_feedback(m: SlackMention) -> Feedback {
+    Feedback {
+        id: "SL-" + m.team + "-" + m.thread.channel + "-" + m.ts.replace_all(".", "-"),
+        title: first_line(m.route.text, 120),
+        body: m.route.text,
+        source: FeedbackSource.Slack,
+        author: Author { email: null, github: null, device_id: "slack:" + m.user },
+        toolchain: toolchain_mentioned(m.route.text),
+        files: {},
+        comments: [],
+        issue_ids: [],
+    }
+}
+
+function persist_mention(m: SlackMention) -> bool {
+    if (!db_configured()) {
+        throw IntakeError { message: "Slack intake needs the store" };
+    };
+    let table = "";
+    let row: map<string, json> = {};
+    if (m.route.kind == "babysit" && m.route.pr != null) {
+        // Both intake paths share the same request ownership. The worker also
+        // coalesces races before it starts a proposal or implementation.
+        table = "babysit_requests";
+        row
+            = {
+                "pr": m.route.pr.to_json(),
+                "channel": m.thread.channel.to_json(),
+                "thread_ts": m.thread.ts.to_json(),
+                "requested_by": m.user.to_json(),
+                "kind": "babysit".to_json(),
+                "dataset": dataset().to_json(),
+            };
+    } else if (m.route.kind == "feedback") {
+        table = "feedback";
+        let fb = mention_feedback(m);
+        guard_dataset(fb.id);
+        row
+            = baml.json.from_json<map<string, json>>(
+                feedback_row(fb, { "kind": "slack", "channel": m.thread.channel, "ts": m.thread.ts }.to_json()),
+            );
+        row.set("slack_thread_ts", m.thread.ts.to_json());
+    } else {
+        // Informational replies create no queue work.
+        return true;
+    };
+    row.set("slack_event_id", m.event_id.to_json());
+    let text = supabase_send(
+        "POST",
+        table + "?on_conflict=slack_event_id",
+        baml.json.stringify([row]),
+        "resolution=ignore-duplicates,return=representation",
+        timeout_s = 2,
+    );
+    rows_of(text).length() > 0
+}
+
+function mention_ack(m: SlackMention) -> string {
+    if (m.route.kind == "shirt") {
+        return "Shirt codes are coming soon.";
+    };
+    if (m.route.kind == "babysit") {
+        if (m.route.pr == null) {
+            return "Use babysit followed by a GitHub PR URL.";
+        };
+        return "Queued this PR for babysitting.";
+    };
+    "Logged as feedback: " + mention_feedback(m).id + ". Triage will follow in this thread."
+}
+
+function signed_slack_request(
+    body: string,
+    timestamp: string,
+    secret: string,
+) -> baml.http.Request {
+    baml.http.Request {
+        method: "POST",
+        url: "/slack/events",
+        headers: {
+            "X-Slack-Request-Timestamp": timestamp,
+            "X-Slack-Signature": "v0=" + hmac_sha256_hex(secret, "v0:" + timestamp + ":" + body),
+        },
+        body: body,
+    }
+}
+
+testset "slack_http" {
+    test "HMAC SHA256 matches standard vectors including a long key" {
+        assert.equal(
+            hmac_sha256_hex("key", "The quick brown fox jumps over the lazy dog"),
+            "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8",
+        );
+        assert.equal(
+            hmac_sha256_hex("", ""),
+            "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad",
+        );
+    }
+    test "HMAC hashes keys longer than its block" {
+        assert.equal(
+            hmac_sha256_hex(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "test",
+            ),
+            "1228d938c9fd0321973d610248b62e03d404697ee5cb7196ac17d7fd18c610ca",
+        );
+    }
+    test "signature covers raw bytes and rejects stale or future replays" {
+        let req = signed_slack_request("{}", "1000", "test-secret");
+        assert.equal(slack_signature_ok(req, "test-secret", 1000n), true);
+        assert.equal(slack_signature_ok(req, "test-secret", 1301n), false);
+        assert.equal(slack_signature_ok(req, "test-secret", 699n), false);
+        assert.equal(slack_signature_ok(req, "wrong", 1000n), false);
+        assert.equal(slack_signature_ok(req, "", 1000n), false);
+        let changed = baml.http.Request { method: req.method, url: req.url, headers: req.headers, body: "{ }" };
+        assert.equal(slack_signature_ok(changed, "test-secret", 1000n), false);
+    }
+    test "signed challenge is JSON escaped and does not touch the store" {
+        let body = `{"type":"url_verification","challenge":"a\\\"b"}`;
+        let out = slack_events(signed_slack_request(body, "1000", "secret"), "secret", 1000n);
+        assert.equal(out.status_code, 200);
+        assert.equal(
+            baml.json.path_or<string>(baml.json.parse(out.text()), ".challenge", ""),
+            "a\"b",
+        );
+        assert.equal(
+            slack_events(signed_slack_request("broken", "1000", "secret"), "secret", 1000n).status_code,
+            400,
+        );
+    }
+    test "mention commands are anchored and links may be Slack wrapped" {
+        assert.equal(
+            parse_mention("<@U1> babysit <https://github.com/BoundaryML/baml/pull/42|PR>").pr ?? "",
+            "https://github.com/BoundaryML/baml/pull/42",
+        );
+        assert.equal(parse_mention("a babysit bug").kind, "feedback");
+        assert.equal(parse_mention("get me a tshirt").kind, "shirt");
+        assert.equal(parse_mention("shirtless function").kind, "feedback");
+    }
+    test "retry identity and original thread are preserved" {
+        let m = slack_mention(
+            baml.json.parse(
+                `{"event_id":"Ev1","team_id":"T1","event":{"type":"app_mention","channel":"C1","user":"U1","ts":"123.4","thread_ts":"123.0","text":"<@BOT> parser broke"}}`,
+            ),
+        )
+            ?? baml.sys.panic("no mention");
+        assert.equal(m.thread.ts, "123.0");
+        assert.equal(m.event_id, "Ev1");
+        assert.equal(mention_feedback(m).id, "SL-T1-C1-123-4");
+        assert.equal(mention_feedback(m).title, "parser broke");
+        assert.equal(slack_mention(baml.json.parse(`{"event":{"bot_id":"B1"}}`)) == null, true);
+    }
+    test "health is public but unsigned event intake is forbidden" {
+        assert.equal(
+            slack_http(baml.http.Request { method: "GET", url: "/health", headers: {}, body: "" }).status_code,
+            200,
+        );
+        assert.equal(
+            slack_http(baml.http.Request { method: "POST", url: "/slack/events", headers: {}, body: "{}" }).status_code,
+            403,
+        );
     }
 }

--- a/tools/atb2/baml_src/merge_issue.baml
+++ b/tools/atb2/baml_src/merge_issue.baml
@@ -256,6 +256,8 @@ function issue_from_pr(snap: PrSnapshot) -> Issue {
         resolution_plan: null,
         difficulty: Difficulty.Medium,
         design_doc: null,
+        slack_ts: null,
+        slack_channel: null,
     }
 }
 

--- a/tools/atb2/baml_src/models.baml
+++ b/tools/atb2/baml_src/models.baml
@@ -115,7 +115,23 @@ class Shipped {
     date: string,
 }
 
-type IssueStatus = Open | InProgress | Rejected | Deferred | Merged | Shipped;
+class AwaitingApproval {
+    state: "awaiting_approval",
+}
+
+class Approved {
+    state: "approved",
+    by: string,
+}
+
+type IssueStatus = AwaitingApproval
+    | Approved
+    | Open
+    | InProgress
+    | Rejected
+    | Deferred
+    | Merged
+    | Shipped;
 
 class Issue {
     id: string,
@@ -139,4 +155,7 @@ class Issue {
     /// Hard issues only: suggested fix + design doc for the shepherd to hand
     /// to their own agent. Null until handle_issue runs the Hard path.
     design_doc: string?,
+    /// The bot message to react to, bound to its Slack channel.
+    slack_ts: string?,
+    slack_channel: string?,
 }

--- a/tools/atb2/baml_src/organize_issue.baml
+++ b/tools/atb2/baml_src/organize_issue.baml
@@ -51,13 +51,17 @@ function shepherd_for(subsystem: Subsystem) -> string {
 
 /// Route an issue to the shepherd of its subsystem. Idempotent: an issue
 /// that already has a shepherd keeps it.
-function organize_issue(issue: Issue) -> Issue {
+function organize_issue(issue: Issue, mapping: string? = null) -> Issue {
     //# keep an existing shepherd
     if (issue.shepherd != null) {
         return issue;
     };
     //# route by subsystem to the most active owner
-    let shepherd = shepherd_for(issue.subsystem);
+    let config = mapping ?? baml.env.get("ATB2_SHEPHERDS") ?? "";
+    let candidates = shepherds_for(issue.subsystem).filter((login: string) -> bool {
+        config.trim().length() == 0 || shepherd_id_in(login, config) != null
+    });
+    let shepherd = candidates.at(0) ?? baml.sys.panic("no mapped shepherd for " + issue.subsystem.to_string());
     log.info({ "issue": issue.id, "subsystem": issue.subsystem.to_string(), "shepherd": shepherd });
     Issue {
         id: issue.id,
@@ -102,6 +106,15 @@ function issue_in(subsystem: Subsystem, shepherd: string?) -> Issue {
 // Checks the deterministic matcher: every subsystem routes to the first of
 // its owners, and organize_issue only ever touches `shepherd`.
 testset "organize_issue" {
+    test "new issues prefer an owner who can be mentioned and approve in Slack" {
+        let issue = organize_issue(issue_in(Subsystem.Tooling, null), mapping = "codeshaunted:U123,hellovai:U456");
+        assert.equal(issue.shepherd, "codeshaunted");
+        assert.contains(
+            issue_created_text(issue, mapping = "codeshaunted:U123"),
+            "shepherd: <@U123>",
+        );
+    }
+
     for (
         let s in [
             Subsystem.Syntax,

--- a/tools/atb2/baml_src/organize_issue.baml
+++ b/tools/atb2/baml_src/organize_issue.baml
@@ -73,6 +73,8 @@ function organize_issue(issue: Issue) -> Issue {
         resolution_plan: issue.resolution_plan,
         difficulty: issue.difficulty,
         design_doc: issue.design_doc,
+        slack_ts: issue.slack_ts,
+        slack_channel: issue.slack_channel,
     }
 }
 
@@ -92,6 +94,8 @@ function issue_in(subsystem: Subsystem, shepherd: string?) -> Issue {
         resolution_plan: null,
         difficulty: null,
         design_doc: null,
+        slack_ts: null,
+        slack_channel: null,
     }
 }
 

--- a/tools/atb2/baml_src/pipeline.baml
+++ b/tools/atb2/baml_src/pipeline.baml
@@ -4,9 +4,9 @@
 //            channel) -> feedback rows
 //   triage   each new report -> create_issue -> organize_issue -> gauge_issue
 //            -> an issues row, and a Slack thread opened for it
-//   handle   every open, gauged issue -> handle_issue -> a runs row; the
+//   handle   every approved, gauged issue -> handle_issue -> a runs row; the
 //            thread hears about the PR, or that a human is needed
-//   merge    every in-progress issue with a PR -> merge_issue -> merged
+//   merge    reconcile issue PRs with the shared merge_issue babysitter queue
 //
 //   cd tools/atb2 && baml run -e 'run_pipeline()'
 //   baml run -e 'run_pipeline(mode = HandleMode.DryRun, stages = "ingest,triage")'
@@ -56,7 +56,13 @@ function run_pipeline(
     // the later stages of this same run
     let created: Issue[] = [];
     if (want.includes("triage")) {
-        for (let fb in fresh) {
+        for (
+            let fb in if (db_configured()) {
+                untriaged_feedback()
+            } else {
+                fresh
+            }
+        ) {
             match (triage_feedback(fb)) {
                 null => report.skipped.push(fb.id + ": no issue (fixed on this toolchain)"),
                 let i: Issue => {
@@ -67,11 +73,14 @@ function run_pipeline(
             };
         }
     };
-    //# handle: open, gauged issues -> handle_issue -> runs row
+    if (want.includes("triage") && db_configured()) {
+        announce_approvals();
+    };
+    //# handle: approved, gauged issues -> handle_issue -> runs row
     let handled: Issue[] = [];
     if (want.includes("handle")) {
         let open = if (db_configured()) {
-            load_issues_in("open")
+            load_issues_in("approved")
         } else {
             created
         };
@@ -278,6 +287,47 @@ function origin_of(fb: Feedback) -> json {
     }
 }
 
+/// Includes durable Slack events and reports ingested in earlier runs. Scan
+/// past no_issue rows so they cannot starve newer reports at the head of a page.
+function untriaged_feedback() -> Feedback[] {
+    let pending: Feedback[] = [];
+    let offset = 0;
+    while (pending.length() < 50) {
+        let rows = select(
+            "feedback",
+            "select=*&issue_ids=eq.%7B%7D&dataset="
+                + eq(dataset())
+                + "&order=created_at,id&limit=100&offset="
+                + offset.to_string(),
+        );
+        for (let row in rows) {
+            let id = baml.json.path_or<string>(row, ".id", "");
+            if (
+                select(
+                    "events",
+                    "select=id&feedback_id="
+                        + eq(id)
+                        + "&kind=eq.no_issue&dataset="
+                        + eq(dataset())
+                        + "&limit=1",
+                )
+                    .length()
+                    == 0
+            ) {
+                pending.push(feedback_from_row(row));
+                if (pending.length() >= 50) {
+                    return pending;
+                };
+            };
+        }
+        if (rows.length() < 100) {
+            return pending;
+        };
+        offset += 100;
+    }
+    pending
+}
+
 // ==================== triage ====================
 
 /// One report through triage. Null when the repro is already fixed on this
@@ -292,10 +342,16 @@ function triage_feedback(fb: Feedback) -> Issue? {
         },
         let issue: Issue => {
             //# organize + gauge
-            let gauged = gauge_issue(organize_issue(issue));
+            let gauged = with_status(gauge_issue(organize_issue(issue)), AwaitingApproval { state: "awaiting_approval" });
             save_issue(gauged);
             //# link the report to its issue
-            save_feedback(with_issue(fb, gauged.id), origin_of(fb));
+            if (db_configured()) {
+                update(
+                    "feedback",
+                    "id=" + eq(fb.id) + "&dataset=" + eq(dataset()),
+                    { "issue_ids": with_issue(fb, gauged.id).issue_ids }.to_json(),
+                );
+            };
             //# open the issue's thread
             notify("issue_created", gauged, issue_created_text(gauged), { "feedback": fb.id }.to_json());
             gauged
@@ -326,6 +382,22 @@ function with_issue(fb: Feedback, issue_id: string) -> Feedback {
 /// handle_issue for one issue, its outcome saved and told. Null when
 /// handle_issue did not run (not ready, already fixed).
 function handle_one(issue: Issue, mode: HandleMode) -> HandleOutcome? {
+    if (!issue_approved(issue) || handle_ready(issue, false) != null) {
+        return null;
+    };
+    match (issue.status) {
+        let approved: Approved => {
+            if (approved.by.starts_with("github:")) {
+                notify(
+                    "approved",
+                    issue,
+                    "Shepherd @" + (issue.shepherd ?? "") + " approved issue on the website.",
+                    approved.to_json(),
+                );
+            };
+        },
+        _ => null,
+    };
     //# a stale outcome.json from an earlier run must not be read as this run's
     let stale = run_dir_for(branch_for(issue)) + "/outcome.json";
     if (baml.fs.exists(stale)) {
@@ -333,6 +405,12 @@ function handle_one(issue: Issue, mode: HandleMode) -> HandleOutcome? {
             _ => null,
         };
     };
+    notify(
+        "fix_started",
+        issue,
+        "Creating a fix for *" + issue.title + "*; preparing the PR.",
+        baml.json.parse("{}"),
+    );
     let after = handle_issue(issue, mode = mode, thread = issue_thread(issue.id));
     let o = read_outcome(issue);
     match (o) {
@@ -369,28 +447,6 @@ function tell_outcome(issue: Issue, o: HandleOutcome, mode: HandleMode) -> null 
 
 // ==================== merge ====================
 
-/// merge_issue for one in-progress issue. Null when it has no PR.
-function merge_one(issue: Issue, mode: HandleMode) -> MergeResult? {
-    let pr = match (issue.status) {
-        let s: InProgress => s.pr,
-        _ => null,
-    };
-    match (pr) {
-        null => null,
-        let url: string => {
-            let r = merge_issue(url, mode = mode, issue_id = issue.id);
-            if (r.kind == "merged") {
-                let merged = with_status(issue, Merged { state: "merged", pr: url });
-                save_issue(merged);
-                notify("merged", merged, merged_text(merged, url), r.to_json());
-            } else {
-                log_event("merge_issue", issue.id, null, r.to_json(), null, null);
-            };
-            r
-        },
-    }
-}
-
 // ==================== Unit tests (token-free) ====================
 
 testset "pipeline" {
@@ -425,5 +481,56 @@ testset "pipeline" {
             assert.equal(r.merged, 0);
             assert.equal(r.ingested, 0);
         };
+    }
+}
+
+/// This gate controls automatic issue implementation. Babysitter review
+/// rounds have their own per-proposal approval gate.
+function issue_approved(issue: Issue) -> bool {
+    match (issue.status) {
+        let s: Approved => {
+            slack_id(s.by)
+                || (
+                    issue.shepherd != null
+                        && s.by.to_lower_case()
+                            == "github:" + (issue.shepherd ?? "").to_lower_case()
+                )
+        },
+        _ => false,
+    }
+}
+
+/// Reannounce pending issues after a Slack outage; also bring pre-gate open
+/// issues into the approval workflow. A missing shepherd mapping stays blocked.
+function announce_approvals() -> null {
+    for (let i in load_issues_in("open")) {
+        save_issue(with_status(i, AwaitingApproval { state: "awaiting_approval" }));
+    }
+    for (let i in load_issues_in("awaiting_approval")) {
+        if (i.slack_ts == null && shepherd_slack_id(i.shepherd) != null) {
+            notify("issue_created", i, issue_created_text(i), { "approval": "requested" }.to_json());
+        };
+    }
+    null
+}
+
+function merge_one(issue: Issue, mode: HandleMode) -> MergeResult? {
+    let pr = match (issue.status) {
+        let s: InProgress => s.pr,
+        _ => null,
+    };
+    match (pr) {
+        null => null,
+        let url: string => {
+            let r = merge_issue(url, mode = mode, issue_id = issue.id);
+            if (r.kind == "merged") {
+                let merged = with_status(issue, Merged { state: "merged", pr: url });
+                save_issue(merged);
+                notify("merged", merged, merged_text(merged, url), r.to_json());
+            } else {
+                log_event("merge_issue", issue.id, null, r.to_json(), null, null);
+            };
+            r
+        },
     }
 }

--- a/tools/atb2/baml_src/pipeline.baml
+++ b/tools/atb2/baml_src/pipeline.baml
@@ -287,45 +287,94 @@ function origin_of(fb: Feedback) -> json {
     }
 }
 
-/// Includes durable Slack events and reports ingested in earlier runs. Scan
-/// past no_issue rows so they cannot starve newer reports at the head of a page.
-function untriaged_feedback() -> Feedback[] {
+/// Includes durable Slack events and reports ingested in earlier runs. Rows
+/// closed as no_issue keep issue_ids = {} forever, so the scan starts at the
+/// persisted "no_issue_scan" cursor (every earlier untriaged row is known
+/// closed) and reads at most max_pages pages per run. The cursor advances
+/// only across the leading run of closed rows, so a report that still needs
+/// triage is never skipped; clearing the cursor row restores the full scan.
+function untriaged_feedback(max_pages: int = 10) -> Feedback[] {
     let pending: Feedback[] = [];
+    let after = get_cursor("no_issue_scan");
+    let frontier: string? = null;
     let offset = 0;
-    while (pending.length() < 50) {
-        let rows = select(
-            "feedback",
-            "select=*&issue_ids=eq.%7B%7D&dataset="
-                + eq(dataset())
-                + "&order=received_at,id&limit=100&offset="
-                + offset.to_string(),
-        );
+    let pages = 0;
+    while (pages < max_pages) {
+        let rows = select("feedback", untriaged_query(after, offset));
+        pages += 1;
         for (let row in rows) {
             let id = baml.json.path_or<string>(row, ".id", "");
-            if (
-                select(
-                    "events",
-                    "select=id&feedback_id="
-                        + eq(id)
-                        + "&kind=eq.no_issue&dataset="
-                        + eq(dataset())
-                        + "&limit=1",
-                )
-                    .length()
-                    == 0
-            ) {
+            let closed = select(
+                "events",
+                "select=id&feedback_id="
+                    + eq(id)
+                    + "&kind=eq.no_issue&dataset="
+                    + eq(dataset())
+                    + "&limit=1",
+            )
+                .length()
+                > 0;
+            frontier = scan_frontier(
+                frontier,
+                pending.length(),
+                closed,
+                baml.json.path_or<string>(row, ".received_at", ""),
+            );
+            if (!closed) {
                 pending.push(feedback_from_row(row));
                 if (pending.length() >= 50) {
+                    save_scan_cursor(frontier);
                     return pending;
                 };
             };
         }
         if (rows.length() < 100) {
+            save_scan_cursor(frontier);
             return pending;
         };
         offset += 100;
     }
+    save_scan_cursor(frontier);
     pending
+}
+
+/// The feedback page at `offset`: untriaged rows (issue_ids = {}) of this
+/// dataset, oldest first, starting at the scan cursor when one is set.
+/// gte re-reads rows sharing the cursor timestamp, so a boundary tie is
+/// re-checked rather than skipped.
+function untriaged_query(after: string?, offset: int) -> string {
+    "select=*&issue_ids=eq.%7B%7D&dataset="
+        + eq(dataset())
+        + match (after) {
+            null => "",
+            let a: string => "&received_at=gte." + url_encode(a),
+        }
+        + "&order=received_at,id&limit=100&offset="
+        + offset.to_string()
+}
+
+/// Where the next scan may start. Moves to this row's received_at only while
+/// no pending report has been found yet and this row is closed; a row still
+/// awaiting triage freezes the frontier for the rest of the scan.
+function scan_frontier(
+    frontier: string?,
+    pending_count: int,
+    closed: bool,
+    received_at: string,
+) -> string? {
+    if (closed && pending_count == 0 && received_at.length() > 0) {
+        received_at
+    } else {
+        frontier
+    }
+}
+
+/// Persist where the next scan starts; null means nothing new was learned.
+function save_scan_cursor(frontier: string?) -> null {
+    match (frontier) {
+        null => null,
+        let f: string => set_cursor("no_issue_scan", f),
+    }
 }
 
 // ==================== triage ====================
@@ -480,6 +529,39 @@ testset "pipeline" {
             let r = run_pipeline(mode = HandleMode.DryRun, stages = "merge");
             assert.equal(r.merged, 0);
             assert.equal(r.ingested, 0);
+        };
+    }
+
+    test "the scan cursor never advances past a pending report" {
+        // a leading closed row advances the frontier
+        assert.equal(scan_frontier(null, 0, true, "t1") ?? "", "t1");
+        // a row that still needs triage does not
+        assert.equal(scan_frontier(null, 0, false, "t1") ?? "", "");
+        // closed rows after a pending one leave the frontier where it was
+        assert.equal(scan_frontier("t1", 1, true, "t2") ?? "", "t1");
+        // a row with no received_at cannot become the cursor
+        assert.equal(scan_frontier("t1", 0, true, "") ?? "", "t1");
+    }
+
+    test "the scan query starts at the cursor, oldest first" {
+        assert.equal(
+            untriaged_query(null, 0),
+            "select=*&issue_ids=eq.%7B%7D&dataset="
+                + eq(dataset())
+                + "&order=received_at,id&limit=100&offset=0",
+        );
+        assert.equal(
+            untriaged_query("2026-09-08T19:41:45+00:00", 100),
+            "select=*&issue_ids=eq.%7B%7D&dataset="
+                + eq(dataset())
+                + "&received_at=gte.2026-09-08T19%3A41%3A45%2B00%3A00"
+                + "&order=received_at,id&limit=100&offset=100",
+        );
+    }
+
+    test "the page cap ends a scan before any store request" {
+        if (!db_configured()) {
+            assert.equal(untriaged_feedback(max_pages = 0).length(), 0);
         };
     }
 }

--- a/tools/atb2/baml_src/pipeline.baml
+++ b/tools/atb2/baml_src/pipeline.baml
@@ -297,7 +297,7 @@ function untriaged_feedback() -> Feedback[] {
             "feedback",
             "select=*&issue_ids=eq.%7B%7D&dataset="
                 + eq(dataset())
-                + "&order=created_at,id&limit=100&offset="
+                + "&order=received_at,id&limit=100&offset="
                 + offset.to_string(),
         );
         for (let row in rows) {

--- a/tools/atb2/baml_src/slack.baml
+++ b/tools/atb2/baml_src/slack.baml
@@ -120,11 +120,25 @@ function slack_post(text: string, thread: SlackRef?) -> SlackRef {
 /// notification for an issue opens its thread; later ones reply in it.
 /// Always logs the event, Slack or not.
 function notify(kind: string, issue: Issue, text: string, payload: json) -> null {
-    let posted = if (slack_configured()) {
-        let thread = issue_thread(issue.id);
-        slack_post(text, thread)
+    let thread = if (slack_configured()) {
+        issue_thread(issue.id) ?? feedback_thread(issue)
     } else {
         null
+    };
+    let posted = if (slack_configured()) {
+        slack_post(text, thread) catch (_) {
+            SlackError => null
+        }
+    } else {
+        null
+    };
+    if (kind == "issue_created" && posted != null && db_configured()) {
+        let anchor = posted ?? baml.sys.panic("checked post");
+        update(
+            "issues",
+            "id=" + eq(issue.id) + "&state=eq.awaiting_approval&dataset=" + eq(dataset()),
+            { "slack_ts": anchor.ts, "slack_channel": anchor.channel }.to_json(),
+        );
     };
     log_event(
         kind,
@@ -137,7 +151,7 @@ function notify(kind: string, issue: Issue, text: string, payload: json) -> null
         },
         match (posted) {
             null => null,
-            let p: SlackRef => p.ts,
+            let p: SlackRef => (thread ?? p).ts,
         },
     );
     log.info({ "issue": issue.id, "notified": kind, "slack": posted != null });
@@ -154,7 +168,7 @@ function issue_link(issue: Issue) -> string {
 
 function issue_created_text(issue: Issue) -> string {
     let n = issue.feedback_ids.length();
-    ":new: *"
+    "ISSUE: *"
         + issue.title
         + "*\n"
         + issue_link(issue)
@@ -181,7 +195,13 @@ function issue_created_text(issue: Issue) -> string {
         + (
             match (issue.shepherd) {
                 null => "",
-                let s: string => " · shepherd " + s,
+                let s: string => {
+                    " · shepherd: "
+                        + match (shepherd_slack_id(issue.shepherd)) {
+                            null => s,
+                            let user: string => "<@" + user + ">",
+                        }
+                },
             }
         )
         + (
@@ -190,10 +210,11 @@ function issue_created_text(issue: Issue) -> string {
                 let d: Difficulty => " · " + d.to_string(),
             }
         )
+        + "\nReact :white_check_mark: or :+1: to this message to approve the fix."
 }
 
 function pr_opened_text(issue: Issue, o: HandleOutcome) -> string {
-    ":rocket: draft PR opened for *"
+    ":rocket: PR opened for *"
         + issue.title
         + "*\n"
         + (o.pr ?? "(no url)")
@@ -255,22 +276,6 @@ function needs_human_text(issue: Issue, o: HandleOutcome) -> string {
 
 function merged_text(issue: Issue, pr: string) -> string {
     ":white_check_mark: merged *" + issue.title + "*\n" + pr
-}
-
-function merge_round_text(issue: Issue, pr: string, round: int, kind: string) -> string {
-    (
-        if (kind == "fixed") {
-            ":arrows_counterclockwise: "
-        } else {
-            ":warning: "
-        }
-    )
-        + "review round "
-        + round.to_string()
-        + " on "
-        + pr
-        + ": "
-        + kind
 }
 
 function failed_steps(g: GateResult) -> string {
@@ -649,5 +654,328 @@ testset "slack" {
             true,
         );
         assert.equal(pr_url_in("hello") == null, true);
+    }
+}
+
+// ==================== Signed HTTP intake ====================
+
+function hmac_sha256_hex(key: string, message: string) -> string {
+    let block = 64;
+    let key_bytes = key.to_utf8();
+    let k = if (key_bytes.length() > block) {
+        let h = baml.crypto.Sha256.new();
+        h.update(key_bytes);
+        h.finish()
+    } else {
+        key_bytes
+    };
+    let ipad = uint8array.zeroes(0) catch_all (e) {
+        _ => baml.sys.panic("zeroes")
+    };
+    let opad = uint8array.zeroes(0) catch_all (e) {
+        _ => baml.sys.panic("zeroes")
+    };
+    for (let i = 0; i < block; i += 1) {
+        let b = k.at(i) ?? 0;
+        ipad.push(b ^ 54);
+        opad.push(b ^ 92);
+    }
+    let inner = baml.crypto.Sha256.new();
+    inner.update(ipad);
+    inner.update(message.to_utf8());
+    let outer = baml.crypto.Sha256.new();
+    outer.update(opad);
+    outer.update(inner.finish());
+    outer.finish().to_hex()
+}
+
+/// Header names are case insensitive. Reject ambiguous duplicates.
+function slack_header(req: baml.http.Request, name: string) -> string? {
+    let found: string? = null;
+    for (let key in req.headers.keys()) {
+        if (key.to_lower_case() == name) {
+            if (found != null) {
+                return null;
+            };
+            found = req.headers.get(key);
+        };
+    }
+    found
+}
+
+/// Raw-body HMAC with Slack's five-minute replay window. No early exit
+/// based on the matching prefix of the signature.
+function slack_signature_ok(req: baml.http.Request, secret: string, now: bigint) -> bool {
+    let ts = slack_header(req, "x-slack-request-timestamp") ?? "";
+    let sig = slack_header(req, "x-slack-signature") ?? "";
+    if (secret.length() == 0 || ts.length() == 0 || ts.length() > 16 || sig.length() != 67) {
+        return false;
+    };
+    let timestamp = bigint.parse(ts) catch (_) {
+        _ => {
+            return false;
+        }
+    };
+    if ((now - timestamp).abs() > 300n) {
+        return false;
+    };
+    let expected = ("v0=" + hmac_sha256_hex(secret, "v0:" + ts + ":" + req.body)).to_utf8();
+    let actual = sig.to_utf8();
+    if (actual.length() != expected.length()) {
+        return false;
+    };
+    let diff = 0;
+    for (let i = 0; i < expected.length(); i += 1) {
+        diff = diff | ((expected.at(i) ?? 0) ^ (actual.at(i) ?? 0));
+    }
+    diff == 0
+}
+
+class MentionRoute {
+    kind: string,
+    text: string,
+    pr: string?,
+}
+
+function parse_mention(raw: string) -> MentionRoute {
+    let text = raw.trim();
+    if (text.starts_with("<@")) {
+        let end = text.index_of(">");
+        if (end != null) {
+            text = text.slice((end ?? 0) + 1, text.length()).trim();
+        };
+    };
+    let command = (text.split(" ").at(0) ?? "").to_lower_case();
+    if (command == "babysit") {
+        return MentionRoute { kind: "babysit", text: text, pr: pr_url_in(text) };
+    };
+    let shirt = text.to_lower_case().split(" ").some((word: string) -> bool {
+        let clean = trim_punct(word);
+        clean == "shirt" || clean == "tshirt" || clean == "t-shirt"
+    });
+    MentionRoute {
+        kind: if (shirt) {
+            "shirt"
+        } else {
+            "feedback"
+        },
+        text: text,
+        pr: null,
+    }
+}
+
+// ==================== Shepherd approval ====================
+
+function shepherd_id_in(login: string?, config: string) -> string? {
+    if (login == null) {
+        return null;
+    };
+    let found: string? = null;
+    for (let entry in config.split(",")) {
+        let pair = entry.trim().split(":");
+        if (
+            pair.length() == 2
+                && (pair.at(0) ?? "").trim().to_lower_case() == (login ?? "").to_lower_case()
+        ) {
+            let user = (pair.at(1) ?? "").trim();
+            if (found != null || !slack_id(user) || !(user.starts_with("U") || user.starts_with("W"))) {
+                return null;
+            };
+            found = user;
+        };
+    }
+    found
+}
+
+function shepherd_slack_id(login: string?) -> string? {
+    shepherd_id_in(login, baml.env.get("ATB2_SHEPHERDS") ?? "")
+}
+
+/// Reply under the original feedback thread. The approval anchor itself is
+/// the bot's distinct message, so two issues in a thread cannot approve each other.
+function feedback_thread(issue: Issue) -> SlackRef? {
+    if (!db_configured()) {
+        return null;
+    };
+    for (let id in issue.feedback_ids) {
+        let rows = select("feedback", "select=origin&id=" + eq(id) + "&dataset=" + eq(dataset()) + "&limit=1");
+        let row = rows.at(0) ?? baml.json.parse("{}");
+        let channel = baml.json.path_or<string>(row, ".origin.channel", "");
+        let ts = baml.json.path_or<string>(row, ".origin.ts", "");
+        if (slack_id(channel) && slack_ts(ts)) {
+            return SlackRef { channel: channel, ts: ts };
+        };
+    }
+    null
+}
+
+class ApprovalReaction {
+    user: string,
+    channel: string,
+    ts: string,
+}
+
+function approval_reaction(event: json) -> ApprovalReaction? {
+    if (
+        baml.json.path_or<string>(event, ".type", "") != "reaction_added"
+            || baml.json.path_or<string>(event, ".item.type", "") != "message"
+    ) {
+        return null;
+    };
+    let emoji = baml.json.path_or<string>(event, ".reaction", "");
+    if (emoji != "white_check_mark" && emoji != "+1") {
+        return null;
+    };
+    let user = baml.json.path_or<string>(event, ".user", "");
+    let channel = baml.json.path_or<string>(event, ".item.channel", "");
+    let ts = baml.json.path_or<string>(event, ".item.ts", "");
+    if (!slack_id(user) || !slack_id(channel) || !slack_ts(ts)) {
+        return null;
+    };
+    ApprovalReaction { user: user, channel: channel, ts: ts }
+}
+
+function can_approve(issue: Issue, reaction: ApprovalReaction, mapping: string) -> bool {
+    let awaiting = match (issue.status) {
+        let s: AwaitingApproval => true,
+        _ => false,
+    };
+    awaiting
+        && issue.slack_ts == reaction.ts
+        && issue.slack_channel == reaction.channel
+        && shepherd_id_in(issue.shepherd, mapping) == reaction.user
+}
+
+function accept_approval(event: json) -> null {
+    let parsed = approval_reaction(event);
+    if (parsed == null) {
+        return null;
+    };
+    if (!db_configured()) {
+        throw IntakeError { message: "approval needs the store" };
+    };
+    let r = parsed ?? baml.sys.panic("checked reaction");
+    let filter = "state=eq.awaiting_approval&slack_ts="
+        + eq(r.ts)
+        + "&slack_channel="
+        + eq(r.channel)
+        + "&dataset="
+        + eq(dataset());
+    let rows = rows_of(supabase_send("GET", "issues?select=*&" + filter + "&limit=2", "", "", timeout_s = 1));
+    // Ambiguous anchors fail closed.
+    if (rows.length() != 1) {
+        return null;
+    };
+    let issue = issue_from_row(rows.at(0) ?? baml.json.parse("{}"));
+    if (!can_approve(issue, r, baml.env.get("ATB2_SHEPHERDS") ?? "")) {
+        return null;
+    };
+    let status = Approved { state: "approved", by: r.user };
+    let saved = rows_of(
+        supabase_send(
+            "PATCH",
+            "issues?" + filter + "&id=" + eq(issue.id) + "&shepherd=" + eq(issue.shepherd ?? ""),
+            baml.json.stringify({ "status": status }.to_json()),
+            "return=representation",
+            timeout_s = 1,
+        ),
+    );
+    if (saved.length() > 0) {
+        spawn {
+            notify(
+                "approved",
+                issue_from_row(saved.at(0) ?? baml.json.parse("{}")),
+                "Shepherd <@" + r.user + "> approved issue; queued for the next fix pass.",
+                status.to_json(),
+            ) catch_all (_) {
+                _ => {
+                    log.warn({ "approval": "narration failed; approval is stored" });
+                    null
+                },
+            };
+        };
+    };
+    null
+}
+
+function approval_fixture() -> Issue {
+    let row = baml.json.from_json<map<string, json>>(
+        issue_row(with_status(gh_issue(1, Difficulty.Easy), AwaitingApproval { state: "awaiting_approval" })),
+    );
+    row.set("shepherd", "owner".to_json());
+    row.set("slack_ts", "123.4".to_json());
+    row.set("slack_channel", "C1".to_json());
+    issue_from_row(row.to_json())
+}
+
+testset "approval" {
+    test "only the assigned shepherd can approve the exact message in its channel" {
+        let issue = approval_fixture();
+        let right = ApprovalReaction { user: "U1", channel: "C1", ts: "123.4" };
+        assert.equal(can_approve(issue, right, "owner:U1"), true);
+        assert.equal(can_approve(issue, right, "owner:U2"), false);
+        assert.equal(can_approve(issue, right, ""), false);
+        assert.equal(
+            can_approve(issue, ApprovalReaction { user: "U1", channel: "C2", ts: "123.4" }, "owner:U1"),
+            false,
+        );
+        assert.equal(
+            can_approve(issue, ApprovalReaction { user: "U1", channel: "C1", ts: "123.0" }, "owner:U1"),
+            false,
+        );
+        assert.equal(
+            can_approve(with_status(issue, Approved { state: "approved", by: "U1" }), right, "owner:U1"),
+            false,
+        );
+    }
+    test "mapping is explicit and ambiguous duplicate mappings are refused" {
+        assert.equal(shepherd_id_in("OWNER", "other:U2, owner:U1") ?? "", "U1");
+        assert.equal(shepherd_id_in("owner", "owner:U1,owner:U2") == null, true);
+        assert.equal(shepherd_id_in("owner", "owner:bad") == null, true);
+        assert.equal(shepherd_id_in(null, "owner:U1") == null, true);
+    }
+    test "only approval emoji on a message becomes an approval" {
+        let r = approval_reaction(
+            baml.json.parse(
+                `{"type":"reaction_added","reaction":"white_check_mark","user":"U1","item":{"type":"message","channel":"C1","ts":"123.4"}}`,
+            ),
+        );
+        assert.equal(r == null, false);
+        assert.equal(
+            approval_reaction(
+                baml.json.parse(
+                    `{"type":"reaction_added","reaction":"heart","user":"U1","item":{"type":"message","channel":"C1","ts":"123.4"}}`,
+                ),
+            )
+                == null,
+            true,
+        );
+        assert.equal(
+            approval_reaction(
+                baml.json.parse(
+                    `{"type":"reaction_removed","reaction":"+1","user":"U1","item":{"type":"message","channel":"C1","ts":"123.4"}}`,
+                ),
+            )
+                == null,
+            true,
+        );
+    }
+    test "automatic handling refuses open and awaiting issues" {
+        let pending = approval_fixture();
+        assert.equal(issue_approved(pending), false);
+        assert.equal(handle_one(pending, HandleMode.DryRun) == null, true);
+        assert.equal(
+            handle_one(with_status(pending, Open { state: "open" }), HandleMode.DryRun) == null,
+            true,
+        );
+        let approved = with_status(pending, Approved { state: "approved", by: "U1" });
+        assert.equal(issue_approved(approved), true);
+        assert.equal(handle_ready(approved, false) == null, true);
+        assert.equal(issue_from_row(issue_row(approved)).slack_ts ?? "", "123.4");
+        assert.equal(issue_from_row(issue_row(approved)).slack_channel ?? "", "C1");
+        assert.equal(
+            with_status(approved, AwaitingApproval { state: "awaiting_approval" }).slack_ts == null,
+            true,
+        );
     }
 }

--- a/tools/atb2/baml_src/slack.baml
+++ b/tools/atb2/baml_src/slack.baml
@@ -120,7 +120,7 @@ function slack_post(text: string, thread: SlackRef?) -> SlackRef {
 /// notification for an issue opens its thread; later ones reply in it.
 /// Always logs the event, Slack or not.
 function notify(kind: string, issue: Issue, text: string, payload: json) -> null {
-    let thread = if (slack_configured()) {
+    let thread = if (slack_configured() && kind != "issue_created") {
         issue_thread(issue.id) ?? feedback_thread(issue)
     } else {
         null
@@ -166,7 +166,7 @@ function issue_link(issue: Issue) -> string {
     }
 }
 
-function issue_created_text(issue: Issue) -> string {
+function issue_created_text(issue: Issue, mapping: string? = null) -> string {
     let n = issue.feedback_ids.length();
     "ISSUE: *"
         + issue.title
@@ -197,7 +197,9 @@ function issue_created_text(issue: Issue) -> string {
                 null => "",
                 let s: string => {
                     " · shepherd: "
-                        + match (shepherd_slack_id(issue.shepherd)) {
+                        + match (
+                            shepherd_id_in(issue.shepherd, mapping ?? baml.env.get("ATB2_SHEPHERDS") ?? "")
+                        ) {
                             null => s,
                             let user: string => "<@" + user + ">",
                         }

--- a/tools/atb2/baml_src/store.baml
+++ b/tools/atb2/baml_src/store.baml
@@ -37,7 +37,13 @@ function dataset() -> string {
 /// shape); the body is JSON text. Panics on transport or non-2xx, like
 /// supabase_get: a store that is configured but broken must not be
 /// silently skipped.
-function supabase_send(method: string, path: string, body: string, prefer: string) -> string {
+function supabase_send(
+    method: string,
+    path: string,
+    body: string,
+    prefer: string,
+    timeout_s: int = 30,
+) -> string {
     let base = baml.env.get("FEEDBACK_SUPABASE_URL") ?? "";
     if (!base.starts_with("https://")) {
         // the service key rides in two headers: never over plain http
@@ -56,7 +62,7 @@ function supabase_send(method: string, path: string, body: string, prefer: strin
     };
     let res = baml.http.send(
         baml.http.Request { method: method, url: url, headers: headers, body: body },
-        timeout = baml.time.Duration.from_seconds(30),
+        timeout = baml.time.Duration.from_seconds(timeout_s),
     ) catch (e) {
         _ => {
             throw StoreError { message: method + " failed for " + url };
@@ -223,6 +229,8 @@ function issue_row(issue: Issue) -> json {
             let d: Difficulty => d.to_string(),
         },
         "design_doc": issue.design_doc,
+        "slack_ts": issue.slack_ts,
+        "slack_channel": issue.slack_channel,
         "dataset": dataset(),
     }
         .to_json()
@@ -245,6 +253,8 @@ function issue_from_row(row: json) -> Issue {
         resolution_plan: baml.json.path_or<string?>(row, ".resolution_plan", null),
         difficulty: difficulty_from(baml.json.path_or<string?>(row, ".difficulty", null)),
         design_doc: baml.json.path_or<string?>(row, ".design_doc", null),
+        slack_ts: baml.json.path_or<string?>(row, ".slack_ts", null),
+        slack_channel: baml.json.path_or<string?>(row, ".slack_channel", null),
     }
 }
 

--- a/tools/atb2/deploy/fly.toml
+++ b/tools/atb2/deploy/fly.toml
@@ -10,15 +10,17 @@
 #
 # Create the volume once:
 #   fly volumes create atb2_data --size 80 --region sjc -a atb2-runner
-# Secrets: the machine holds one, INFISICAL_TOKEN; the entrypoint pulls the
-# rest from Infisical (boundary-tools, prod) in the root launcher at start:
-#   fly secrets set -a atb2-runner INFISICAL_TOKEN=...   # once
+# Fly secrets: INFISICAL_CLIENT_ID and INFISICAL_CLIENT_SECRET from the existing
+# machine identity. The root launcher logs in via Universal Auth on every boot
+# and fetches boundary-tools prod. Stage the pair with fly secrets import.
+# INFISICAL_TOKEN is also supported when no client credentials are configured.
 # Everything the pipeline reads is in that project already: FEEDBACK_SUPABASE_URL/_KEY,
 # ATB_SLACK_BOT_TOKEN, ATB_SLACK_FIX_CHANNEL, ATB_POSTHOG_*, ATB_GITHUB_TOKEN (used as
 # GH_TOKEN). The agent's Claude Code CLI uses its own login on the machine (HOME on the
 # volume; `fly ssh console -a atb2-runner` then
 # `runuser -u atb2 -- env HOME=/data/home claude` to log in once); no Claude
-# credential is stored in Infisical or passed by atb2. CI holds only a Fly deploy token.
+# credential is stored in Infisical or exposed inside the agent sandbox. A local
+# broker uses the persistent login outside that boundary. CI holds only a Fly deploy token.
 app = "atb2-runner"
 primary_region = "sjc"
 
@@ -36,7 +38,7 @@ primary_region = "sjc"
   INFISICAL_ENV = "prod"
 
 [processes]
-  runner = "runner_loop(every_s = 300)"
+  runner = "main_ingress(every_s = 300)"
 
 # a panic ends the process; Fly restarts it and the loops resume from the store
 [[restart]]
@@ -54,5 +56,17 @@ primary_region = "sjc"
   memory = "32gb"
   processes = ["runner"]
 
-[checks]
-  # no http surface; liveness is the process itself
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["runner"]
+
+  [[http_service.checks]]
+    method = "GET"
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "30m"

--- a/tools/atb2/deploy/fly.toml
+++ b/tools/atb2/deploy/fly.toml
@@ -4,7 +4,7 @@
 # target, run dirs). One machine on purpose: a Fly volume attaches to one
 # machine, and the pipeline and the requests share the same build cache.
 #
-#   fly deploy tools/atb2 --config tools/atb2/deploy/fly.toml
+#   fly deploy tools/atb2 --config deploy/fly.toml
 #   (from the repo root; the build context is tools/atb2; CI does this on
 #    every push to canary touching tools/atb2)
 #
@@ -25,20 +25,22 @@ app = "atb2-runner"
 primary_region = "sjc"
 
 [build]
-  dockerfile = "deploy/Dockerfile"
-  # relative to the build context, tools/atb2
+  dockerfile = "Dockerfile"
+  # relative to this config file; build context is tools/atb2
 
 [env]
   ATB2_HOME = "/data"
   # pin the canary revision the runner builds (a commit sha); unset = origin/canary head
   # ATB2_CANARY_REV = ""
   ATB2_DATASET = "live"
+  ATB2_SLACK_CHANNEL = "C0B36EDQEN6"
+  ATB2_POSTHOG_PROJECT_ID = "490278"
   ATB2_POLL_S = "60"
   INFISICAL_PROJECT_ID = "bdd280e2-259c-4750-9b16-a8597a67214c"
   INFISICAL_ENV = "prod"
 
 [processes]
-  runner = "main_ingress(every_s = 300)"
+  runner = "main_ingress(every_s=300)"
 
 # a panic ends the process; Fly restarts it and the loops resume from the store
 [[restart]]

--- a/tools/atb2/deploy/test_slack_http.py
+++ b/tools/atb2/deploy/test_slack_http.py
@@ -1,0 +1,81 @@
+"""Offline HTTP smoke: real BAML listener, no agents or external credentials."""
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+
+class SlackHTTPTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cli = os.environ.get("BAML_CLI", str(Path.home() / ".atb2/target/debug/baml-cli"))
+        if not Path(cli).is_file():
+            raise unittest.SkipTest("set BAML_CLI to canary's baml-cli")
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", 0))
+            port = listener.getsockname()[1]
+        cls.base = f"http://127.0.0.1:{port}"
+        cls.secret = "offline-test-signing-key"
+        # Never forward the invoking shell's service keys, Slack token or login.
+        env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
+        env.update(ATB_SLACK_SIGNING_SECRET=cls.secret, BAML_TELEMETRY_DISABLED="1", BAML_AGENT_SKILL_CHECK="off")
+        cls.proc = subprocess.Popen([cli, "run", "-e", f"serve_slack(port = {port})"],
+            cwd=Path(__file__).resolve().parents[1], env=env,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        for _ in range(300):
+            if cls.proc.poll() is not None:
+                break
+            try:
+                with urllib.request.urlopen(cls.base + "/health", timeout=0.2) as res:
+                    if res.status == 200:
+                        return
+            except (OSError, urllib.error.URLError):
+                time.sleep(0.1)
+        cls.proc.terminate()
+        cls.proc.wait(timeout=10)
+        raise AssertionError("BAML listener did not become healthy")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.wait(timeout=10)
+
+    def post(self, payload, timestamp=None, signed=True):
+        raw = json.dumps(payload).encode()
+        ts = str(int(time.time()) if timestamp is None else timestamp)
+        headers = {"Content-Type": "application/json", "X-Slack-Request-Timestamp": ts}
+        if signed:
+            digest = hmac.new(self.secret.encode(), b"v0:" + ts.encode() + b":" + raw, hashlib.sha256).hexdigest()
+            headers["X-Slack-Signature"] = "v0=" + digest
+        req = urllib.request.Request(self.base + "/slack/events", data=raw, headers=headers)
+        try:
+            res = urllib.request.urlopen(req, timeout=3)
+        except urllib.error.HTTPError as err:
+            res = err
+        with res:
+            return res.status, json.load(res)
+
+    def test_signed_challenge(self):
+        challenge = 'quoted"challenge\\newline\n'
+        self.assertEqual(self.post({"type": "url_verification", "challenge": challenge}),
+                         (200, {"challenge": challenge}))
+
+    def test_unsigned_and_stale_requests_are_rejected(self):
+        self.assertEqual(self.post({}, signed=False)[0], 403)
+        self.assertEqual(self.post({}, timestamp=int(time.time()) - 301)[0], 403)
+
+    def test_store_failure_is_not_acknowledged(self):
+        payload = {"type": "event_callback", "event_id": "Ev1", "team_id": "T1", "event": {
+            "type": "app_mention", "user": "U1", "channel": "C1", "ts": "123.4", "text": "<@B1> broken"}}
+        self.assertEqual(self.post(payload)[0], 503)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typescript2/app-feedback/package.json
+++ b/typescript2/app-feedback/package.json
@@ -1,14 +1,4 @@
 {
-  "name": "app-feedback",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "eslint",
-    "typecheck": "tsc --noEmit"
-  },
   "dependencies": {
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
@@ -31,8 +21,18 @@
     "eslint-config-next": "15.5.25",
     "typescript": "^5"
   },
+  "name": "app-feedback",
   "overrides": {
-    "postcss": "8.5.28",
-    "nanoid": "3.3.18"
-  }
+    "nanoid": "3.3.18",
+    "postcss": "8.5.28"
+  },
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev",
+    "lint": "eslint",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "version": "0.1.0"
 }

--- a/typescript2/app-feedback/package.json
+++ b/typescript2/app-feedback/package.json
@@ -16,7 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
-    "next": "15",
+    "next": "15.5.25",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "tailwind-merge": "^3.4.0",
@@ -28,7 +28,11 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15",
+    "eslint-config-next": "15.5.25",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "8.5.28",
+    "nanoid": "3.3.18"
   }
 }

--- a/typescript2/app-feedback/src/app/auth/github/callback/route.ts
+++ b/typescript2/app-feedback/src/app/auth/github/callback/route.ts
@@ -1,30 +1,68 @@
-import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { cookieOptions, identity, setSession, siteOrigin, STATE_COOKIE, unseal } from "@/lib/approval-auth";
+import { cookies } from 'next/headers';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  cookieOptions,
+  identity,
+  STATE_COOKIE,
+  setSession,
+  siteOrigin,
+  unseal,
+} from '@/lib/approval-auth';
 
 export async function GET(request: NextRequest) {
   const jar = await cookies();
-  const stored = unseal(jar.get(STATE_COOKIE)?.value ?? "");
-  jar.set(STATE_COOKIE, "", { ...cookieOptions, maxAge: 0 });
-  const code = request.nextUrl.searchParams.get("code");
-  if (!stored || !code || stored.state !== request.nextUrl.searchParams.get("state")
-    || typeof stored.verifier !== "string" || typeof stored.returnTo !== "string"
-    || !/^\/(?:issues|proposals)\/[a-zA-Z0-9-]{1,100}$/.test(stored.returnTo)) {
-    return new NextResponse("Invalid or expired sign-in. Please start again.", { status: 400 });
+  const stored = unseal(jar.get(STATE_COOKIE)?.value ?? '');
+  jar.set(STATE_COOKIE, '', { ...cookieOptions, maxAge: 0 });
+  const code = request.nextUrl.searchParams.get('code');
+  if (
+    !stored ||
+    !code ||
+    stored.state !== request.nextUrl.searchParams.get('state') ||
+    typeof stored.verifier !== 'string' ||
+    typeof stored.returnTo !== 'string' ||
+    !/^\/(?:issues|proposals)\/[a-zA-Z0-9-]{1,100}$/.test(stored.returnTo)
+  ) {
+    return new NextResponse('Invalid or expired sign-in. Please start again.', {
+      status: 400,
+    });
   }
   try {
-    const response = await fetch("https://github.com/login/oauth/access_token", {
-      method: "POST", headers: { Accept: "application/json", "Content-Type": "application/json" },
-      body: JSON.stringify({ client_id: process.env.FEEDBACK_GITHUB_CLIENT_ID,
-        client_secret: process.env.FEEDBACK_GITHUB_CLIENT_SECRET, code, code_verifier: stored.verifier,
-        redirect_uri: `${siteOrigin()}/auth/github/callback` }),
-      cache: "no-store", redirect: "error", signal: AbortSignal.timeout(10000),
-    });
+    const response = await fetch(
+      'https://github.com/login/oauth/access_token',
+      {
+        body: JSON.stringify({
+          client_id: process.env.FEEDBACK_GITHUB_CLIENT_ID,
+          client_secret: process.env.FEEDBACK_GITHUB_CLIENT_SECRET,
+          code,
+          code_verifier: stored.verifier,
+          redirect_uri: `${siteOrigin()}/auth/github/callback`,
+        }),
+        cache: 'no-store',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+        redirect: 'error',
+        signal: AbortSignal.timeout(10000),
+      },
+    );
     const result = await response.json();
-    if (!response.ok || typeof result.access_token !== "string" || !await identity(result.access_token)) {
-      return new NextResponse("A verified GitHub account is required.", { status: 403 });
+    if (
+      !response.ok ||
+      typeof result.access_token !== 'string' ||
+      !(await identity(result.access_token))
+    ) {
+      return new NextResponse('A verified GitHub account is required.', {
+        status: 403,
+      });
     }
     await setSession(result.access_token);
     return NextResponse.redirect(new URL(stored.returnTo, siteOrigin()));
-  } catch { return new NextResponse("Sign-in could not be verified. Please try again.", { status: 503 }); }
+  } catch {
+    return new NextResponse(
+      'Sign-in could not be verified. Please try again.',
+      { status: 503 },
+    );
+  }
 }

--- a/typescript2/app-feedback/src/app/auth/github/callback/route.ts
+++ b/typescript2/app-feedback/src/app/auth/github/callback/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { cookieOptions, identity, setSession, siteOrigin, STATE_COOKIE, unseal } from "@/lib/approval-auth";
+
+export async function GET(request: NextRequest) {
+  const jar = await cookies();
+  const stored = unseal(jar.get(STATE_COOKIE)?.value ?? "");
+  jar.set(STATE_COOKIE, "", { ...cookieOptions, maxAge: 0 });
+  const code = request.nextUrl.searchParams.get("code");
+  if (!stored || !code || stored.state !== request.nextUrl.searchParams.get("state")
+    || typeof stored.verifier !== "string" || typeof stored.returnTo !== "string"
+    || !/^\/(?:issues|proposals)\/[a-zA-Z0-9-]{1,100}$/.test(stored.returnTo)) {
+    return new NextResponse("Invalid or expired sign-in. Please start again.", { status: 400 });
+  }
+  try {
+    const response = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST", headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: process.env.FEEDBACK_GITHUB_CLIENT_ID,
+        client_secret: process.env.FEEDBACK_GITHUB_CLIENT_SECRET, code, code_verifier: stored.verifier,
+        redirect_uri: `${siteOrigin()}/auth/github/callback` }),
+      cache: "no-store", redirect: "error", signal: AbortSignal.timeout(10000),
+    });
+    const result = await response.json();
+    if (!response.ok || typeof result.access_token !== "string" || !await identity(result.access_token)) {
+      return new NextResponse("A verified GitHub account is required.", { status: 403 });
+    }
+    await setSession(result.access_token);
+    return NextResponse.redirect(new URL(stored.returnTo, siteOrigin()));
+  } catch { return new NextResponse("Sign-in could not be verified. Please try again.", { status: 503 }); }
+}

--- a/typescript2/app-feedback/src/app/auth/github/route.ts
+++ b/typescript2/app-feedback/src/app/auth/github/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { challenge, cookieOptions, nonce, issuePath, proposalPath, seal, siteOrigin, STATE_COOKIE } from "@/lib/approval-auth";
+
+export async function GET(request: NextRequest) {
+  try {
+    const id = request.nextUrl.searchParams.get("proposal") ?? "";
+    const issue = request.nextUrl.searchParams.get("issue");
+    const returnTo = issue !== null ? issuePath(issue) : proposalPath(id);
+    const clientId = process.env.FEEDBACK_GITHUB_CLIENT_ID;
+    if (!clientId) throw new Error("OAuth not configured");
+    const state = nonce(), verifier = nonce();
+    (await cookies()).set(STATE_COOKIE, seal({ state, verifier, returnTo, expires: Date.now() + 600000 }),
+      { ...cookieOptions, maxAge: 600 });
+    const url = new URL("https://github.com/login/oauth/authorize");
+    url.search = new URLSearchParams({ client_id: clientId, redirect_uri: `${siteOrigin()}/auth/github/callback`,
+      scope: "read:user", state, code_challenge: challenge(verifier), code_challenge_method: "S256" }).toString();
+    return NextResponse.redirect(url);
+  } catch {
+    return new NextResponse("Website approval sign-in is unavailable. You can approve the proposal in Slack.", { status: 503 });
+  }
+}

--- a/typescript2/app-feedback/src/app/auth/github/route.ts
+++ b/typescript2/app-feedback/src/app/auth/github/route.ts
@@ -1,22 +1,44 @@
-import { NextRequest, NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { challenge, cookieOptions, nonce, issuePath, proposalPath, seal, siteOrigin, STATE_COOKIE } from "@/lib/approval-auth";
+import { cookies } from 'next/headers';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  challenge,
+  cookieOptions,
+  issuePath,
+  nonce,
+  proposalPath,
+  STATE_COOKIE,
+  seal,
+  siteOrigin,
+} from '@/lib/approval-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    const id = request.nextUrl.searchParams.get("proposal") ?? "";
-    const issue = request.nextUrl.searchParams.get("issue");
+    const id = request.nextUrl.searchParams.get('proposal') ?? '';
+    const issue = request.nextUrl.searchParams.get('issue');
     const returnTo = issue !== null ? issuePath(issue) : proposalPath(id);
     const clientId = process.env.FEEDBACK_GITHUB_CLIENT_ID;
-    if (!clientId) throw new Error("OAuth not configured");
-    const state = nonce(), verifier = nonce();
-    (await cookies()).set(STATE_COOKIE, seal({ state, verifier, returnTo, expires: Date.now() + 600000 }),
-      { ...cookieOptions, maxAge: 600 });
-    const url = new URL("https://github.com/login/oauth/authorize");
-    url.search = new URLSearchParams({ client_id: clientId, redirect_uri: `${siteOrigin()}/auth/github/callback`,
-      scope: "read:user", state, code_challenge: challenge(verifier), code_challenge_method: "S256" }).toString();
+    if (!clientId) throw new Error('OAuth not configured');
+    const state = nonce();
+    const verifier = nonce();
+    (await cookies()).set(
+      STATE_COOKIE,
+      seal({ expires: Date.now() + 600000, returnTo, state, verifier }),
+      { ...cookieOptions, maxAge: 600 },
+    );
+    const url = new URL('https://github.com/login/oauth/authorize');
+    url.search = new URLSearchParams({
+      client_id: clientId,
+      code_challenge: challenge(verifier),
+      code_challenge_method: 'S256',
+      redirect_uri: `${siteOrigin()}/auth/github/callback`,
+      scope: 'read:user',
+      state,
+    }).toString();
     return NextResponse.redirect(url);
   } catch {
-    return new NextResponse("Website approval sign-in is unavailable. You can approve the proposal in Slack.", { status: 503 });
+    return new NextResponse(
+      'Website approval sign-in is unavailable. You can approve the proposal in Slack.',
+      { status: 503 },
+    );
   }
 }

--- a/typescript2/app-feedback/src/app/issues/[id]/approve/route.ts
+++ b/typescript2/app-feedback/src/app/issues/[id]/approve/route.ts
@@ -1,21 +1,51 @@
-import { NextRequest, NextResponse } from "next/server";
-import { currentUser, issuePath, siteOrigin } from "@/lib/approval-auth";
-import { isShepherd, issueStore, type ApprovalIssue } from "@/lib/issue-approval";
-export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+import { type NextRequest, NextResponse } from 'next/server';
+import { currentUser, issuePath, siteOrigin } from '@/lib/approval-auth';
+import {
+  type ApprovalIssue,
+  isShepherd,
+  issueStore,
+} from '@/lib/issue-approval';
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   try {
-    if (request.headers.get("origin") !== siteOrigin()) return new NextResponse("Forbidden", { status: 403 });
+    if (request.headers.get('origin') !== siteOrigin())
+      return new NextResponse('Forbidden', { status: 403 });
     const login = await currentUser();
-    if (!login) return new NextResponse("Sign in first", { status: 403 });
+    if (!login) return new NextResponse('Sign in first', { status: 403 });
     const { id } = await params;
     let path: string;
-    try { path = issuePath(id); } catch { return new NextResponse("Invalid issue", { status: 400 }); }
+    try {
+      path = issuePath(id);
+    } catch {
+      return new NextResponse('Invalid issue', { status: 400 });
+    }
     const filter = `id=eq.${encodeURIComponent(id)}&dataset=eq.live`;
-    const [issue] = await issueStore<ApprovalIssue[]>(`select=id,shepherd,status&${filter}&limit=1`);
-    if (!issue || !isShepherd(login, issue)) return new NextResponse("Assigned shepherd required", { status: 403 });
-    const rows = await issueStore<ApprovalIssue[]>(`${filter}&state=eq.awaiting_approval&shepherd=eq.${encodeURIComponent(issue.shepherd!)}`, {
-      method: "PATCH", body: JSON.stringify({ status: { state: "approved", by: `github:${login}` } }),
-    });
-    if (rows.length !== 1) return new NextResponse("Issue changed or was already approved. Refresh the page.", { status: 409 });
+    const [issue] = await issueStore<ApprovalIssue[]>(
+      `select=id,shepherd,status&${filter}&limit=1`,
+    );
+    if (!issue || !isShepherd(login, issue))
+      return new NextResponse('Assigned shepherd required', { status: 403 });
+    const rows = await issueStore<ApprovalIssue[]>(
+      `${filter}&state=eq.awaiting_approval&shepherd=eq.${encodeURIComponent(issue.shepherd!)}`,
+      {
+        body: JSON.stringify({
+          status: { by: `github:${login}`, state: 'approved' },
+        }),
+        method: 'PATCH',
+      },
+    );
+    if (rows.length !== 1)
+      return new NextResponse(
+        'Issue changed or was already approved. Refresh the page.',
+        { status: 409 },
+      );
     return NextResponse.redirect(new URL(path, siteOrigin()), 303);
-  } catch { return new NextResponse("Approval unavailable. Please retry or use Slack.", { status: 503 }); }
+  } catch {
+    return new NextResponse(
+      'Approval unavailable. Please retry or use Slack.',
+      { status: 503 },
+    );
+  }
 }

--- a/typescript2/app-feedback/src/app/issues/[id]/approve/route.ts
+++ b/typescript2/app-feedback/src/app/issues/[id]/approve/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { currentUser, issuePath, siteOrigin } from "@/lib/approval-auth";
+import { isShepherd, issueStore, type ApprovalIssue } from "@/lib/issue-approval";
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    if (request.headers.get("origin") !== siteOrigin()) return new NextResponse("Forbidden", { status: 403 });
+    const login = await currentUser();
+    if (!login) return new NextResponse("Sign in first", { status: 403 });
+    const { id } = await params;
+    let path: string;
+    try { path = issuePath(id); } catch { return new NextResponse("Invalid issue", { status: 400 }); }
+    const filter = `id=eq.${encodeURIComponent(id)}&dataset=eq.live`;
+    const [issue] = await issueStore<ApprovalIssue[]>(`select=id,shepherd,status&${filter}&limit=1`);
+    if (!issue || !isShepherd(login, issue)) return new NextResponse("Assigned shepherd required", { status: 403 });
+    const rows = await issueStore<ApprovalIssue[]>(`${filter}&state=eq.awaiting_approval&shepherd=eq.${encodeURIComponent(issue.shepherd!)}`, {
+      method: "PATCH", body: JSON.stringify({ status: { state: "approved", by: `github:${login}` } }),
+    });
+    if (rows.length !== 1) return new NextResponse("Issue changed or was already approved. Refresh the page.", { status: 409 });
+    return NextResponse.redirect(new URL(path, siteOrigin()), 303);
+  } catch { return new NextResponse("Approval unavailable. Please retry or use Slack.", { status: 503 }); }
+}

--- a/typescript2/app-feedback/src/app/issues/[id]/page.tsx
+++ b/typescript2/app-feedback/src/app/issues/[id]/page.tsx
@@ -1,19 +1,32 @@
-import { ApproveIssue } from "@/components/issues/approve-issue";
-import { notFound } from "next/navigation";
-import { IssueDetail } from "@/components/issues/issue-detail";
-import { Activity } from "@/components/issues/activity";
-import { LiveUpdates } from "@/components/issues/live-updates";
-import { loadIssueEvents, loadIssue } from "@/lib/db";
+import { notFound } from 'next/navigation';
+import { Activity } from '@/components/issues/activity';
+import { ApproveIssue } from '@/components/issues/approve-issue';
+import { IssueDetail } from '@/components/issues/issue-detail';
+import { LiveUpdates } from '@/components/issues/live-updates';
+import { loadIssue, loadIssueEvents } from '@/lib/db';
 
 // On demand, never prerendered at build: the data source is decided by the
 // server's environment. revalidate = 0 keeps the route dynamic while the
 // fetch-level cache in db.ts (REVALIDATE_S) still bounds the reads.
 export const revalidate = 0;
 
-export default async function IssuePage({ params }: { params: Promise<{ id: string }> }) {
+export default async function IssuePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   const { id } = await params;
   const issue = await loadIssue(id);
   if (!issue) notFound();
   const events = await loadIssueEvents(id, issue.dataset);
-  return <><LiveUpdates /><ApproveIssue issue={issue} /><IssueDetail issue={issue} /><Activity events={events} /></>;
+  // Approval is a live-dataset flow: eval rows are pipeline test fixtures and
+  // the approve route only writes dataset=live, so never offer the form here.
+  return (
+    <>
+      <LiveUpdates />
+      {issue.dataset === 'live' && <ApproveIssue issue={issue} />}
+      <IssueDetail issue={issue} />
+      <Activity events={events} />
+    </>
+  );
 }

--- a/typescript2/app-feedback/src/app/issues/[id]/page.tsx
+++ b/typescript2/app-feedback/src/app/issues/[id]/page.tsx
@@ -1,6 +1,9 @@
+import { ApproveIssue } from "@/components/issues/approve-issue";
 import { notFound } from "next/navigation";
 import { IssueDetail } from "@/components/issues/issue-detail";
-import { loadIssue } from "@/lib/db";
+import { Activity } from "@/components/issues/activity";
+import { LiveUpdates } from "@/components/issues/live-updates";
+import { loadIssueEvents, loadIssue } from "@/lib/db";
 
 // On demand, never prerendered at build: the data source is decided by the
 // server's environment. revalidate = 0 keeps the route dynamic while the
@@ -11,5 +14,6 @@ export default async function IssuePage({ params }: { params: Promise<{ id: stri
   const { id } = await params;
   const issue = await loadIssue(id);
   if (!issue) notFound();
-  return <IssueDetail issue={issue} />;
+  const events = await loadIssueEvents(id, issue.dataset);
+  return <><LiveUpdates /><ApproveIssue issue={issue} /><IssueDetail issue={issue} /><Activity events={events} /></>;
 }

--- a/typescript2/app-feedback/src/components/issues/activity.tsx
+++ b/typescript2/app-feedback/src/components/issues/activity.tsx
@@ -1,18 +1,41 @@
-import Link from "next/link";
-import type { IssueEvent } from "@/lib/db";
-import { activityText, eventProposalPath } from "@/lib/activity";
+import Link from 'next/link';
+import { activityText, eventProposalPath } from '@/lib/activity';
+import type { IssueEvent } from '@/lib/db';
 
 export function Activity({ events }: { events: IssueEvent[] }) {
-  return <section className="space-y-4">
-    <h2 className="text-lg font-semibold">Activity</h2>
-    {events.length === 0 ? <p className="text-sm text-muted-foreground">No activity recorded yet.</p> :
-      <ol className="space-y-4 border-l pl-5">{events.map(event => {
-        const proposal = eventProposalPath(event);
-        return <li key={event.id} className="space-y-1">
-          <time className="text-xs text-muted-foreground" dateTime={event.created_at}>{new Date(event.created_at).toLocaleString("en-US", { timeZone: "UTC" })} UTC</time>
-          <p>{activityText(event)}</p>
-          {proposal && <Link className="text-sm underline" href={proposal}>View proposed fix and approval</Link>}
-        </li>;
-      })}</ol>}
-  </section>;
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold">Activity</h2>
+      {events.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No activity recorded yet.
+        </p>
+      ) : (
+        <ol className="space-y-4 border-l pl-5">
+          {events.map((event) => {
+            const proposal = eventProposalPath(event);
+            return (
+              <li className="space-y-1" key={event.id}>
+                <time
+                  className="text-xs text-muted-foreground"
+                  dateTime={event.created_at}
+                >
+                  {new Date(event.created_at).toLocaleString('en-US', {
+                    timeZone: 'UTC',
+                  })}{' '}
+                  UTC
+                </time>
+                <p>{activityText(event)}</p>
+                {proposal && (
+                  <Link className="text-sm underline" href={proposal}>
+                    View proposed fix and approval
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
 }

--- a/typescript2/app-feedback/src/components/issues/activity.tsx
+++ b/typescript2/app-feedback/src/components/issues/activity.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import type { IssueEvent } from "@/lib/db";
+import { activityText, eventProposalPath } from "@/lib/activity";
+
+export function Activity({ events }: { events: IssueEvent[] }) {
+  return <section className="space-y-4">
+    <h2 className="text-lg font-semibold">Activity</h2>
+    {events.length === 0 ? <p className="text-sm text-muted-foreground">No activity recorded yet.</p> :
+      <ol className="space-y-4 border-l pl-5">{events.map(event => {
+        const proposal = eventProposalPath(event);
+        return <li key={event.id} className="space-y-1">
+          <time className="text-xs text-muted-foreground" dateTime={event.created_at}>{new Date(event.created_at).toLocaleString("en-US", { timeZone: "UTC" })} UTC</time>
+          <p>{activityText(event)}</p>
+          {proposal && <Link className="text-sm underline" href={proposal}>View proposed fix and approval</Link>}
+        </li>;
+      })}</ol>}
+  </section>;
+}

--- a/typescript2/app-feedback/src/components/issues/approve-issue.tsx
+++ b/typescript2/app-feedback/src/components/issues/approve-issue.tsx
@@ -1,10 +1,29 @@
-import { currentUser } from "@/lib/approval-auth";
-import { isShepherd, type ApprovalIssue } from "@/lib/issue-approval";
+import { currentUser } from '@/lib/approval-auth';
+import { type ApprovalIssue, isShepherd } from '@/lib/issue-approval';
 export async function ApproveIssue({ issue }: { issue: ApprovalIssue }) {
-  if (issue.status.state !== "awaiting_approval") return null;
+  if (issue.status.state !== 'awaiting_approval') return null;
   let login: string | null;
-  try { login = await currentUser(); } catch { return <p>Website approval is unavailable. You can approve in Slack.</p>; }
-  if (!login) return <a href={`/auth/github?issue=${encodeURIComponent(issue.id)}`}>Sign in to approve this issue</a>;
-  if (!isShepherd(login, issue)) return <p>Waiting for approval from @{issue.shepherd}.</p>;
-  return <form action={`/issues/${encodeURIComponent(issue.id)}/approve`} method="post"><button type="submit" className="rounded border px-3 py-2">Approve issue</button></form>;
+  try {
+    login = await currentUser();
+  } catch {
+    return <p>Website approval is unavailable. You can approve in Slack.</p>;
+  }
+  if (!login)
+    return (
+      <a href={`/auth/github?issue=${encodeURIComponent(issue.id)}`}>
+        Sign in to approve this issue
+      </a>
+    );
+  if (!isShepherd(login, issue))
+    return <p>Waiting for approval from @{issue.shepherd}.</p>;
+  return (
+    <form
+      action={`/issues/${encodeURIComponent(issue.id)}/approve`}
+      method="post"
+    >
+      <button className="rounded border px-3 py-2" type="submit">
+        Approve issue
+      </button>
+    </form>
+  );
 }

--- a/typescript2/app-feedback/src/components/issues/approve-issue.tsx
+++ b/typescript2/app-feedback/src/components/issues/approve-issue.tsx
@@ -1,0 +1,10 @@
+import { currentUser } from "@/lib/approval-auth";
+import { isShepherd, type ApprovalIssue } from "@/lib/issue-approval";
+export async function ApproveIssue({ issue }: { issue: ApprovalIssue }) {
+  if (issue.status.state !== "awaiting_approval") return null;
+  let login: string | null;
+  try { login = await currentUser(); } catch { return <p>Website approval is unavailable. You can approve in Slack.</p>; }
+  if (!login) return <a href={`/auth/github?issue=${encodeURIComponent(issue.id)}`}>Sign in to approve this issue</a>;
+  if (!isShepherd(login, issue)) return <p>Waiting for approval from @{issue.shepherd}.</p>;
+  return <form action={`/issues/${encodeURIComponent(issue.id)}/approve`} method="post"><button type="submit" className="rounded border px-3 py-2">Approve issue</button></form>;
+}

--- a/typescript2/app-feedback/src/components/issues/issue-list.tsx
+++ b/typescript2/app-feedback/src/components/issues/issue-list.tsx
@@ -16,6 +16,8 @@ type ViewMode = "list" | "board";
 const STATUS_OPTIONS: { value: StatusState | "all"; label: string }[] = [
   { value: "all", label: "All" },
   { value: "open", label: "Open" },
+  { value: "awaiting_approval", label: "Awaiting approval" },
+  { value: "approved", label: "Approved" },
   { value: "in_progress", label: "In progress" },
   { value: "merged", label: "Merged" },
   { value: "shipped", label: "Shipped" },
@@ -28,6 +30,8 @@ const DIFFICULTIES: Difficulty[] = ["Trivial", "Easy", "Medium", "Hard"];
 
 const BOARD_COLUMNS: { state: StatusState; label: string; color: string }[] = [
   { state: "open", label: "Open", color: "bg-blue-500" },
+  { state: "awaiting_approval", label: "Awaiting approval", color: "bg-orange-600" },
+  { state: "approved", label: "Approved", color: "bg-teal-600" },
   { state: "in_progress", label: "In progress", color: "bg-amber-500" },
   { state: "merged", label: "Merged", color: "bg-purple-500" },
   { state: "shipped", label: "Shipped", color: "bg-green-600" },

--- a/typescript2/app-feedback/src/components/issues/issue-list.tsx
+++ b/typescript2/app-feedback/src/components/issues/issue-list.tsx
@@ -1,42 +1,53 @@
-"use client";
+'use client';
 
-import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { ArrowUpDown, Columns3, LayoutList, Search } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import type { Difficulty, Issue, StatusState, Subsystem } from "@/lib/types";
-import { progress, relativeTime, stageInfo } from "@/lib/pipeline";
-import { DifficultyBadge, StatusBadge, SubsystemBadge } from "./issue-status";
-import { PipelineStrip } from "./pipeline-strip";
+import { ArrowUpDown, Columns3, LayoutList, Search } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { progress, relativeTime, stageInfo } from '@/lib/pipeline';
+import type { Difficulty, Issue, StatusState, Subsystem } from '@/lib/types';
+import { DifficultyBadge, StatusBadge, SubsystemBadge } from './issue-status';
+import { PipelineStrip } from './pipeline-strip';
 
-type ViewMode = "list" | "board";
+type ViewMode = 'list' | 'board';
 
-const STATUS_OPTIONS: { value: StatusState | "all"; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "open", label: "Open" },
-  { value: "awaiting_approval", label: "Awaiting approval" },
-  { value: "approved", label: "Approved" },
-  { value: "in_progress", label: "In progress" },
-  { value: "merged", label: "Merged" },
-  { value: "shipped", label: "Shipped" },
-  { value: "deferred", label: "Deferred" },
-  { value: "rejected", label: "Rejected" },
+const STATUS_OPTIONS: { value: StatusState | 'all'; label: string }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Open', value: 'open' },
+  { label: 'Awaiting approval', value: 'awaiting_approval' },
+  { label: 'Approved', value: 'approved' },
+  { label: 'In progress', value: 'in_progress' },
+  { label: 'Merged', value: 'merged' },
+  { label: 'Shipped', value: 'shipped' },
+  { label: 'Deferred', value: 'deferred' },
+  { label: 'Rejected', value: 'rejected' },
 ];
 
-const SUBSYSTEMS: Subsystem[] = ["Syntax", "Compiler", "Runtime", "StdLibrary", "Tooling", "Unknown"];
-const DIFFICULTIES: Difficulty[] = ["Trivial", "Easy", "Medium", "Hard"];
+const SUBSYSTEMS: Subsystem[] = [
+  'Syntax',
+  'Compiler',
+  'Runtime',
+  'StdLibrary',
+  'Tooling',
+  'Unknown',
+];
+const DIFFICULTIES: Difficulty[] = ['Trivial', 'Easy', 'Medium', 'Hard'];
 
 const BOARD_COLUMNS: { state: StatusState; label: string; color: string }[] = [
-  { state: "open", label: "Open", color: "bg-blue-500" },
-  { state: "awaiting_approval", label: "Awaiting approval", color: "bg-orange-600" },
-  { state: "approved", label: "Approved", color: "bg-teal-600" },
-  { state: "in_progress", label: "In progress", color: "bg-amber-500" },
-  { state: "merged", label: "Merged", color: "bg-purple-500" },
-  { state: "shipped", label: "Shipped", color: "bg-green-600" },
-  { state: "deferred", label: "Deferred", color: "bg-slate-500" },
-  { state: "rejected", label: "Rejected", color: "bg-red-500" },
+  { color: 'bg-blue-500', label: 'Open', state: 'open' },
+  {
+    color: 'bg-orange-600',
+    label: 'Awaiting approval',
+    state: 'awaiting_approval',
+  },
+  { color: 'bg-teal-600', label: 'Approved', state: 'approved' },
+  { color: 'bg-amber-500', label: 'In progress', state: 'in_progress' },
+  { color: 'bg-purple-500', label: 'Merged', state: 'merged' },
+  { color: 'bg-green-600', label: 'Shipped', state: 'shipped' },
+  { color: 'bg-slate-500', label: 'Deferred', state: 'deferred' },
+  { color: 'bg-red-500', label: 'Rejected', state: 'rejected' },
 ];
 
 /** The clock the relative times are measured against; ticks every minute, the
@@ -53,22 +64,26 @@ function useNow() {
 
 function IssueRow({ issue, now }: { issue: Issue; now: number }) {
   const stages = stageInfo(issue);
-  const current = stages.find((s) => s.state === "running") ?? stages.find((s) => s.state === "failed");
+  const current =
+    stages.find((s) => s.state === 'running') ??
+    stages.find((s) => s.state === 'failed');
   return (
     <Link
-      href={`/issues/${issue.id}`}
       className="grid grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[minmax(0,1fr)_180px_150px] items-center gap-4 px-4 py-3 border-b last:border-b-0 hover:bg-accent/50 transition-colors"
+      href={`/issues/${issue.id}`}
     >
       <div className="min-w-0">
         <div className="flex items-center gap-2 min-w-0">
-          <span className="font-mono text-xs text-muted-foreground shrink-0">{issue.id}</span>
+          <span className="font-mono text-xs text-muted-foreground shrink-0">
+            {issue.id}
+          </span>
           <span className="font-medium truncate">{issue.title}</span>
         </div>
         <div className="mt-1.5 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <SubsystemBadge subsystem={issue.subsystem} />
           <DifficultyBadge difficulty={issue.difficulty} />
-          {issue.dataset === "eval" && <EvalBadge />}
-          <span>{issue.shepherd ? `@${issue.shepherd}` : "unassigned"}</span>
+          {issue.dataset === 'eval' && <EvalBadge />}
+          <span>{issue.shepherd ? `@${issue.shepherd}` : 'unassigned'}</span>
           <span>·</span>
           <span>v{issue.version}</span>
           {now > 0 && (
@@ -82,7 +97,9 @@ function IssueRow({ issue, now }: { issue: Issue; now: number }) {
       <div className="hidden sm:block">
         <PipelineStrip stages={stages} />
         <div className="mt-1 text-[11px] text-muted-foreground truncate">
-          {current ? `${current.stage}: ${current.detail}` : `${Math.round(progress(issue) * 100)}% through the pipeline`}
+          {current
+            ? `${current.stage}: ${current.detail}`
+            : `${Math.round(progress(issue) * 100)}% through the pipeline`}
         </div>
       </div>
       <div className="justify-self-end">
@@ -95,14 +112,16 @@ function IssueRow({ issue, now }: { issue: Issue; now: number }) {
 function BoardCard({ issue }: { issue: Issue }) {
   return (
     <Link
-      href={`/issues/${issue.id}`}
       className="block rounded-md border bg-card p-3 hover:bg-accent/50 transition-colors"
+      href={`/issues/${issue.id}`}
     >
       <div className="flex items-center gap-2 font-mono text-[11px] text-muted-foreground">
         {issue.id}
-        {issue.dataset === "eval" && <EvalBadge />}
+        {issue.dataset === 'eval' && <EvalBadge />}
       </div>
-      <div className="mt-0.5 text-sm font-medium leading-snug line-clamp-2">{issue.title}</div>
+      <div className="mt-0.5 text-sm font-medium leading-snug line-clamp-2">
+        {issue.title}
+      </div>
       <div className="mt-2 flex items-center justify-between gap-2">
         <PipelineStrip stages={stageInfo(issue)} />
         <DifficultyBadge difficulty={issue.difficulty} />
@@ -113,48 +132,63 @@ function BoardCard({ issue }: { issue: Issue }) {
 
 export function IssueList({ issues }: { issues: Issue[] }) {
   const now = useNow();
-  const [status, setStatus] = useState<StatusState | "all">("all");
-  const [subsystem, setSubsystem] = useState<Subsystem | "all">("all");
-  const [difficulty, setDifficulty] = useState<Difficulty | "all">("all");
-  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<StatusState | 'all'>('all');
+  const [subsystem, setSubsystem] = useState<Subsystem | 'all'>('all');
+  const [difficulty, setDifficulty] = useState<Difficulty | 'all'>('all');
+  const [query, setQuery] = useState('');
   const [oldestFirst, setOldestFirst] = useState(false);
-  const [view, setView] = useState<ViewMode>("list");
+  const [view, setView] = useState<ViewMode>('list');
   const [showEval, setShowEval] = useState(false);
-  const evalCount = useMemo(() => issues.filter((i) => i.dataset === "eval").length, [issues]);
+  const evalCount = useMemo(
+    () => issues.filter((i) => i.dataset === 'eval').length,
+    [issues],
+  );
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return issues
-      .filter((i) => showEval || i.dataset !== "eval")
-      .filter((i) => view === "board" || status === "all" || i.status.state === status)
-      .filter((i) => subsystem === "all" || i.subsystem === subsystem)
-      .filter((i) => difficulty === "all" || i.difficulty === difficulty)
+      .filter((i) => showEval || i.dataset !== 'eval')
+      .filter(
+        (i) =>
+          view === 'board' || status === 'all' || i.status.state === status,
+      )
+      .filter((i) => subsystem === 'all' || i.subsystem === subsystem)
+      .filter((i) => difficulty === 'all' || i.difficulty === difficulty)
       .filter(
         (i) =>
           !q ||
           i.title.toLowerCase().includes(q) ||
           i.id.toLowerCase().includes(q) ||
-          (i.shepherd ?? "").toLowerCase().includes(q),
+          (i.shepherd ?? '').toLowerCase().includes(q),
       )
       .sort((a, b) =>
         oldestFirst
           ? a.updated_at.localeCompare(b.updated_at)
           : b.updated_at.localeCompare(a.updated_at),
       );
-  }, [issues, status, subsystem, difficulty, query, oldestFirst, view, showEval]);
+  }, [
+    issues,
+    status,
+    subsystem,
+    difficulty,
+    query,
+    oldestFirst,
+    view,
+    showEval,
+  ]);
 
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-3">
         <div className="flex flex-col lg:flex-row gap-3 lg:items-center justify-between">
-          {view === "list" ? (
+          {view === 'list' ? (
             <div className="flex flex-wrap gap-1.5">
               {STATUS_OPTIONS.map((o) => (
                 <Badge
-                  key={o.value}
-                  variant={status === o.value ? "default" : "outline"}
                   className="cursor-pointer select-none"
+                  key={o.value}
                   onClick={() => setStatus(o.value)}
+                  variant={status === o.value ? 'default' : 'outline'}
                 >
                   {o.label}
                 </Badge>
@@ -167,32 +201,37 @@ export function IssueList({ issues }: { issues: Issue[] }) {
             <div className="relative flex-1 lg:w-64">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
+                className="pl-9"
+                onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search issues, ids, shepherds"
                 value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                className="pl-9"
               />
             </div>
-            <Button variant="outline" size="sm" onClick={() => setOldestFirst((v) => !v)} className="shrink-0">
+            <Button
+              className="shrink-0"
+              onClick={() => setOldestFirst((v) => !v)}
+              size="sm"
+              variant="outline"
+            >
               <ArrowUpDown className="h-4 w-4" />
-              {oldestFirst ? "Oldest" : "Newest"}
+              {oldestFirst ? 'Oldest' : 'Newest'}
             </Button>
             <div className="flex border rounded-md">
               <Button
-                variant={view === "list" ? "default" : "ghost"}
-                size="sm"
-                onClick={() => setView("list")}
-                className="rounded-r-none"
                 aria-label="List view"
+                className="rounded-r-none"
+                onClick={() => setView('list')}
+                size="sm"
+                variant={view === 'list' ? 'default' : 'ghost'}
               >
                 <LayoutList className="h-4 w-4" />
               </Button>
               <Button
-                variant={view === "board" ? "default" : "ghost"}
-                size="sm"
-                onClick={() => setView("board")}
-                className="rounded-l-none"
                 aria-label="Board view"
+                className="rounded-l-none"
+                onClick={() => setView('board')}
+                size="sm"
+                variant={view === 'board' ? 'default' : 'ghost'}
               >
                 <Columns3 className="h-4 w-4" />
               </Button>
@@ -200,13 +239,18 @@ export function IssueList({ issues }: { issues: Issue[] }) {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
-          <label className="flex items-center gap-1.5" htmlFor="filter-subsystem">
+          <label
+            className="flex items-center gap-1.5"
+            htmlFor="filter-subsystem"
+          >
             subsystem
             <select
-              id="filter-subsystem"
-              value={subsystem}
-              onChange={(e) => setSubsystem(e.target.value as Subsystem | "all")}
               className="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground"
+              id="filter-subsystem"
+              onChange={(e) =>
+                setSubsystem(e.target.value as Subsystem | 'all')
+              }
+              value={subsystem}
             >
               <option value="all">all</option>
               {SUBSYSTEMS.map((s) => (
@@ -216,13 +260,18 @@ export function IssueList({ issues }: { issues: Issue[] }) {
               ))}
             </select>
           </label>
-          <label className="flex items-center gap-1.5" htmlFor="filter-difficulty">
+          <label
+            className="flex items-center gap-1.5"
+            htmlFor="filter-difficulty"
+          >
             difficulty
             <select
-              id="filter-difficulty"
-              value={difficulty}
-              onChange={(e) => setDifficulty(e.target.value as Difficulty | "all")}
               className="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground"
+              id="filter-difficulty"
+              onChange={(e) =>
+                setDifficulty(e.target.value as Difficulty | 'all')
+              }
+              value={difficulty}
             >
               <option value="all">all</option>
               {DIFFICULTIES.map((d) => (
@@ -235,12 +284,12 @@ export function IssueList({ issues }: { issues: Issue[] }) {
           {evalCount > 0 && (
             <label className="flex items-center gap-1.5 cursor-pointer select-none">
               <input
-                type="checkbox"
                 checked={showEval}
-                onChange={(e) => setShowEval(e.target.checked)}
                 className="accent-foreground"
+                onChange={(e) => setShowEval(e.target.checked)}
+                type="checkbox"
               />
-              show {evalCount} eval {evalCount === 1 ? "row" : "rows"}
+              show {evalCount} eval {evalCount === 1 ? 'row' : 'rows'}
             </label>
           )}
           <span className="ml-auto flex items-center gap-3">
@@ -252,7 +301,7 @@ export function IssueList({ issues }: { issues: Issue[] }) {
         </div>
       </div>
 
-      {view === "list" ? (
+      {view === 'list' ? (
         filtered.length > 0 ? (
           <div className="rounded-lg border bg-card">
             <div className="hidden sm:grid grid-cols-[minmax(0,1fr)_180px_150px] gap-4 px-4 py-2 border-b text-[11px] uppercase tracking-wide text-muted-foreground">
@@ -261,26 +310,30 @@ export function IssueList({ issues }: { issues: Issue[] }) {
               <span className="justify-self-end">Status</span>
             </div>
             {filtered.map((i) => (
-              <IssueRow key={i.id} issue={i} now={now} />
+              <IssueRow issue={i} key={i.id} now={now} />
             ))}
           </div>
         ) : (
-          <div className="text-center py-12 text-muted-foreground">No issues match.</div>
+          <div className="text-center py-12 text-muted-foreground">
+            No issues match.
+          </div>
         )
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-6 gap-4">
           {BOARD_COLUMNS.map((col) => {
             const items = filtered.filter((i) => i.status.state === col.state);
             return (
-              <div key={col.state} className="flex flex-col min-h-[160px]">
+              <div className="flex flex-col min-h-[160px]" key={col.state}>
                 <div className="flex items-center gap-2 mb-2 pb-2 border-b">
                   <div className={`w-2.5 h-2.5 rounded-full ${col.color}`} />
                   <h3 className="font-medium text-sm">{col.label}</h3>
-                  <span className="text-xs text-muted-foreground ml-auto tabular-nums">{items.length}</span>
+                  <span className="text-xs text-muted-foreground ml-auto tabular-nums">
+                    {items.length}
+                  </span>
                 </div>
                 <div className="flex flex-col gap-2 flex-1">
                   {items.length > 0 ? (
-                    items.map((i) => <BoardCard key={i.id} issue={i} />)
+                    items.map((i) => <BoardCard issue={i} key={i.id} />)
                   ) : (
                     <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground bg-muted/30 rounded-md">
                       none
@@ -299,7 +352,11 @@ export function IssueList({ issues }: { issues: Issue[] }) {
 /** Rows the evals wrote (dataset = eval): never a real user's report. */
 function EvalBadge() {
   return (
-    <Badge variant="outline" className="border-dashed text-[10px] uppercase tracking-wide" title="Written by the evals, not a real report">
+    <Badge
+      className="border-dashed text-[10px] uppercase tracking-wide"
+      title="Written by the evals, not a real report"
+      variant="outline"
+    >
       eval
     </Badge>
   );

--- a/typescript2/app-feedback/src/components/issues/live-updates.tsx
+++ b/typescript2/app-feedback/src/components/issues/live-updates.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export function LiveUpdates() {
+  const router = useRouter();
+  useEffect(() => {
+    const timer = setInterval(() => { if (document.visibilityState === "visible") router.refresh(); }, 30000);
+    return () => clearInterval(timer);
+  }, [router]);
+  return null;
+}

--- a/typescript2/app-feedback/src/components/issues/live-updates.tsx
+++ b/typescript2/app-feedback/src/components/issues/live-updates.tsx
@@ -1,11 +1,13 @@
-"use client";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+'use client';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 export function LiveUpdates() {
   const router = useRouter();
   useEffect(() => {
-    const timer = setInterval(() => { if (document.visibilityState === "visible") router.refresh(); }, 30000);
+    const timer = setInterval(() => {
+      if (document.visibilityState === 'visible') router.refresh();
+    }, 30000);
     return () => clearInterval(timer);
   }, [router]);
   return null;

--- a/typescript2/app-feedback/src/components/ui/badge.tsx
+++ b/typescript2/app-feedback/src/components/ui/badge.tsx
@@ -1,39 +1,41 @@
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
 
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
+    defaultVariants: {
+      variant: 'default',
+    },
     variants: {
       variant: {
+        approved: 'border-transparent bg-teal-600 text-white',
+        awaiting_approval: 'border-transparent bg-orange-600 text-white',
         default:
-          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        deferred: 'border-transparent bg-slate-500 text-white',
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
-        open: "border-transparent bg-blue-500 text-white",
-        awaiting_approval: "border-transparent bg-orange-600 text-white",
-        approved: "border-transparent bg-teal-600 text-white",
-        in_progress: "border-transparent bg-amber-500 text-white",
-        merged: "border-transparent bg-purple-500 text-white",
-        shipped: "border-transparent bg-green-600 text-white",
-        deferred: "border-transparent bg-slate-500 text-white",
-        rejected: "border-transparent bg-red-500 text-white",
-        trivial: "border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200",
-        easy: "border-transparent bg-sky-100 text-sky-800 dark:bg-sky-900/50 dark:text-sky-200",
-        medium: "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200",
-        hard: "border-transparent bg-rose-100 text-rose-800 dark:bg-rose-900/50 dark:text-rose-200",
-        subsystem: "bg-muted text-muted-foreground font-medium",
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        easy: 'border-transparent bg-sky-100 text-sky-800 dark:bg-sky-900/50 dark:text-sky-200',
+        hard: 'border-transparent bg-rose-100 text-rose-800 dark:bg-rose-900/50 dark:text-rose-200',
+        in_progress: 'border-transparent bg-amber-500 text-white',
+        medium:
+          'border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200',
+        merged: 'border-transparent bg-purple-500 text-white',
+        open: 'border-transparent bg-blue-500 text-white',
+        outline: 'text-foreground',
+        rejected: 'border-transparent bg-red-500 text-white',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        shipped: 'border-transparent bg-green-600 text-white',
+        subsystem: 'bg-muted text-muted-foreground font-medium',
+        trivial:
+          'border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200',
       },
     },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
+  },
 );
 
 export interface BadgeProps

--- a/typescript2/app-feedback/src/components/ui/badge.tsx
+++ b/typescript2/app-feedback/src/components/ui/badge.tsx
@@ -16,6 +16,8 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         outline: "text-foreground",
         open: "border-transparent bg-blue-500 text-white",
+        awaiting_approval: "border-transparent bg-orange-600 text-white",
+        approved: "border-transparent bg-teal-600 text-white",
         in_progress: "border-transparent bg-amber-500 text-white",
         merged: "border-transparent bg-purple-500 text-white",
         shipped: "border-transparent bg-green-600 text-white",

--- a/typescript2/app-feedback/src/lib/activity.ts
+++ b/typescript2/app-feedback/src/lib/activity.ts
@@ -1,0 +1,38 @@
+import type { IssueEvent } from "./db";
+
+// Deliberately render known lifecycle fields only, never arbitrary event payloads
+// (which can include historical agent output or CI diagnostics).
+export function activityText(event: IssueEvent): string {
+  switch (event.kind) {
+    case "issue_created": return "Issue created; waiting for shepherd approval.";
+    case "approved": return "Shepherd approved the issue.";
+    case "fix_started": return "Creating a fix and preparing the PR.";
+    case "pr_opened": return "Fix PR created; handed to the shared babysitter.";
+    case "needs_human": return "Fix creation needs a human.";
+    case "fixed_dry_run": return "Dry-run fix passed; nothing pushed.";
+    case "merged": return "PR merged.";
+    case "babysit_started": return "Babysitter investigating CI and reviewer feedback.";
+    case "babysit_proposed": return "CI or reviewer feedback needs a fix. Review the proposal and approve its push.";
+    case "babysit_approved": return "Fix approved; implementing the plan and running tests.";
+    case "babysit_pushing": return "Approved fix passed tests; pushing to the PR branch.";
+    case "babysit_round": return event.payload.result === "fixed"
+      ? "Fix completed; checking the updated PR." : "Fix attempt stopped; human attention required.";
+    case "babysit_result": {
+      const results: Record<string, string> = {
+        green: "CI has no reported failures and no unaddressed configured-reviewer feedback. Still watching for changes.",
+        awaiting_approval: "Waiting for approval of the proposed fix.",
+        waiting_on_checks: "CI is still running; watching continues.",
+        merged: "PR merged; babysitting complete.", closed: "PR closed; babysitting complete.",
+        round_failed: "Babysitting failed; inspect the proposal and retry explicitly.",
+        out_of_rounds: "Round limit reached; human attention required.",
+        fork_refused: "Fork PR cannot be modified by this runner.", dry_run: "Dry run complete; nothing pushed.",
+      };
+      return results[String(event.payload.result)] ?? "Babysitter status updated.";
+    }
+    default: return "Issue status updated.";
+  }
+}
+export function eventProposalPath(event: IssueEvent): string | null {
+  const id = event.payload.proposal_id;
+  return typeof id === "string" && /^[a-zA-Z0-9-]{1,80}$/.test(id) ? `/proposals/${id}` : null;
+}

--- a/typescript2/app-feedback/src/lib/activity.ts
+++ b/typescript2/app-feedback/src/lib/activity.ts
@@ -1,38 +1,60 @@
-import type { IssueEvent } from "./db";
+import type { IssueEvent } from './db';
 
 // Deliberately render known lifecycle fields only, never arbitrary event payloads
 // (which can include historical agent output or CI diagnostics).
 export function activityText(event: IssueEvent): string {
   switch (event.kind) {
-    case "issue_created": return "Issue created; waiting for shepherd approval.";
-    case "approved": return "Shepherd approved the issue.";
-    case "fix_started": return "Creating a fix and preparing the PR.";
-    case "pr_opened": return "Fix PR created; handed to the shared babysitter.";
-    case "needs_human": return "Fix creation needs a human.";
-    case "fixed_dry_run": return "Dry-run fix passed; nothing pushed.";
-    case "merged": return "PR merged.";
-    case "babysit_started": return "Babysitter investigating CI and reviewer feedback.";
-    case "babysit_proposed": return "CI or reviewer feedback needs a fix. Review the proposal and approve its push.";
-    case "babysit_approved": return "Fix approved; implementing the plan and running tests.";
-    case "babysit_pushing": return "Approved fix passed tests; pushing to the PR branch.";
-    case "babysit_round": return event.payload.result === "fixed"
-      ? "Fix completed; checking the updated PR." : "Fix attempt stopped; human attention required.";
-    case "babysit_result": {
+    case 'issue_created':
+      return 'Issue created; waiting for shepherd approval.';
+    case 'approved':
+      return 'Shepherd approved the issue.';
+    case 'fix_started':
+      return 'Creating a fix and preparing the PR.';
+    case 'pr_opened':
+      return 'Fix PR created; handed to the shared babysitter.';
+    case 'needs_human':
+      return 'Fix creation needs a human.';
+    case 'fixed_dry_run':
+      return 'Dry-run fix passed; nothing pushed.';
+    case 'merged':
+      return 'PR merged.';
+    case 'babysit_started':
+      return 'Babysitter investigating CI and reviewer feedback.';
+    case 'babysit_proposed':
+      return 'CI or reviewer feedback needs a fix. Review the proposal and approve its push.';
+    case 'babysit_approved':
+      return 'Fix approved; implementing the plan and running tests.';
+    case 'babysit_pushing':
+      return 'Approved fix passed tests; pushing to the PR branch.';
+    case 'babysit_round':
+      return event.payload.result === 'fixed'
+        ? 'Fix completed; checking the updated PR.'
+        : 'Fix attempt stopped; human attention required.';
+    case 'babysit_result': {
       const results: Record<string, string> = {
-        green: "CI has no reported failures and no unaddressed configured-reviewer feedback. Still watching for changes.",
-        awaiting_approval: "Waiting for approval of the proposed fix.",
-        waiting_on_checks: "CI is still running; watching continues.",
-        merged: "PR merged; babysitting complete.", closed: "PR closed; babysitting complete.",
-        round_failed: "Babysitting failed; inspect the proposal and retry explicitly.",
-        out_of_rounds: "Round limit reached; human attention required.",
-        fork_refused: "Fork PR cannot be modified by this runner.", dry_run: "Dry run complete; nothing pushed.",
+        awaiting_approval: 'Waiting for approval of the proposed fix.',
+        closed: 'PR closed; babysitting complete.',
+        dry_run: 'Dry run complete; nothing pushed.',
+        fork_refused: 'Fork PR cannot be modified by this runner.',
+        green:
+          'CI has no reported failures and no unaddressed configured-reviewer feedback. Still watching for changes.',
+        merged: 'PR merged; babysitting complete.',
+        out_of_rounds: 'Round limit reached; human attention required.',
+        round_failed:
+          'Babysitting failed; inspect the proposal and retry explicitly.',
+        waiting_on_checks: 'CI is still running; watching continues.',
       };
-      return results[String(event.payload.result)] ?? "Babysitter status updated.";
+      return (
+        results[String(event.payload.result)] ?? 'Babysitter status updated.'
+      );
     }
-    default: return "Issue status updated.";
+    default:
+      return 'Issue status updated.';
   }
 }
 export function eventProposalPath(event: IssueEvent): string | null {
   const id = event.payload.proposal_id;
-  return typeof id === "string" && /^[a-zA-Z0-9-]{1,80}$/.test(id) ? `/proposals/${id}` : null;
+  return typeof id === 'string' && /^[a-zA-Z0-9-]{1,80}$/.test(id)
+    ? `/proposals/${id}`
+    : null;
 }

--- a/typescript2/app-feedback/src/lib/approval-auth.ts
+++ b/typescript2/app-feedback/src/lib/approval-auth.ts
@@ -1,0 +1,77 @@
+import "server-only";
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { cookies } from "next/headers";
+
+const SESSION = "__Host-babysit-session";
+export const STATE_COOKIE = "__Host-babysit-oauth";
+export const cookieOptions = { httpOnly: true, secure: true, sameSite: "lax" as const, path: "/" };
+
+export function siteOrigin(): string {
+  const url = new URL(process.env.FEEDBACK_SITE_URL ?? "");
+  if (url.protocol !== "https:" || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error("FEEDBACK_SITE_URL must be an HTTPS origin");
+  }
+  return url.origin;
+}
+function key(): Buffer {
+  const value = process.env.FEEDBACK_APPROVAL_SESSION_KEY ?? "";
+  if (!/^[a-f0-9]{64}$/i.test(value)) throw new Error("Approval session key is not configured");
+  return Buffer.from(value, "hex");
+}
+export function seal(value: object): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key(), iv);
+  const encrypted = Buffer.concat([cipher.update(JSON.stringify(value), "utf8"), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString("base64url");
+}
+export function unseal(value: string): Record<string, unknown> | null {
+  try {
+    if (value.length > 6000) return null;
+    const data = Buffer.from(value, "base64url");
+    const decipher = createDecipheriv("aes-256-gcm", key(), data.subarray(0, 12));
+    decipher.setAuthTag(data.subarray(12, 28));
+    const obj = JSON.parse(Buffer.concat([decipher.update(data.subarray(28)), decipher.final()]).toString());
+    return typeof obj.expires === "number" && obj.expires > Date.now() ? obj : null;
+  } catch { return null; }
+}
+export function nonce(): string { return randomBytes(32).toString("base64url"); }
+export function challenge(verifier: string): string { return createHash("sha256").update(verifier).digest("base64url"); }
+export function proposalPath(id: string): string {
+  if (!/^[a-zA-Z0-9-]{1,80}$/.test(id)) throw new Error("Invalid proposal ID");
+  return `/proposals/${id}`;
+}
+async function github(path: string, token: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+    cache: "no-store", redirect: "error", signal: AbortSignal.timeout(10000),
+  });
+  if (!response.ok) throw new Error("GitHub authorization could not be verified");
+  return response.json();
+}
+export async function maintainer(token: string): Promise<string | null> {
+  const [user, repo] = await Promise.all([github("/user", token), github("/repos/BoundaryML/baml", token)]);
+  const permissions = repo.permissions as Record<string, boolean> | undefined;
+  return typeof user.login === "string" && (permissions?.admin === true || permissions?.maintain === true) ? user.login : null;
+}
+export async function currentApprover(): Promise<string | null> {
+  const session = unseal((await cookies()).get(SESSION)?.value ?? "");
+  if (typeof session?.token !== "string") return null;
+  // Revalidate membership at every read/approval, so revocation takes effect.
+  return maintainer(session.token);
+}
+export async function setSession(token: string): Promise<void> {
+  (await cookies()).set(SESSION, seal({ token, expires: Date.now() + 3600000 }), { ...cookieOptions, maxAge: 3600 });
+}
+
+export function issuePath(id: string): string {
+  if (!/^[a-zA-Z0-9-]{1,100}$/.test(id)) throw new Error("Invalid issue ID");
+  return `/issues/${id}`;
+}
+export async function identity(token: string): Promise<string | null> {
+  const user = await github("/user", token);
+  return typeof user.login === "string" && /^[a-zA-Z0-9-]{1,39}$/.test(user.login) ? user.login : null;
+}
+export async function currentUser(): Promise<string | null> {
+  const session = unseal((await cookies()).get(SESSION)?.value ?? "");
+  return typeof session?.token === "string" ? identity(session.token) : null;
+}

--- a/typescript2/app-feedback/src/lib/approval-auth.ts
+++ b/typescript2/app-feedback/src/lib/approval-auth.ts
@@ -1,77 +1,140 @@
-import "server-only";
-import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
-import { cookies } from "next/headers";
+import 'server-only';
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from 'node:crypto';
+import { cookies } from 'next/headers';
 
-const SESSION = "__Host-babysit-session";
-export const STATE_COOKIE = "__Host-babysit-oauth";
-export const cookieOptions = { httpOnly: true, secure: true, sameSite: "lax" as const, path: "/" };
+const SESSION = '__Host-babysit-session';
+export const STATE_COOKIE = '__Host-babysit-oauth';
+export const cookieOptions = {
+  httpOnly: true,
+  path: '/',
+  sameSite: 'lax' as const,
+  secure: true,
+};
 
 export function siteOrigin(): string {
-  const url = new URL(process.env.FEEDBACK_SITE_URL ?? "");
-  if (url.protocol !== "https:" || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
-    throw new Error("FEEDBACK_SITE_URL must be an HTTPS origin");
+  const url = new URL(process.env.FEEDBACK_SITE_URL ?? '');
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error('FEEDBACK_SITE_URL must be an HTTPS origin');
   }
   return url.origin;
 }
 function key(): Buffer {
-  const value = process.env.FEEDBACK_APPROVAL_SESSION_KEY ?? "";
-  if (!/^[a-f0-9]{64}$/i.test(value)) throw new Error("Approval session key is not configured");
-  return Buffer.from(value, "hex");
+  const value = process.env.FEEDBACK_APPROVAL_SESSION_KEY ?? '';
+  if (!/^[a-f0-9]{64}$/i.test(value))
+    throw new Error('Approval session key is not configured');
+  return Buffer.from(value, 'hex');
 }
 export function seal(value: object): string {
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key(), iv);
-  const encrypted = Buffer.concat([cipher.update(JSON.stringify(value), "utf8"), cipher.final()]);
-  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString("base64url");
+  const cipher = createCipheriv('aes-256-gcm', key(), iv);
+  const encrypted = Buffer.concat([
+    cipher.update(JSON.stringify(value), 'utf8'),
+    cipher.final(),
+  ]);
+  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString(
+    'base64url',
+  );
 }
 export function unseal(value: string): Record<string, unknown> | null {
   try {
     if (value.length > 6000) return null;
-    const data = Buffer.from(value, "base64url");
-    const decipher = createDecipheriv("aes-256-gcm", key(), data.subarray(0, 12));
+    const data = Buffer.from(value, 'base64url');
+    const decipher = createDecipheriv(
+      'aes-256-gcm',
+      key(),
+      data.subarray(0, 12),
+    );
     decipher.setAuthTag(data.subarray(12, 28));
-    const obj = JSON.parse(Buffer.concat([decipher.update(data.subarray(28)), decipher.final()]).toString());
-    return typeof obj.expires === "number" && obj.expires > Date.now() ? obj : null;
-  } catch { return null; }
+    const obj = JSON.parse(
+      Buffer.concat([
+        decipher.update(data.subarray(28)),
+        decipher.final(),
+      ]).toString(),
+    );
+    return typeof obj.expires === 'number' && obj.expires > Date.now()
+      ? obj
+      : null;
+  } catch {
+    return null;
+  }
 }
-export function nonce(): string { return randomBytes(32).toString("base64url"); }
-export function challenge(verifier: string): string { return createHash("sha256").update(verifier).digest("base64url"); }
+export function nonce(): string {
+  return randomBytes(32).toString('base64url');
+}
+export function challenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
 export function proposalPath(id: string): string {
-  if (!/^[a-zA-Z0-9-]{1,80}$/.test(id)) throw new Error("Invalid proposal ID");
+  if (!/^[a-zA-Z0-9-]{1,80}$/.test(id)) throw new Error('Invalid proposal ID');
   return `/proposals/${id}`;
 }
-async function github(path: string, token: string): Promise<Record<string, unknown>> {
+async function github(
+  path: string,
+  token: string,
+): Promise<Record<string, unknown>> {
   const response = await fetch(`https://api.github.com${path}`, {
-    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
-    cache: "no-store", redirect: "error", signal: AbortSignal.timeout(10000),
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    redirect: 'error',
+    signal: AbortSignal.timeout(10000),
   });
-  if (!response.ok) throw new Error("GitHub authorization could not be verified");
+  if (!response.ok)
+    throw new Error('GitHub authorization could not be verified');
   return response.json();
 }
 export async function maintainer(token: string): Promise<string | null> {
-  const [user, repo] = await Promise.all([github("/user", token), github("/repos/BoundaryML/baml", token)]);
+  const [user, repo] = await Promise.all([
+    github('/user', token),
+    github('/repos/BoundaryML/baml', token),
+  ]);
   const permissions = repo.permissions as Record<string, boolean> | undefined;
-  return typeof user.login === "string" && (permissions?.admin === true || permissions?.maintain === true) ? user.login : null;
+  return typeof user.login === 'string' &&
+    (permissions?.admin === true || permissions?.maintain === true)
+    ? user.login
+    : null;
 }
 export async function currentApprover(): Promise<string | null> {
-  const session = unseal((await cookies()).get(SESSION)?.value ?? "");
-  if (typeof session?.token !== "string") return null;
+  const session = unseal((await cookies()).get(SESSION)?.value ?? '');
+  if (typeof session?.token !== 'string') return null;
   // Revalidate membership at every read/approval, so revocation takes effect.
   return maintainer(session.token);
 }
 export async function setSession(token: string): Promise<void> {
-  (await cookies()).set(SESSION, seal({ token, expires: Date.now() + 3600000 }), { ...cookieOptions, maxAge: 3600 });
+  (await cookies()).set(
+    SESSION,
+    seal({ expires: Date.now() + 3600000, token }),
+    { ...cookieOptions, maxAge: 3600 },
+  );
 }
 
 export function issuePath(id: string): string {
-  if (!/^[a-zA-Z0-9-]{1,100}$/.test(id)) throw new Error("Invalid issue ID");
+  if (!/^[a-zA-Z0-9-]{1,100}$/.test(id)) throw new Error('Invalid issue ID');
   return `/issues/${id}`;
 }
 export async function identity(token: string): Promise<string | null> {
-  const user = await github("/user", token);
-  return typeof user.login === "string" && /^[a-zA-Z0-9-]{1,39}$/.test(user.login) ? user.login : null;
+  const user = await github('/user', token);
+  return typeof user.login === 'string' &&
+    /^[a-zA-Z0-9-]{1,39}$/.test(user.login)
+    ? user.login
+    : null;
 }
 export async function currentUser(): Promise<string | null> {
-  const session = unseal((await cookies()).get(SESSION)?.value ?? "");
-  return typeof session?.token === "string" ? identity(session.token) : null;
+  const session = unseal((await cookies()).get(SESSION)?.value ?? '');
+  return typeof session?.token === 'string' ? identity(session.token) : null;
 }

--- a/typescript2/app-feedback/src/lib/db.ts
+++ b/typescript2/app-feedback/src/lib/db.ts
@@ -11,15 +11,15 @@
 // Without them the pages render the mock dataset, so the UI can be built
 // and previewed with nothing provisioned; the header says which it is.
 
-import { ISSUES, findIssue } from "./mock-data";
-import type { Comment, HandleOutcome, Issue } from "./types";
+import { findIssue, ISSUES } from './mock-data';
+import type { Comment, HandleOutcome, Issue } from './types';
 
-const URL = process.env.FEEDBACK_SUPABASE_URL?.replace(/\/$/, "");
+const URL = process.env.FEEDBACK_SUPABASE_URL?.replace(/\/$/, '');
 const KEY = process.env.FEEDBACK_SUPABASE_ANON_KEY;
 
-export type DataSource = "supabase" | "mock";
+export type DataSource = 'supabase' | 'mock';
 
-export const dataSource: DataSource = URL && KEY ? "supabase" : "mock";
+export const dataSource: DataSource = URL && KEY ? 'supabase' : 'mock';
 
 /** Seconds a page result is cached before PostgREST is asked again. */
 export const REVALIDATE_S = 30;
@@ -28,22 +28,30 @@ export const REVALIDATE_S = 30;
 const TIMEOUT_MS = 10_000;
 
 async function rest<T>(path: string): Promise<T> {
-  if (!URL || !KEY) throw new Error("supabase is not configured");
+  if (!URL || !KEY) throw new Error('supabase is not configured');
   let res: Response;
   try {
     res = await fetch(`${URL}/rest/v1/${path}`, {
-      headers: { apikey: KEY, Authorization: `Bearer ${KEY}`, Accept: "application/json" },
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${KEY}`,
+        apikey: KEY,
+      },
       next: { revalidate: REVALIDATE_S },
       signal: AbortSignal.timeout(TIMEOUT_MS),
     });
   } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      throw new Error(`supabase: no answer within ${TIMEOUT_MS / 1000}s for ${path}`);
+    if (err instanceof Error && err.name === 'TimeoutError') {
+      throw new Error(
+        `supabase: no answer within ${TIMEOUT_MS / 1000}s for ${path}`,
+      );
     }
     throw err;
   }
   if (!res.ok) {
-    throw new Error(`supabase: ${res.status} for ${path}: ${(await res.text()).slice(0, 200)}`);
+    throw new Error(
+      `supabase: ${res.status} for ${path}: ${(await res.text()).slice(0, 200)}`,
+    );
   }
   return (await res.json()) as T;
 }
@@ -54,76 +62,85 @@ interface IssueRow {
   title: string;
   description: string;
   shepherd: string | null;
-  subsystem: Issue["subsystem"];
-  repros: Issue["repros"];
+  subsystem: Issue['subsystem'];
+  repros: Issue['repros'];
   version: string;
   feedback_ids: string[];
-  status: Issue["status"];
+  status: Issue['status'];
   comments: Array<{ author: string; body: string; at?: string }>;
   resolution_plan: string | null;
-  difficulty: Issue["difficulty"];
+  difficulty: Issue['difficulty'];
   design_doc: string | null;
-  dataset: "live" | "eval";
+  dataset: 'live' | 'eval';
   created_at: string;
   updated_at: string;
-  outcome: (Partial<HandleOutcome> & { id?: number; mode?: string; created_at?: string }) | null;
+  outcome:
+    | (Partial<HandleOutcome> & {
+        id?: number;
+        mode?: string;
+        created_at?: string;
+      })
+    | null;
 }
 
 function outcomeOf(row: IssueRow): HandleOutcome | null {
   const o = row.outcome;
   if (!o || !o.kind) return null;
   return {
-    kind: o.kind,
     branch: o.branch ?? null,
+    design_doc: o.design_doc ?? null,
+    gate: o.gate ?? null,
+    kind: o.kind,
     pr: o.pr ?? null,
-    turns: o.turns ?? 0,
+    reason: o.reason ?? null,
     seconds: o.seconds ?? 0,
     timed_out: o.timed_out ?? false,
-    gate: o.gate ?? null,
-    design_doc: o.design_doc ?? null,
-    reason: o.reason ?? null,
+    turns: o.turns ?? 0,
   };
 }
 
 function issueOf(row: IssueRow): Issue {
   const comments: Comment[] = (row.comments ?? []).map((c) => ({
+    at: c.at ?? row.updated_at,
     author: c.author,
     body: c.body,
-    at: c.at ?? row.updated_at,
   }));
   return {
-    id: row.id,
-    title: row.title,
-    description: row.description,
-    shepherd: row.shepherd,
-    subsystem: row.subsystem,
-    repros: row.repros ?? [],
-    version: row.version,
-    feedback_ids: row.feedback_ids ?? [],
-    status: row.status,
     comments,
-    resolution_plan: row.resolution_plan,
-    difficulty: row.difficulty,
-    design_doc: row.design_doc,
-    outcome: outcomeOf(row),
-    dataset: row.dataset ?? "live",
     created_at: row.created_at,
+    dataset: row.dataset ?? 'live',
+    description: row.description,
+    design_doc: row.design_doc,
+    difficulty: row.difficulty,
+    feedback_ids: row.feedback_ids ?? [],
+    id: row.id,
+    outcome: outcomeOf(row),
+    repros: row.repros ?? [],
+    resolution_plan: row.resolution_plan,
+    shepherd: row.shepherd,
+    status: row.status,
+    subsystem: row.subsystem,
+    title: row.title,
     updated_at: row.updated_at,
+    version: row.version,
   };
 }
 
-const COLUMNS = "select=*";
+const COLUMNS = 'select=*';
 
 /** Every issue, most recently updated first. */
 export async function loadIssues(): Promise<Issue[]> {
-  if (dataSource === "mock") return ISSUES.map((i) => ({ ...i, dataset: i.dataset ?? "live" }));
-  const rows = await rest<IssueRow[]>(`issues_with_outcome?${COLUMNS}&order=updated_at.desc`);
+  if (dataSource === 'mock')
+    return ISSUES.map((i) => ({ ...i, dataset: i.dataset ?? 'live' }));
+  const rows = await rest<IssueRow[]>(
+    `issues_with_outcome?${COLUMNS}&order=updated_at.desc`,
+  );
   return rows.map(issueOf);
 }
 
 /** One issue by id, or undefined. */
 export async function loadIssue(id: string): Promise<Issue | undefined> {
-  if (dataSource === "mock") return findIssue(id);
+  if (dataSource === 'mock') return findIssue(id);
   const rows = await rest<IssueRow[]>(
     `issues_with_outcome?${COLUMNS}&id=eq.${encodeURIComponent(id)}&limit=1`,
   );
@@ -139,17 +156,23 @@ export interface IssueEvent {
   created_at: string;
 }
 
-export async function loadIssueEvents(id: string, dataset: "live" | "eval" = "live"): Promise<IssueEvent[]> {
-  if (dataSource === "mock") return [];
+export async function loadIssueEvents(
+  id: string,
+  dataset: 'live' | 'eval' = 'live',
+): Promise<IssueEvent[]> {
+  if (dataSource === 'mock') return [];
   return rest<IssueEvent[]>(
     `events?select=id,kind,payload,slack_ts,created_at&issue_id=eq.${encodeURIComponent(id)}&dataset=eq.${dataset}&order=created_at,id`,
   );
 }
 
 /** Public lifecycle metadata; private plans are read only on authorized proposal pages. */
-export async function loadPrEvents(number: string, dataset: "live" | "eval" = "live"): Promise<IssueEvent[]> {
-  if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error("Invalid PR number");
-  if (dataSource === "mock") return [];
+export async function loadPrEvents(
+  number: string,
+  dataset: 'live' | 'eval' = 'live',
+): Promise<IssueEvent[]> {
+  if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error('Invalid PR number');
+  if (dataSource === 'mock') return [];
   const pr = `https://github.com/BoundaryML/baml/pull/${number}`;
   return rest<IssueEvent[]>(
     `events?select=id,kind,payload,slack_ts,created_at&payload->>pr=eq.${encodeURIComponent(pr)}&dataset=eq.${dataset}&order=created_at,id`,

--- a/typescript2/app-feedback/src/lib/db.ts
+++ b/typescript2/app-feedback/src/lib/db.ts
@@ -1,4 +1,4 @@
-// The data source: the atb2 store in Supabase (tools/atb2/db/schema.sql),
+// The data source: the atb2 store in Supabase,
 // read through PostgREST with the anon key, which sees issues, runs and
 // events but never a reporter's identity (feedback only via feedback_public).
 //
@@ -139,9 +139,19 @@ export interface IssueEvent {
   created_at: string;
 }
 
-export async function loadIssueEvents(id: string): Promise<IssueEvent[]> {
+export async function loadIssueEvents(id: string, dataset: "live" | "eval" = "live"): Promise<IssueEvent[]> {
   if (dataSource === "mock") return [];
   return rest<IssueEvent[]>(
-    `events?select=id,kind,payload,slack_ts,created_at&issue_id=eq.${encodeURIComponent(id)}&order=created_at`,
+    `events?select=id,kind,payload,slack_ts,created_at&issue_id=eq.${encodeURIComponent(id)}&dataset=eq.${dataset}&order=created_at,id`,
+  );
+}
+
+/** Public lifecycle metadata; private plans are read only on authorized proposal pages. */
+export async function loadPrEvents(number: string, dataset: "live" | "eval" = "live"): Promise<IssueEvent[]> {
+  if (!/^[1-9][0-9]{0,9}$/.test(number)) throw new Error("Invalid PR number");
+  if (dataSource === "mock") return [];
+  const pr = `https://github.com/BoundaryML/baml/pull/${number}`;
+  return rest<IssueEvent[]>(
+    `events?select=id,kind,payload,slack_ts,created_at&payload->>pr=eq.${encodeURIComponent(pr)}&dataset=eq.${dataset}&order=created_at,id`,
   );
 }

--- a/typescript2/app-feedback/src/lib/issue-approval.ts
+++ b/typescript2/app-feedback/src/lib/issue-approval.ts
@@ -1,17 +1,48 @@
-import "server-only";
-import type { IssueStatus } from "./types";
-export interface ApprovalIssue { id: string; shepherd: string | null; status: IssueStatus }
-export function isShepherd(login: string | null, issue: ApprovalIssue): boolean {
-  return !!login && !!issue.shepherd && login.toLowerCase() === issue.shepherd.toLowerCase();
+import 'server-only';
+import type { IssueStatus } from './types';
+export interface ApprovalIssue {
+  id: string;
+  shepherd: string | null;
+  status: IssueStatus;
 }
-export async function issueStore<T>(query: string, init: RequestInit = {}): Promise<T> {
-  const origin = new URL(process.env.FEEDBACK_SUPABASE_URL ?? "");
+export function isShepherd(
+  login: string | null,
+  issue: ApprovalIssue,
+): boolean {
+  return (
+    !!login &&
+    !!issue.shepherd &&
+    login.toLowerCase() === issue.shepherd.toLowerCase()
+  );
+}
+export async function issueStore<T>(
+  query: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const origin = new URL(process.env.FEEDBACK_SUPABASE_URL ?? '');
   const key = process.env.FEEDBACK_APPROVAL_SUPABASE_KEY;
-  if (!key || origin.protocol !== "https:" || origin.username || origin.password || origin.pathname !== "/" || origin.search || origin.hash) throw new Error("Approval store unavailable");
+  if (
+    !key ||
+    origin.protocol !== 'https:' ||
+    origin.username ||
+    origin.password ||
+    origin.pathname !== '/' ||
+    origin.search ||
+    origin.hash
+  )
+    throw new Error('Approval store unavailable');
   const response = await fetch(`${origin.origin}/rest/v1/issues?${query}`, {
-    ...init, headers: { apikey: key, Authorization: `Bearer ${key}`, "Content-Type": "application/json", Prefer: "return=representation" },
-    cache: "no-store", redirect: "error", signal: AbortSignal.timeout(5000),
+    ...init,
+    cache: 'no-store',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      apikey: key,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    redirect: 'error',
+    signal: AbortSignal.timeout(5000),
   });
-  if (!response.ok) throw new Error("Approval store failed");
+  if (!response.ok) throw new Error('Approval store failed');
   return response.json();
 }

--- a/typescript2/app-feedback/src/lib/issue-approval.ts
+++ b/typescript2/app-feedback/src/lib/issue-approval.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import type { IssueStatus } from "./types";
+export interface ApprovalIssue { id: string; shepherd: string | null; status: IssueStatus }
+export function isShepherd(login: string | null, issue: ApprovalIssue): boolean {
+  return !!login && !!issue.shepherd && login.toLowerCase() === issue.shepherd.toLowerCase();
+}
+export async function issueStore<T>(query: string, init: RequestInit = {}): Promise<T> {
+  const origin = new URL(process.env.FEEDBACK_SUPABASE_URL ?? "");
+  const key = process.env.FEEDBACK_APPROVAL_SUPABASE_KEY;
+  if (!key || origin.protocol !== "https:" || origin.username || origin.password || origin.pathname !== "/" || origin.search || origin.hash) throw new Error("Approval store unavailable");
+  const response = await fetch(`${origin.origin}/rest/v1/issues?${query}`, {
+    ...init, headers: { apikey: key, Authorization: `Bearer ${key}`, "Content-Type": "application/json", Prefer: "return=representation" },
+    cache: "no-store", redirect: "error", signal: AbortSignal.timeout(5000),
+  });
+  if (!response.ok) throw new Error("Approval store failed");
+  return response.json();
+}

--- a/typescript2/app-feedback/src/lib/pipeline.ts
+++ b/typescript2/app-feedback/src/lib/pipeline.ts
@@ -139,6 +139,10 @@ export function statusLabel(issue: Issue): string {
   switch (s.state) {
     case "open":
       return "Open";
+    case "awaiting_approval":
+      return "Awaiting approval";
+    case "approved":
+      return "Approved";
     case "in_progress":
       return s.pr ? "PR open" : "In progress";
     case "merged":

--- a/typescript2/app-feedback/src/lib/pipeline.ts
+++ b/typescript2/app-feedback/src/lib/pipeline.ts
@@ -1,21 +1,21 @@
-import type { Issue } from "./types";
+import type { Issue } from './types';
 
 // The pipeline an issue moves through, in order. The first three are the
 // triage stages (create_issue / organize_issue / gauge_issue); the rest are
 // handle_issue's passes, read from its outcome.json.
 export const STAGES = [
-  "triaged",
-  "organized",
-  "gauged",
-  "design",
-  "fix",
-  "gate",
-  "pr",
+  'triaged',
+  'organized',
+  'gauged',
+  'design',
+  'fix',
+  'gate',
+  'pr',
 ] as const;
 
 export type Stage = (typeof STAGES)[number];
 
-export type StageState = "done" | "running" | "failed" | "skipped" | "todo";
+export type StageState = 'done' | 'running' | 'failed' | 'skipped' | 'todo';
 
 export interface StageInfo {
   stage: Stage;
@@ -25,47 +25,51 @@ export interface StageInfo {
 }
 
 export const STAGE_LABELS: Record<Stage, string> = {
-  triaged: "Triaged",
-  organized: "Organized",
-  gauged: "Gauged",
-  design: "Design pass",
-  fix: "Fix pass",
-  gate: "Gate",
-  pr: "PR",
+  design: 'Design pass',
+  fix: 'Fix pass',
+  gate: 'Gate',
+  gauged: 'Gauged',
+  organized: 'Organized',
+  pr: 'PR',
+  triaged: 'Triaged',
 };
 
 export function stageInfo(issue: Issue): StageInfo[] {
   const out: StageInfo[] = [];
   out.push({
-    stage: "triaged",
-    state: "done",
-    detail: `${issue.repros.length} repro${issue.repros.length === 1 ? "" : "s"} from ${issue.feedback_ids.length} report${issue.feedback_ids.length === 1 ? "" : "s"}`,
+    detail: `${issue.repros.length} repro${issue.repros.length === 1 ? '' : 's'} from ${issue.feedback_ids.length} report${issue.feedback_ids.length === 1 ? '' : 's'}`,
+    stage: 'triaged',
+    state: 'done',
   });
   out.push(
     issue.shepherd
-      ? { stage: "organized", state: "done", detail: `shepherd: ${issue.shepherd}` }
-      : { stage: "organized", state: "todo", detail: "no shepherd yet" },
+      ? {
+          detail: `shepherd: ${issue.shepherd}`,
+          stage: 'organized',
+          state: 'done',
+        }
+      : { detail: 'no shepherd yet', stage: 'organized', state: 'todo' },
   );
   out.push(
     issue.difficulty
-      ? { stage: "gauged", state: "done", detail: issue.difficulty }
-      : { stage: "gauged", state: "todo", detail: "not gauged" },
+      ? { detail: issue.difficulty, stage: 'gauged', state: 'done' }
+      : { detail: 'not gauged', stage: 'gauged', state: 'todo' },
   );
 
   const o = issue.outcome;
   const terminal =
-    issue.status.state === "rejected" || issue.status.state === "deferred";
+    issue.status.state === 'rejected' || issue.status.state === 'deferred';
   const todo = (stage: Stage, detail: string): StageInfo => ({
-    stage,
-    state: terminal ? "skipped" : "todo",
     detail,
+    stage,
+    state: terminal ? 'skipped' : 'todo',
   });
 
   if (!o) {
-    out.push(todo("design", "not started"));
-    out.push(todo("fix", "not started"));
-    out.push(todo("gate", "not run"));
-    out.push(todo("pr", "none"));
+    out.push(todo('design', 'not started'));
+    out.push(todo('fix', 'not started'));
+    out.push(todo('gate', 'not run'));
+    out.push(todo('pr', 'none'));
     return out;
   }
 
@@ -73,55 +77,84 @@ export function stageInfo(issue: Issue): StageInfo[] {
   const runInfo = `${o.turns} turns, ${mins} min`;
 
   if (o.running) {
-    const order: Stage[] = ["design", "fix", "gate", "pr"];
+    const order: Stage[] = ['design', 'fix', 'gate', 'pr'];
     for (const s of order) {
-      if (s === o.running) out.push({ stage: s, state: "running", detail: `running (${runInfo})` });
+      if (s === o.running)
+        out.push({
+          detail: `running (${runInfo})`,
+          stage: s,
+          state: 'running',
+        });
       else if (order.indexOf(s) < order.indexOf(o.running))
-        out.push({ stage: s, state: "done", detail: "done" });
-      else out.push({ stage: s, state: "todo", detail: "pending" });
+        out.push({ detail: 'done', stage: s, state: 'done' });
+      else out.push({ detail: 'pending', stage: s, state: 'todo' });
     }
     return out;
   }
 
   switch (o.kind) {
-    case "agent_stopped": {
+    case 'agent_stopped': {
       const inFix = o.branch !== null && o.design_doc !== null;
       out.push(
         inFix
-          ? { stage: "design", state: "done", detail: "plan written" }
-          : { stage: "design", state: "failed", detail: o.reason ?? "stopped" },
+          ? { detail: 'plan written', stage: 'design', state: 'done' }
+          : { detail: o.reason ?? 'stopped', stage: 'design', state: 'failed' },
       );
       out.push(
         inFix
-          ? { stage: "fix", state: "failed", detail: o.reason ?? "stopped" }
-          : { stage: "fix", state: "skipped", detail: "not reached" },
+          ? { detail: o.reason ?? 'stopped', stage: 'fix', state: 'failed' }
+          : { detail: 'not reached', stage: 'fix', state: 'skipped' },
       );
-      out.push({ stage: "gate", state: "skipped", detail: "not run" });
-      out.push({ stage: "pr", state: "skipped", detail: "none" });
+      out.push({ detail: 'not run', stage: 'gate', state: 'skipped' });
+      out.push({ detail: 'none', stage: 'pr', state: 'skipped' });
       return out;
     }
-    case "hard":
-      out.push({ stage: "design", state: "done", detail: `design doc written (${runInfo})` });
-      out.push({ stage: "fix", state: "skipped", detail: "hard: handed to the shepherd" });
-      out.push({ stage: "gate", state: "skipped", detail: "not run" });
-      out.push({ stage: "pr", state: "skipped", detail: "none" });
+    case 'hard':
+      out.push({
+        detail: `design doc written (${runInfo})`,
+        stage: 'design',
+        state: 'done',
+      });
+      out.push({
+        detail: 'hard: handed to the shepherd',
+        stage: 'fix',
+        state: 'skipped',
+      });
+      out.push({ detail: 'not run', stage: 'gate', state: 'skipped' });
+      out.push({ detail: 'none', stage: 'pr', state: 'skipped' });
       return out;
-    case "gate_failed": {
+    case 'gate_failed': {
       const failed = o.gate?.steps.find((s) => !s.ok);
-      out.push({ stage: "design", state: "done", detail: "plan written" });
-      out.push({ stage: "fix", state: "done", detail: runInfo });
-      out.push({ stage: "gate", state: "failed", detail: failed ? `${failed.name} failed` : "failed" });
-      out.push({ stage: "pr", state: "skipped", detail: "branch kept for a human" });
+      out.push({ detail: 'plan written', stage: 'design', state: 'done' });
+      out.push({ detail: runInfo, stage: 'fix', state: 'done' });
+      out.push({
+        detail: failed ? `${failed.name} failed` : 'failed',
+        stage: 'gate',
+        state: 'failed',
+      });
+      out.push({
+        detail: 'branch kept for a human',
+        stage: 'pr',
+        state: 'skipped',
+      });
       return out;
     }
-    case "fixed":
-      out.push({ stage: "design", state: "done", detail: "plan written" });
-      out.push({ stage: "fix", state: "done", detail: runInfo });
-      out.push({ stage: "gate", state: "done", detail: `${o.gate?.steps.length ?? 0} steps green` });
+    case 'fixed':
+      out.push({ detail: 'plan written', stage: 'design', state: 'done' });
+      out.push({ detail: runInfo, stage: 'fix', state: 'done' });
+      out.push({
+        detail: `${o.gate?.steps.length ?? 0} steps green`,
+        stage: 'gate',
+        state: 'done',
+      });
       out.push(
         o.pr
-          ? { stage: "pr", state: "done", detail: o.pr.replace("https://github.com/", "") }
-          : { stage: "pr", state: "todo", detail: "dry run: not pushed" },
+          ? {
+              detail: o.pr.replace('https://github.com/', ''),
+              stage: 'pr',
+              state: 'done',
+            }
+          : { detail: 'dry run: not pushed', stage: 'pr', state: 'todo' },
       );
       return out;
   }
@@ -130,29 +163,29 @@ export function stageInfo(issue: Issue): StageInfo[] {
 /** 0..1, how far the issue is through the pipeline. */
 export function progress(issue: Issue): number {
   const infos = stageInfo(issue);
-  const done = infos.filter((s) => s.state === "done").length;
+  const done = infos.filter((s) => s.state === 'done').length;
   return done / infos.length;
 }
 
 export function statusLabel(issue: Issue): string {
   const s = issue.status;
   switch (s.state) {
-    case "open":
-      return "Open";
-    case "awaiting_approval":
-      return "Awaiting approval";
-    case "approved":
-      return "Approved";
-    case "in_progress":
-      return s.pr ? "PR open" : "In progress";
-    case "merged":
-      return "Merged";
-    case "shipped":
+    case 'open':
+      return 'Open';
+    case 'awaiting_approval':
+      return 'Awaiting approval';
+    case 'approved':
+      return 'Approved';
+    case 'in_progress':
+      return s.pr ? 'PR open' : 'In progress';
+    case 'merged':
+      return 'Merged';
+    case 'shipped':
       return `Shipped ${s.version}`;
-    case "deferred":
-      return "Deferred";
-    case "rejected":
-      return "Rejected";
+    case 'deferred':
+      return 'Deferred';
+    case 'rejected':
+      return 'Rejected';
   }
 }
 
@@ -165,11 +198,11 @@ export function formatSeconds(s: number): string {
 
 export function relativeTime(iso: string, now: number): string {
   const diff = now - new Date(iso).getTime();
-  if (diff < 0) return "in the future";
+  if (diff < 0) return 'in the future';
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(diff / 3600000);
   const days = Math.floor(diff / 86400000);
-  if (minutes < 1) return "just now";
+  if (minutes < 1) return 'just now';
   if (minutes < 60) return `${minutes}m ago`;
   if (hours < 24) return `${hours}h ago`;
   if (days < 30) return `${days}d ago`;

--- a/typescript2/app-feedback/src/lib/types.ts
+++ b/typescript2/app-feedback/src/lib/types.ts
@@ -13,6 +13,8 @@ export type Difficulty = "Trivial" | "Easy" | "Medium" | "Hard";
 
 export type IssueStatus =
   | { state: "open" }
+  | { state: "awaiting_approval" }
+  | { state: "approved"; by: string }
   | { state: "in_progress"; pr: string | null }
   | { state: "rejected"; reason: string }
   | { state: "deferred"; reason: string; workaround: string | null }

--- a/typescript2/app-feedback/src/lib/types.ts
+++ b/typescript2/app-feedback/src/lib/types.ts
@@ -2,32 +2,32 @@
 // (HandleOutcome). Keep in sync when the BAML models change.
 
 export type Subsystem =
-  | "Syntax"
-  | "Compiler"
-  | "Runtime"
-  | "StdLibrary"
-  | "Tooling"
-  | "Unknown";
+  | 'Syntax'
+  | 'Compiler'
+  | 'Runtime'
+  | 'StdLibrary'
+  | 'Tooling'
+  | 'Unknown';
 
-export type Difficulty = "Trivial" | "Easy" | "Medium" | "Hard";
+export type Difficulty = 'Trivial' | 'Easy' | 'Medium' | 'Hard';
 
 export type IssueStatus =
-  | { state: "open" }
-  | { state: "awaiting_approval" }
-  | { state: "approved"; by: string }
-  | { state: "in_progress"; pr: string | null }
-  | { state: "rejected"; reason: string }
-  | { state: "deferred"; reason: string; workaround: string | null }
-  | { state: "merged"; pr: string }
-  | { state: "shipped"; version: string; date: string };
+  | { state: 'open' }
+  | { state: 'awaiting_approval' }
+  | { state: 'approved'; by: string }
+  | { state: 'in_progress'; pr: string | null }
+  | { state: 'rejected'; reason: string }
+  | { state: 'deferred'; reason: string; workaround: string | null }
+  | { state: 'merged'; pr: string }
+  | { state: 'shipped'; version: string; date: string };
 
-export type StatusState = IssueStatus["state"];
+export type StatusState = IssueStatus['state'];
 
 export type Expectation =
-  | { check: "should_compile" }
-  | { check: "should_not_compile"; diagnostic_contains: string | null }
-  | { check: "should_evaluate_to"; expected: unknown }
-  | { check: "requires_inspection"; instructions: string };
+  | { check: 'should_compile' }
+  | { check: 'should_not_compile'; diagnostic_contains: string | null }
+  | { check: 'should_evaluate_to'; expected: unknown }
+  | { check: 'requires_inspection'; instructions: string };
 
 export interface Repro {
   files: Record<string, string>;
@@ -57,7 +57,7 @@ export interface GateResult {
 
 /** ~/.atb2/runs/<branch>/outcome.json, as handle_issue writes it. */
 export interface HandleOutcome {
-  kind: "fixed" | "hard" | "gate_failed" | "agent_stopped";
+  kind: 'fixed' | 'hard' | 'gate_failed' | 'agent_stopped';
   branch: string | null;
   pr: string | null;
   turns: number;
@@ -67,7 +67,7 @@ export interface HandleOutcome {
   design_doc: string | null;
   reason: string | null;
   /** Which pass the run was in when it stopped (mock-only). */
-  running?: "design" | "fix" | "gate" | "pr";
+  running?: 'design' | 'fix' | 'gate' | 'pr';
 }
 
 export interface Issue {
@@ -92,4 +92,4 @@ export interface Issue {
   updated_at: string;
 }
 
-export type Dataset = "live" | "eval";
+export type Dataset = 'live' | 'eval';

--- a/typescript2/app-feedback/tests/activity.test.mjs
+++ b/typescript2/app-feedback/tests/activity.test.mjs
@@ -1,20 +1,51 @@
-import { expect, test } from "bun:test";
-import { activityText, eventProposalPath } from "../src/lib/activity.ts";
+import { expect, test } from 'bun:test';
+import { activityText, eventProposalPath } from '../src/lib/activity.ts';
 
-test("issue and PR lifecycle render without exposing arbitrary payloads", () => {
-  for (const kind of ["issue_created", "approved", "fix_started", "pr_opened", "babysit_started", "babysit_proposed", "babysit_approved", "babysit_pushing", "babysit_round", "babysit_result", "unknown"]) {
-    const text = activityText({ kind, payload: { plan: "private-fixture", summary: "private-fixture", result: "private-fixture" } });
-    expect(text).not.toContain("private-fixture");
+test('issue and PR lifecycle render without exposing arbitrary payloads', () => {
+  for (const kind of [
+    'issue_created',
+    'approved',
+    'fix_started',
+    'pr_opened',
+    'babysit_started',
+    'babysit_proposed',
+    'babysit_approved',
+    'babysit_pushing',
+    'babysit_round',
+    'babysit_result',
+    'unknown',
+  ]) {
+    const text = activityText({
+      kind,
+      payload: {
+        plan: 'private-fixture',
+        result: 'private-fixture',
+        summary: 'private-fixture',
+      },
+    });
+    expect(text).not.toContain('private-fixture');
     expect(text.length).toBeGreaterThan(10);
   }
 });
-test("green is monitoring, not automatic merge or claimed review approval", () => {
-  expect(activityText({ kind: "babysit_result", payload: { result: "green" } })).toContain("Still watching");
-  expect(activityText({ kind: "approved", payload: {} })).toContain("Shepherd approved");
+test('green is monitoring, not automatic merge or claimed review approval', () => {
+  expect(
+    activityText({ kind: 'babysit_result', payload: { result: 'green' } }),
+  ).toContain('Still watching');
+  expect(activityText({ kind: 'approved', payload: {} })).toContain(
+    'Shepherd approved',
+  );
 });
-test("proposal links reject control characters and external paths", () => {
-  for (const id of ["../secret", "https://example.invalid", "x?next=bad", "x\n", ""]) {
+test('proposal links reject control characters and external paths', () => {
+  for (const id of [
+    '../secret',
+    'https://example.invalid',
+    'x?next=bad',
+    'x\n',
+    '',
+  ]) {
     expect(eventProposalPath({ payload: { proposal_id: id } })).toBeNull();
   }
-  expect(eventProposalPath({ payload: { proposal_id: "p-123" } })).toBe("/proposals/p-123");
+  expect(eventProposalPath({ payload: { proposal_id: 'p-123' } })).toBe(
+    '/proposals/p-123',
+  );
 });

--- a/typescript2/app-feedback/tests/activity.test.mjs
+++ b/typescript2/app-feedback/tests/activity.test.mjs
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import { activityText, eventProposalPath } from "../src/lib/activity.ts";
+
+test("issue and PR lifecycle render without exposing arbitrary payloads", () => {
+  for (const kind of ["issue_created", "approved", "fix_started", "pr_opened", "babysit_started", "babysit_proposed", "babysit_approved", "babysit_pushing", "babysit_round", "babysit_result", "unknown"]) {
+    const text = activityText({ kind, payload: { plan: "private-fixture", summary: "private-fixture", result: "private-fixture" } });
+    expect(text).not.toContain("private-fixture");
+    expect(text.length).toBeGreaterThan(10);
+  }
+});
+test("green is monitoring, not automatic merge or claimed review approval", () => {
+  expect(activityText({ kind: "babysit_result", payload: { result: "green" } })).toContain("Still watching");
+  expect(activityText({ kind: "approved", payload: {} })).toContain("Shepherd approved");
+});
+test("proposal links reject control characters and external paths", () => {
+  for (const id of ["../secret", "https://example.invalid", "x?next=bad", "x\n", ""]) {
+    expect(eventProposalPath({ payload: { proposal_id: id } })).toBeNull();
+  }
+  expect(eventProposalPath({ payload: { proposal_id: "p-123" } })).toBe("/proposals/p-123");
+});

--- a/typescript2/app-feedback/tests/issue-approval.test.mjs
+++ b/typescript2/app-feedback/tests/issue-approval.test.mjs
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { NextRequest } from "next/server";
+const jar = new Map();
+mock.module("server-only", () => ({}));
+mock.module("next/headers", () => ({ cookies: async () => ({
+  get: (name) => jar.has(name) ? { value: jar.get(name) } : undefined,
+  set: (name, value) => jar.set(name, value),
+}) }));
+const auth = await import("../src/lib/approval-auth.ts");
+const { POST } = await import("../src/app/issues/[id]/approve/route.ts");
+const originalFetch = globalThis.fetch;
+const names = ["FEEDBACK_APPROVAL_SESSION_KEY", "FEEDBACK_SITE_URL", "FEEDBACK_SUPABASE_URL", "FEEDBACK_APPROVAL_SUPABASE_KEY"];
+const originalEnv = Object.fromEntries(names.map(k => [k, process.env[k]]));
+let writes, role;
+beforeEach(() => {
+  jar.clear(); writes = 0; role = "maintain";
+  process.env.FEEDBACK_APPROVAL_SESSION_KEY = "a".repeat(64);
+  process.env.FEEDBACK_SITE_URL = "https://feedback.example.invalid";
+  process.env.FEEDBACK_SUPABASE_URL = "https://store.example.invalid";
+  process.env.FEEDBACK_APPROVAL_SUPABASE_KEY = "offline-fixture";
+  globalThis.fetch = mock(async (url, init) => {
+    if (url === "https://api.github.com/user") return Response.json({ login: "maintainer" });
+    if (url === "https://api.github.com/repos/BoundaryML/baml") return Response.json({ permissions: { [role]: true } });
+    if (String(url).startsWith("https://store.example.invalid/")) {
+      if (!init.method) return Response.json([{ id: "p1", shepherd: role === "maintain" ? "maintainer" : "someone-else", status: { state: "awaiting_approval" } }]);
+      expect(init.method).toBe("PATCH");
+      expect(String(url)).toContain("state=eq.awaiting_approval&shepherd=eq.maintainer");
+      expect(String(url)).toContain("dataset=eq.live");
+      expect(JSON.parse(init.body).status.by).toBe("github:maintainer");
+      writes += 1;
+      return Response.json(writes === 1 ? [{ id: "p1" }] : []);
+    }
+    throw new Error("Unexpected network call");
+  });
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const k of names) originalEnv[k] === undefined ? delete process.env[k] : process.env[k] = originalEnv[k];
+});
+function request(origin = "https://feedback.example.invalid", head = "b".repeat(40)) {
+  return new NextRequest("https://feedback.example.invalid/issues/p1/approve", {
+    method: "POST", headers: { origin, "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ head }),
+  });
+}
+const params = { params: Promise.resolve({ id: "p1" }) };
+test("sessions reject tampering, expiration and the wrong encryption key", () => {
+  const sealed = auth.seal({ token: "fixture", expires: Date.now() + 60000 });
+  expect(auth.unseal(sealed)?.token).toBe("fixture");
+  const bytes = Buffer.from(sealed, "base64url"); bytes[30] ^= 1;
+  expect(auth.unseal(bytes.toString("base64url"))).toBeNull();
+  expect(auth.unseal(auth.seal({ token: "fixture", expires: 1 }))).toBeNull();
+  process.env.FEEDBACK_APPROVAL_SESSION_KEY = "c".repeat(64);
+  expect(auth.unseal(sealed)).toBeNull();
+});
+test("anonymous and cross-origin approvals never write", async () => {
+  expect((await POST(request(), params)).status).toBe(403);
+  await auth.setSession("fixture");
+  expect((await POST(request("https://attacker.example.invalid"), params)).status).toBe(403);
+  expect(writes).toBe(0);
+});
+test("the assigned shepherd is required", async () => {
+  await auth.setSession("fixture"); role = "push";
+  expect((await POST(request(), params)).status).toBe(403);
+  expect(writes).toBe(0);
+});
+test("approval records verified actor and uses a one-shot conditional write", async () => {
+  await auth.setSession("fixture");
+  expect((await POST(request(), params)).status).toBe(303);
+  expect((await POST(request(), params)).status).toBe(409);
+});
+test("invalid issue and redirect paths are refused", async () => {
+  await auth.setSession("fixture");
+  expect((await POST(request(), { params: Promise.resolve({ id: "bad&state=eq.approved" }) })).status).toBe(400);
+  expect(() => auth.proposalPath("//attacker.invalid")).toThrow();
+  expect(writes).toBe(0);
+});
+test("GitHub authorization failures fail closed", async () => {
+  await auth.setSession("fixture");
+  globalThis.fetch = mock(async () => new Response("unavailable", { status: 503 }));
+  expect((await POST(request(), params)).status).toBe(503);
+  expect(writes).toBe(0);
+});

--- a/typescript2/app-feedback/tests/issue-approval.test.mjs
+++ b/typescript2/app-feedback/tests/issue-approval.test.mjs
@@ -1,83 +1,124 @@
-import { afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { NextRequest } from "next/server";
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test';
+import { NextRequest } from 'next/server';
+
 const jar = new Map();
-mock.module("server-only", () => ({}));
-mock.module("next/headers", () => ({ cookies: async () => ({
-  get: (name) => jar.has(name) ? { value: jar.get(name) } : undefined,
-  set: (name, value) => jar.set(name, value),
-}) }));
-const auth = await import("../src/lib/approval-auth.ts");
-const { POST } = await import("../src/app/issues/[id]/approve/route.ts");
+mock.module('server-only', () => ({}));
+mock.module('next/headers', () => ({
+  cookies: async () => ({
+    get: (name) => (jar.has(name) ? { value: jar.get(name) } : undefined),
+    set: (name, value) => jar.set(name, value),
+  }),
+}));
+const auth = await import('../src/lib/approval-auth.ts');
+const { POST } = await import('../src/app/issues/[id]/approve/route.ts');
 const originalFetch = globalThis.fetch;
-const names = ["FEEDBACK_APPROVAL_SESSION_KEY", "FEEDBACK_SITE_URL", "FEEDBACK_SUPABASE_URL", "FEEDBACK_APPROVAL_SUPABASE_KEY"];
-const originalEnv = Object.fromEntries(names.map(k => [k, process.env[k]]));
-let writes, role;
+const names = [
+  'FEEDBACK_APPROVAL_SESSION_KEY',
+  'FEEDBACK_SITE_URL',
+  'FEEDBACK_SUPABASE_URL',
+  'FEEDBACK_APPROVAL_SUPABASE_KEY',
+];
+const originalEnv = Object.fromEntries(names.map((k) => [k, process.env[k]]));
+let writes;
+let role;
 beforeEach(() => {
-  jar.clear(); writes = 0; role = "maintain";
-  process.env.FEEDBACK_APPROVAL_SESSION_KEY = "a".repeat(64);
-  process.env.FEEDBACK_SITE_URL = "https://feedback.example.invalid";
-  process.env.FEEDBACK_SUPABASE_URL = "https://store.example.invalid";
-  process.env.FEEDBACK_APPROVAL_SUPABASE_KEY = "offline-fixture";
+  jar.clear();
+  writes = 0;
+  role = 'maintain';
+  process.env.FEEDBACK_APPROVAL_SESSION_KEY = 'a'.repeat(64);
+  process.env.FEEDBACK_SITE_URL = 'https://feedback.example.invalid';
+  process.env.FEEDBACK_SUPABASE_URL = 'https://store.example.invalid';
+  process.env.FEEDBACK_APPROVAL_SUPABASE_KEY = 'offline-fixture';
   globalThis.fetch = mock(async (url, init) => {
-    if (url === "https://api.github.com/user") return Response.json({ login: "maintainer" });
-    if (url === "https://api.github.com/repos/BoundaryML/baml") return Response.json({ permissions: { [role]: true } });
-    if (String(url).startsWith("https://store.example.invalid/")) {
-      if (!init.method) return Response.json([{ id: "p1", shepherd: role === "maintain" ? "maintainer" : "someone-else", status: { state: "awaiting_approval" } }]);
-      expect(init.method).toBe("PATCH");
-      expect(String(url)).toContain("state=eq.awaiting_approval&shepherd=eq.maintainer");
-      expect(String(url)).toContain("dataset=eq.live");
-      expect(JSON.parse(init.body).status.by).toBe("github:maintainer");
+    if (url === 'https://api.github.com/user')
+      return Response.json({ login: 'maintainer' });
+    if (url === 'https://api.github.com/repos/BoundaryML/baml')
+      return Response.json({ permissions: { [role]: true } });
+    if (String(url).startsWith('https://store.example.invalid/')) {
+      if (!init.method)
+        return Response.json([
+          {
+            id: 'p1',
+            shepherd: role === 'maintain' ? 'maintainer' : 'someone-else',
+            status: { state: 'awaiting_approval' },
+          },
+        ]);
+      expect(init.method).toBe('PATCH');
+      expect(String(url)).toContain(
+        'state=eq.awaiting_approval&shepherd=eq.maintainer',
+      );
+      expect(String(url)).toContain('dataset=eq.live');
+      expect(JSON.parse(init.body).status.by).toBe('github:maintainer');
       writes += 1;
-      return Response.json(writes === 1 ? [{ id: "p1" }] : []);
+      return Response.json(writes === 1 ? [{ id: 'p1' }] : []);
     }
-    throw new Error("Unexpected network call");
+    throw new Error('Unexpected network call');
   });
 });
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  for (const k of names) originalEnv[k] === undefined ? delete process.env[k] : process.env[k] = originalEnv[k];
+  for (const k of names) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
 });
-function request(origin = "https://feedback.example.invalid", head = "b".repeat(40)) {
-  return new NextRequest("https://feedback.example.invalid/issues/p1/approve", {
-    method: "POST", headers: { origin, "Content-Type": "application/x-www-form-urlencoded" },
+function request(
+  origin = 'https://feedback.example.invalid',
+  head = 'b'.repeat(40),
+) {
+  return new NextRequest('https://feedback.example.invalid/issues/p1/approve', {
     body: new URLSearchParams({ head }),
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', origin },
+    method: 'POST',
   });
 }
-const params = { params: Promise.resolve({ id: "p1" }) };
-test("sessions reject tampering, expiration and the wrong encryption key", () => {
-  const sealed = auth.seal({ token: "fixture", expires: Date.now() + 60000 });
-  expect(auth.unseal(sealed)?.token).toBe("fixture");
-  const bytes = Buffer.from(sealed, "base64url"); bytes[30] ^= 1;
-  expect(auth.unseal(bytes.toString("base64url"))).toBeNull();
-  expect(auth.unseal(auth.seal({ token: "fixture", expires: 1 }))).toBeNull();
-  process.env.FEEDBACK_APPROVAL_SESSION_KEY = "c".repeat(64);
+const params = { params: Promise.resolve({ id: 'p1' }) };
+test('sessions reject tampering, expiration and the wrong encryption key', () => {
+  const sealed = auth.seal({ expires: Date.now() + 60000, token: 'fixture' });
+  expect(auth.unseal(sealed)?.token).toBe('fixture');
+  const bytes = Buffer.from(sealed, 'base64url');
+  bytes[30] ^= 1;
+  expect(auth.unseal(bytes.toString('base64url'))).toBeNull();
+  expect(auth.unseal(auth.seal({ expires: 1, token: 'fixture' }))).toBeNull();
+  process.env.FEEDBACK_APPROVAL_SESSION_KEY = 'c'.repeat(64);
   expect(auth.unseal(sealed)).toBeNull();
 });
-test("anonymous and cross-origin approvals never write", async () => {
+test('anonymous and cross-origin approvals never write', async () => {
   expect((await POST(request(), params)).status).toBe(403);
-  await auth.setSession("fixture");
-  expect((await POST(request("https://attacker.example.invalid"), params)).status).toBe(403);
+  await auth.setSession('fixture');
+  expect(
+    (await POST(request('https://attacker.example.invalid'), params)).status,
+  ).toBe(403);
   expect(writes).toBe(0);
 });
-test("the assigned shepherd is required", async () => {
-  await auth.setSession("fixture"); role = "push";
+test('the assigned shepherd is required', async () => {
+  await auth.setSession('fixture');
+  role = 'push';
   expect((await POST(request(), params)).status).toBe(403);
   expect(writes).toBe(0);
 });
-test("approval records verified actor and uses a one-shot conditional write", async () => {
-  await auth.setSession("fixture");
+test('approval records verified actor and uses a one-shot conditional write', async () => {
+  await auth.setSession('fixture');
   expect((await POST(request(), params)).status).toBe(303);
   expect((await POST(request(), params)).status).toBe(409);
 });
-test("invalid issue and redirect paths are refused", async () => {
-  await auth.setSession("fixture");
-  expect((await POST(request(), { params: Promise.resolve({ id: "bad&state=eq.approved" }) })).status).toBe(400);
-  expect(() => auth.proposalPath("//attacker.invalid")).toThrow();
+test('invalid issue and redirect paths are refused', async () => {
+  await auth.setSession('fixture');
+  expect(
+    (
+      await POST(request(), {
+        params: Promise.resolve({ id: 'bad&state=eq.approved' }),
+      })
+    ).status,
+  ).toBe(400);
+  expect(() => auth.proposalPath('//attacker.invalid')).toThrow();
   expect(writes).toBe(0);
 });
-test("GitHub authorization failures fail closed", async () => {
-  await auth.setSession("fixture");
-  globalThis.fetch = mock(async () => new Response("unavailable", { status: 503 }));
+test('GitHub authorization failures fail closed', async () => {
+  await auth.setSession('fixture');
+  globalThis.fetch = mock(
+    async () => new Response('unavailable', { status: 503 }),
+  );
   expect((await POST(request(), params)).status).toBe(503);
   expect(writes).toBe(0);
 });

--- a/typescript2/app-feedback/tests/issue-page.test.mjs
+++ b/typescript2/app-feedback/tests/issue-page.test.mjs
@@ -1,0 +1,46 @@
+import { expect, mock, test } from 'bun:test';
+
+mock.module('server-only', () => ({}));
+mock.module('next/headers', () => ({
+  cookies: async () => ({ get: () => undefined, set: () => {} }),
+}));
+const issue = (id, dataset) => ({
+  comments: [],
+  created_at: '2026-09-01T00:00:00Z',
+  dataset,
+  description: '',
+  design_doc: null,
+  difficulty: null,
+  feedback_ids: [],
+  id,
+  outcome: null,
+  repros: [],
+  resolution_plan: null,
+  shepherd: 'maintainer',
+  status: { state: 'awaiting_approval' },
+  subsystem: 'Compiler',
+  title: 'fixture',
+  updated_at: '2026-09-01T00:00:00Z',
+  version: '0.17.0',
+});
+mock.module('../src/lib/db.ts', () => ({
+  dataSource: 'mock',
+  loadIssue: async (id) =>
+    id === 'GH-1' ? issue('GH-1', 'eval') : issue('ISSUE-01k1', 'live'),
+  loadIssueEvents: async () => [],
+  REVALIDATE_S: 30,
+}));
+const { ApproveIssue } = await import(
+  '../src/components/issues/approve-issue.tsx'
+);
+const { default: IssuePage } = await import('../src/app/issues/[id]/page.tsx');
+async function offersApproval(id) {
+  const page = await IssuePage({ params: Promise.resolve({ id }) });
+  return [page.props.children]
+    .flat()
+    .some((child) => child && child.type === ApproveIssue);
+}
+test('website approval is offered for live issues only, never for eval fixtures', async () => {
+  expect(await offersApproval('ISSUE-01k1')).toBe(true);
+  expect(await offersApproval('GH-1')).toBe(false);
+});

--- a/typescript2/pnpm-lock.yaml
+++ b/typescript2/pnpm-lock.yaml
@@ -297,8 +297,8 @@ importers:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.5)
       next:
-        specifier: '15'
-        version: 15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 15.5.25
+        version: 15.5.25(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -328,8 +328,8 @@ importers:
         specifier: ^9
         version: 9.32.0(jiti@2.6.1)
       eslint-config-next:
-        specifier: '15'
-        version: 15.4.4(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 15.5.25
+        version: 15.5.25(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -4077,6 +4077,9 @@ packages:
   '@next/env@14.2.35':
     resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
 
+  '@next/env@15.5.25':
+    resolution: {integrity: sha512-42h1lLr07vl4gawALP1hsgRZjHB1xYa58JfUfHwr0f7jG/zhPakh5GHkADHXOC9ZxUvlQFOPIrp7s6qX4DezPQ==}
+
   '@next/env@15.5.9':
     resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
 
@@ -4089,8 +4092,17 @@ packages:
   '@next/eslint-plugin-next@15.4.4':
     resolution: {integrity: sha512-1FDsyN//ai3Jd97SEd7scw5h1yLdzDACGOPRofr2GD3sEFsBylEEoL0MHSerd4n2dq9Zm/mFMqi4+NRMOreOKA==}
 
+  '@next/eslint-plugin-next@15.5.25':
+    resolution: {integrity: sha512-dAzOqZQCAOgIq5yQpsuMBZcwxK0AtzGqHMQpxNWYLQlvf79rsP3SDwdGPNQC4ySaMSihOQXMO/VXubQ3JWW+3A==}
+
   '@next/swc-darwin-arm64@14.2.33':
     resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@15.5.25':
+    resolution: {integrity: sha512-w+RR0v/QuApnWEjRGm1z6gcObKwGMb5YPA7V3bzBEVSBpMFUXprer0tS27UxjUcEnqbhL7Zuzohej79B6rYmBg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -4113,6 +4125,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@15.5.25':
+    resolution: {integrity: sha512-QiGGBUSakt8S1H4Lt9Ehsh6Ja87axiBnQQgysOObvCbI7iUfJnRGntF1P64S4/ijuHFnSB8KLsEddkY3nN26uw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-darwin-x64@15.5.7':
     resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
     engines: {node: '>= 10'}
@@ -4127,6 +4145,13 @@ packages:
 
   '@next/swc-linux-arm64-gnu@14.2.33':
     resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@15.5.25':
+    resolution: {integrity: sha512-ehLos/66zo0d/mJCU5u96a/VDcr01aaUrX0o/i16UdInxz8qPTCDSxGtjk/Lps1sIr1RJFdiX3hxc0fxJo+cPA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4153,6 +4178,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@15.5.25':
+    resolution: {integrity: sha512-ZVMrqLiJ7DiChgmbkQwFtdhAnUkSH/4p7tB29QY+giATb0Q/XGHNRSKAb/B8XGDHRUaA67NepOW5W8u3ZRJBAA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
@@ -4169,6 +4201,13 @@ packages:
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@15.5.25':
+    resolution: {integrity: sha512-UOewtDGkTMJTiODrEdeLZ50yGb59xCZSriNpXkfPMxRRgwDkGc7i8mLWqV5076wEdb+Ca/XN7MhJyM3CupyNyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4195,6 +4234,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@15.5.25':
+    resolution: {integrity: sha512-UBHwA8AhkCZgtRfU1aJpunuAJe/6gZv6jDESQe4p5MjTb5V0YEeJBWCdNqx15Vj3x+5jmauRfeMJSjfQj9HGFQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
@@ -4211,6 +4257,12 @@ packages:
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-arm64-msvc@15.5.25':
+    resolution: {integrity: sha512-QcFcPRr16djk5IqK5+e8O80eZfgWzIvVBXfitIq0tQ/uc+eyfdoZ0NmKc0cnbIJyfVwREapKuG97YcxWA9gcpA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -4235,6 +4287,12 @@ packages:
 
   '@next/swc-win32-x64-msvc@14.2.33':
     resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.25':
+    resolution: {integrity: sha512-zREeykps3ndWr9egJgvJKqVkkDuaw6Zrrg23cYBos0ygydFkAWYU4+PaPVwXzP1eAYQJe53ShSK45iDM529BOg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8577,6 +8635,15 @@ packages:
       typescript:
         optional: true
 
+  eslint-config-next@15.5.25:
+    resolution: {integrity: sha512-hB1oClZzRO3vMAeMmBMch0FHNJ4irH74LvQWDEMHkJtG/Us9+SAsg1f5Pvcw9jz4tc8wSGnvbmF050BRAAIbBg==}
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
@@ -10702,6 +10769,27 @@ packages:
       '@opentelemetry/api':
         optional: true
       '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+
+  next@15.5.25:
+    resolution: {integrity: sha512-OMWNulIIqKM2ykvC2qMjIt0IoavB4UB2SCs4iXJ6z6847FvyH8jBmBWcvrF5iuhTu8Przh20Fo/aoszIdqx4PA==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
         optional: true
       sass:
         optional: true
@@ -15973,6 +16061,8 @@ snapshots:
 
   '@next/env@14.2.35': {}
 
+  '@next/env@15.5.25': {}
+
   '@next/env@15.5.9': {}
 
   '@next/env@16.3.4': {}
@@ -15985,7 +16075,14 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
+  '@next/eslint-plugin-next@15.5.25':
+    dependencies:
+      fast-glob: 3.3.1
+
   '@next/swc-darwin-arm64@14.2.33':
+    optional: true
+
+  '@next/swc-darwin-arm64@15.5.25':
     optional: true
 
   '@next/swc-darwin-arm64@15.5.7':
@@ -15997,6 +16094,9 @@ snapshots:
   '@next/swc-darwin-x64@14.2.33':
     optional: true
 
+  '@next/swc-darwin-x64@15.5.25':
+    optional: true
+
   '@next/swc-darwin-x64@15.5.7':
     optional: true
 
@@ -16004,6 +16104,9 @@ snapshots:
     optional: true
 
   '@next/swc-linux-arm64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.25':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.5.7':
@@ -16015,6 +16118,9 @@ snapshots:
   '@next/swc-linux-arm64-musl@14.2.33':
     optional: true
 
+  '@next/swc-linux-arm64-musl@15.5.25':
+    optional: true
+
   '@next/swc-linux-arm64-musl@15.5.7':
     optional: true
 
@@ -16022,6 +16128,9 @@ snapshots:
     optional: true
 
   '@next/swc-linux-x64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.25':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.5.7':
@@ -16033,6 +16142,9 @@ snapshots:
   '@next/swc-linux-x64-musl@14.2.33':
     optional: true
 
+  '@next/swc-linux-x64-musl@15.5.25':
+    optional: true
+
   '@next/swc-linux-x64-musl@15.5.7':
     optional: true
 
@@ -16040,6 +16152,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-arm64-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.25':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.7':
@@ -16052,6 +16167,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.25':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.5.7':
@@ -21778,6 +21896,26 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-next@15.5.25(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 15.5.25
+      '@rushstack/eslint-patch': 1.15.0
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.32.0(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.32.0(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.32.0(jiti@2.6.1))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.32.0(jiti@2.6.1))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -24631,6 +24769,31 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@15.5.25(@opentelemetry/api@1.9.0)(@types/node@20.19.27)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 15.5.25
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001761
+      postcss: 8.4.31
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.25
+      '@next/swc-darwin-x64': 15.5.25
+      '@next/swc-linux-arm64-gnu': 15.5.25
+      '@next/swc-linux-arm64-musl': 15.5.25
+      '@next/swc-linux-x64-gnu': 15.5.25
+      '@next/swc-linux-x64-musl': 15.5.25
+      '@next/swc-win32-arm64-msvc': 15.5.25
+      '@next/swc-win32-x64-msvc': 15.5.25
+      '@opentelemetry/api': 1.9.0
+      sharp: 0.35.4(@types/node@20.19.27)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+
   next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
@@ -26285,6 +26448,40 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 24.12.4
+
+  sharp@0.35.4(@types/node@20.19.27):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+      '@types/node': 20.19.27
+    optional: true
 
   sharp@0.35.4(@types/node@24.1.0):
     dependencies:


### PR DESCRIPTION
Signed Slack mentions persist a request before HTTP acknowledgement. Feedback joins the shared triage pipeline; each new issue is announced in Slack with its assigned shepherd and website link. Handling starts only after that shepherd approves via a Slack reaction or an authenticated website click. The website checks the assigned GitHub identity and uses a conditional one-shot update.

Pins the website runtime to Next 15.5.25 and patched transitive dependencies before adding authenticated approval routes.

Validation: 97 BAML tests, offline signed-HTTP checks, website approval authorization/CSRF tests, and the production website build. Website runtime dependencies are pinned and checked against the npm advisory API.

Setup: apply the SQL below (idempotent columns previously reported applied). Configure ATB2_SHEPHERDS and ATB2_UI_URL on the runner. Configure FEEDBACK_SITE_URL, FEEDBACK_GITHUB_CLIENT_ID, FEEDBACK_GITHUB_CLIENT_SECRET, FEEDBACK_APPROVAL_SESSION_KEY (64 random hex characters), and FEEDBACK_APPROVAL_SUPABASE_KEY on the website, alongside its existing public store read credentials. Register <FEEDBACK_SITE_URL>/auth/github/callback. Wait for the next approval layer before activating Slack Events.

Stack position 2/7. Base: baml/feedback-5a-runtime.

Apply in the Supabase SQL editor before deploying this layer:

```sql
alter table public.feedback add column if not exists slack_event_id text unique;
alter table public.feedback add column if not exists slack_thread_ts text;
alter table public.babysit_requests add column if not exists slack_event_id text unique;
alter table public.babysit_requests add column if not exists kind text not null default 'babysit';
alter table public.issues add column if not exists slack_ts text;
alter table public.issues add column if not exists slack_channel text;
create unique index if not exists issues_approval_message
  on public.issues (dataset, slack_channel, slack_ts)
  where slack_ts is not null;
```

<details>
<summary>Changed files (31)</summary>

- `tools/atb2/README.md`
- `tools/atb2/baml_src/create_issue.baml`
- `tools/atb2/baml_src/gauge_issue.baml`
- `tools/atb2/baml_src/handle_issue.baml`
- `tools/atb2/baml_src/intake.baml`
- `tools/atb2/baml_src/merge_issue.baml`
- `tools/atb2/baml_src/models.baml`
- `tools/atb2/baml_src/organize_issue.baml`
- `tools/atb2/baml_src/pipeline.baml`
- `tools/atb2/baml_src/slack.baml`
- `tools/atb2/baml_src/store.baml`
- `tools/atb2/deploy/fly.toml`
- `tools/atb2/deploy/test_slack_http.py`
- `typescript2/app-feedback/package.json`
- `typescript2/app-feedback/src/app/auth/github/callback/route.ts`
- `typescript2/app-feedback/src/app/auth/github/route.ts`
- `typescript2/app-feedback/src/app/issues/[id]/approve/route.ts`
- `typescript2/app-feedback/src/app/issues/[id]/page.tsx`
- `typescript2/app-feedback/src/components/issues/activity.tsx`
- `typescript2/app-feedback/src/components/issues/approve-issue.tsx`
- `typescript2/app-feedback/src/components/issues/issue-list.tsx`
- `typescript2/app-feedback/src/components/issues/live-updates.tsx`
- `typescript2/app-feedback/src/components/ui/badge.tsx`
- `typescript2/app-feedback/src/lib/activity.ts`
- `typescript2/app-feedback/src/lib/approval-auth.ts`
- `typescript2/app-feedback/src/lib/db.ts`
- `typescript2/app-feedback/src/lib/issue-approval.ts`
- `typescript2/app-feedback/src/lib/pipeline.ts`
- `typescript2/app-feedback/src/lib/types.ts`
- `typescript2/app-feedback/tests/activity.test.mjs`
- `typescript2/app-feedback/tests/issue-approval.test.mjs`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added issue approval workflows through Slack reactions and the website.
  * Added GitHub sign-in for authorized issue shepherds to approve issues.
  * Added “Awaiting approval” and “Approved” statuses and board filters.
  * Added issue activity history with timestamps and proposed-fix links.
  * Added automatic page refreshes for current issue updates.
  * Slack intake now supports feedback, babysit requests, approval notifications, signed requests, and health monitoring.
  * Added deployment health checks and improved configuration support.
  * Approval controls are now available only for live issues.

* **Bug Fixes**
  * Preserved Slack conversation links as issues progress through the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->