### PR TITLE
Resolve feedback fixes to verified published releases

### DIFF
--- a/tools/atb2/.dockerignore
+++ b/tools/atb2/.dockerignore
@@ -14,3 +14,4 @@
 !deploy/cli-cache-service.py
 !deploy/build-version.py
 !deploy/push-scan.py
+!deploy/reconcile-releases.py

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -379,3 +379,15 @@ immutable executables under `/data/cli-cache/<version>/<revision>/baml-cli`.
 Cache hits never build or fetch. Sandboxes mount this cache read-only.
 PR CI is the build/test gate; fixes do not automatically rebuild the CLI or run
 the full local workspace gate before pushing.
+## Published feedback fixes
+
+The hourly controller indexer backfills merge SHAs from GitHub for merged live
+issues, then checks published stable `baml-language-X.Y.Z` tags and their package
+manifests. It records the first verified containing release in `issues.fixed_in`.
+Nightlies, drafts, unpublished manifests, and unverified ancestry never produce
+update notices. The private Git index and polling lock live on the Fly volume.
+
+Apply the part 6a SQL from its PR description before deployment.
+`feedback_resolutions(report_ids uuid[])` accepts at most 100 full report UUIDs
+and exposes only linked issue IDs, status and fixed version. Its lookup uses
+feedback/issue primary keys; it does not expose reporter identities or contents.

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -341,11 +341,14 @@ loopback store fixture; no model requests or production credentials are used.
    shepherd approve it. Verify fix creation, PR creation, shared babysitter
    activity and eventual manually merged status on both surfaces.
 
-Part 6 is a separate follow-up PR: record the release version containing a fix,
-map stored feedback IDs back to issues, and poll from ordinary CLI commands at
-most daily. Show “Your issue … was fixed in …; update using baml toolchain update”
-until the installed toolchain contains the fix. That notice is not required to
-start babysitting or process feedback end to end, and is not implemented here.
+Part 6a is implemented here: the hourly reconciler records the first verified
+release containing each merged fix, and `feedback_resolutions(report_ids uuid[])`
+maps stored report UUIDs to issue state and fixed version — see “Published
+feedback fixes” below, and apply its part 6a SQL migration before deploying
+this layer. Only the CLI side is a separate follow-up: poll at most daily and
+show “Your issue … was fixed in …; update using baml toolchain update” until the
+installed toolchain contains the fix. That notice is not required to start
+babysitting or process feedback end to end.
 
 ## Slack intake and issue approval
 

--- a/tools/atb2/baml_src/pipeline.baml
+++ b/tools/atb2/baml_src/pipeline.baml
@@ -40,6 +40,11 @@ function run_pipeline(
         s.trim()
     });
     let report = PipelineReport { ingested: 0, issues_created: 0, handled: 0, merged: 0, skipped: [] };
+    //# release resolution: every Live entrypoint reconciles; the indexer
+    // rate-limits itself to one attempt per hour on the volume
+    if (mode == HandleMode.Live && db_configured()) {
+        reconcile_feedback_releases();
+    };
     if (!db_configured()) {
         report.skipped.push(
             "store: FEEDBACK_SUPABASE_URL/KEY unset; nothing is remembered between runs",
@@ -158,9 +163,6 @@ function failed_run(what: string) -> PipelineReport {
 function pipeline_loop(every_s: int = 300, mode: HandleMode = HandleMode.Live) -> null {
     while (true) {
         //# one run; a store, intake or Slack failure ends this run only
-        if (mode == HandleMode.Live && db_configured()) {
-            reconcile_feedback_releases();
-        };
         let r = run_pipeline(mode = mode) catch (e) {
             StoreError => failed_run("store"),
             IntakeError => failed_run("intake"),

--- a/tools/atb2/baml_src/pipeline.baml
+++ b/tools/atb2/baml_src/pipeline.baml
@@ -158,6 +158,9 @@ function failed_run(what: string) -> PipelineReport {
 function pipeline_loop(every_s: int = 300, mode: HandleMode = HandleMode.Live) -> null {
     while (true) {
         //# one run; a store, intake or Slack failure ends this run only
+        if (mode == HandleMode.Live && db_configured()) {
+            reconcile_feedback_releases();
+        };
         let r = run_pipeline(mode = mode) catch (e) {
             StoreError => failed_run("store"),
             IntakeError => failed_run("intake"),
@@ -511,5 +514,27 @@ function announce_approvals() -> null {
             notify("issue_created", i, issue_created_text(i), { "approval": "requested" }.to_json());
         };
     }
+    null
+}
+
+/// Only controller credentials enter the root-owned release indexer, never an agent.
+function reconcile_feedback_releases() -> null {
+    let result = run_with(
+        Cmd {
+            program: "/usr/bin/python3",
+            args: ["-I", "/usr/local/lib/atb2/reconcile-releases.py"],
+            cwd: atb2_home(),
+            timeout_ms: 600000,
+        },
+        {
+            "PATH": "/usr/bin:/bin",
+            "FEEDBACK_SUPABASE_URL": baml.env.get("FEEDBACK_SUPABASE_URL") ?? "",
+            "FEEDBACK_SUPABASE_KEY": baml.env.get("FEEDBACK_SUPABASE_KEY") ?? "",
+            "GH_TOKEN": baml.env.get("GH_TOKEN") ?? baml.env.get("ATB_GITHUB_TOKEN") ?? "",
+        },
+    );
+    if (!result.ok) {
+        log.warn({ "release_resolution": "unavailable; retrying next pass" });
+    };
     null
 }

--- a/tools/atb2/deploy/Dockerfile
+++ b/tools/atb2/deploy/Dockerfile
@@ -58,6 +58,7 @@ WORKDIR /app
 COPY baml.toml ./
 COPY baml_src ./baml_src
 COPY deploy/cache-cli.py deploy/cli-cache-service.py deploy/build-version.py /usr/local/lib/atb2/
+COPY deploy/reconcile-releases.py /usr/local/lib/atb2/
 COPY deploy/sandbox.py deploy/push.py deploy/push-scan.py /usr/local/lib/atb2/
 COPY deploy/entrypoint.sh /usr/local/bin/atb2-entrypoint
 COPY deploy/build-cli.sh /usr/local/bin/atb2-build-cli

--- a/tools/atb2/deploy/reconcile-releases.py
+++ b/tools/atb2/deploy/reconcile-releases.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode, urlsplit
 REPO = 'BoundaryML/baml'
 VERSION = re.compile(r'baml-language-((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\Z')
 SHA = re.compile(r'[0-9a-f]{40}\Z')
+CURSOR = re.compile(r'[A-Za-z0-9_.:-]{1,80}\Z')
 
 
 def request(host, path, token=None, method='GET', body=None, apikey=None):
@@ -101,7 +102,12 @@ class Reconciler:
         return self.manifests[version]
     def run(self):
         releases = None
-        after = ''
+        # The scan resumes from the persisted cursor so a large prefix of
+        # still-unresolved rows cannot starve later merged issues forever.
+        cursor = self.folder/'scan-cursor'
+        try: after = cursor.read_text()
+        except OSError: after = ''
+        if not CURSOR.fullmatch(after): after = ''
         for _ in range(100):
             query = {'select':'id,status,merge_sha,merged_at','dataset':'eq.live','state':'eq.merged',
                      'fixed_in':'is.null','order':'id','limit':'100'}
@@ -127,8 +133,13 @@ class Reconciler:
                         self.store(urlencode({'id':'eq.'+row['id'],'dataset':'eq.live','state':'eq.merged','fixed_in':'is.null','merge_sha':'eq.'+sha}),{'fixed_in':version})
                 except (ValueError, OSError, subprocess.SubprocessError, KeyError):
                     print('atb2: one release resolution could not be verified; will retry',flush=True)
-            if len(rows) < 100: return
-        raise ValueError('issue pagination incomplete')
+            if len(rows) < 100:
+                # A completed scan restarts from the top next hour, retrying
+                # every row that is still unresolved.
+                cursor.write_text('')
+                return
+            cursor.write_text(after)
+        print('atb2: issue scan window exhausted; next run resumes from the saved cursor',flush=True)
 
 
 def main():

--- a/tools/atb2/deploy/reconcile-releases.py
+++ b/tools/atb2/deploy/reconcile-releases.py
@@ -119,7 +119,9 @@ class Reconciler:
                     sha, merged_at = row.get('merge_sha'), row.get('merged_at')
                     # Backfill pre-feature merged issues from the PR API itself.
                     if not sha:
-                        match = re.fullmatch(r'https://github.com/BoundaryML/baml/pull/([1-9][0-9]{0,9})',row['status'].get('pr',''))
+                        status = row.get('status')
+                        match = re.fullmatch(r'https://github.com/BoundaryML/baml/pull/([1-9][0-9]{0,9})',
+                                             status.get('pr','') if isinstance(status,dict) else '')
                         if not match: continue
                         pr = self.api(f'/repos/{REPO}/pulls/{match[1]}')
                         sha, merged_at = pr.get('merge_commit_sha'), pr.get('merged_at')
@@ -131,7 +133,7 @@ class Reconciler:
                     version = first_fixed_version(sha,merged_at,releases,self.contains,self.manifest)
                     if version:
                         self.store(urlencode({'id':'eq.'+row['id'],'dataset':'eq.live','state':'eq.merged','fixed_in':'is.null','merge_sha':'eq.'+sha}),{'fixed_in':version})
-                except (ValueError, OSError, subprocess.SubprocessError, KeyError):
+                except (ValueError, OSError, subprocess.SubprocessError, KeyError, AttributeError, TypeError):
                     print('atb2: one release resolution could not be verified; will retry',flush=True)
             if len(rows) < 100:
                 # A completed scan restarts from the top next hour, retrying

--- a/tools/atb2/deploy/reconcile-releases.py
+++ b/tools/atb2/deploy/reconcile-releases.py
@@ -1,0 +1,149 @@
+"""Resolve merged feedback issues to published stable toolchains, once per hour.
+
+Only controller code runs here. The Git index is private and contains no agent
+checkout/configuration. A published GitHub tag AND immutable package manifest
+are required before a version is advertised to reporters.
+"""
+import fcntl
+import http.client
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+from urllib.parse import urlencode, urlsplit
+
+REPO = 'BoundaryML/baml'
+VERSION = re.compile(r'baml-language-((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\Z')
+SHA = re.compile(r'[0-9a-f]{40}\Z')
+
+
+def request(host, path, token=None, method='GET', body=None, apikey=None):
+    headers = {'Accept': 'application/json', 'User-Agent': 'atb2-release-index'}
+    if token: headers['Authorization'] = 'Bearer ' + token
+    if apikey: headers['apikey'] = apikey
+    if body is not None:
+        body = json.dumps(body); headers['Content-Type'] = 'application/json'
+        headers['Prefer'] = 'return=representation'
+    conn = http.client.HTTPSConnection(host, timeout=15)
+    try:
+        conn.request(method, path, body, headers)
+        response = conn.getresponse()
+        raw = response.read(4_000_001)
+        if not 200 <= response.status < 300 or len(raw) > 4_000_000:
+            raise ValueError('release/store request failed')
+        return json.loads(raw) if raw else None
+    finally: conn.close()
+
+
+def published_releases(api):
+    releases = []
+    for page in range(1, 101):
+        rows = api(f'/repos/{REPO}/releases?per_page=100&page={page}')
+        for row in rows:
+            match = VERSION.fullmatch(row.get('tag_name', ''))
+            if match and not row.get('draft') and not row.get('prerelease') and row.get('published_at'):
+                releases.append((row['published_at'], match[1], row['tag_name']))
+        if len(rows) < 100: return sorted(releases)
+    raise ValueError('release catalog incomplete')
+
+
+def first_fixed_version(merge_sha, merged_at, releases, contains, manifest):
+    for published_at, version, tag in releases:
+        if merged_at and published_at < merged_at: continue
+        if not contains(tag, merge_sha): continue
+        data = manifest(version)
+        if data.get('version') == version and data.get('channel') == 'canary' and data.get('artifacts'):
+            return version
+        # Never substitute a newer release when the earliest containing release
+        # cannot be verified. A later hourly run retries publication failures.
+        raise ValueError('release manifest could not be verified')
+    return None
+
+
+class Reconciler:
+    def __init__(self, folder):
+        url = urlsplit(os.environ['FEEDBACK_SUPABASE_URL'])
+        if url.scheme != 'https' or not url.hostname or url.username or url.password or url.path not in ('','/') or url.query or url.fragment or url.port:
+            raise ValueError('invalid store origin')
+        self.host = url.hostname
+        self.key = os.environ['FEEDBACK_SUPABASE_KEY']
+        self.token = os.environ.get('GH_TOKEN') or os.environ.get('ATB_GITHUB_TOKEN')
+        self.folder = folder
+        self.env = {'PATH':'/usr/bin:/bin', 'HOME':str(folder), 'GIT_CONFIG_GLOBAL':'/dev/null',
+                    'GIT_CONFIG_SYSTEM':'/dev/null','GIT_CONFIG_NOSYSTEM':'1','GIT_TERMINAL_PROMPT':'0'}
+        self.tags = {}
+        self.manifests = {}
+        if not (folder/'index.git').exists(): self.git('init','--bare','index.git')
+    def git(self, *args):
+        return subprocess.run(['/usr/bin/git',*args],cwd=self.folder,env=self.env,
+                              stdout=subprocess.PIPE,stderr=subprocess.PIPE,timeout=120,check=True).stdout.decode().strip()
+    def api(self, path): return request('api.github.com',path,self.token)
+    def store(self, query, patch=None):
+        return request(self.host,'/rest/v1/issues?'+query,self.key,'PATCH' if patch is not None else 'GET',patch,self.key)
+    def contains(self, tag, sha):
+        if tag not in self.tags:
+            self.git('--git-dir=index.git','-c','core.hooksPath=/dev/null','fetch','--no-tags',
+                     f'https://github.com/{REPO}.git','refs/tags/'+tag)
+            self.tags[tag] = self.git('--git-dir=index.git','rev-parse','FETCH_HEAD^{commit}')
+        result = subprocess.run(['/usr/bin/git','--git-dir=index.git','merge-base','--is-ancestor',sha,self.tags[tag]],
+                                cwd=self.folder,env=self.env,stdout=subprocess.PIPE,stderr=subprocess.PIPE,timeout=30)
+        # Missing commit means it cannot be in this fetched release's history.
+        if result.returncode == 128:
+            try: self.git('--git-dir=index.git','cat-file','-e',sha+'^{commit}')
+            except subprocess.CalledProcessError: return False
+        if result.returncode not in (0,1): raise ValueError('ancestry verification failed')
+        return result.returncode == 0
+    def manifest(self, version):
+        if version not in self.manifests:
+            self.manifests[version] = request('pkg.boundaryml.com',f'/manifest/v1/version/{version}.json')
+        return self.manifests[version]
+    def run(self):
+        releases = None
+        after = ''
+        for _ in range(100):
+            query = {'select':'id,status,merge_sha,merged_at','dataset':'eq.live','state':'eq.merged',
+                     'fixed_in':'is.null','order':'id','limit':'100'}
+            if after: query['id'] = 'gt.' + after
+            rows = self.store(urlencode(query))
+            for row in rows:
+                after = row['id']
+                try:
+                    sha, merged_at = row.get('merge_sha'), row.get('merged_at')
+                    # Backfill pre-feature merged issues from the PR API itself.
+                    if not sha:
+                        match = re.fullmatch(r'https://github.com/BoundaryML/baml/pull/([1-9][0-9]{0,9})',row['status'].get('pr',''))
+                        if not match: continue
+                        pr = self.api(f'/repos/{REPO}/pulls/{match[1]}')
+                        sha, merged_at = pr.get('merge_commit_sha'), pr.get('merged_at')
+                        if not pr.get('merged') or not merged_at or not SHA.fullmatch(sha or ''): continue
+                        self.store(urlencode({'id':'eq.'+row['id'],'dataset':'eq.live','state':'eq.merged'}),
+                                   {'merge_sha':sha,'merged_at':merged_at})
+                    if not SHA.fullmatch(sha or ''): continue
+                    if releases is None: releases = published_releases(self.api)
+                    version = first_fixed_version(sha,merged_at,releases,self.contains,self.manifest)
+                    if version:
+                        self.store(urlencode({'id':'eq.'+row['id'],'dataset':'eq.live','state':'eq.merged','fixed_in':'is.null','merge_sha':'eq.'+sha}),{'fixed_in':version})
+                except (ValueError, OSError, subprocess.SubprocessError, KeyError):
+                    print('atb2: one release resolution could not be verified; will retry',flush=True)
+            if len(rows) < 100: return
+        raise ValueError('issue pagination incomplete')
+
+
+def main():
+    folder = Path('/data/release-index')
+    folder.mkdir(mode=0o700,exist_ok=True)
+    with (folder/'poll.lock').open('a+') as lock:
+        try: fcntl.flock(lock,fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError: return
+        marker = folder/'last-poll'
+        if marker.exists() and time.time() - marker.stat().st_mtime < 3600: return
+        Reconciler(folder).run()
+        marker.touch(mode=0o600)
+
+if __name__ == '__main__':
+    try: main()
+    except Exception:
+        print('atb2: release resolution unavailable; no unverified versions recorded',flush=True)
+        raise SystemExit(1)

--- a/tools/atb2/deploy/test_releases.py
+++ b/tools/atb2/deploy/test_releases.py
@@ -26,8 +26,8 @@ def scan_reconciler(folder, rows, contained_sha):
     return rec
 
 
-def merged_row(id, sha):
-    return {'id':id,'status':{},'merge_sha':sha,'merged_at':'2026-09-01T00:00:00Z','fixed_in':None}
+def merged_row(id, sha, status={}):
+    return {'id':id,'status':status,'merge_sha':sha,'merged_at':'2026-09-01T00:00:00Z','fixed_in':None}
 class ReleaseTests(unittest.TestCase):
     def test_catalog_excludes_drafts_nightlies_and_other_products(self):
         rows=[{'tag_name':tag,'draft':draft,'prerelease':pre,'published_at':'2026-09-06T00:00:00Z'} for tag,draft,pre in [
@@ -57,6 +57,19 @@ class ReleaseTests(unittest.TestCase):
             rec.run()
             self.assertEqual(rows[10_000]['fixed_in'],'0.19.0')
             self.assertEqual(rows[10_049]['fixed_in'],'0.19.0')
+            self.assertEqual((folder/'scan-cursor').read_text(),'')
+    def test_malformed_status_rows_cannot_abort_the_scan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            folder = Path(tmp)
+            # A null and a non-object status (both possible in the store) must be
+            # skipped, not abort the run and re-poison every later hourly scan.
+            rows = [merged_row('I-00000',None,status=None),
+                    merged_row('I-00001',None,status='merged'),
+                    merged_row('I-00002','b'*40)]
+            scan_reconciler(folder,rows,'b'*40).run()
+            self.assertIsNone(rows[0]['fixed_in'])
+            self.assertIsNone(rows[1]['fixed_in'])
+            self.assertEqual(rows[2]['fixed_in'],'0.19.0')
             self.assertEqual((folder/'scan-cursor').read_text(),'')
     def test_corrupt_cursor_falls_back_to_a_full_rescan(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/atb2/deploy/test_releases.py
+++ b/tools/atb2/deploy/test_releases.py
@@ -1,0 +1,24 @@
+"""Release identity and containment must be verified, not inferred at merge."""
+import importlib.util
+from pathlib import Path
+import unittest
+spec = importlib.util.spec_from_file_location('releases',Path(__file__).with_name('reconcile-releases.py'))
+r=importlib.util.module_from_spec(spec);spec.loader.exec_module(r)
+class ReleaseTests(unittest.TestCase):
+    def test_catalog_excludes_drafts_nightlies_and_other_products(self):
+        rows=[{'tag_name':tag,'draft':draft,'prerelease':pre,'published_at':'2026-09-06T00:00:00Z'} for tag,draft,pre in [
+            ('baml-language-0.18.0',False,False),('baml-language-0.19.0-nightly.20260906',False,True),
+            ('baml-language-0.19.0',True,False),('0.226.0',False,False)]]
+        self.assertEqual(r.published_releases(lambda _:rows),[('2026-09-06T00:00:00Z','0.18.0','baml-language-0.18.0')])
+    def test_first_containing_published_version_is_selected(self):
+        releases=[('2026-09-01','0.18.0','old'),('2026-09-03','0.19.0','first'),('2026-09-04','0.20.0','later')]
+        self.assertEqual(r.first_fixed_version('a'*40,'2026-09-02',releases,lambda tag,sha:tag!='old',
+            lambda v:{'version':v,'channel':'canary','artifacts':{'fixture':{}}}),'0.19.0')
+    def test_merge_without_published_containing_release_is_not_fixed(self):
+        self.assertIsNone(r.first_fixed_version('a'*40,'2026-09-02',[('2026-09-03','0.19.0','tag')],lambda *args:False,lambda _:self.fail('must not load unrelated manifest')))
+    def test_missing_manifest_never_substitutes_a_later_version(self):
+        with self.assertRaises(ValueError):
+            r.first_fixed_version('a'*40,None,[('2026-09-03','0.19.0','tag')],lambda *args:True,lambda _:{})
+    def test_partial_release_catalog_fails_closed(self):
+        with self.assertRaises(ValueError): r.published_releases(lambda _:[{}]*100)
+if __name__=='__main__': unittest.main()

--- a/tools/atb2/deploy/test_releases.py
+++ b/tools/atb2/deploy/test_releases.py
@@ -1,9 +1,33 @@
 """Release identity and containment must be verified, not inferred at merge."""
 import importlib.util
 from pathlib import Path
+import tempfile
 import unittest
+from urllib.parse import parse_qsl
 spec = importlib.util.spec_from_file_location('releases',Path(__file__).with_name('reconcile-releases.py'))
 r=importlib.util.module_from_spec(spec);spec.loader.exec_module(r)
+
+
+def scan_reconciler(folder, rows, contained_sha):
+    """A Reconciler over an in-memory issues table, one verified release, and ancestry by SHA."""
+    rec = r.Reconciler.__new__(r.Reconciler)
+    rec.folder = folder
+    def store(query, patch=None):
+        q = dict(parse_qsl(query))
+        if patch is not None:
+            for row in rows:
+                if row['id'] == q['id'][3:]: row['fixed_in'] = patch['fixed_in']
+            return []
+        return [row for row in rows if row['fixed_in'] is None and row['id'] > q.get('id','gt.')[3:]][:100]
+    rec.store = store
+    rec.api = lambda _:[{'tag_name':'baml-language-0.19.0','draft':False,'prerelease':False,'published_at':'2026-09-05T00:00:00Z'}]
+    rec.contains = lambda tag,sha: sha == contained_sha
+    rec.manifest = lambda v:{'version':v,'channel':'canary','artifacts':{'fixture':{}}}
+    return rec
+
+
+def merged_row(id, sha):
+    return {'id':id,'status':{},'merge_sha':sha,'merged_at':'2026-09-01T00:00:00Z','fixed_in':None}
 class ReleaseTests(unittest.TestCase):
     def test_catalog_excludes_drafts_nightlies_and_other_products(self):
         rows=[{'tag_name':tag,'draft':draft,'prerelease':pre,'published_at':'2026-09-06T00:00:00Z'} for tag,draft,pre in [
@@ -21,4 +45,25 @@ class ReleaseTests(unittest.TestCase):
             r.first_fixed_version('a'*40,None,[('2026-09-03','0.19.0','tag')],lambda *args:True,lambda _:{})
     def test_partial_release_catalog_fails_closed(self):
         with self.assertRaises(ValueError): r.published_releases(lambda _:[{}]*100)
+    def test_unresolved_prefix_cannot_starve_later_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            folder = Path(tmp)
+            # 10,050 merged rows; the first 10,000 stay unresolved (not in any release).
+            rows = [merged_row(f'I-{i:05d}',('a' if i < 10_000 else 'b')*40) for i in range(10_050)]
+            rec = scan_reconciler(folder,rows,'b'*40)
+            rec.run()
+            self.assertIsNone(rows[10_000]['fixed_in'])
+            self.assertEqual((folder/'scan-cursor').read_text(),'I-09999')
+            rec.run()
+            self.assertEqual(rows[10_000]['fixed_in'],'0.19.0')
+            self.assertEqual(rows[10_049]['fixed_in'],'0.19.0')
+            self.assertEqual((folder/'scan-cursor').read_text(),'')
+    def test_corrupt_cursor_falls_back_to_a_full_rescan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            folder = Path(tmp)
+            (folder/'scan-cursor').write_text('../evil cursor\n')
+            rows = [merged_row('I-00000','b'*40)]
+            scan_reconciler(folder,rows,'b'*40).run()
+            self.assertEqual(rows[0]['fixed_in'],'0.19.0')
+            self.assertEqual((folder/'scan-cursor').read_text(),'')
 if __name__=='__main__': unittest.main()


### PR DESCRIPTION
The controller indexes merged live issues hourly, backfills their merge SHA from the GitHub PR API, and finds the first published stable release whose Git history contains the merge. It verifies the published package manifest before setting fixed_in; merging alone cannot trigger a release notice. Nightlies and unverified manifests do not qualify.

A bounded feedback_resolutions(report_ids uuid[]) RPC maps up to 100 full report UUIDs through indexed feedback/issue IDs and returns only issue IDs, state and fixed version. It exposes neither reporter identity nor feedback contents.

Validation: 97 BAML tests, 5 release-index tests, runner image build, and isolated PostgreSQL checks for live-only resolution, multiple linked issues, anonymous RPC access and the 100-ID limit.

Setup: apply the SQL below before deploying this layer. The existing controller GitHub token and service-role store key are used; no extra credential is passed to agents. Old merged issues are backfilled when the indexer next runs.

Stack position 4/7. Base: baml/feedback-5c-babysit.

Apply in the Supabase SQL editor before deploying this layer:

```sql
begin;
alter table public.issues add column if not exists merge_sha text;
alter table public.issues add column if not exists merged_at timestamptz;
alter table public.issues add column if not exists fixed_in text;
create index if not exists issues_unreleased on public.issues (dataset,id)
  where state='merged' and fixed_in is null;
create or replace function public.feedback_resolutions(report_ids uuid[])
returns table(report_id uuid, issue_id text, state text, fixed_in text)
language plpgsql stable security definer set search_path = ''
set statement_timeout = '2s'
as $$
begin
  if coalesce(cardinality(report_ids),0) > 100 then
    raise exception 'at most 100 report IDs';
  end if;
  return query
  select r.id, i.id, i.state, case when i.state='merged' then i.fixed_in else null end
  from (select distinct unnest(report_ids) as id) r
  join public.feedback f on f.id='PH-' || r.id::text and f.dataset='live'
  left join lateral jsonb_array_elements_text(to_jsonb(f.issue_ids)) linked(id) on true
  left join public.issues i on i.id=linked.id and i.dataset='live';
end;
$$;
revoke all on function public.feedback_resolutions(uuid[]) from public;
grant execute on function public.feedback_resolutions(uuid[]) to anon, authenticated, service_role;
commit;
```

<details>
<summary>Changed files (6)</summary>

- `tools/atb2/.dockerignore`
- `tools/atb2/README.md`
- `tools/atb2/baml_src/pipeline.baml`
- `tools/atb2/deploy/Dockerfile`
- `tools/atb2/deploy/reconcile-releases.py`
- `tools/atb2/deploy/test_releases.py`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic hourly reconciliation of merged feedback issues with published stable toolchain releases.
  * Feedback records can now show the first verified version containing their fix.
  * Added approval-aware feedback triage and notifications when approved fixes begin processing.
  * Added safeguards to validate release ancestry and package manifests before recording fix versions.
  * Reconciliation continues safely when release information is temporarily unavailable.

* **Documentation**
  * Documented feedback release reconciliation and resolution-query limitations.

* **Tests**
  * Added coverage for release filtering, commit matching, manifest validation, and incomplete release data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->