### PR TITLE
Show cached feedback resolutions and shipped-fix update notices in the CLI

### DIFF
--- a/.github/workflows/build2-toolchain.reusable.yaml
+++ b/.github/workflows/build2-toolchain.reusable.yaml
@@ -28,6 +28,8 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  BAML_FEEDBACK_SUPABASE_URL: ${{ vars.BAML_FEEDBACK_SUPABASE_URL }}
+  BAML_FEEDBACK_PUBLISHABLE_KEY: ${{ vars.BAML_FEEDBACK_PUBLISHABLE_KEY }}
   BAML_WORKOS_CLIENT_ID: ${{ vars.BAML_WORKOS_CLIENT_ID }}
 
 jobs:
@@ -42,18 +44,18 @@ jobs:
       matrix:
         include: ${{ fromJson(inputs.toolchain_matrix_json) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.source_sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release-plan
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: baml-vscode-vsix
           path: vsix
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: baml-playground-dist
           path: playground-dist
@@ -89,7 +91,7 @@ jobs:
         run: |
           set -euo pipefail
           cross_config="$RUNNER_TEMP/baml-toolchain-cross.toml"
-          passthrough='"BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID"'
+          passthrough='"BAML_GIT_SHA", "BAML_WORKOS_CLIENT_ID", "BAML_FEEDBACK_SUPABASE_URL", "BAML_FEEDBACK_PUBLISHABLE_KEY"'
           if [[ "$TARGET" == "x86_64-unknown-linux-gnu" ]]; then
             # The glibc-2.17 image's target GCC is 4.8 and cannot compile
             # mimalloc v3's warning flags. Its host GCC is current; point that
@@ -140,7 +142,7 @@ jobs:
           else
             tar -C staging -czf "baml-language-$VERSION-$TARGET.tar.gz" .
           fi
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: toolchain-${{ matrix.target }}
           path: baml-language-${{ inputs.version }}-${{ matrix.target }}.*

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -355,6 +355,9 @@ impl RuntimeCli {
 
         if self.command.requires_agent_skill() {
             crate::skill_check::check(self.command.agent_skill_project_path())?;
+            if self.global.quiet == 0 {
+                crate::feedback_command::poll_resolutions();
+            }
         }
 
         // Fire anonymous, best-effort telemetry for this invocation. The

--- a/baml_language/crates/baml_cli/src/feedback_command.rs
+++ b/baml_language/crates/baml_cli/src/feedback_command.rs
@@ -12,8 +12,8 @@
 // backfill job; the merge *is* the backfill.
 //
 // Every report is also recorded in `<BAML_HOME>/feedback.json`, which is
-// what `status`/`list`/`view` read: the embedded PostHog key is write-only,
-// so past reports cannot be queried back from the server. Records start as
+// read by `status`/`list`/`view`, with a separate bounded Supabase resolution
+// cache for linked issues and published fixes. Delivery records start as
 // `open` and flip to `anonymous`/`reported` once delivered, so an offline
 // send is saved locally and synced on a later run instead of failing.
 
@@ -219,6 +219,39 @@ impl FeedbackInner {
             sync_open_reports(&mut store);
         }
 
+        if store.enabled
+            && matches!(
+                self.action,
+                Some(FeedbackAction::Status)
+                    | Some(FeedbackAction::List { .. })
+                    | Some(FeedbackAction::View { .. })
+            )
+        {
+            let _ = crate::feedback_resolution::refresh(
+                &store
+                    .reports
+                    .iter()
+                    .filter(|r| r.status != ReportStatus::Open)
+                    .map(|r| r.event_uuid)
+                    .collect::<Vec<_>>(),
+                true,
+                false,
+                baml_version::CANONICAL_VERSION,
+            );
+        }
+        let cached = crate::feedback_resolution::load();
+        for report in &mut store.reports {
+            report.issues = cached
+                .reports
+                .get(&report.event_uuid)
+                .cloned()
+                .unwrap_or_default();
+            report.resolution = crate::feedback_resolution::resolution(
+                &report.issues,
+                baml_version::CANONICAL_VERSION,
+            )
+            .into();
+        }
         match &self.action {
             Some(FeedbackAction::Status) => return run_status(&store),
             Some(FeedbackAction::List {
@@ -548,6 +581,11 @@ struct FeedbackRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     status: ReportStatus,
+    /// Resolution is a cache overlay, independent of delivery/anonymity.
+    #[serde(default, skip_deserializing)]
+    issues: Vec<crate::feedback_resolution::IssueResolution>,
+    #[serde(default, skip_deserializing)]
+    resolution: String,
     /// The user explicitly asked for anonymity (`--anonymous`). A deferred
     /// delivery must honor it even if a login exists by sync time.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -627,6 +665,8 @@ impl FeedbackRecord {
                 .and_then(Value::as_str)
                 .map(str::to_string),
             status: ReportStatus::Open,
+            issues: Vec::new(),
+            resolution: "triaging".into(),
             forced_anonymous,
             email: if identified {
                 email.map(str::to_string)
@@ -766,7 +806,13 @@ fn run_status(store: &FeedbackStore) -> Result<crate::ExitCode> {
     } else {
         println!("Reports:");
         for r in &store.reports {
-            println!("  [{}] {}: {}", r.status, r.id, r.title);
+            println!(
+                "  [{}; {}] {}: {}",
+                r.status,
+                resolution_text(r),
+                r.id,
+                r.title
+            );
         }
     }
     Ok(crate::ExitCode::Success)
@@ -795,7 +841,14 @@ fn run_list(
         return Ok(crate::ExitCode::Success);
     }
     for r in matching {
-        println!("{}\t{}\t{}\t{}", r.id, r.status, r.created_at, r.title);
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            r.id,
+            r.status,
+            r.created_at,
+            r.title,
+            resolution_text(r)
+        );
     }
     Ok(crate::ExitCode::Success)
 }
@@ -823,6 +876,7 @@ fn run_view(store: &FeedbackStore, id: &str, json: bool) -> Result<crate::ExitCo
         println!("Files:       {}", listed.join(", "));
     }
     println!("Status:      {}", r.status);
+    println!("Resolution:  {}", resolution_text(r));
     if let Some(email) = &r.email {
         println!("Email:       {email}");
     }
@@ -1056,4 +1110,41 @@ mod tests {
         assert!(err.contains("unknown feedback field"), "{err}");
         assert!(err.contains("issue"), "{err}");
     }
+}
+
+fn resolution_text(report: &FeedbackRecord) -> String {
+    let details = report
+        .issues
+        .iter()
+        .map(|i| match &i.fixed_in {
+            Some(v) => format!("{} fixed in {}", i.issue_id, v),
+            None => format!("{} {}", i.issue_id, i.state),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    if details.is_empty() {
+        report.resolution.clone()
+    } else {
+        format!("{}: {}", report.resolution, details)
+    }
+}
+
+pub(crate) fn poll_resolutions() {
+    use std::io::IsTerminal as _;
+    if !std::io::stderr().is_terminal() || !std::io::stdout().is_terminal() {
+        return;
+    }
+    let Ok(store) = FeedbackStore::load() else {
+        return;
+    };
+    if !store.enabled {
+        return;
+    }
+    let ids = store
+        .reports
+        .iter()
+        .filter(|r| r.status != ReportStatus::Open)
+        .map(|r| r.event_uuid)
+        .collect::<Vec<_>>();
+    let _ = crate::feedback_resolution::refresh(&ids, false, true, baml_version::CANONICAL_VERSION);
 }

--- a/baml_language/crates/baml_cli/src/feedback_resolution.rs
+++ b/baml_language/crates/baml_cli/src/feedback_resolution.rs
@@ -120,6 +120,9 @@ fn apply(cache: &mut Cache, ids: &[Uuid], rows: Vec<Row>) -> Result<()> {
                 "merged",
                 "closed",
                 "wont_fix",
+                "rejected",
+                "deferred",
+                "shipped",
                 "duplicate",
             ]
             .contains(&state.as_str())
@@ -310,5 +313,24 @@ mod tests {
         apply(&mut cache, &[a], vec![]).unwrap();
         assert!(cache.reports[&a].is_empty());
         assert_eq!(cache.reports[&b].len(), 1);
+    }
+    #[test]
+    fn terminal_and_deferred_issues_do_not_block_other_reports() {
+        let id = Uuid::new_v4();
+        let mut cache = Cache::default();
+        for state in ["rejected", "deferred", "shipped"] {
+            apply(
+                &mut cache,
+                &[id],
+                vec![Row {
+                    report_id: id,
+                    issue_id: Some("i1".into()),
+                    state: Some(state.into()),
+                    fixed_in: None,
+                }],
+            )
+            .unwrap();
+            assert_eq!(cache.reports[&id][0].state, state);
+        }
     }
 }

--- a/baml_language/crates/baml_cli/src/feedback_resolution.rs
+++ b/baml_language/crates/baml_cli/src/feedback_resolution.rs
@@ -1,0 +1,314 @@
+//! Bounded, anonymous resolution lookups. Delivery records are never rewritten.
+use std::{
+    collections::BTreeMap,
+    fs::OpenOptions,
+    io::Read,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const DAY: u64 = 86400;
+const BATCH: usize = 100;
+const URL: &str = match option_env!("BAML_FEEDBACK_SUPABASE_URL") {
+    Some(value) => value,
+    None => "https://igraichzcidsylvzkjlc.supabase.co",
+};
+// Public publishable key only. No runtime service-role environment fallback.
+const KEY: Option<&str> = option_env!("BAML_FEEDBACK_PUBLISHABLE_KEY");
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct IssueResolution {
+    pub issue_id: String,
+    pub state: String,
+    pub fixed_in: Option<String>,
+}
+#[derive(Default, Deserialize, Serialize)]
+#[serde(default)]
+pub(crate) struct Cache {
+    last_attempt: u64,
+    last_notice: u64,
+    next: usize,
+    pub reports: BTreeMap<Uuid, Vec<IssueResolution>>,
+}
+#[derive(Deserialize)]
+struct Row {
+    report_id: Uuid,
+    issue_id: Option<String>,
+    state: Option<String>,
+    fixed_in: Option<String>,
+}
+
+pub(crate) fn stable_version(value: &str) -> Option<(u64, u64, u64)> {
+    let parts: Vec<_> = value.split('.').collect();
+    if parts.len() != 3
+        || parts.iter().any(|p| {
+            p.is_empty()
+                || !p.bytes().all(|b| b.is_ascii_digit())
+                || (p.len() > 1 && p.starts_with('0'))
+        })
+    {
+        return None;
+    }
+    Some((
+        parts[0].parse().ok()?,
+        parts[1].parse().ok()?,
+        parts[2].parse().ok()?,
+    ))
+}
+
+pub(crate) fn resolution(issues: &[IssueResolution], installed: &str) -> &'static str {
+    if issues.is_empty() {
+        return "triaging";
+    }
+    let all_fixed = issues
+        .iter()
+        .all(|i| i.state == "merged" && i.fixed_in.as_deref().and_then(stable_version).is_some());
+    if !all_fixed {
+        return "in_progress";
+    }
+    if stable_version(installed).is_some_and(|current| {
+        issues.iter().all(|i| {
+            i.fixed_in
+                .as_deref()
+                .and_then(stable_version)
+                .is_some_and(|fixed| current >= fixed)
+        })
+    }) {
+        "resolved"
+    } else {
+        "fixed"
+    }
+}
+
+fn cache_path() -> std::path::PathBuf {
+    baml_release::baml_home().join("feedback-resolutions.json")
+}
+pub(crate) fn load() -> Cache {
+    std::fs::read(cache_path())
+        .ok()
+        .and_then(|data| serde_json::from_slice(&data).ok())
+        .unwrap_or_default()
+}
+fn save(cache: &Cache) -> Result<()> {
+    let path = cache_path();
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    crate::auth::write_owner_only(&tmp, &serde_json::to_string(cache)?)?;
+    // All writers hold the separate lock; readers see either complete version.
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+fn apply(cache: &mut Cache, ids: &[Uuid], rows: Vec<Row>) -> Result<()> {
+    let mut updates: BTreeMap<Uuid, Vec<IssueResolution>> =
+        ids.iter().map(|id| (*id, Vec::new())).collect();
+    for row in rows {
+        let Some(issues) = updates.get_mut(&row.report_id) else {
+            anyhow::bail!("unexpected report ID");
+        };
+        if let Some(id) = row.issue_id {
+            if id.len() > 100 || !id.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'-') {
+                anyhow::bail!("invalid issue ID");
+            }
+            let state = row.state.unwrap_or_default();
+            if ![
+                "open",
+                "awaiting_approval",
+                "approved",
+                "in_progress",
+                "merged",
+                "closed",
+                "wont_fix",
+                "duplicate",
+            ]
+            .contains(&state.as_str())
+            {
+                anyhow::bail!("unknown issue state");
+            }
+            if row
+                .fixed_in
+                .as_deref()
+                .is_some_and(|v| stable_version(v).is_none())
+            {
+                anyhow::bail!("invalid release version");
+            }
+            if !issues.iter().any(|i| i.issue_id == id) {
+                issues.push(IssueResolution {
+                    issue_id: id,
+                    state,
+                    fixed_in: row.fixed_in,
+                });
+            }
+        }
+    }
+    cache.reports.extend(updates);
+    Ok(())
+}
+
+/// At most 1.5 seconds total, including all batches; a later poll resumes at the
+/// next batch. Missing configuration and network errors preserve cached results.
+pub(crate) fn refresh(ids: &[Uuid], force: bool, notice: bool, installed: &str) -> Result<()> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let path = cache_path();
+    std::fs::create_dir_all(path.parent().expect("cache parent"))?;
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path.with_extension("lock"))?;
+    if lock.try_lock().is_err() {
+        return Ok(());
+    }
+    let mut cache = load();
+    let now = crate::auth::now_unix();
+    if force || now.saturating_sub(cache.last_attempt) >= DAY {
+        cache.last_attempt = now;
+        if let Some(key) = KEY.filter(|k| k.starts_with("sb_publishable_") && k.len() < 256) {
+            let base = reqwest::Url::parse(URL)?;
+            anyhow::ensure!(
+                base.scheme() == "https"
+                    && base.username().is_empty()
+                    && base.password().is_none()
+                    && base.path() == "/"
+                    && base.query().is_none()
+                    && base.fragment().is_none(),
+                "invalid status origin"
+            );
+            let client = reqwest::blocking::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?;
+            let started = Instant::now();
+            let budget = Duration::from_millis(1500);
+            let start = cache.next % ids.len();
+            let ordered: Vec<_> = ids[start..]
+                .iter()
+                .chain(ids[..start].iter())
+                .copied()
+                .collect();
+            for batch in ordered.chunks(BATCH) {
+                let Some(left) = budget.checked_sub(started.elapsed()) else {
+                    break;
+                };
+                let result = (|| -> Result<Vec<Row>> {
+                    let response = client
+                        .post(base.join("rest/v1/rpc/feedback_resolutions")?)
+                        .header("apikey", key)
+                        .json(&serde_json::json!({"report_ids":batch}))
+                        .timeout(left)
+                        .send()?
+                        .error_for_status()?;
+                    let mut bytes = Vec::new();
+                    response.take(1_000_001).read_to_end(&mut bytes)?;
+                    anyhow::ensure!(bytes.len() <= 1_000_000, "oversized resolution response");
+                    Ok(serde_json::from_slice(&bytes)?)
+                })();
+                match result {
+                    Ok(rows) => {
+                        if apply(&mut cache, batch, rows).is_err() {
+                            break;
+                        }
+                        cache.next = (cache.next + batch.len()) % ids.len();
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+    cache.reports.retain(|id, _| ids.contains(id));
+    let mut messages = Vec::new();
+    if notice && now.saturating_sub(cache.last_notice) >= DAY {
+        for (id, issues) in &cache.reports {
+            for issue in issues {
+                if issue.state == "merged"
+                    && let Some(version) = &issue.fixed_in
+                    && let Some(fixed) = stable_version(version)
+                    && stable_version(installed).is_none_or(|current| current < fixed)
+                {
+                    messages.push(format!("Your feedback {} (issue {}) was fixed in BAML {}. Update using baml toolchain update.", &id.to_string()[..8], issue.issue_id, version));
+                }
+            }
+        }
+        if !messages.is_empty() {
+            cache.last_notice = now;
+        }
+    }
+    save(&cache)?;
+    for message in messages {
+        crate::reporter::print_warning(message);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn issue(id: &str, state: &str, fixed: Option<&str>) -> IssueResolution {
+        IssueResolution {
+            issue_id: id.into(),
+            state: state.into(),
+            fixed_in: fixed.map(str::to_owned),
+        }
+    }
+    #[test]
+    fn resolution_requires_every_linked_issue_and_suppresses_after_upgrade() {
+        let fixed = issue("i1", "merged", Some("0.19.0"));
+        assert_eq!(resolution(&[], "0.18.0"), "triaging");
+        assert_eq!(
+            resolution(&[fixed.clone(), issue("i2", "approved", None)], "0.18.0"),
+            "in_progress"
+        );
+        assert_eq!(resolution(&[fixed.clone()], "0.18.0"), "fixed");
+        assert_eq!(resolution(&[fixed.clone()], "0.19.0"), "resolved");
+        assert_eq!(resolution(&[fixed], "0.19.0-nightly.1"), "fixed");
+    }
+    #[test]
+    fn invalid_or_unrelated_response_cannot_partially_update_cache() {
+        let id = Uuid::new_v4();
+        let mut cache = Cache::default();
+        cache
+            .reports
+            .insert(id, vec![issue("original", "approved", None)]);
+        assert!(
+            apply(
+                &mut cache,
+                &[id],
+                vec![Row {
+                    report_id: Uuid::new_v4(),
+                    issue_id: None,
+                    state: None,
+                    fixed_in: None
+                }]
+            )
+            .is_err()
+        );
+        assert_eq!(cache.reports[&id][0].issue_id, "original");
+        assert!(
+            apply(
+                &mut cache,
+                &[id],
+                vec![Row {
+                    report_id: id,
+                    issue_id: Some("i1".into()),
+                    state: Some("merged".into()),
+                    fixed_in: Some("0.19.0\nunsafe".into())
+                }]
+            )
+            .is_err()
+        );
+        assert_eq!(cache.reports[&id][0].issue_id, "original");
+    }
+    #[test]
+    fn bounded_response_updates_only_its_batch_and_handles_missing_records() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let mut cache = Cache::default();
+        cache.reports.insert(b, vec![issue("i2", "approved", None)]);
+        apply(&mut cache, &[a], vec![]).unwrap();
+        assert!(cache.reports[&a].is_empty());
+        assert_eq!(cache.reports[&b].len(), 1);
+    }
+}

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -24,6 +24,7 @@ pub(crate) mod diagnostics_cache;
 #[cfg(test)]
 mod diagnostics_cache_oracle;
 pub(crate) mod feedback_command;
+pub(crate) mod feedback_resolution;
 pub(crate) mod file_signature;
 pub(crate) mod format;
 pub(crate) mod generate;

--- a/tools/atb2/README.md
+++ b/tools/atb2/README.md
@@ -394,3 +394,17 @@ Apply the part 6a SQL from its PR description before deployment.
 `feedback_resolutions(report_ids uuid[])` accepts at most 100 full report UUIDs
 and exposes only linked issue IDs, status and fixed version. Its lookup uses
 feedback/issue primary keys; it does not expose reporter identities or contents.
+
+### CLI resolution polling
+
+`baml feedback status/list/view` refresh resolution data with a 1.5-second total
+budget, falling back to the local cache when offline. Ordinary interactive
+commands poll at most daily and print an update notice on stderr. After upgrading
+to a stable toolchain containing the fix, the cached report displays `resolved`
+and its reminder stops. Delivery state and anonymity remain separate.
+
+Set repository variables `BAML_FEEDBACK_SUPABASE_URL` and
+`BAML_FEEDBACK_PUBLISHABLE_KEY` before publishing the CLI. The latter must be a
+public Supabase `sb_publishable_` key, never a service-role key. The toolchain
+release workflow embeds these public values, including cross builds. Builds
+without the publishable key leave polling inactive.


### PR DESCRIPTION
baml feedback status/list/view refresh linked issue states and fixed versions with a 1.5-second total network budget, falling back to a private local cache. Ordinary interactive commands poll at most daily and notify the reporter when a linked fix is in a newer stable release: update using baml toolchain update. After the installed version contains the fix, the report displays resolved and the reminder stops.

Polling uses bounded rotating batches and a separate nonblocking cache lock. Feedback delivery state is preserved. Quiet/noninteractive commands do not emit unsolicited notices. Release builds embed only public Supabase configuration, including cross builds; without a publishable key polling stays inactive.

Validation: 12 Rust feedback tests, cargo fmt, and 97 BAML tests. The compile was completed with debug information and incremental compilation disabled to reduce disk use.

Setup: set repository variables BAML_FEEDBACK_SUPABASE_URL and BAML_FEEDBACK_PUBLISHABLE_KEY before publishing the CLI. The key must be a public sb_publishable_ key, never a service-role key. Apply the preceding resolution RPC SQL. This layer has no additional SQL and requires a new published toolchain before installed users receive the feature.

Stack position 5/7. Base: baml/feedback-6a-resolution.

<details>
<summary>Changed files (6)</summary>

- `.github/workflows/build2-toolchain.reusable.yaml`
- `baml_language/crates/baml_cli/src/commands.rs`
- `baml_language/crates/baml_cli/src/feedback_command.rs`
- `baml_language/crates/baml_cli/src/feedback_resolution.rs`
- `baml_language/crates/baml_cli/src/lib.rs`
- `tools/atb2/README.md`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feedback status, list, and view commands now display issue-resolution updates, including triaging, in-progress, fixed, and resolved states.
  - Interactive, non-quiet CLI commands refresh resolution information and notify you when fixes are available; quiet commands remain unchanged.
  - Resolution details remain available from a local cache when offline or when refreshing is unavailable.
  - Resolution checks are rate-limited and can identify fixes not yet included in your installed version.

- **Documentation**
  - Added guidance for CLI resolution polling, caching behavior, refresh timing, and publishing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->