### PR TITLE
Serve stdlib sources through read-only editor documents

### DIFF
--- a/baml_language/crates/baml_cli/src/ide_command.rs
+++ b/baml_language/crates/baml_cli/src/ide_command.rs
@@ -67,29 +67,6 @@ impl IdeArgs {
 
 impl IdeInstallArgs {
     pub fn run(&self) -> Result<ExitCode> {
-        // Editor-independent toolchain asset: a real on-disk copy of the
-        // stdlib stubs, so goto-definition into the stdlib opens a file the
-        // editor can display. The language server finds it next to the
-        // binary (`resolve_stdlib_dir`); a failure here (read-only toolchain
-        // dir) degrades to declined stdlib navigation, not a broken install.
-        match materialize_stdlib() {
-            Ok(dir) => {
-                #[allow(clippy::print_stdout)]
-                {
-                    println!("materialized BAML stdlib sources to {}", dir.display());
-                }
-            }
-            Err(error) => {
-                #[allow(clippy::print_stderr)]
-                {
-                    eprintln!(
-                        "warning: could not materialize the stdlib sources \
-                         (stdlib navigation stays off): {error:#}"
-                    );
-                }
-            }
-        }
-
         let vsix = active_toolchain_vsix()?;
         if let Some(dir) = &self.dir {
             fs::create_dir_all(dir)
@@ -153,41 +130,6 @@ impl IdeInstallArgs {
             )),
         }
     }
-}
-
-/// Write the embedded stdlib stubs next to the running binary
-/// (`<bin>/../stdlib/<package>/<relative_path>`), where the language
-/// server's `resolve_stdlib_dir` looks for them.
-///
-/// Idempotent full overwrite: the copy is an artifact of this binary's
-/// embedded sources, so rerunning `baml ide install` after a toolchain
-/// update refreshes it. (Nothing semantic reads these files — the database
-/// serves the embedded text under `<builtin>/…` virtual paths; this copy
-/// only gives goto-definition a real file to open, so drift shows up as
-/// stale-looking jumps, never wrong analysis.)
-fn materialize_stdlib() -> Result<PathBuf> {
-    let exe = env::current_exe().context("failed to locate the running binary")?;
-    let bin_dir = exe
-        .parent()
-        .ok_or_else(|| anyhow!("the binary path has no parent directory"))?;
-    let stdlib_dir = bin_dir.join("..").join("stdlib");
-    materialize_stdlib_into(&stdlib_dir)?;
-    Ok(std::fs::canonicalize(&stdlib_dir).unwrap_or(stdlib_dir))
-}
-
-/// Write every embedded stdlib file under `dir`, mirroring the
-/// `<package>/<relative_path>` layout of the `<builtin>/…` virtual paths.
-fn materialize_stdlib_into(dir: &Path) -> Result<()> {
-    for file in baml_builtins2::ALL {
-        let dest = dir.join(file.package).join(file.relative_path);
-        if let Some(parent) = dest.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create {}", parent.display()))?;
-        }
-        fs::write(&dest, file.contents)
-            .with_context(|| format!("failed to write {}", dest.display()))?;
-    }
-    Ok(())
 }
 
 /// The IDE is often installed without its CLI shim (on macOS the `code`
@@ -316,30 +258,6 @@ mod tests {
     fn install_dir_flag_binds() {
         let parsed = Wrapper::try_parse_from(["install", "--output-dir", "out"]).unwrap();
         assert_eq!(parsed.args.dir, Some(PathBuf::from("out")));
-    }
-
-    /// The materialized layout mirrors the `<builtin>/…` virtual paths (the
-    /// language server maps `<stdlib_dir>/<pkg>/<path>` ↔
-    /// `<builtin>/<pkg>/<path>` byte for byte), and rerunning refreshes
-    /// stale content in place.
-    #[test]
-    fn materialize_stdlib_mirrors_the_embedded_layout() {
-        let temp = tempfile::tempdir().unwrap();
-        materialize_stdlib_into(temp.path()).unwrap();
-
-        assert!(!baml_builtins2::ALL.is_empty());
-        for file in baml_builtins2::ALL {
-            let dest = temp.path().join(file.package).join(file.relative_path);
-            let on_disk = fs::read_to_string(&dest)
-                .unwrap_or_else(|e| panic!("{} must exist: {e}", dest.display()));
-            assert_eq!(on_disk, file.contents, "{}", dest.display());
-        }
-
-        // Idempotent refresh: a stale copy is overwritten.
-        let stale = temp.path().join("baml").join("containers.baml");
-        fs::write(&stale, "// stale\n").unwrap();
-        materialize_stdlib_into(temp.path()).unwrap();
-        assert_ne!(fs::read_to_string(&stale).unwrap(), "// stale\n");
     }
 
     /// Pin the missing-CLI error verbatim so any wording change is a

--- a/baml_language/crates/baml_lsp/Cargo.toml
+++ b/baml_language/crates/baml_lsp/Cargo.toml
@@ -17,6 +17,7 @@ baml_version = { workspace = true }
 crossbeam-channel = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+percent-encoding = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }
 serde_json = { workspace = true }
@@ -29,11 +30,6 @@ web-time = { workspace = true }
 # touches the disk; wasm hosts supply their own `ProjectFs`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ignore = { workspace = true }
-
-# `url` gates `Url::{from,to}_file_path` on unix/windows; the browser build
-# spells the conversion by hand.
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-percent-encoding = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/baml_language/crates/baml_lsp/src/dispatch/mod.rs
+++ b/baml_language/crates/baml_lsp/src/dispatch/mod.rs
@@ -34,19 +34,28 @@ use crate::{
     state::{GlobalState, OwnerEvent, Responder, SessionKey, SessionLifecycle},
 };
 
+macro_rules! lsp_request_type {
+    ("baml/stdlibSource") => {
+        $crate::dispatch::requests::StdlibSourceRequest
+    };
+    ($name:tt) => {
+        lsp_types::lsp_request!($name)
+    };
+}
+
 macro_rules! lsp_request_method {
     ($name:tt) => {
-        <lsp_types::lsp_request!($name) as lsp_types::request::Request>::METHOD
+        <lsp_request_type!($name) as lsp_types::request::Request>::METHOD
     };
 }
 macro_rules! lsp_request_params {
     ($name:tt) => {
-        <lsp_types::lsp_request!($name) as lsp_types::request::Request>::Params
+        <lsp_request_type!($name) as lsp_types::request::Request>::Params
     };
 }
 macro_rules! lsp_request_result {
     ($name:tt) => {
-        <lsp_types::lsp_request!($name) as lsp_types::request::Request>::Result
+        <lsp_request_type!($name) as lsp_types::request::Request>::Result
     };
 }
 macro_rules! lsp_notification_method {
@@ -244,6 +253,7 @@ define_request_tables! {
         "codeLens/resolve" => code_lens_resolve,
     }
     snapshot {
+        "baml/stdlibSource" => stdlib_source,
         "textDocument/formatting" => formatting,
         "textDocument/completion" => completion,
         "textDocument/hover" => hover,

--- a/baml_language/crates/baml_lsp/src/dispatch/proto.rs
+++ b/baml_language/crates/baml_lsp/src/dispatch/proto.rs
@@ -12,8 +12,7 @@ use lsp_types::{DocumentSymbol, SymbolKind};
 use crate::{paths, position_codec::PositionCodec, snapshot::Snapshot};
 
 /// The LSP location for an ide-layer location, in the session's encoding.
-/// `None` when the target has no client-openable presentation (a stdlib file
-/// without a materialized directory).
+/// `None` when the target path cannot be represented as a URI.
 pub(super) fn location(
     snap: &Snapshot,
     target: baml_ide::resolve::Location,

--- a/baml_language/crates/baml_lsp/src/dispatch/requests.rs
+++ b/baml_language/crates/baml_lsp/src/dispatch/requests.rs
@@ -470,8 +470,6 @@ pub(super) fn goto_definition(
     let Some(target) = baml_ide::definition_at(snap.db(), file, offset) else {
         return Ok(None);
     };
-    // A stdlib target with no materialized directory has no URI to open —
-    // "no definition" is the honest answer, not an error.
     Ok(super::proto::location(snap, target).map(lsp_types::GotoDefinitionResponse::Scalar))
 }
 
@@ -929,4 +927,43 @@ mod tests {
             Some(std::path::Path::new("/toolchain/stdlib"))
         );
     }
+}
+
+pub(super) enum StdlibSourceRequest {}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(super) struct StdlibSourceParams {
+    uri: lsp_types::Url,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(super) struct StdlibSourceResult {
+    content: String,
+}
+
+impl lsp_types::request::Request for StdlibSourceRequest {
+    type Params = StdlibSourceParams;
+    type Result = StdlibSourceResult;
+    const METHOD: &'static str = "baml/stdlibSource";
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "dispatch-table signature: handlers own their params"
+)]
+pub(super) fn stdlib_source(
+    snap: &crate::snapshot::Snapshot,
+    params: StdlibSourceParams,
+) -> Result<StdlibSourceResult, LspError> {
+    if params.uri.scheme() != crate::paths::STDLIB_SCHEME {
+        return Err(LspError::InvalidParams("expected a stdlib URI".to_owned()));
+    }
+    let path = crate::paths::canonical_document_path(snap.roots(), &params.uri)?;
+    let file = snap
+        .db()
+        .get_file(&path)
+        .ok_or(LspError::FileNotFound(path))?;
+    Ok(StdlibSourceResult {
+        content: file.text(snap.db()).clone(),
+    })
 }

--- a/baml_language/crates/baml_lsp/src/paths.rs
+++ b/baml_language/crates/baml_lsp/src/paths.rs
@@ -11,9 +11,8 @@
 //!   buffer under a symlinked directory shares its root's prefix.
 //! - **Stdlib mapping.** The database stores stdlib files under the virtual
 //!   `<builtin>/<pkg>/…` prefix (a wire contract shared with emitted
-//!   bytecode); when the host materialized the stubs on disk,
-//!   [`crate::roots::RootsView`] swaps that prefix for the directory in both
-//!   directions.
+//!   bytecode). Read-only documents use `baml-stdlib:/<pkg>/...` URIs.
+//!   Legacy materialized paths remain accepted as input aliases.
 //!
 //! The Windows lowercase folding the previous server applied is deliberately
 //! absent: the database does not fold case, and the owner's root index must
@@ -25,7 +24,12 @@ use std::path::{Path, PathBuf};
 
 use lsp_types::Url;
 
-use crate::{error::LspError, roots::RootsView};
+use crate::{
+    error::LspError,
+    roots::{BUILTIN_PREFIX, RootsView},
+};
+
+pub const STDLIB_SCHEME: &str = "baml-stdlib";
 
 /// One physical identity for a filesystem path.
 ///
@@ -68,8 +72,28 @@ fn lexically_normalize(path: &Path) -> PathBuf {
 }
 
 /// The database path for a document URI: physical identity, then the stdlib
-/// mapping. Non-`file:` URIs are `InvalidPath`.
+/// mapping. Stdlib document URIs retain their virtual database identity.
 pub fn canonical_document_path(roots: &RootsView, uri: &Url) -> Result<PathBuf, LspError> {
+    if uri.scheme() == STDLIB_SCHEME {
+        let invalid = || LspError::InvalidPath {
+            path: PathBuf::from(uri.as_str()),
+            message: "invalid stdlib URI".to_owned(),
+        };
+        if uri.has_host() || uri.query().is_some() || uri.fragment().is_some() {
+            return Err(invalid());
+        }
+        let path = uri.path().strip_prefix('/').ok_or_else(invalid)?;
+        let decoded = percent_encoding::percent_decode_str(path)
+            .decode_utf8()
+            .map_err(|_| invalid())?;
+        if decoded
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == ".." || part.contains('\\'))
+        {
+            return Err(invalid());
+        }
+        return Ok(PathBuf::from(format!("{BUILTIN_PREFIX}/{decoded}")));
+    }
     let path = url_to_file_path(uri).ok_or_else(|| LspError::InvalidPath {
         path: PathBuf::from(uri.as_str()),
         message: "not a file URI".to_owned(),
@@ -77,12 +101,21 @@ pub fn canonical_document_path(roots: &RootsView, uri: &Url) -> Result<PathBuf, 
     Ok(roots.to_db_path(&canonical_physical_path(&path)))
 }
 
-/// The URI a client can open for a database path. `None` when the path has
-/// no presentation (a stdlib file with no materialized directory) or cannot
-/// be spelled as a `file:` URL.
-pub fn uri_for_db_path(roots: &RootsView, db_path: &Path) -> Option<Url> {
-    let presentation = roots.to_presentation_path(db_path)?;
-    file_path_to_url(&presentation)
+/// The URI a client can open for a database path.
+/// Stdlib sources always use read-only virtual documents.
+pub fn uri_for_db_path(_roots: &RootsView, db_path: &Path) -> Option<Url> {
+    if let Ok(rest) = db_path.strip_prefix(BUILTIN_PREFIX) {
+        let mut uri = Url::parse("baml-stdlib:/").ok()?;
+        {
+            let mut segments = uri.path_segments_mut().ok()?;
+            segments.clear();
+            for component in rest.components() {
+                segments.push(component.as_os_str().to_str()?);
+            }
+        }
+        return Some(uri);
+    }
+    file_path_to_url(db_path)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -195,29 +228,15 @@ mod tests {
     }
 
     #[test]
-    fn stdlib_round_trip_through_a_materialized_directory() {
+    fn stdlib_round_trips_with_or_without_a_materialized_directory() {
         let temp = tempfile::tempdir().unwrap();
-        // The view stores the canonical directory, as the owner does.
-        let stdlib_dir = temp.path().canonicalize().unwrap();
-        let roots = roots(Some(stdlib_dir.clone()));
-
-        let db_path = Path::new("<builtin>/std/prelude.baml");
-        let uri = uri_for_db_path(&roots, db_path).expect("materialized stdlib has a URI");
-        // Compare as URIs: both sides then pass through the same URL
-        // normalization. Comparing `uri.to_file_path()` against the joined
-        // path would fail on Windows, where `canonicalize` spells the
-        // directory with the `\\?\` verbatim prefix and the URL round trip
-        // (correctly) drops it.
-        assert_eq!(
-            uri,
-            Url::from_file_path(stdlib_dir.join("std").join("prelude.baml")).unwrap()
-        );
-        assert_eq!(canonical_document_path(&roots, &uri).unwrap(), db_path);
-    }
-
-    #[test]
-    fn stdlib_without_a_directory_has_no_uri() {
-        assert!(uri_for_db_path(&roots(None), Path::new("<builtin>/std/prelude.baml")).is_none());
+        for directory in [None, Some(temp.path().canonicalize().unwrap())] {
+            let roots = roots(directory);
+            let path = Path::new("<builtin>/baml/ns_env/env.baml");
+            let uri = uri_for_db_path(&roots, path).unwrap();
+            assert_eq!(uri.as_str(), "baml-stdlib:/baml/ns_env/env.baml");
+            assert_eq!(canonical_document_path(&roots, &uri).unwrap(), path);
+        }
     }
 
     #[test]

--- a/baml_language/crates/baml_lsp/tests/protocol.rs
+++ b/baml_language/crates/baml_lsp/tests/protocol.rs
@@ -659,14 +659,12 @@ fn closing_a_vanished_file_removes_it_and_clears_markers() {
     assert!(h.state.file_text(&h.ws.join("keep.baml")).is_some());
 }
 
-/// A stdlib file presents under the materialized directory and maps back to
-/// its virtual database path; opening it tracks nothing.
+/// Stdlib documents map back to the database and never create editor overlays.
 #[test]
 fn stdlib_paths_round_trip_through_the_materialized_directory() {
     let stdlib_temp = tempfile::tempdir().unwrap();
     // Deliberately the non-canonical spelling: the owner canonicalizes it.
     let mut h = Harness::with_stdlib_dir(Some(stdlib_temp.path().to_path_buf()));
-    let canonical_dir = stdlib_temp.path().canonicalize().unwrap();
     let s = SessionKey(1);
     h.init_session(s, &[]);
 
@@ -685,15 +683,7 @@ fn stdlib_paths_round_trip_through_the_materialized_directory() {
         .map(|entry| entry.path.join("prelude.baml"))
         .expect("a stdlib root");
     let uri = baml_lsp::paths::uri_for_db_path(h.state.roots(), &db_path).unwrap();
-    // Prefix-compare as URIs: both sides then pass through the same URL
-    // normalization. A `Path::starts_with` against the canonical directory
-    // would fail on Windows, where `canonicalize` spells it with the `\\?\`
-    // verbatim prefix and the URL round trip (correctly) drops it.
-    assert!(
-        uri.as_str()
-            .starts_with(Url::from_file_path(&canonical_dir).unwrap().as_str()),
-        "{uri}"
-    );
+    assert_eq!(uri.scheme(), "baml-stdlib");
     assert_eq!(
         baml_lsp::paths::canonical_document_path(h.state.roots(), &uri).unwrap(),
         db_path
@@ -1245,7 +1235,7 @@ fn document_symbols_nest_members_with_distinct_ranges() {
 fn workspace_symbols_cover_user_and_materialized_stdlib() {
     let temp = tempfile::tempdir().unwrap();
     let stdlib_dir = temp.path().canonicalize().unwrap();
-    let mut harness = Harness::with_stdlib_dir(Some(stdlib_dir.clone()));
+    let mut harness = Harness::with_stdlib_dir(Some(stdlib_dir));
     harness.fs.add_project(&harness.ws);
     harness
         .fs
@@ -1266,7 +1256,7 @@ fn workspace_symbols_cover_user_and_materialized_stdlib() {
         "user symbol found, got: {symbols:?}"
     );
 
-    // A stdlib symbol resolves to a URI under the materialized directory.
+    // Even with a legacy disk directory configured, use read-only documents.
     let response = harness
         .request(
             SessionKey(1),
@@ -1281,9 +1271,90 @@ fn workspace_symbols_cover_user_and_materialized_stdlib() {
         .unwrap_or_else(|| panic!("stdlib symbol found, got: {symbols:?}"));
     let uri = stdlib_hit["location"]["uri"].as_str().unwrap();
     assert!(
-        uri.starts_with(Url::from_file_path(&stdlib_dir).unwrap().as_str()),
-        "stdlib URI maps under the materialized dir, got: {uri}"
+        uri.starts_with("baml-stdlib:/"),
+        "stdlib URI uses the document provider, got: {uri}"
     );
+}
+
+#[test]
+fn stdlib_source_and_nested_navigation_without_disk_sources() {
+    let mut h = Harness::new();
+    let session = SessionKey(1);
+    h.fs.add_project(&h.ws);
+    let text = "function main() -> string { baml.env.get_or_panic(\"KEY\") }";
+    h.fs.write(h.ws.join("main.baml"), text);
+    h.init_session(session, &[]);
+    h.settle();
+    let target = h
+        .request(
+            session,
+            "textDocument/definition",
+            json!({
+                "textDocument": { "uri": h.uri("main.baml") },
+                "position": { "line": 0, "character": text.find("get_or_panic").unwrap() + 2 }
+            }),
+        )
+        .unwrap();
+    let uri = Url::parse(target["uri"].as_str().unwrap()).unwrap();
+    assert_eq!(uri.as_str(), "baml-stdlib:/baml/ns_env/env.baml");
+    let response = h
+        .request(session, "baml/stdlibSource", json!({ "uri": uri }))
+        .unwrap();
+    let content = response["content"].as_str().unwrap();
+    assert_eq!(
+        content,
+        include_str!("../../baml_builtins2/baml_std/baml/ns_env/env.baml")
+    );
+    let offset = content.find("root.sys.panic").unwrap() + "root.sys.".len();
+    let codec = baml_lsp::position_codec::PositionCodec::new(
+        content,
+        baml_lsp::position_codec::PositionEncoding::UTF16,
+    );
+    let params = json!({ "textDocument": { "uri": uri }, "position": codec.offset_to_position(offset.try_into().unwrap()) });
+    let nested = h
+        .request(session, "textDocument/definition", params.clone())
+        .unwrap();
+    assert!(
+        nested["uri"]
+            .as_str()
+            .unwrap()
+            .starts_with("baml-stdlib:/baml/ns_sys/")
+    );
+    assert!(
+        !h.request(session, "textDocument/hover", params)
+            .unwrap()
+            .is_null()
+    );
+    for method in [
+        "textDocument/semanticTokens/full",
+        "textDocument/documentSymbol",
+    ] {
+        assert!(
+            !h.request(session, method, json!({ "textDocument": { "uri": uri } }))
+                .unwrap()
+                .is_null()
+        );
+    }
+    h.open(session, &uri, 1, "invalid replacement");
+    h.change(session, &uri, 2, "changed");
+    h.settle();
+    let path = baml_lsp::paths::canonical_document_path(h.state.roots(), &uri).unwrap();
+    assert!(h.state.open_document(&path).is_none());
+    assert_eq!(
+        h.request(session, "baml/stdlibSource", json!({ "uri": uri }))
+            .unwrap(),
+        response
+    );
+    for invalid in [
+        "file:///etc/passwd",
+        "baml-stdlib:/missing.baml",
+        "baml-stdlib://host/baml/ns_env/env.baml",
+    ] {
+        assert!(
+            h.request(session, "baml/stdlibSource", json!({ "uri": invalid }))
+                .is_err()
+        );
+    }
 }
 
 #[test]

--- a/baml_language/crates/baml_lsp_server/src/lib.rs
+++ b/baml_language/crates/baml_lsp_server/src/lib.rs
@@ -352,15 +352,10 @@ pub fn version() -> &'static str {
 // Bootstrap
 // ---------------------------------------------------------------------------
 
-/// Where the materialized stdlib stubs live, so goto-definition into the
-/// stdlib can open a real file: `BAML_STDLIB_DIR`, else `<exe dir>/../stdlib`
-/// (the toolchain copy `baml ide install` writes), else the in-repo
-/// `baml_std/` checkout the binary was built from (a compile-time path, so it
-/// exists only on the build machine — the dev fallback), else none (the
-/// protocol layer then declines stdlib navigation targets). Runs before
-/// `initialize`, so a client-supplied
-/// `initializationOptions.bamlClient.stdlibDir` — if the protocol layer
-/// consumes one — is its concern, not the host's.
+/// Locate legacy stdlib files so incoming file URIs can alias embedded sources.
+/// Checks `BAML_STDLIB_DIR`, then `<exe dir>/../stdlib` from older installs,
+/// then the build-time `baml_std/` checkout. Clients can override this through
+/// `initializationOptions.bamlClient.stdlibDir`.
 fn resolve_stdlib_dir() -> Option<PathBuf> {
     if let Some(dir) = std::env::var_os("BAML_STDLIB_DIR") {
         let dir = PathBuf::from(dir);

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -95,7 +95,8 @@
     ]
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.0"
+    "vscode-languageclient": "^9.0.0",
+    "@b/pkg-lsp": "workspace:*"
   },
   "description": "BAML, the Programming Language for AI.",
   "devDependencies": {

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -95,8 +95,8 @@
     ]
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.0",
-    "@b/pkg-lsp": "workspace:*"
+    "@b/pkg-lsp": "workspace:*",
+    "vscode-languageclient": "^9.0.0"
   },
   "description": "BAML, the Programming Language for AI.",
   "devDependencies": {

--- a/typescript2/app-vscode-ext/src/extension.ts
+++ b/typescript2/app-vscode-ext/src/extension.ts
@@ -1,5 +1,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {
+  STDLIB_SCHEME,
+  STDLIB_SOURCE_METHOD,
+  StdlibDocuments,
+  type StdlibSourceResult,
+} from '@b/pkg-lsp';
 import * as vscode from 'vscode';
 import {
   LanguageClient,
@@ -21,7 +27,7 @@ import { WebviewPanel } from './panels/WebviewPanel';
 //
 // The server multiplexes projects: it receives the window's workspace
 // folders, discovers every BAML project underneath them, and serves ALL
-// `.baml` documents — including materialized stdlib sources, which belong
+// `.baml` documents, including read-only stdlib documents, which belong
 // to no project and previously caused the extension to spawn a doomed
 // sibling server per stdlib directory (its `baml.openBamlPanel`
 // registration collided with the first client's and start() rejected).
@@ -30,6 +36,8 @@ import { WebviewPanel } from './panels/WebviewPanel';
 // window instead of one arbitrary project.
 
 let client: LanguageClient | undefined;
+let stdlibDocuments: StdlibDocuments;
+let stdlibConnection: vscode.Disposable | undefined;
 let clientStartFailed = false;
 let knownProjects: string[] = [];
 let currentServerState: 'starting' | 'running' | 'stopped' | 'error' =
@@ -198,11 +206,14 @@ function createClient(context: vscode.ExtensionContext): LanguageClient {
   const clientOptions: LanguageClientOptions = {
     // Every `.baml` document in the window — project files, files outside
     // any project (the server mints provisional roots for those), and
-    // materialized stdlib sources alike. No `workspaceFolder` pin: the
+    // read-only stdlib documents alike. No `workspaceFolder` pin: the
     // client library forwards ALL workspace folders in `initialize` and
     // `workspace/didChangeWorkspaceFolders`, and the server discovers
     // projects underneath them.
-    documentSelector: [{ language: 'baml', scheme: 'file' }],
+    documentSelector: [
+      { language: 'baml', scheme: 'file' },
+      { language: 'baml', scheme: STDLIB_SCHEME },
+    ],
     initializationOptions: {
       bamlClient: {
         capabilities: [
@@ -248,11 +259,21 @@ function createClient(context: vscode.ExtensionContext): LanguageClient {
         updateStatusBar('starting');
         break;
       case State.Running:
+        stdlibConnection?.dispose();
+        stdlibConnection = stdlibDocuments.connect((uri, token) =>
+          created.sendRequest<StdlibSourceResult>(
+            STDLIB_SOURCE_METHOD,
+            { uri },
+            token,
+          ),
+        );
         clientStartFailed = false;
         updateStatusBar('running');
         validateServerCompatibility(created);
         break;
       case State.Stopped:
+        stdlibConnection?.dispose();
+        stdlibConnection = undefined;
         knownProjects = [];
         updateStatusBar(clientStartFailed ? 'error' : 'stopped');
         break;
@@ -330,6 +351,8 @@ function validateServerCompatibility(client: LanguageClient) {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
+  stdlibDocuments = new StdlibDocuments(vscode);
+  context.subscriptions.push(stdlibDocuments);
   const config = vscode.workspace.getConfiguration('baml');
   playgroundDir = getPlaygroundDir(context);
   wrapperPath =

--- a/typescript2/app-vscode-ext/tsconfig.json
+++ b/typescript2/app-vscode-ext/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "node",
+    "noEmit": false,
     "outDir": "dist",
-    "types": ["node", "vscode"],
-    "noEmit": false
+    "types": ["node", "vscode"]
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "extends": "../tsconfig.base.json",
+  "include": ["src"]
 }

--- a/typescript2/app-vscode-ext/tsconfig.json
+++ b/typescript2/app-vscode-ext/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "dist",
-    "rootDir": "src",
     "types": ["node", "vscode"],
     "noEmit": false
   },

--- a/typescript2/pkg-editor/package.json
+++ b/typescript2/pkg-editor/package.json
@@ -23,7 +23,8 @@
     "monaco-editor": "^0.55.1",
     "monaco-languageclient": "^10.7.0",
     "vscode": "npm:@codingame/monaco-vscode-extension-api@^25.1.2",
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "@b/pkg-lsp": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",

--- a/typescript2/pkg-editor/src/MonacoEditor.tsx
+++ b/typescript2/pkg-editor/src/MonacoEditor.tsx
@@ -19,6 +19,11 @@
  *     WebSocket to a real server). See `@b/pkg-editor/remote`.
  */
 
+import {
+  STDLIB_SOURCE_METHOD,
+  StdlibDocuments,
+  type StdlibSourceResult,
+} from '@b/pkg-lsp';
 import { type FC, useEffect, useRef, useState } from 'react';
 import './views-workbench.css';
 import type { Dimension } from '@codingame/monaco-vscode-api/vscode/vs/base/browser/dom';
@@ -1141,6 +1146,8 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
       // Backend — connect LSP transport + runtime (re-run on reload)
       // ════════════════════════════════════════════════════════════════
 
+      const stdlibDocuments = new StdlibDocuments(vscode);
+      disposables.push(stdlibDocuments);
       const connect = async () => {
         if (disposed) return;
 
@@ -1183,6 +1190,15 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
         // for the browser's own write-throughs.
         const lspClient = lcWrapper.getLanguageClient();
         if (lspClient) {
+          connDisposablesRef.current.push(
+            stdlibDocuments.connect((uri, token) =>
+              lspClient.sendRequest<StdlibSourceResult>(
+                STDLIB_SOURCE_METHOD,
+                { uri },
+                token,
+              ),
+            ),
+          );
           const diskChangeSub = lspClient.onNotification(
             'baml/fileChangedOnDisk',
             async (params: { uri: string; text: string }) => {

--- a/typescript2/pkg-lsp/package.json
+++ b/typescript2/pkg-lsp/package.json
@@ -1,0 +1,17 @@
+{
+  "devDependencies": {
+    "@types/vscode": "^1.63.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.16"
+  },
+  "main": "src/stdlib-documents.ts",
+  "name": "@b/pkg-lsp",
+  "private": true,
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "type": "module",
+  "types": "src/stdlib-documents.ts",
+  "version": "0.1.0"
+}

--- a/typescript2/pkg-lsp/src/stdlib-documents.test.ts
+++ b/typescript2/pkg-lsp/src/stdlib-documents.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import type * as VSCode from 'vscode';
+import { StdlibDocuments } from './stdlib-documents';
+
+function uri(name: string): VSCode.Uri {
+  const text = `baml-stdlib:/baml/${name}.baml`;
+  return {
+    path: new URL(text).pathname,
+    scheme: 'baml-stdlib',
+    toString: () => text,
+  } as VSCode.Uri;
+}
+
+function setup(openUris: VSCode.Uri[] = []) {
+  let provider: VSCode.TextDocumentContentProvider;
+  const fire = vi.fn();
+  const unregister = vi.fn();
+  const api = {
+    EventEmitter: class {
+      event = vi.fn();
+      fire = fire;
+      dispose = vi.fn();
+    },
+    workspace: {
+      registerTextDocumentContentProvider: (
+        _scheme: string,
+        value: VSCode.TextDocumentContentProvider,
+      ) => {
+        provider = value;
+        return { dispose: unregister };
+      },
+      textDocuments: openUris.map((uri) => ({ uri })),
+    },
+  } as unknown as ConstructorParameters<typeof StdlibDocuments>[0];
+  const documents = new StdlibDocuments(api);
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: vi.fn(),
+  };
+  return {
+    documents,
+    fire,
+    read: (session: string) =>
+      provider.provideTextDocumentContent(uri(session), token),
+    token,
+    unregister,
+  };
+}
+
+describe('stdlib documents', () => {
+  it('forwards source reads and cancellation to the current server', async () => {
+    const { documents, read, token } = setup();
+    await expect(read('first')).rejects.toThrow('unavailable');
+    const first = vi.fn().mockResolvedValue({ content: 'first toolchain' });
+    documents.connect(first);
+    expect(await read('first')).toBe('first toolchain');
+    expect(first).toHaveBeenCalledWith(uri('first').toString(), token);
+    documents.dispose();
+  });
+
+  it('refreshes open source after reconnect without a stale disposer removing the replacement', async () => {
+    const open = uri('first');
+    const { documents, read, fire, unregister } = setup([open]);
+    const old = documents.connect(async () => ({
+      content: 'old source',
+    }));
+    fire.mockClear();
+    const current = documents.connect(async () => ({
+      content: 'new source',
+    }));
+    old.dispose();
+    expect(fire).toHaveBeenCalledExactlyOnceWith(open);
+    expect(await read('first')).toBe('new source');
+    current.dispose();
+    await expect(read('first')).rejects.toThrow('unavailable');
+    documents.dispose();
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+
+  it('propagates server errors rather than displaying them as source text', async () => {
+    const { documents, read } = setup();
+    documents.connect(async () => {
+      throw new Error('request cancelled');
+    });
+    await expect(read('first')).rejects.toThrow('request cancelled');
+    documents.dispose();
+  });
+});

--- a/typescript2/pkg-lsp/src/stdlib-documents.ts
+++ b/typescript2/pkg-lsp/src/stdlib-documents.ts
@@ -1,0 +1,58 @@
+import type * as VSCode from 'vscode';
+
+export const STDLIB_SCHEME = 'baml-stdlib';
+export const STDLIB_SOURCE_METHOD = 'baml/stdlibSource';
+
+export interface StdlibSourceResult {
+  content: string;
+}
+
+type LoadSource = (
+  uri: string,
+  token: VSCode.CancellationToken,
+) => Promise<StdlibSourceResult>;
+
+export class StdlibDocuments implements VSCode.Disposable {
+  private load: LoadSource | undefined;
+  private readonly changed: VSCode.EventEmitter<VSCode.Uri>;
+  private readonly registration: VSCode.Disposable;
+
+  constructor(
+    private readonly vscode: Pick<typeof VSCode, 'workspace' | 'EventEmitter'>,
+  ) {
+    this.changed = new vscode.EventEmitter<VSCode.Uri>();
+    this.registration = vscode.workspace.registerTextDocumentContentProvider(
+      STDLIB_SCHEME,
+      {
+        onDidChange: this.changed.event,
+        provideTextDocumentContent: async (uri, token) => {
+          const load = this.load;
+          if (!load)
+            throw new Error(
+              'The BAML language server for this stdlib document is unavailable.',
+            );
+          return (await load(uri.toString(), token)).content;
+        },
+      },
+    );
+  }
+
+  connect(load: LoadSource): VSCode.Disposable {
+    this.load = load;
+    for (const document of this.vscode.workspace.textDocuments) {
+      if (document.uri.scheme === STDLIB_SCHEME)
+        this.changed.fire(document.uri);
+    }
+    return {
+      dispose: () => {
+        if (this.load === load) this.load = undefined;
+      },
+    };
+  }
+
+  dispose(): void {
+    this.registration.dispose();
+    this.changed.dispose();
+    this.load = undefined;
+  }
+}

--- a/typescript2/pkg-lsp/tsconfig.json
+++ b/typescript2/pkg-lsp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/typescript2/pnpm-lock.yaml
+++ b/typescript2/pnpm-lock.yaml
@@ -605,6 +605,9 @@ importers:
 
   app-vscode-ext:
     dependencies:
+      '@b/pkg-lsp':
+        specifier: workspace:*
+        version: link:../pkg-lsp
       vscode-languageclient:
         specifier: ^9.0.0
         version: 9.0.1
@@ -1157,6 +1160,9 @@ importers:
       '@b/pkg-grammar':
         specifier: workspace:*
         version: link:../pkg-grammar
+      '@b/pkg-lsp':
+        specifier: workspace:*
+        version: link:../pkg-lsp
       '@b/pkg-playground':
         specifier: workspace:*
         version: link:../pkg-playground
@@ -1284,6 +1290,18 @@ importers:
       tree-sitter-cli:
         specifier: ^0.25.8
         version: 0.25.10
+
+  pkg-lsp:
+    devDependencies:
+      '@types/vscode':
+        specifier: ^1.63.0
+        version: 1.107.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@24.12.4)(typescript@5.9.3))(tsx@4.22.4)(yaml@2.9.0)
 
   pkg-playground:
     dependencies:
@@ -6193,6 +6211,7 @@ packages:
   '@shikijs/primitive@4.4.3':
     resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
     engines: {node: '>=20'}
+
   '@shikijs/themes@3.23.0':
     resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
 
@@ -18836,6 +18855,7 @@ snapshots:
       '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
+
   '@shikijs/themes@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0


### PR DESCRIPTION
## Changes

Go to definition on stdlib functions now opens the compiler's embedded source in both PromptFiddle and native VS Code. The LSP returns `baml-stdlib:/<package>/<path>` URIs and serves their contents through `baml/stdlibSource`; both editors use the same read-only document provider.

Stdlib URIs map back into the existing LSP database, so hover, highlighting, symbols, and further navigation work inside these documents. Reconnecting refreshes open stdlib documents. `baml ide install` no longer extracts stdlib sources to disk. Legacy file-path aliases remain available for existing copies.

## Testing

- `cargo test -p baml_cli ide_command --offline`: 2 installer tests passed.

- `cargo test -p baml_lsp --offline`: 64 tests passed, including source retrieval, nested navigation, and ignored edits without disk sources.
- `cargo check -p baml_lsp --target wasm32-unknown-unknown --offline`
- `cargo clippy -p baml_lsp --lib --offline -- -D warnings`
- Typechecks for `@b/pkg-lsp`, `@b/pkg-editor`, and `baml-language`.
- Provider, editor, and extension tests: 15 passed.
- Native extension build, Rust formatting, and Biome checks for the changed TypeScript source.

Automated validation only; manual browser and VS Code smoke tests are still pending.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only stdlib document support using virtual `baml-stdlib:` URIs.
  * Definitions, navigation, hover, symbols, semantic tokens, and source viewing now work for stdlib files, including when no files exist on disk.
  * VS Code and Monaco editors can retrieve stdlib source through the language server.

* **Bug Fixes**
  * Improved validation and handling of stdlib document URIs.
  * Standardized stdlib behavior across materialized and non-materialized environments.

* **Changes**
  * The IDE installer no longer creates local copies of embedded stdlib files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->