### PR TITLE
chore(release): improve format of release slack notifications

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -285,8 +285,8 @@ jobs:
             -f source_ci_run_id="$SOURCE_CI_RUN_ID"
           echo "Dispatched a nightly release for $SOURCE_SHA (CI run $SOURCE_CI_RUN_ID)."
 
-  notify-slack:
-    name: Notify Slack on failure
+  notify-nightly-dispatch-failure:
+    name: Notify Slack of nightly dispatch failure
     needs: [dispatch-nightly]
     # Only on failure. The sibling notifier in release-baml-language.yml runs
     # `always()` because it fans in from forty jobs and one of them can go green
@@ -296,7 +296,7 @@ jobs:
     if: ${{ always() && github.repository == 'BoundaryML/baml' && needs.dispatch-nightly.result == 'failure' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: boundary-tools-dev
+    environment: infisical-github-baml-language-release
     permissions:
       actions: read
       contents: read
@@ -313,7 +313,7 @@ jobs:
       - uses: ./.github/actions/setup-mise
         with:
           install_args: uv
-      - name: Find failures and notify Slack
+      - name: Notify Slack of nightly dispatch failure
         env:
           GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -305,7 +305,6 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-mise
-            .github/workflows/nightly-release.yml
             mise.toml
             tools/notify-release-failure.py
           sparse-checkout-cone-mode: false
@@ -315,6 +314,8 @@ jobs:
           install_args: uv
       - name: Notify Slack of nightly dispatch failure
         env:
+          # Code search follows the default branch (canary) and finds the invocation as lines move.
+          NOTIFICATION_SOURCE_URL: "https://github.com/search?q=repo%3ABoundaryML%2Fbaml%20path%3A.github%2Fworkflows%2Fnightly-release.yml%20%22notify-release-failure%22&type=code"
           GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -285,8 +285,8 @@ jobs:
             -f source_ci_run_id="$SOURCE_CI_RUN_ID"
           echo "Dispatched a nightly release for $SOURCE_SHA (CI run $SOURCE_CI_RUN_ID)."
 
-  notify-nightly-dispatch-failure:
-    name: Notify Slack of nightly dispatch failure
+  notify-slack:
+    name: Notify Slack on failure
     needs: [dispatch-nightly]
     # Only on failure. The sibling notifier in release-baml-language.yml runs
     # `always()` because it fans in from forty jobs and one of them can go green
@@ -312,10 +312,8 @@ jobs:
       - uses: ./.github/actions/setup-mise
         with:
           install_args: uv
-      - name: Notify Slack of nightly dispatch failure
+      - name: Find failures and notify Slack
         env:
-          # Code search follows the default branch (canary) and finds the invocation as lines move.
-          NOTIFICATION_SOURCE_URL: "https://github.com/search?q=repo%3ABoundaryML%2Fbaml%20path%3A.github%2Fworkflows%2Fnightly-release.yml%20%22notify-release-failure%22&type=code"
           GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -305,6 +305,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/setup-mise
+            .github/workflows/nightly-release.yml
             mise.toml
             tools/notify-release-failure.py
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2233,8 +2233,8 @@ jobs:
       source_sha: ${{ needs.plan.outputs.source_sha }}
       csharp_platform_matrix_json: ${{ needs.build-matrix.outputs.csharp }}
 
-  notify-slack:
-    name: Notify Slack
+  notify-release-result:
+    name: Notify Slack of release result
     needs:
       - plan
       - build-matrix
@@ -2279,7 +2279,7 @@ jobs:
     # This job must run after failed dependencies. Every production release result notifies Slack, including successful nightlies.
     if: ${{ always() && inputs.dry_run == false && (needs.plan.outputs.source_branch == 'canary' || (needs.plan.result == 'failure' && github.ref_type == 'tag' && github.ref_name == format('baml-language-source-{0}', inputs.source_sha))) }}
     runs-on: ubuntu-latest
-    environment: boundary-tools-dev
+    environment: infisical-github-baml-language-release
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2289,6 +2289,7 @@ jobs:
           ref: ${{ needs.plan.outputs.source_sha || github.sha }}
           sparse-checkout: |
             .github/actions/setup-mise
+            .github/workflows/release-baml-language.yml
             mise.toml
             tools/notify-release-failure.py
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2289,7 +2289,6 @@ jobs:
           ref: ${{ needs.plan.outputs.source_sha || github.sha }}
           sparse-checkout: |
             .github/actions/setup-mise
-            .github/workflows/release-baml-language.yml
             mise.toml
             tools/notify-release-failure.py
           sparse-checkout-cone-mode: false
@@ -2299,6 +2298,8 @@ jobs:
           install_args: uv
       - name: Notify Slack of the release result
         env:
+          # Code search follows the default branch (canary) and finds the invocation as lines move.
+          NOTIFICATION_SOURCE_URL: "https://github.com/search?q=repo%3ABoundaryML%2Fbaml%20path%3A.github%2Fworkflows%2Frelease-baml-language.yml%20%22notify-release-failure%22&type=code"
           GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2233,8 +2233,8 @@ jobs:
       source_sha: ${{ needs.plan.outputs.source_sha }}
       csharp_platform_matrix_json: ${{ needs.build-matrix.outputs.csharp }}
 
-  notify-release-result:
-    name: Notify Slack of release result
+  notify-slack:
+    name: Notify Slack
     needs:
       - plan
       - build-matrix
@@ -2298,8 +2298,6 @@ jobs:
           install_args: uv
       - name: Notify Slack of the release result
         env:
-          # Code search follows the default branch (canary) and finds the invocation as lines move.
-          NOTIFICATION_SOURCE_URL: "https://github.com/search?q=repo%3ABoundaryML%2Fbaml%20path%3A.github%2Fworkflows%2Frelease-baml-language.yml%20%22notify-release-failure%22&type=code"
           GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -184,27 +184,29 @@ def main() -> int:
             message = (
                 f"❌ BAML {channel} release failed: {version}, "
                 f"started at {format_pacific_time(started_at)}\n\n"
-                f"*Failures:*\n{failure_text}\n\n"
-                f"*Run:* <{run_url}|View workflow run>"
+                f"*Failures:*\n{failure_text}"
             )
         else:
             message = (
                 f"✅ BAML {channel} release succeeded: {version}, "
-                f"started at {format_pacific_time(started_at)}\n\n"
-                f"*Run:* <{run_url}|View workflow run>"
+                f"started at {format_pacific_time(started_at)}"
             )
 
         blocks = [
             {"type": "section", "text": {"type": "mrkdwn", "text": paragraph}}
             for paragraph in message.split("\n\n")
         ]
+        footer = (
+            f"<{run_url}|View workflow run> · "
+            f"<{notification_source_url(repository)}|View notification source>"
+        )
         blocks.append(
             {
                 "type": "context",
                 "elements": [
                     {
                         "type": "mrkdwn",
-                        "text": f"<{notification_source_url(repository)}|Notification source: release workflow step>",
+                        "text": footer,
                     }
                 ],
             }
@@ -212,7 +214,7 @@ def main() -> int:
 
         WebClient(token=slack_token).chat_postMessage(
             channel=slack_channel,
-            text=message,
+            text=f"{message}\n\n{footer}",
             blocks=blocks,
             unfurl_links=False,
         )

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -23,6 +23,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError, SlackClientError
 
 GITHUB_API_TIMEOUT_SECONDS = 30
+SLACK_SECTION_TEXT_LIMIT = 2800
 SUCCESSFUL_JOB_CONCLUSIONS = {"success", "skipped"}
 
 
@@ -184,7 +185,17 @@ def main() -> int:
             )
 
         blocks = [
-            {"type": "section", "text": {"type": "mrkdwn", "text": paragraph}}
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        paragraph[: SLACK_SECTION_TEXT_LIMIT - 3] + "..."
+                        if len(paragraph) > SLACK_SECTION_TEXT_LIMIT
+                        else paragraph
+                    ),
+                },
+            }
             for paragraph in message.split("\n\n")
         ]
         footer = (

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -14,7 +14,9 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 from zoneinfo import ZoneInfo
 
 from slack_sdk import WebClient
@@ -132,6 +134,17 @@ def format_failure(failure: Failure) -> str:
     return f"• {job} — job concluded {conclusion}"
 
 
+def notification_source_url(repository: str) -> str:
+    workflow_path = (
+        required_env("GITHUB_WORKFLOW_REF")
+        .removeprefix(f"{repository}/")
+        .rsplit("@", 1)[0]
+    )
+    # GitHub code search follows the repository's default branch (canary).
+    query = f'repo:{repository} path:"{workflow_path}" "{Path(__file__).name}"'
+    return f"https://github.com/search?{urlencode({'q': query, 'type': 'code'})}"
+
+
 def main() -> int:
     """Notify Slack of the current release result."""
     try:
@@ -141,7 +154,6 @@ def main() -> int:
         github_token = required_env("GH_TOKEN")
         slack_channel = required_env("SLACK_CHANNEL")
         slack_token = required_env("SLACK_BOT_TOKEN")
-        notification_source_url = required_env("NOTIFICATION_SOURCE_URL")
 
         version = os.environ.get("VERSION") or "unknown version"
         channel = os.environ.get("CHANNEL") or "unknown channel"
@@ -177,7 +189,7 @@ def main() -> int:
         ]
         footer = (
             f"<{run_url}|View workflow run> · "
-            f"<{notification_source_url}|View notification source>"
+            f"<{notification_source_url(repository)}|View notification source>"
         )
         blocks.append(
             {

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -9,13 +9,11 @@
 
 import json
 import os
-import subprocess
 import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -134,26 +132,6 @@ def format_failure(failure: Failure) -> str:
     return f"• {job} — job concluded {conclusion}"
 
 
-def notification_source_url(repository: str) -> str:
-    workflow_path = (
-        required_env("GITHUB_WORKFLOW_REF")
-        .removeprefix(f"{repository}/")
-        .rsplit("@", 1)[0]
-    )
-    # Match the line number to the checked-out revision, which can differ from
-    # the workflow revision when the release explicitly checks out source_sha.
-    source_sha = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], text=True
-    ).strip()
-    url = f"https://github.com/{repository}/blob/{source_sha}/{workflow_path}"
-    for line_number, line in enumerate(
-        Path(workflow_path).read_text().splitlines(), start=1
-    ):
-        if line.strip() == "run: uv run --script tools/notify-release-failure.py":
-            return f"{url}#L{line_number}"
-    return url
-
-
 def main() -> int:
     """Notify Slack of the current release result."""
     try:
@@ -163,6 +141,7 @@ def main() -> int:
         github_token = required_env("GH_TOKEN")
         slack_channel = required_env("SLACK_CHANNEL")
         slack_token = required_env("SLACK_BOT_TOKEN")
+        notification_source_url = required_env("NOTIFICATION_SOURCE_URL")
 
         version = os.environ.get("VERSION") or "unknown version"
         channel = os.environ.get("CHANNEL") or "unknown channel"
@@ -198,7 +177,7 @@ def main() -> int:
         ]
         footer = (
             f"<{run_url}|View workflow run> · "
-            f"<{notification_source_url(repository)}|View notification source>"
+            f"<{notification_source_url}|View notification source>"
         )
         blocks.append(
             {

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -9,11 +9,13 @@
 
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -132,6 +134,26 @@ def format_failure(failure: Failure) -> str:
     return f"• {job} — job concluded {conclusion}"
 
 
+def notification_source_url(repository: str) -> str:
+    workflow_path = (
+        required_env("GITHUB_WORKFLOW_REF")
+        .removeprefix(f"{repository}/")
+        .rsplit("@", 1)[0]
+    )
+    # Match the line number to the checked-out revision, which can differ from
+    # the workflow revision when the release explicitly checks out source_sha.
+    source_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], text=True
+    ).strip()
+    url = f"https://github.com/{repository}/blob/{source_sha}/{workflow_path}"
+    for line_number, line in enumerate(
+        Path(workflow_path).read_text().splitlines(), start=1
+    ):
+        if line.strip() == "run: uv run --script tools/notify-release-failure.py":
+            return f"{url}#L{line_number}"
+    return url
+
+
 def main() -> int:
     """Notify Slack of the current release result."""
     try:
@@ -172,9 +194,26 @@ def main() -> int:
                 f"*Run:* <{run_url}|View workflow run>"
             )
 
+        blocks = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": paragraph}}
+            for paragraph in message.split("\n\n")
+        ]
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"<{notification_source_url(repository)}|Notification source: release workflow step>",
+                    }
+                ],
+            }
+        )
+
         WebClient(token=slack_token).chat_postMessage(
             channel=slack_channel,
             text=message,
+            blocks=blocks,
             unfurl_links=False,
         )
         return 0


### PR DESCRIPTION
Add "View notification source" to the Slack notifications we send for failed/successful nightly and canary releases, to make it easier to understand where the notification comes from.

Clean up along the way (move secret into the baml language release environment)