### PR TITLE
chore: document BAML language and wrapper releases

### DIFF
--- a/baml_language/.markdown-whitelist
+++ b/baml_language/.markdown-whitelist
@@ -3,8 +3,9 @@
 # Supports glob patterns (*, **)
 # Only long-term informational .md files should be listed here
 
-# Release history
+# Release documentation
 CHANGELOG.md
+RELEASING.md
 
 # Test documentation
 crates/baml_tests/BENCHMARKS.md

--- a/baml_language/RELEASING.md
+++ b/baml_language/RELEASING.md
@@ -1,14 +1,22 @@
 # BAML Language Releases
 
-The BAML language release process runs as follows:
+To see the status of the latest ongoing release, visit the status page for [`release-baml-language.yml`](https://github.com/BoundaryML/baml/actions/workflows/release-baml-language.yml). Release failure/success is automatically posted to Slack.
 
-1. A human or agent merges a PR into `canary` that bumps the language release version and updates the corresponding package versions.
-2. Once CI passes for that commit, GitHub Actions starts a canary release from that exact source. Nightly releases use a separate daily schedule to select a green commit.
-3. The release workflow builds the toolchain and SDKs, then publishes packages and downloadable artifacts. During publication, it creates the GitHub release and attaches the version tag to the source commit.
-4. Once publishing and the required checks of published packages succeed, the workflow publishes the matching developer documentation and advances the channel to the new release.
-5. The workflow runs further artifact verification and reports the result in Slack. The current oncall follows the release through to completion and fixes any failures.
+**The current oncall is responsible for getting a canary release out every Friday and for investigating all failed releases.**
 
-**The current oncall is responsible for getting a canary release out every Friday and for keeping the release workflows working.** Merging the version bump starts the release; oncall owns the outcome.
+Both the nightly and canary release channels follow this process:
+
+1. Something triggers the release. (This is the primary difference between nightly and canary).
+2. `release-baml-language.yml` runs:
+   1. builds artifacts in parallel where possible
+   2. waits for `all-builds` to confirm that all builds succeeded
+   3. publishes individual artifacts:
+      1. uploads the toolchain to a GitHub release and assigns its tag to the source commit, e.g. `baml-language-0.18.0` or `baml-language-0.18.1-nightly.20260906.a`
+      2. publishes bridge packages and the version manifest (e.g. `pkg.boundaryml.com/manifest/v1/version/0.18.0.json`); the version manifest must be available before the Go package publishes
+   4. after required publishing, package checks, and documentation succeed, makes the new release available via `baml toolchain update` by updating the `pkg.boundaryml.com` channel manifest (`canary.json` or `nightly.json`)
+   5. runs further artifact verification
+3. Reports success or failure in Slack `#general`.
+4. Users can now pick up the new toolchain with `baml toolchain update`.
 
 ## Table of contents
 
@@ -19,19 +27,20 @@ The BAML language release process runs as follows:
 
 ## Nightly release
 
-1. Around midnight Pacific time, the [nightly dispatcher](../.github/workflows/nightly-release.yml) chooses the newest eligible commit on `canary` that has passed CI. Nights with no new eligible changes normally produce no release.
-2. The dispatcher uses the commit's existing `baml-language-source-<sha>` tag, created by CI, to start [release-baml-language.yml](../.github/workflows/release-baml-language.yml) with the `nightly` channel and the computed release version. The tag itself does not trigger the release.
-3. After the builds succeed, the workflow publishes artifacts and creates the GitHub release and tag `baml-language-<version>`, such as `baml-language-0.18.1-nightly.20260907.a`, at the source commit. The nightly channel advances after the required publishing, checks, and documentation steps succeed.
-4. Users who selected nightly with `baml toolchain use nightly` can then pick up the new release with `baml toolchain update`.
+Nightly releases are numbered like `0.18.1-nightly.20260906.a`
 
-Nightly versions use the next patch after the canary version, followed by the Pacific date that just ended and a letter distinguishing additional cuts that day.
+1. Around midnight Pacific time, the [nightly dispatcher workflow](../.github/workflows/nightly-release.yml) chooses the newest eligible commit on `canary` that has passed CI. Humans/agents can also manually trigger nightly releases.
+2. The dispatcher uses the commit's existing `baml-language-source-<sha>` tag, created by CI, to start [release-baml-language.yml](../.github/workflows/release-baml-language.yml) for the `nightly` channel.
+3. `release-baml-language.yml` runs, first building everything, then publishing the individual pieces, and updating the nightly channel manifest once its prerequisites succeed.
+   1. It computes the nightly release version before building, e.g. `0.18.1-nightly.20260906.a`.
+4. Users with `baml toolchain use nightly` can now pick up the new release with `baml toolchain update`.
 
 ## Canary release
 
-1. Merge a PR into `canary` that bumps the BAML language version in [release.toml](release.toml) and the corresponding versions throughout the repo. [Example](https://github.com/BoundaryML/baml/pull/4629).
-2. Once CI passes for that commit, automation creates the `baml-language-source-<sha>` tag and starts [release-baml-language.yml](../.github/workflows/release-baml-language.yml) with the `canary` channel and the new version. The channel is explicitly requested, rather than inferred from the tag.
-3. After the builds succeed, the workflow publishes artifacts and creates the GitHub release and tag `baml-language-<version>`, such as `baml-language-0.18.0`, at the source commit. The canary channel advances after the required publishing, checks, and documentation steps succeed.
-4. Users who selected canary with `baml toolchain use canary` can then pick up the new release with `baml toolchain update`.
+1. Merge a PR into `canary` to bump the release version in 20+ files in the repo: [release.toml](release.toml) and every BAML bridge's release version metadata, e.g. `pyproject.toml` or `package.json`. [Example](https://github.com/BoundaryML/baml/pull/4629).
+2. Once post-merge CI passes, automation creates the `baml-language-source-<sha>` tag and starts [release-baml-language.yml](../.github/workflows/release-baml-language.yml) with the `canary` channel and the new version.
+3. `release-baml-language.yml` runs, first building everything, then publishing the individual pieces, and updating the canary channel manifest once its prerequisites succeed.
+4. Users with `baml toolchain use canary` can now pick up the new release with `baml toolchain update`.
 
 ## What gets published
 

--- a/baml_language/RELEASING.md
+++ b/baml_language/RELEASING.md
@@ -1,4 +1,4 @@
-# BAML v1 Releases
+# BAML Language Releases
 
 The BAML language release process runs as follows:
 
@@ -14,7 +14,7 @@ The BAML language release process runs as follows:
 
 - [Nightly release](#nightly-release): scheduled releases, version tags, and updating a nightly toolchain.
 - [Canary release](#canary-release): version-bump PRs, release tags, and updating a canary toolchain.
-- [What gets published](#what-gets-published): released artifacts, package destinations, and architectures.
+- [What gets published](#what-gets-published): released toolchains, bridges, editor extensions, and documentation.
 - [BAML wrapper releases](#baml-wrapper-releases): the wrapper's separate version, publication, and package manager follow-through.
 
 ## Nightly release
@@ -37,27 +37,28 @@ Nightly versions use the next patch after the canary version, followed by the Pa
 
 Canary and nightly releases ship the language toolchain and SDKs under the selected release version, with registry-specific version formatting where needed.
 
-- GitHub release: `baml-language-<version>-<target>` toolchain archives containing `baml-cli`, `baml-pack-host`, the VS Code extension, and playground assets (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
-- GitHub release: `baml-language-<version>.vsix` VS Code extension (platform independent).
-- GitHub release: `libbaml_cffi` shared libraries, named `baml_cffi` on Windows (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
-- PyPI: `baml-bridge` wheels (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
-- npm: `@boundaryml/baml-bridge` and its platform packages (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows). Canary publishes under `latest`; nightly publishes under `nightly`.
-- npm: `@boundaryml/baml-bridge-web` (WebAssembly, `wasm32-unknown-unknown`), using the same npm tags.
-- Maven Central: `com.boundaryml:baml-bridge`, including main, sources, Javadoc, and native JARs (x64-linux-gnu, aarch64-linux-gnu, x64-darwin, aarch64-darwin, x64-windows; experimental builds for x64-linux-musl, aarch64-linux-musl, and aarch64-windows may be omitted if they fail).
-- Maven Central: `com.boundaryml:baml-bridge-kotlin`, `com.boundaryml:baml-gradle-plugin`, and the `com.boundaryml.baml` plugin marker (JVM). Canary also publishes the plugin to the Gradle Plugin Portal.
-- NuGet: `baml-bridge`, including native runtimes (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
-- crates.io: `baml_bridge` (source crate; uses the shared native libraries listed above).
-- Go: [`github.com/boundaryml/baml-go`](https://github.com/BoundaryML/baml-go) version tag (source module; uses the shared native libraries listed above).
-- Swift: [`BoundaryML/baml-swift`](https://github.com/BoundaryML/baml-swift) version tag and `BamlBridgeFFI-<version>.xcframework.zip` on the GitHub release (x64-darwin, aarch64-darwin, aarch64-ios, x64-ios-simulator, aarch64-ios-simulator).
-- GitHub release: SHA-256 checksum files for toolchain archives, the VS Code extension, and shared native libraries.
-- `pkg.boundaryml.com`: version and channel manifests, the download page, and `install.sh` / `install.ps1` installers.
-- `developer.boundaryml.com`: the generated developer reference for the released toolchain.
-
-Publication happens across several destinations. Packages and the GitHub release can become visible before the whole release succeeds. The toolchain channel advances only after its required publishing, public-package checks, and documentation steps complete; further artifact verification runs afterward.
+- Toolchain: `baml toolchain use 0.18.0`
+  - CLI itself (per-architecture, packaged in the GitHub release).
+  - `pkg.boundaryml.com` release manifests: `/manifest/v1/canary.json`, `/manifest/v1/nightly.json`, and `/manifest/v1/version/<version>.json`.
+- VS Code extension: `.vsix` (platform independent, packaged in the GitHub release and toolchain archives).
+- BAML bridges
+  - CFFI dynamic library: `.dylib`, `.so`, `.dll` (per-architecture, packaged in the GitHub release).
+  - Python package: PyPI `baml-bridge`, installed with `uv add baml-bridge` (per-architecture wheels).
+  - `typescript/node` npm package: `@boundaryml/baml-bridge` (with per-architecture native packages).
+  - `typescript/web` npm package: `@boundaryml/baml-bridge-web` (platform-independent WebAssembly).
+    - Includes bridges for browsers (Chrome, Firefox) and Cloudflare Workers.
+  - Java package: Maven Central `com.boundaryml:baml-bridge` (with per-architecture native JARs).
+  - Kotlin package: Maven Central `com.boundaryml:baml-bridge-kotlin`.
+  - Gradle plugin: Maven Central `com.boundaryml:baml-gradle-plugin` and the `com.boundaryml.baml` plugin marker; also published to the Gradle Plugin Portal for canary releases.
+  - C# package: NuGet `baml-bridge` (one package containing per-architecture native libraries).
+  - Rust crate: crates.io `baml_bridge`.
+  - Go release: the bridge runtime is pushed to `github.com/BoundaryML/baml-go` under a new version tag.
+  - Swift release: the bridge runtime is pushed to `github.com/BoundaryML/baml-swift` under a new version tag, with `BamlBridgeFFI-<version>.xcframework.zip` published on the GitHub release (macOS, iOS, and iOS Simulator).
+- Documentation: the generated developer reference at `developer.boundaryml.com`.
 
 # BAML wrapper releases
 
-The wrapper is the `baml` command that installs, selects, and launches language toolchains. It has an independent version and is shared by the canary and nightly channels. Updating the wrapper does not itself change the user's selected language toolchain.
+The wrapper is the `baml` command that installs, selects, and launches language toolchains. It is versioned independently.
 
 1. Prepare a PR that bumps the wrapper version in its [package manifest](crates/baml/Cargo.toml) when wrapper changes need to ship. For a first wrapper release, talk to Paulo or Avery before changing that version, as the manifest requests.
 2. Merge the PR into `canary`. The next language release containing the bump, whether canary or nightly, also publishes the wrapper if its version differs from the currently published wrapper. A wrapper-only bump does not by itself trigger an immediate canary release.

--- a/baml_language/RELEASING.md
+++ b/baml_language/RELEASING.md
@@ -8,15 +8,13 @@ The BAML language release process runs as follows:
 4. Once publishing and the required checks of published packages succeed, the workflow publishes the matching developer documentation and advances the channel to the new release.
 5. The workflow runs further artifact verification and reports the result in Slack. The current oncall follows the release through to completion and fixes any failures.
 
-**The current oncall is responsible for getting a canary release out every Friday and for keeping the release workflows working.** Merging the version bump starts the release; oncall owns the outcome.
+**The [current oncall](../tools/bctl_src/oncall/data/schedule.oncall) is responsible for getting a canary release out every Friday and for keeping the release workflows working.**
 
 ## Table of contents
 
 - [Nightly and canary](#nightly-and-canary): release cadence, source selection, and version names.
-- [Friday release ownership](#friday-release-ownership): oncall's responsibilities and handoff expectations.
 - [Preparing a canary release](#preparing-a-canary-release): what belongs in the release PR and what starts publication.
 - [What gets published](#what-gets-published): the toolchain, SDKs, editor package, and documentation.
-- [Confirming completion and handling failures](#confirming-completion-and-handling-failures): how to track a release and recover when it stalls.
 - [BAML wrapper releases](#baml-wrapper-releases): the wrapper's separate version, publication, and package manager follow-through.
 
 ## Nightly and canary
@@ -26,7 +24,7 @@ Both channels release code from the `canary` branch. The branch name and the rel
 | | Canary | Nightly |
 | --- | --- | --- |
 | Purpose | The deliberately selected release we ship each Friday. | A daily way to try newer changes between canary releases. |
-| Trigger | A merged language version bump followed by green CI on that commit. | The nightly schedule, around midnight Pacific time. |
+| Trigger | A merged language version bump followed by green CI on that commit. | The [nightly schedule](https://github.com/BoundaryML/baml/actions/workflows/nightly-release.yml), around midnight Pacific time. |
 | Source | The exact version-bump commit. | The newest eligible `canary` commit with successful CI. |
 | Version | The version in [release.toml](release.toml), such as `0.18.0`. | The next patch version with a nightly suffix, such as `0.18.1-nightly.20260907.a`. |
 
@@ -36,22 +34,11 @@ A night with no new eligible changes normally produces no release. The schedule 
 
 Friday is our release commitment, rather than an automatic canary schedule. Oncall must arrange the version bump and follow the resulting release. Additional canary releases can use the same process when needed.
 
-## Friday release ownership
-
-The current oncall, as recorded in the [oncall schedule](../tools/bctl_src/oncall/data/schedule.oncall), is accountable for the Friday canary release and failures in either release channel.
-
-- Arrange the release PR early enough for review, CI, publication, and repairs to finish on Friday.
-- Monitor the source commit's CI and the resulting release workflow until publishing and verification finish.
-- Fix broken workflows and release blockers, involving the relevant owners as needed while retaining responsibility for getting the release out.
-- If a release is still blocked at handoff, explicitly hand over the affected version, workflow run, blocker, and next action to the incoming oncall.
-
-A green nightly does not replace the Friday canary release. An unresolved release failure remains oncall work even if some artifacts have already published.
-
 ## Preparing a canary release
 
 1. Choose a new, unreleased language version and prepare a PR with the intended release changes.
 2. Update [release.toml](release.toml) and the corresponding package versions together using the [language version tooling](../scripts/baml-language-version). Review the resulting changes and describe what is shipping in the PR.
-3. Merge into `canary`, then follow **CI - BAML Language** for the merged commit. Successful CI automatically starts **BAML Language Release** for the new version.
+3. Merge into `canary`, then follow [CI - BAML Language](https://github.com/BoundaryML/baml/actions/workflows/ci.yaml) for the merged commit. Successful CI automatically starts [BAML Language Release](https://github.com/BoundaryML/baml/actions/workflows/release-baml-language.yml) for the new version.
 
 The release uses that tested commit even if more PRs merge while it is running. GitHub Actions creates the language release tag, `baml-language-<version>`, during publication; creating a tag manually is not part of starting a language release.
 
@@ -64,27 +51,17 @@ Canary and nightly releases ship the language toolchain and SDKs under the selec
 | Deliverable | Destination |
 | --- | --- |
 | Language toolchain, VS Code extension package, and native libraries | [GitHub releases](https://github.com/BoundaryML/baml/releases) |
-| Python SDK | PyPI |
-| Node.js and browser SDKs | npm, under the matching `canary` or `nightly` tag |
-| Java SDK | Maven Central |
-| Gradle plugin | Gradle Plugin Portal for canary releases; skipped for nightlies |
-| C# SDK | NuGet |
-| Rust SDK | crates.io |
-| Go and Swift SDKs | Their package mirror repositories, with supporting release assets |
-| Toolchain download catalog and channel selection | `pkg.boundaryml.com` |
-| Generated developer reference | The developer documentation site, matched to the released toolchain |
+| Python SDK | [baml-bridge on PyPI](https://pypi.org/project/baml-bridge/) |
+| Node.js and browser SDKs | [@boundaryml/baml-bridge](https://www.npmjs.com/package/@boundaryml/baml-bridge) and [@boundaryml/baml-bridge-web](https://www.npmjs.com/package/@boundaryml/baml-bridge-web) on npm; canary uses `latest`, nightly uses `nightly` |
+| Java and Kotlin SDKs | [baml-bridge](https://central.sonatype.com/artifact/com.boundaryml/baml-bridge) and [baml-bridge-kotlin](https://central.sonatype.com/artifact/com.boundaryml/baml-bridge-kotlin) on Maven Central |
+| Gradle plugin | [Maven Central](https://central.sonatype.com/artifact/com.boundaryml/baml-gradle-plugin) for both channels; also the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.boundaryml.baml) for canary |
+| C# SDK | [baml-bridge on NuGet](https://www.nuget.org/packages/baml-bridge) |
+| Rust SDK | [baml_bridge on crates.io](https://crates.io/crates/baml_bridge) |
+| Go and Swift SDKs | [baml-go](https://github.com/BoundaryML/baml-go) and [baml-swift](https://github.com/BoundaryML/baml-swift) package mirrors, with supporting release assets |
+| Toolchain download catalog and channel selection | [pkg.boundaryml.com](https://pkg.boundaryml.com) |
+| Generated developer reference | [developer.boundaryml.com](https://developer.boundaryml.com), matched to the released toolchain |
 
 Publication happens across several destinations. Packages and the GitHub release can become visible before the whole release succeeds. The toolchain channel advances only after its required publishing, public-package checks, and documentation steps complete; further artifact verification runs afterward.
-
-## Confirming completion and handling failures
-
-Track the source commit in [CI - BAML Language](https://github.com/BoundaryML/baml/actions/workflows/ci.yaml) and publication in [BAML Language Release](https://github.com/BoundaryML/baml/actions/workflows/release-baml-language.yml). For a missing nightly, also check [Nightly BAML Language Release](https://github.com/BoundaryML/baml/actions/workflows/nightly-release.yml), which selects the source and starts the release.
-
-Before considering the release done, confirm that the intended version and source match, all required publishing and verification jobs have succeeded, and the corresponding toolchain channel and developer reference have advanced. Slack reports release results in `#general`, but a notification or an existing GitHub tag alone is not sufficient evidence of completion.
-
-For a transient failure, retry the failed jobs in the original release run and monitor the remaining work. A rerun still uses the original source; it does not pick up later fixes merged into `canary`.
-
-If the product or workflow needs a source change, merge the fix and release a new version through the appropriate channel. Preserve published versions and tags. A partially published canary may already be visible to users, and CI may see its existing GitHub release and decline to start another cut of that version. Oncall owns resolving that partial release and verifying the replacement.
 
 # BAML wrapper releases
 
@@ -92,7 +69,7 @@ The wrapper is the `baml` command that installs, selects, and launches language 
 
 1. Prepare a PR that bumps the wrapper version in its [package manifest](crates/baml/Cargo.toml) when wrapper changes need to ship. For a first wrapper release, talk to Paulo or Avery before changing that version, as the manifest requests.
 2. Merge the PR into `canary`. The next language release containing the bump, whether canary or nightly, also publishes the wrapper if its version differs from the currently published wrapper. A wrapper-only bump does not by itself trigger an immediate canary release.
-3. The release workflow publishes wrapper downloads and a `baml-wrapper-<version>` GitHub release and tag, updates the wrapper download catalog, and tests and updates the BoundaryML Homebrew tap.
+3. The release workflow publishes wrapper downloads and a `baml-wrapper-<version>` GitHub release and tag, updates the wrapper download catalog, and tests and updates the [BoundaryML Homebrew tap](https://github.com/BoundaryML/homebrew-tap).
 4. Follow the release workflow and any resulting Homebrew Core version-bump PR through to success. Homebrew Core may open that PR automatically; its completion needs separate attention from the language release workflow.
 
 The person arranging the wrapper release must plan to monitor both the workflow and Homebrew follow-through, with the current oncall retaining responsibility for release failures. Users receive wrapper updates through the standalone installer's self-update support or their package manager. A language release with no wrapper version change reuses the published wrapper.

--- a/baml_language/RELEASING.md
+++ b/baml_language/RELEASING.md
@@ -14,7 +14,6 @@ Both the nightly and canary release channels follow this process:
       1. uploads the toolchain to a GitHub release and assigns its tag to the source commit, e.g. `baml-language-0.18.0` or `baml-language-0.18.1-nightly.20260906.a`
       2. publishes bridge packages and the version manifest (e.g. `pkg.boundaryml.com/manifest/v1/version/0.18.0.json`); the version manifest must be available before the Go package publishes
    4. after required publishing, package checks, and documentation succeed, makes the new release available via `baml toolchain update` by updating the `pkg.boundaryml.com` channel manifest (`canary.json` or `nightly.json`)
-   5. runs further artifact verification
 3. Reports success or failure in Slack `#general`.
 4. Users can now pick up the new toolchain with `baml toolchain update`.
 

--- a/baml_language/RELEASING.md
+++ b/baml_language/RELEASING.md
@@ -1,0 +1,98 @@
+# BAML v1 Releases
+
+The BAML language release process runs as follows:
+
+1. A human or agent merges a PR into `canary` that bumps the language release version and updates the corresponding package versions.
+2. Once CI passes for that commit, GitHub Actions starts a canary release from that exact source. Nightly releases use a separate daily schedule to select a green commit.
+3. The release workflow builds the toolchain and SDKs, then publishes packages and downloadable artifacts. During publication, it creates the GitHub release and attaches the version tag to the source commit.
+4. Once publishing and the required checks of published packages succeed, the workflow publishes the matching developer documentation and advances the channel to the new release.
+5. The workflow runs further artifact verification and reports the result in Slack. The current oncall follows the release through to completion and fixes any failures.
+
+**The current oncall is responsible for getting a canary release out every Friday and for keeping the release workflows working.** Merging the version bump starts the release; oncall owns the outcome.
+
+## Table of contents
+
+- [Nightly and canary](#nightly-and-canary): release cadence, source selection, and version names.
+- [Friday release ownership](#friday-release-ownership): oncall's responsibilities and handoff expectations.
+- [Preparing a canary release](#preparing-a-canary-release): what belongs in the release PR and what starts publication.
+- [What gets published](#what-gets-published): the toolchain, SDKs, editor package, and documentation.
+- [Confirming completion and handling failures](#confirming-completion-and-handling-failures): how to track a release and recover when it stalls.
+- [BAML wrapper releases](#baml-wrapper-releases): the wrapper's separate version, publication, and package manager follow-through.
+
+## Nightly and canary
+
+Both channels release code from the `canary` branch. The branch name and the release channel are separate concepts: merging ordinary changes makes them eligible for a nightly; a language version bump requests a canary release.
+
+| | Canary | Nightly |
+| --- | --- | --- |
+| Purpose | The deliberately selected release we ship each Friday. | A daily way to try newer changes between canary releases. |
+| Trigger | A merged language version bump followed by green CI on that commit. | The nightly schedule, around midnight Pacific time. |
+| Source | The exact version-bump commit. | The newest eligible `canary` commit with successful CI. |
+| Version | The version in [release.toml](release.toml), such as `0.18.0`. | The next patch version with a nightly suffix, such as `0.18.1-nightly.20260907.a`. |
+
+The nightly date names the Pacific day that just ended; the letter distinguishes additional cuts for the same date. Registries may represent this version differently to fit their own version rules.
+
+A night with no new eligible changes normally produces no release. The schedule also avoids starting another release when a successful release already exists or a run is in progress for the selected commit, so a canary cut can cause that night's nightly to be skipped. Nightlies do not require a version-bump PR, and releasing a canary does not immediately trigger a nightly.
+
+Friday is our release commitment, rather than an automatic canary schedule. Oncall must arrange the version bump and follow the resulting release. Additional canary releases can use the same process when needed.
+
+## Friday release ownership
+
+The current oncall, as recorded in the [oncall schedule](../tools/bctl_src/oncall/data/schedule.oncall), is accountable for the Friday canary release and failures in either release channel.
+
+- Arrange the release PR early enough for review, CI, publication, and repairs to finish on Friday.
+- Monitor the source commit's CI and the resulting release workflow until publishing and verification finish.
+- Fix broken workflows and release blockers, involving the relevant owners as needed while retaining responsibility for getting the release out.
+- If a release is still blocked at handoff, explicitly hand over the affected version, workflow run, blocker, and next action to the incoming oncall.
+
+A green nightly does not replace the Friday canary release. An unresolved release failure remains oncall work even if some artifacts have already published.
+
+## Preparing a canary release
+
+1. Choose a new, unreleased language version and prepare a PR with the intended release changes.
+2. Update [release.toml](release.toml) and the corresponding package versions together using the [language version tooling](../scripts/baml-language-version). Review the resulting changes and describe what is shipping in the PR.
+3. Merge into `canary`, then follow **CI - BAML Language** for the merged commit. Successful CI automatically starts **BAML Language Release** for the new version.
+
+The release uses that tested commit even if more PRs merge while it is running. GitHub Actions creates the language release tag, `baml-language-<version>`, during publication; creating a tag manually is not part of starting a language release.
+
+The wrapper has its own version and release responsibilities, described [below](#baml-wrapper-releases). A normal language release only needs a language version bump.
+
+## What gets published
+
+Canary and nightly releases ship the language toolchain and SDKs under the selected release version, with registry-specific version formatting where needed.
+
+| Deliverable | Destination |
+| --- | --- |
+| Language toolchain, VS Code extension package, and native libraries | [GitHub releases](https://github.com/BoundaryML/baml/releases) |
+| Python SDK | PyPI |
+| Node.js and browser SDKs | npm, under the matching `canary` or `nightly` tag |
+| Java SDK | Maven Central |
+| Gradle plugin | Gradle Plugin Portal for canary releases; skipped for nightlies |
+| C# SDK | NuGet |
+| Rust SDK | crates.io |
+| Go and Swift SDKs | Their package mirror repositories, with supporting release assets |
+| Toolchain download catalog and channel selection | `pkg.boundaryml.com` |
+| Generated developer reference | The developer documentation site, matched to the released toolchain |
+
+Publication happens across several destinations. Packages and the GitHub release can become visible before the whole release succeeds. The toolchain channel advances only after its required publishing, public-package checks, and documentation steps complete; further artifact verification runs afterward.
+
+## Confirming completion and handling failures
+
+Track the source commit in [CI - BAML Language](https://github.com/BoundaryML/baml/actions/workflows/ci.yaml) and publication in [BAML Language Release](https://github.com/BoundaryML/baml/actions/workflows/release-baml-language.yml). For a missing nightly, also check [Nightly BAML Language Release](https://github.com/BoundaryML/baml/actions/workflows/nightly-release.yml), which selects the source and starts the release.
+
+Before considering the release done, confirm that the intended version and source match, all required publishing and verification jobs have succeeded, and the corresponding toolchain channel and developer reference have advanced. Slack reports release results in `#general`, but a notification or an existing GitHub tag alone is not sufficient evidence of completion.
+
+For a transient failure, retry the failed jobs in the original release run and monitor the remaining work. A rerun still uses the original source; it does not pick up later fixes merged into `canary`.
+
+If the product or workflow needs a source change, merge the fix and release a new version through the appropriate channel. Preserve published versions and tags. A partially published canary may already be visible to users, and CI may see its existing GitHub release and decline to start another cut of that version. Oncall owns resolving that partial release and verifying the replacement.
+
+# BAML wrapper releases
+
+The wrapper is the `baml` command that installs, selects, and launches language toolchains. It has an independent version and is shared by the canary and nightly channels. Updating the wrapper does not itself change the user's selected language toolchain.
+
+1. Prepare a PR that bumps the wrapper version in its [package manifest](crates/baml/Cargo.toml) when wrapper changes need to ship. For a first wrapper release, talk to Paulo or Avery before changing that version, as the manifest requests.
+2. Merge the PR into `canary`. The next language release containing the bump, whether canary or nightly, also publishes the wrapper if its version differs from the currently published wrapper. A wrapper-only bump does not by itself trigger an immediate canary release.
+3. The release workflow publishes wrapper downloads and a `baml-wrapper-<version>` GitHub release and tag, updates the wrapper download catalog, and tests and updates the BoundaryML Homebrew tap.
+4. Follow the release workflow and any resulting Homebrew Core version-bump PR through to success. Homebrew Core may open that PR automatically; its completion needs separate attention from the language release workflow.
+
+The person arranging the wrapper release must plan to monitor both the workflow and Homebrew follow-through, with the current oncall retaining responsibility for release failures. Users receive wrapper updates through the standalone installer's self-update support or their package manager. A language release with no wrapper version change reuses the published wrapper.

--- a/baml_language/RELEASING.md
+++ b/baml_language/RELEASING.md
@@ -8,58 +8,50 @@ The BAML language release process runs as follows:
 4. Once publishing and the required checks of published packages succeed, the workflow publishes the matching developer documentation and advances the channel to the new release.
 5. The workflow runs further artifact verification and reports the result in Slack. The current oncall follows the release through to completion and fixes any failures.
 
-**The [current oncall](../tools/bctl_src/oncall/data/schedule.oncall) is responsible for getting a canary release out every Friday and for keeping the release workflows working.**
+**The current oncall is responsible for getting a canary release out every Friday and for keeping the release workflows working.** Merging the version bump starts the release; oncall owns the outcome.
 
 ## Table of contents
 
-- [Nightly and canary](#nightly-and-canary): release cadence, source selection, and version names.
-- [Preparing a canary release](#preparing-a-canary-release): what belongs in the release PR and what starts publication.
-- [What gets published](#what-gets-published): the toolchain, SDKs, editor package, and documentation.
+- [Nightly release](#nightly-release): scheduled releases, version tags, and updating a nightly toolchain.
+- [Canary release](#canary-release): version-bump PRs, release tags, and updating a canary toolchain.
+- [What gets published](#what-gets-published): released artifacts, package destinations, and architectures.
 - [BAML wrapper releases](#baml-wrapper-releases): the wrapper's separate version, publication, and package manager follow-through.
 
-## Nightly and canary
+## Nightly release
 
-Both channels release code from the `canary` branch. The branch name and the release channel are separate concepts: merging ordinary changes makes them eligible for a nightly; a language version bump requests a canary release.
+1. Around midnight Pacific time, the [nightly dispatcher](../.github/workflows/nightly-release.yml) chooses the newest eligible commit on `canary` that has passed CI. Nights with no new eligible changes normally produce no release.
+2. The dispatcher uses the commit's existing `baml-language-source-<sha>` tag, created by CI, to start [release-baml-language.yml](../.github/workflows/release-baml-language.yml) with the `nightly` channel and the computed release version. The tag itself does not trigger the release.
+3. After the builds succeed, the workflow publishes artifacts and creates the GitHub release and tag `baml-language-<version>`, such as `baml-language-0.18.1-nightly.20260907.a`, at the source commit. The nightly channel advances after the required publishing, checks, and documentation steps succeed.
+4. Users who selected nightly with `baml toolchain use nightly` can then pick up the new release with `baml toolchain update`.
 
-| | Canary | Nightly |
-| --- | --- | --- |
-| Purpose | The deliberately selected release we ship each Friday. | A daily way to try newer changes between canary releases. |
-| Trigger | A merged language version bump followed by green CI on that commit. | The [nightly schedule](https://github.com/BoundaryML/baml/actions/workflows/nightly-release.yml), around midnight Pacific time. |
-| Source | The exact version-bump commit. | The newest eligible `canary` commit with successful CI. |
-| Version | The version in [release.toml](release.toml), such as `0.18.0`. | The next patch version with a nightly suffix, such as `0.18.1-nightly.20260907.a`. |
+Nightly versions use the next patch after the canary version, followed by the Pacific date that just ended and a letter distinguishing additional cuts that day.
 
-The nightly date names the Pacific day that just ended; the letter distinguishes additional cuts for the same date. Registries may represent this version differently to fit their own version rules.
+## Canary release
 
-A night with no new eligible changes normally produces no release. The schedule also avoids starting another release when a successful release already exists or a run is in progress for the selected commit, so a canary cut can cause that night's nightly to be skipped. Nightlies do not require a version-bump PR, and releasing a canary does not immediately trigger a nightly.
-
-Friday is our release commitment, rather than an automatic canary schedule. Oncall must arrange the version bump and follow the resulting release. Additional canary releases can use the same process when needed.
-
-## Preparing a canary release
-
-1. Choose a new, unreleased language version and prepare a PR with the intended release changes.
-2. Update [release.toml](release.toml) and the corresponding package versions together using the [language version tooling](../scripts/baml-language-version). Review the resulting changes and describe what is shipping in the PR.
-3. Merge into `canary`, then follow [CI - BAML Language](https://github.com/BoundaryML/baml/actions/workflows/ci.yaml) for the merged commit. Successful CI automatically starts [BAML Language Release](https://github.com/BoundaryML/baml/actions/workflows/release-baml-language.yml) for the new version.
-
-The release uses that tested commit even if more PRs merge while it is running. GitHub Actions creates the language release tag, `baml-language-<version>`, during publication; creating a tag manually is not part of starting a language release.
-
-The wrapper has its own version and release responsibilities, described [below](#baml-wrapper-releases). A normal language release only needs a language version bump.
+1. Merge a PR into `canary` that bumps the BAML language version in [release.toml](release.toml) and the corresponding versions throughout the repo. [Example](https://github.com/BoundaryML/baml/pull/4629).
+2. Once CI passes for that commit, automation creates the `baml-language-source-<sha>` tag and starts [release-baml-language.yml](../.github/workflows/release-baml-language.yml) with the `canary` channel and the new version. The channel is explicitly requested, rather than inferred from the tag.
+3. After the builds succeed, the workflow publishes artifacts and creates the GitHub release and tag `baml-language-<version>`, such as `baml-language-0.18.0`, at the source commit. The canary channel advances after the required publishing, checks, and documentation steps succeed.
+4. Users who selected canary with `baml toolchain use canary` can then pick up the new release with `baml toolchain update`.
 
 ## What gets published
 
 Canary and nightly releases ship the language toolchain and SDKs under the selected release version, with registry-specific version formatting where needed.
 
-| Deliverable | Destination |
-| --- | --- |
-| Language toolchain, VS Code extension package, and native libraries | [GitHub releases](https://github.com/BoundaryML/baml/releases) |
-| Python SDK | [baml-bridge on PyPI](https://pypi.org/project/baml-bridge/) |
-| Node.js and browser SDKs | [@boundaryml/baml-bridge](https://www.npmjs.com/package/@boundaryml/baml-bridge) and [@boundaryml/baml-bridge-web](https://www.npmjs.com/package/@boundaryml/baml-bridge-web) on npm; canary uses `latest`, nightly uses `nightly` |
-| Java and Kotlin SDKs | [baml-bridge](https://central.sonatype.com/artifact/com.boundaryml/baml-bridge) and [baml-bridge-kotlin](https://central.sonatype.com/artifact/com.boundaryml/baml-bridge-kotlin) on Maven Central |
-| Gradle plugin | [Maven Central](https://central.sonatype.com/artifact/com.boundaryml/baml-gradle-plugin) for both channels; also the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.boundaryml.baml) for canary |
-| C# SDK | [baml-bridge on NuGet](https://www.nuget.org/packages/baml-bridge) |
-| Rust SDK | [baml_bridge on crates.io](https://crates.io/crates/baml_bridge) |
-| Go and Swift SDKs | [baml-go](https://github.com/BoundaryML/baml-go) and [baml-swift](https://github.com/BoundaryML/baml-swift) package mirrors, with supporting release assets |
-| Toolchain download catalog and channel selection | [pkg.boundaryml.com](https://pkg.boundaryml.com) |
-| Generated developer reference | [developer.boundaryml.com](https://developer.boundaryml.com), matched to the released toolchain |
+- GitHub release: `baml-language-<version>-<target>` toolchain archives containing `baml-cli`, `baml-pack-host`, the VS Code extension, and playground assets (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
+- GitHub release: `baml-language-<version>.vsix` VS Code extension (platform independent).
+- GitHub release: `libbaml_cffi` shared libraries, named `baml_cffi` on Windows (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
+- PyPI: `baml-bridge` wheels (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
+- npm: `@boundaryml/baml-bridge` and its platform packages (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows). Canary publishes under `latest`; nightly publishes under `nightly`.
+- npm: `@boundaryml/baml-bridge-web` (WebAssembly, `wasm32-unknown-unknown`), using the same npm tags.
+- Maven Central: `com.boundaryml:baml-bridge`, including main, sources, Javadoc, and native JARs (x64-linux-gnu, aarch64-linux-gnu, x64-darwin, aarch64-darwin, x64-windows; experimental builds for x64-linux-musl, aarch64-linux-musl, and aarch64-windows may be omitted if they fail).
+- Maven Central: `com.boundaryml:baml-bridge-kotlin`, `com.boundaryml:baml-gradle-plugin`, and the `com.boundaryml.baml` plugin marker (JVM). Canary also publishes the plugin to the Gradle Plugin Portal.
+- NuGet: `baml-bridge`, including native runtimes (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows).
+- crates.io: `baml_bridge` (source crate; uses the shared native libraries listed above).
+- Go: [`github.com/boundaryml/baml-go`](https://github.com/BoundaryML/baml-go) version tag (source module; uses the shared native libraries listed above).
+- Swift: [`BoundaryML/baml-swift`](https://github.com/BoundaryML/baml-swift) version tag and `BamlBridgeFFI-<version>.xcframework.zip` on the GitHub release (x64-darwin, aarch64-darwin, aarch64-ios, x64-ios-simulator, aarch64-ios-simulator).
+- GitHub release: SHA-256 checksum files for toolchain archives, the VS Code extension, and shared native libraries.
+- `pkg.boundaryml.com`: version and channel manifests, the download page, and `install.sh` / `install.ps1` installers.
+- `developer.boundaryml.com`: the generated developer reference for the released toolchain.
 
 Publication happens across several destinations. Packages and the GitHub release can become visible before the whole release succeeds. The toolchain channel advances only after its required publishing, public-package checks, and documentation steps complete; further artifact verification runs afterward.
 
@@ -69,7 +61,7 @@ The wrapper is the `baml` command that installs, selects, and launches language 
 
 1. Prepare a PR that bumps the wrapper version in its [package manifest](crates/baml/Cargo.toml) when wrapper changes need to ship. For a first wrapper release, talk to Paulo or Avery before changing that version, as the manifest requests.
 2. Merge the PR into `canary`. The next language release containing the bump, whether canary or nightly, also publishes the wrapper if its version differs from the currently published wrapper. A wrapper-only bump does not by itself trigger an immediate canary release.
-3. The release workflow publishes wrapper downloads and a `baml-wrapper-<version>` GitHub release and tag, updates the wrapper download catalog, and tests and updates the [BoundaryML Homebrew tap](https://github.com/BoundaryML/homebrew-tap).
+3. The release workflow publishes wrapper archives and checksums (x64-linux-gnu, aarch64-linux-gnu, x64-linux-musl, aarch64-linux-musl, x64-darwin, aarch64-darwin, x64-windows, aarch64-windows) and a `baml-wrapper-<version>` GitHub release and tag, updates the wrapper download catalog, and tests and updates the BoundaryML Homebrew tap.
 4. Follow the release workflow and any resulting Homebrew Core version-bump PR through to success. Homebrew Core may open that PR automatically; its completion needs separate attention from the language release workflow.
 
 The person arranging the wrapper release must plan to monitor both the workflow and Homebrew follow-through, with the current oncall retaining responsibility for release failures. Users receive wrapper updates through the standalone installer's self-update support or their package manager. A language release with no wrapper version change reuses the published wrapper.


### PR DESCRIPTION
Add documentation about how the baml language release works, and everything that an oncaller needs to know to understand what to do.