### PR TITLE
Add shared rainbow animation for native Rust sigils

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -27,7 +27,7 @@ pub use baml_base::escape::unescape_string_literal;
 pub use disambiguate::{FIELD_ATTR_NAMES, is_field_attr};
 pub use docstring::extract_docstring;
 pub use lower_cst::{
-    lower_file, lower_file_with_path, lower_file_with_path_and_test_owner,
+    check_builtin_body, lower_file, lower_file_with_path, lower_file_with_path_and_test_owner,
     lower_session_file_with_path_and_test_owner,
 };
 pub use lower_expr_body::{EnvVarRef, synthesize_spec_stream_body};

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -547,7 +547,7 @@ fn lower_function(
 ///
 /// The expected CST structure is:
 /// `EXPR_FUNCTION_BODY { BLOCK_EXPR { L_BRACE PATH_EXPR { WORD("$rust_function") } R_BRACE } }`
-fn check_builtin_body(expr_body_node: &SyntaxNode) -> Option<BuiltinKind> {
+pub fn check_builtin_body(expr_body_node: &SyntaxNode) -> Option<BuiltinKind> {
     use baml_compiler_syntax::SyntaxKind;
 
     // Collect all non-trivia tokens from the body

--- a/baml_language/crates/baml_ide/src/definition.rs
+++ b/baml_language/crates/baml_ide/src/definition.rs
@@ -47,6 +47,40 @@ mod tests {
     }
 
     #[test]
+    fn qualified_builtin_type_resolves_in_annotations() {
+        for annotation in [
+            "function Inspect(file: baml.fs.Fi<[CURSOR]le) -> int { 0 }",
+            "function Inspect() -> baml.fs.Fi<[CURSOR]le { null }",
+            "class Handles { files: baml.fs.Fi<[CURSOR]le[], }",
+        ] {
+            let source = format!("class File {{ local: int, }}\n{annotation}");
+            let test = CursorTest::new(&source);
+            let loc = test.goto_definition().expect("qualified File definition");
+            assert!(
+                loc.file
+                    .path(&test.db)
+                    .to_string_lossy()
+                    .ends_with("baml/ns_fs/fs.baml"),
+                "wrong target: {}",
+                loc.file.path(&test.db).display()
+            );
+            assert_eq!(
+                &loc.file.text(&test.db)
+                    [usize::from(loc.range.start())..usize::from(loc.range.end())],
+                "File"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_qualified_type_does_not_resolve_to_an_unrelated_bare_type() {
+        let test = CursorTest::new(
+            "class File {}\nfunction Inspect(file: missing.fs.Fi<[CURSOR]le) -> int { 0 }",
+        );
+        assert!(test.goto_definition().is_none());
+    }
+
+    #[test]
     fn test_goto_def_parameter() {
         let test = CursorTest::new(
             r#"

--- a/baml_language/crates/baml_ide/src/resolve.rs
+++ b/baml_language/crates/baml_ide/src/resolve.rs
@@ -155,6 +155,14 @@ pub fn symbol_at(
         };
     }
 
+    if token
+        .parent()
+        .is_some_and(|node| node.kind() == SyntaxKind::TYPE_EXPR)
+        && crate::syntax::dotted_chain_to(&token).len() > 1
+    {
+        return qualified_item_at(db, file, offset, &token);
+    }
+
     if let Some(target) = local_at(db, file, offset, &name) {
         return Some(target);
     }

--- a/baml_language/crates/baml_ide/src/tokens.rs
+++ b/baml_language/crates/baml_ide/src/tokens.rs
@@ -72,6 +72,8 @@ pub enum SemanticTokenType {
     /// Boolean literal (`true` / `false`) — a custom type beyond the standard
     /// LSP legend, mirroring rust-analyzer's `boolean`.
     Boolean,
+    RustFunction,
+    RustType,
 }
 
 /// Token type legend — order determines the LSP legend index.
@@ -82,12 +84,16 @@ pub enum SemanticTokenType {
 pub const TOKEN_TYPES: &[SemanticTokenType] = &SemanticTokenType::ALL;
 
 impl SemanticTokenType {
+    pub fn is_rust_sigil(self) -> bool {
+        matches!(self, Self::RustFunction | Self::RustType)
+    }
+
     /// Every token type, in legend order.
     ///
     /// [`Self::legend_index`] is the enforcing source of the ordering; the
     /// round-trip unit test pins this array to it, so a variant can be
     /// neither missing here nor listed out of order without a test failure.
-    pub const ALL: [SemanticTokenType; 25] = [
+    pub const ALL: [SemanticTokenType; 27] = [
         SemanticTokenType::Namespace,
         SemanticTokenType::Type,
         SemanticTokenType::Class,
@@ -113,6 +119,8 @@ impl SemanticTokenType {
         SemanticTokenType::Decorator,
         SemanticTokenType::EscapeSequence,
         SemanticTokenType::Boolean,
+        SemanticTokenType::RustFunction,
+        SemanticTokenType::RustType,
     ];
 
     /// The index of this token type in the [`TOKEN_TYPES`] legend — the
@@ -147,6 +155,8 @@ impl SemanticTokenType {
             Self::Decorator => 22,
             Self::EscapeSequence => 23,
             Self::Boolean => 24,
+            Self::RustFunction => 25,
+            Self::RustType => 26,
         }
     }
 
@@ -178,6 +188,8 @@ impl SemanticTokenType {
             Self::Decorator => "decorator",
             Self::EscapeSequence => "escapeSequence",
             Self::Boolean => "boolean",
+            Self::RustFunction => "bamlRustFunction",
+            Self::RustType => "bamlRustType",
         }
     }
 }
@@ -194,10 +206,16 @@ pub fn semantic_highlight_style(
 
     let (foreground, base_dim) = match token_type {
         T::Keyword | T::Modifier => (Some(HighlightColor::Magenta), false),
-        T::Class | T::Struct | T::Interface | T::Enum | T::Type | T::TypeParameter => {
-            (Some(HighlightColor::Yellow), false)
+        T::Class
+        | T::Struct
+        | T::Interface
+        | T::Enum
+        | T::Type
+        | T::TypeParameter
+        | T::RustType => (Some(HighlightColor::Yellow), false),
+        T::Function | T::Method | T::Macro | T::RustFunction => {
+            (Some(HighlightColor::BrightBlue), false)
         }
-        T::Function | T::Method | T::Macro => (Some(HighlightColor::BrightBlue), false),
         T::EnumMember | T::Property => (Some(HighlightColor::Cyan), false),
         T::Parameter => (Some(HighlightColor::Yellow), true),
         T::Namespace => (Some(HighlightColor::BrightCyan), false),
@@ -603,6 +621,27 @@ impl Walk<'_> {
             _ => {}
         }
         if kind == SyntaxKind::WORD {
+            if token.text().starts_with('$')
+                && token
+                    .parent_ancestors()
+                    .find(|node| node.kind() == SyntaxKind::EXPR_FUNCTION_BODY)
+                    .and_then(|body| baml_compiler2_ast::check_builtin_body(&body))
+                    .is_some_and(|kind| {
+                        matches!(
+                            kind,
+                            baml_compiler2_ast::BuiltinKind::Vm
+                                | baml_compiler2_ast::BuiltinKind::Io
+                        )
+                    })
+            {
+                emit(
+                    token.text_range(),
+                    plain(SemanticTokenType::RustFunction),
+                    out,
+                );
+                return;
+            }
+
             if let Some(class) = (self.resolve)(token.text_range()) {
                 emit(token.text_range(), class, out);
             }
@@ -1060,6 +1099,9 @@ fn classify_type_token(
     name: &str,
     offset: TextSize,
 ) -> Class {
+    if name == "$rust_type" {
+        return plain(SemanticTokenType::RustType);
+    }
     if let Some(class) = classify::classify_primitive(name) {
         return class;
     }
@@ -1218,5 +1260,40 @@ function greet(person: Person) -> string {
             .cloned()
             .collect();
         assert_eq!(ranged, expected);
+    }
+}
+
+#[cfg(test)]
+mod rainbow_tests {
+    use super::*;
+    use crate::test_support::CursorTest;
+
+    #[test]
+    fn only_native_sigils_receive_the_magic_type() {
+        let test = CursorTest::new(
+            r#"
+class Handle { _data: $rust_type, }
+function Native() -> int { <[CURSOR]$rust_function }
+function Io() -> int { /* $rust_function */ $rust_io_function }
+function Text() -> string { "$rust_function $rust_type" }
+// $rust_function $rust_type
+function Ordinary() -> int { let x = 1; $rust_function }
+"#,
+        );
+        let text = test.cursor.file.text(&test.db);
+        let tokens = semantic_tokens(&test.db, test.cursor.file);
+        let magic: Vec<_> = tokens
+            .iter()
+            .filter(|t| t.token_type.is_rust_sigil())
+            .map(|t| &text[usize::from(t.range.start())..usize::from(t.range.end())])
+            .collect();
+        assert_eq!(magic, ["$rust_type", "$rust_function", "$rust_io_function"]);
+        let viewport = semantic_tokens_in_range(
+            &test.db,
+            test.cursor.file,
+            0,
+            u32::try_from(text.len()).unwrap(),
+        );
+        assert_eq!(tokens, &viewport);
     }
 }

--- a/baml_language/crates/baml_lsp/src/dispatch/mod.rs
+++ b/baml_language/crates/baml_lsp/src/dispatch/mod.rs
@@ -155,11 +155,14 @@ macro_rules! define_request_tables {
                                         match outcome {
                                             Ok(Ok((result, commit))) => {
                                                 if let Some(commit) = commit {
-                                                    state.store_token_baseline(
-                                                        session,
-                                                        commit.path,
-                                                        commit.baseline,
-                                                    );
+                                                    if commit.has_rust_sigil
+                                                        && let Ok(session_state) = state.session_mut(session)
+                                                    {
+                                                        session_state.rainbow.observe(commit.path.clone(), web_time::Instant::now());
+                                                    }
+                                                    if let Some(baseline) = commit.baseline {
+                                                        state.store_token_baseline(session, commit.path, baseline);
+                                                    }
                                                 }
                                                 respond(result);
                                             }
@@ -261,11 +264,11 @@ define_request_tables! {
         "textDocument/references" => references,
         "textDocument/documentSymbol" => document_symbol,
         "workspace/symbol" => workspace_symbol,
-        "textDocument/semanticTokens/range" => semantic_tokens_range,
         "textDocument/inlayHint" => inlay_hint,
         "textDocument/codeLens" => code_lens,
     }
     snapshot_commit {
+        "textDocument/semanticTokens/range" => semantic_tokens_range,
         "textDocument/semanticTokens/full" => semantic_tokens_full,
         "textDocument/semanticTokens/full/delta" => semantic_tokens_delta,
     }

--- a/baml_language/crates/baml_lsp/src/dispatch/requests.rs
+++ b/baml_language/crates/baml_lsp/src/dispatch/requests.rs
@@ -82,6 +82,11 @@ pub fn server_capabilities(encoding: PositionEncoding, open_panel: bool) -> Serv
                     token_types: baml_ide::TOKEN_TYPES
                         .iter()
                         .map(|t| lsp_types::SemanticTokenType::new(t.as_str()))
+                        .chain(
+                            crate::rainbow::PALETTE.iter().map(|color| {
+                                lsp_types::SemanticTokenType::from(color.token.clone())
+                            }),
+                        )
                         .collect(),
                     token_modifiers: baml_ide::TOKEN_MODIFIERS
                         .iter()
@@ -143,6 +148,8 @@ pub fn initialize_result(encoding: PositionEncoding, open_panel: bool) -> Initia
 #[serde(rename_all = "camelCase")]
 struct InitializationOptions {
     #[serde(default)]
+    rust_function_rainbow: bool,
+    #[serde(default)]
     baml_client: BamlClientOptions,
 }
 
@@ -198,6 +205,7 @@ pub(super) fn initialize(
     if let Some(options) = params.initialization_options {
         match serde_json::from_value::<InitializationOptions>(options) {
             Ok(options) => {
+                state.session_mut(session)?.rainbow.enabled = options.rust_function_rainbow;
                 if let Some(stdlib_dir) = options.baml_client.stdlib_dir {
                     state.set_stdlib_dir(Some(stdlib_dir));
                 }
@@ -213,6 +221,13 @@ pub(super) fn initialize(
         "session initialized"
     );
     let session_state = state.session_mut(session)?;
+    session_state.rainbow.refresh = params
+        .capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.semantic_tokens.as_ref())
+        .and_then(|tokens| tokens.refresh_support)
+        .unwrap_or(false);
     session_state.encoding = Some(encoding);
     session_state.snippet_support = snippet_support;
     session_state.workspace_folders = workspace_folders;
@@ -565,26 +580,49 @@ pub(super) fn workspace_symbol(
 fn encode_semantic_tokens(
     tokens: &[baml_ide::SemanticToken],
     codec: &PositionCodec<'_>,
+    rainbow_phase: Option<usize>,
 ) -> Vec<lsp_types::SemanticToken> {
     let mut out = Vec::with_capacity(tokens.len());
     let (mut prev_line, mut prev_start) = (0u32, 0u32);
     for token in tokens {
         for segment in codec.token_segments(token.range) {
-            let delta_line = segment.line - prev_line;
-            let delta_start = if delta_line == 0 {
-                segment.start_character - prev_start
-            } else {
-                segment.start_character
-            };
-            out.push(lsp_types::SemanticToken {
-                delta_line,
-                delta_start,
-                length: segment.length,
-                token_type: token.token_type.legend_index(),
-                token_modifiers_bitset: token.modifiers.bits(),
-            });
-            prev_line = segment.line;
-            prev_start = segment.start_character;
+            let magic = token.token_type.is_rust_sigil() && rainbow_phase.is_some();
+            let count = if magic { segment.length } else { 1 };
+            for character in 0..count {
+                let start = segment.start_character + character;
+                let delta_line = segment.line - prev_line;
+                let delta_start = if delta_line == 0 {
+                    start - prev_start
+                } else {
+                    start
+                };
+                out.push(lsp_types::SemanticToken {
+                    delta_line,
+                    delta_start,
+                    length: if magic { 1 } else { segment.length },
+                    token_type: if magic {
+                        crate::rainbow::token_type(
+                            character,
+                            segment.length,
+                            rainbow_phase.unwrap_or(0),
+                        )
+                    } else {
+                        match token.token_type {
+                            baml_ide::SemanticTokenType::RustFunction => {
+                                baml_ide::SemanticTokenType::Macro
+                            }
+                            baml_ide::SemanticTokenType::RustType => {
+                                baml_ide::SemanticTokenType::Type
+                            }
+                            other => other,
+                        }
+                        .legend_index()
+                    },
+                    token_modifiers_bitset: token.modifiers.bits(),
+                });
+                prev_line = segment.line;
+                prev_start = start;
+            }
         }
     }
     out
@@ -602,17 +640,22 @@ fn full_tokens_with_commit(
         return Err(LspError::FileNotFound(path));
     };
     let codec = PositionCodec::new(file.text(db), snap.cx().encoding);
-    let encoded = encode_semantic_tokens(baml_ide::semantic_tokens(db, file), &codec);
-    let result_id = snap.revision();
+    let ide_tokens = baml_ide::semantic_tokens(db, file);
+    let phase = snap.cx().rainbow.phase(&path);
+    let encoded = encode_semantic_tokens(ide_tokens, &codec, phase);
+    let result_id = format!("{}-{}", snap.revision().0, phase.unwrap_or(0));
     let tokens = Arc::new(encoded);
     Ok((
         lsp_types::SemanticTokens {
-            result_id: Some(result_id.0.to_string()),
+            result_id: Some(result_id.clone()),
             data: tokens.as_ref().clone(),
         },
         crate::state::BaselineCommit {
             path,
-            baseline: crate::state::TokenBaseline { result_id, tokens },
+            baseline: Some(crate::state::TokenBaseline { result_id, tokens }),
+            has_rust_sigil: ide_tokens
+                .iter()
+                .any(|token| token.token_type.is_rust_sigil()),
         },
     ))
 }
@@ -649,7 +692,7 @@ pub(super) fn semantic_tokens_delta(
         .cx()
         .token_baselines
         .get(&commit.path)
-        .filter(|baseline| baseline.result_id.0.to_string() == previous_result_id);
+        .filter(|baseline| baseline.result_id == previous_result_id);
     let Some(baseline) = baseline else {
         return (
             Ok(Some(lsp_types::SemanticTokensFullDeltaResult::Tokens(
@@ -660,7 +703,7 @@ pub(super) fn semantic_tokens_delta(
     };
 
     let previous = baseline.tokens.as_slice();
-    let current = commit.baseline.tokens.as_slice();
+    let current = tokens.data.as_slice();
     let prefix = previous
         .iter()
         .zip(current)
@@ -697,23 +740,36 @@ pub(super) fn semantic_tokens_delta(
 pub(super) fn semantic_tokens_range(
     snap: &crate::snapshot::Snapshot,
     params: lsp_types::SemanticTokensRangeParams,
-) -> Result<Option<lsp_types::SemanticTokensRangeResult>, LspError> {
-    let (text_document, range) = (params.text_document, params.range);
-    let path = crate::paths::canonical_document_path(snap.roots(), &text_document.uri)?;
-    let db = snap.db();
-    let Some(file) = db.get_file(&path) else {
-        return Err(LspError::FileNotFound(path));
-    };
-    let codec = PositionCodec::new(file.text(db), snap.cx().encoding);
-    let start = codec.position_to_offset(range.start)?;
-    let end = codec.position_to_offset(range.end)?;
-    let tokens = baml_ide::semantic_tokens_in_range(db, file, u32::from(start), u32::from(end));
-    Ok(Some(lsp_types::SemanticTokensRangeResult::Tokens(
-        lsp_types::SemanticTokens {
-            result_id: None,
-            data: encode_semantic_tokens(&tokens, &codec),
-        },
-    )))
+) -> CommitOutcome<Option<lsp_types::SemanticTokensRangeResult>> {
+    let result = (|| {
+        let (text_document, range) = (params.text_document, params.range);
+        let path = crate::paths::canonical_document_path(snap.roots(), &text_document.uri)?;
+        let db = snap.db();
+        let Some(file) = db.get_file(&path) else {
+            return Err(LspError::FileNotFound(path));
+        };
+        let codec = PositionCodec::new(file.text(db), snap.cx().encoding);
+        let start = codec.position_to_offset(range.start)?;
+        let end = codec.position_to_offset(range.end)?;
+        let tokens = baml_ide::semantic_tokens_in_range(db, file, u32::from(start), u32::from(end));
+        Ok((
+            Some(lsp_types::SemanticTokensRangeResult::Tokens(
+                lsp_types::SemanticTokens {
+                    result_id: None,
+                    data: encode_semantic_tokens(&tokens, &codec, snap.cx().rainbow.phase(&path)),
+                },
+            )),
+            crate::state::BaselineCommit {
+                path,
+                baseline: None,
+                has_rust_sigil: tokens.iter().any(|token| token.token_type.is_rust_sigil()),
+            },
+        ))
+    })();
+    match result {
+        Ok((tokens, commit)) => (Ok(tokens), Some(commit)),
+        Err(error) => (Err(error), None),
+    }
 }
 
 pub(super) fn inlay_hint(
@@ -966,4 +1022,58 @@ pub(super) fn stdlib_source(
     Ok(StdlibSourceResult {
         content: file.text(snap.db()).clone(),
     })
+}
+
+#[cfg(test)]
+mod rainbow_encoding_tests {
+    use baml_ide::{SemanticToken, SemanticTokenType};
+    use text_size::TextRange;
+
+    use super::*;
+
+    #[test]
+    fn rainbow_preserves_positions_and_changes_only_colors() {
+        let source = "// unicode: \u{1f308}\n$rust_type $rust_function $rust_io_function";
+        let tokens: Vec<_> = [
+            ("$rust_type", SemanticTokenType::RustType),
+            ("$rust_function", SemanticTokenType::RustFunction),
+            ("$rust_io_function", SemanticTokenType::RustFunction),
+        ]
+        .into_iter()
+        .map(|(text, token_type)| {
+            let start = u32::try_from(source.find(text).unwrap()).unwrap();
+            SemanticToken {
+                range: TextRange::new(
+                    start.into(),
+                    (start + u32::try_from(text.len()).unwrap()).into(),
+                ),
+                token_type,
+                modifiers: baml_ide::ModifierSet::default(),
+            }
+        })
+        .collect();
+        for encoding in [PositionEncoding::UTF8, PositionEncoding::UTF16] {
+            let codec = PositionCodec::new(source, encoding);
+            let stable = encode_semantic_tokens(&tokens, &codec, Some(0));
+            let next =
+                encode_semantic_tokens(&tokens, &codec, Some(crate::rainbow::PALETTE.len() - 1));
+            assert_eq!(stable.len(), 10 + 14 + 17);
+            for (before, after) in stable.iter().zip(&next) {
+                assert_eq!(before.length, 1);
+                assert_ne!(before.token_type, after.token_type);
+                assert_eq!(before.delta_line, after.delta_line);
+                assert_eq!(before.delta_start, after.delta_start);
+            }
+            let fallback = encode_semantic_tokens(&tokens, &codec, None);
+            assert_eq!(fallback.len(), 3);
+            assert_eq!(
+                fallback[0].token_type,
+                SemanticTokenType::Type.legend_index()
+            );
+            assert_eq!(
+                fallback[1].token_type,
+                SemanticTokenType::Macro.legend_index()
+            );
+        }
+    }
 }

--- a/baml_language/crates/baml_lsp/src/lib.rs
+++ b/baml_language/crates/baml_lsp/src/lib.rs
@@ -31,6 +31,7 @@ pub mod executor;
 pub mod mutation;
 pub mod paths;
 pub mod position_codec;
+mod rainbow;
 pub mod roots;
 pub mod snapshot;
 pub mod state;

--- a/baml_language/crates/baml_lsp/src/rainbow.json
+++ b/baml_language/crates/baml_lsp/src/rainbow.json
@@ -1,0 +1,98 @@
+[
+  {
+    "token": "bamlRainbow0",
+    "color": "#f25c5c"
+  },
+  {
+    "token": "bamlRainbow1",
+    "color": "#f2825c"
+  },
+  {
+    "token": "bamlRainbow2",
+    "color": "#f2a75c"
+  },
+  {
+    "token": "bamlRainbow3",
+    "color": "#f2cd5c"
+  },
+  {
+    "token": "bamlRainbow4",
+    "color": "#f2f25c"
+  },
+  {
+    "token": "bamlRainbow5",
+    "color": "#cdf25c"
+  },
+  {
+    "token": "bamlRainbow6",
+    "color": "#a7f25c"
+  },
+  {
+    "token": "bamlRainbow7",
+    "color": "#82f25c"
+  },
+  {
+    "token": "bamlRainbow8",
+    "color": "#5cf25c"
+  },
+  {
+    "token": "bamlRainbow9",
+    "color": "#5cf282"
+  },
+  {
+    "token": "bamlRainbow10",
+    "color": "#5cf2a7"
+  },
+  {
+    "token": "bamlRainbow11",
+    "color": "#5cf2cd"
+  },
+  {
+    "token": "bamlRainbow12",
+    "color": "#5cf2f2"
+  },
+  {
+    "token": "bamlRainbow13",
+    "color": "#5ccdf2"
+  },
+  {
+    "token": "bamlRainbow14",
+    "color": "#5ca7f2"
+  },
+  {
+    "token": "bamlRainbow15",
+    "color": "#5c82f2"
+  },
+  {
+    "token": "bamlRainbow16",
+    "color": "#5c5cf2"
+  },
+  {
+    "token": "bamlRainbow17",
+    "color": "#825cf2"
+  },
+  {
+    "token": "bamlRainbow18",
+    "color": "#a75cf2"
+  },
+  {
+    "token": "bamlRainbow19",
+    "color": "#cd5cf2"
+  },
+  {
+    "token": "bamlRainbow20",
+    "color": "#f25cf2"
+  },
+  {
+    "token": "bamlRainbow21",
+    "color": "#f25ccd"
+  },
+  {
+    "token": "bamlRainbow22",
+    "color": "#f25ca7"
+  },
+  {
+    "token": "bamlRainbow23",
+    "color": "#f25c82"
+  }
+]

--- a/baml_language/crates/baml_lsp/src/rainbow.rs
+++ b/baml_language/crates/baml_lsp/src/rainbow.rs
@@ -1,0 +1,161 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+    time::Duration,
+};
+
+use web_time::Instant;
+
+#[derive(serde::Deserialize)]
+pub(crate) struct Color {
+    pub token: String,
+}
+
+pub(crate) static PALETTE: LazyLock<Vec<Color>> = LazyLock::new(|| {
+    serde_json::from_str(include_str!("rainbow.json")).expect("valid rainbow palette")
+});
+
+const FRAME: Duration = Duration::from_millis(42);
+
+fn phase(elapsed: Duration) -> Option<usize> {
+    let step = elapsed.as_millis() / FRAME.as_millis();
+    let count = PALETTE.len() as u128;
+    (step < count).then_some(((count - step % count) % count) as usize)
+}
+
+#[derive(Default)]
+pub(crate) struct Rainbow {
+    pub enabled: bool,
+    pub refresh: bool,
+    documents: HashMap<PathBuf, Option<Instant>>,
+    due: Option<Instant>,
+    sequence: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RainbowView {
+    enabled: bool,
+    phases: HashMap<PathBuf, usize>,
+}
+
+impl RainbowView {
+    pub(crate) fn phase(&self, path: &Path) -> Option<usize> {
+        self.enabled
+            .then(|| self.phases.get(path).copied().unwrap_or(0))
+    }
+}
+
+impl Rainbow {
+    pub(crate) fn view(&self, now: Instant) -> RainbowView {
+        RainbowView {
+            enabled: self.enabled,
+            phases: self
+                .documents
+                .iter()
+                .filter_map(|(path, start)| {
+                    start
+                        .and_then(|start| phase(now.saturating_duration_since(start)))
+                        .map(|phase| (path.clone(), phase))
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn observe(&mut self, path: PathBuf, now: Instant) {
+        if !self.enabled || !self.refresh || self.documents.contains_key(&path) {
+            return;
+        }
+        self.documents.insert(path, Some(now));
+        self.due.get_or_insert(now + FRAME);
+    }
+
+    pub(crate) fn settle(&mut self, path: &Path) {
+        if let Some(start) = self.documents.get_mut(path) {
+            *start = None;
+        }
+        if self.documents.values().all(Option::is_none) {
+            self.due = None;
+        }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<Instant> {
+        self.due
+    }
+
+    pub(crate) fn tick(&mut self, now: Instant) -> Option<lsp_server::Request> {
+        if self.due.is_none_or(|due| due > now) {
+            return None;
+        }
+        for start in self.documents.values_mut() {
+            if start.is_some_and(|start| phase(now.saturating_duration_since(start)).is_none()) {
+                *start = None;
+            }
+        }
+        self.due = self
+            .documents
+            .values()
+            .any(Option::is_some)
+            .then_some(now + FRAME);
+        self.sequence += 1;
+        Some(lsp_server::Request::new(
+            format!("baml-rainbow-{}", self.sequence).into(),
+            <lsp_types::request::SemanticTokensRefresh as lsp_types::request::Request>::METHOD
+                .to_owned(),
+            (),
+        ))
+    }
+}
+
+pub(crate) fn token_type(character: u32, length: u32, phase: usize) -> u32 {
+    let color = (character as usize * PALETTE.len() / length as usize + phase) % PALETTE.len();
+    u32::try_from(baml_ide::TOKEN_TYPES.len() + color).expect("small token legend")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverse_scroll_settles_after_one_second_without_replaying() {
+        let mut rainbow = Rainbow {
+            enabled: true,
+            refresh: true,
+            ..Rainbow::default()
+        };
+        let path = PathBuf::from("/magic.baml");
+        let now = Instant::now();
+        rainbow.observe(path.clone(), now);
+        assert_eq!(rainbow.view(now).phase(&path), Some(0));
+        assert!(rainbow.tick(now + FRAME).is_some());
+        assert_eq!(
+            rainbow.view(now + FRAME).phase(&path),
+            Some(PALETTE.len() - 1)
+        );
+        let end = now + Duration::from_millis(1008);
+        assert!(rainbow.tick(end).is_some());
+        assert_eq!(rainbow.view(end).phase(&path), Some(0));
+        assert!(rainbow.next_deadline().is_none());
+        rainbow.settle(&path);
+        rainbow.observe(path, end);
+        assert!(rainbow.next_deadline().is_none());
+    }
+
+    #[test]
+    fn opt_in_and_refresh_support_are_independent() {
+        let path = PathBuf::from("/magic.baml");
+        let now = Instant::now();
+        let mut rainbow = Rainbow::default();
+        rainbow.observe(path.clone(), now);
+        assert_eq!(rainbow.view(now).phase(&path), None);
+        rainbow.enabled = true;
+        rainbow.observe(path.clone(), now);
+        assert_eq!(rainbow.view(now).phase(&path), Some(0));
+        assert!(rainbow.next_deadline().is_none());
+        rainbow.refresh = true;
+        rainbow.observe(path.clone(), now);
+        assert!(rainbow.next_deadline().is_some());
+        rainbow.settle(&path);
+        assert!(rainbow.next_deadline().is_none());
+    }
+}

--- a/baml_language/crates/baml_lsp/src/snapshot.rs
+++ b/baml_language/crates/baml_lsp/src/snapshot.rs
@@ -35,6 +35,7 @@ pub struct RequestCx {
     /// negotiation, matching the LSP default).
     pub encoding: PositionEncoding,
     pub snippet_support: bool,
+    pub(crate) rainbow: crate::rainbow::RainbowView,
     /// The session's semantic-token baselines at mint time (immutable view;
     /// the owner replaces the map on store). Delta requests diff against
     /// this on the pool.
@@ -46,6 +47,7 @@ impl Default for RequestCx {
         Self {
             encoding: PositionEncoding::UTF16,
             snippet_support: false,
+            rainbow: crate::rainbow::RainbowView::default(),
             token_baselines: Arc::new(std::collections::HashMap::new()),
         }
     }

--- a/baml_language/crates/baml_lsp/src/state.rs
+++ b/baml_language/crates/baml_lsp/src/state.rs
@@ -75,6 +75,12 @@ pub type OpenDocuments = HashMap<PathBuf, OpenDocument>;
 
 /// The host's channel to one client.
 pub trait ClientSender: Send + Sync {
+    fn send_request(&self, _request: lsp_server::Request) -> Result<(), LspError> {
+        Err(LspError::RequestFailed(
+            "server requests are unavailable".into(),
+        ))
+    }
+
     fn send_notification(&self, method: &str, params: serde_json::Value) -> Result<(), LspError>;
 }
 
@@ -99,23 +105,21 @@ pub struct SessionState {
     /// there is no lock, and the owner records a new baseline *before* the
     /// response carrying its result id leaves.
     pub semantic_tokens: Arc<HashMap<PathBuf, TokenBaseline>>,
+    pub(crate) rainbow: crate::rainbow::Rainbow,
 }
 
-/// What a session was last served for one document: the result id the
-/// client holds, and the encoded tokens behind it.
-///
-/// The result id is the [`SourceRevision`] the tokens were computed at —
-/// tokens cannot differ within a revision, so two requests at the same
-/// revision legitimately share an id.
-/// A baseline the owner must record for a session before responding.
+/// Semantic-token effects to commit before responding. Range requests start
+/// the animation without replacing the full-document delta baseline.
 pub struct BaselineCommit {
     pub path: PathBuf,
-    pub baseline: TokenBaseline,
+    pub baseline: Option<TokenBaseline>,
+    pub has_rust_sigil: bool,
 }
 
+/// The result id includes both the source revision and the rainbow phase.
 #[derive(Debug, Clone)]
 pub struct TokenBaseline {
-    pub result_id: SourceRevision,
+    pub result_id: String,
     pub tokens: Arc<Vec<lsp_types::SemanticToken>>,
 }
 
@@ -476,6 +480,7 @@ impl GlobalState {
             encoding,
             token_baselines: Arc::clone(&state.semantic_tokens),
             snippet_support: state.snippet_support,
+            rainbow: state.rainbow.view(Instant::now()),
         })
     }
 
@@ -574,6 +579,7 @@ impl GlobalState {
                 workspace_folders: Vec::new(),
                 lifecycle: SessionLifecycle::Uninitialized,
                 semantic_tokens: Arc::new(HashMap::new()),
+                rainbow: crate::rainbow::Rainbow::default(),
             },
         );
     }
@@ -650,6 +656,7 @@ impl GlobalState {
     /// so the client will re-request from scratch if it reopens).
     pub fn evict_token_baselines(&mut self, path: &Path) {
         for state in self.sessions.values_mut() {
+            state.rainbow.settle(path);
             if state.semantic_tokens.contains_key(path) {
                 Arc::make_mut(&mut state.semantic_tokens).remove(path);
             }
@@ -1034,11 +1041,23 @@ impl GlobalState {
         self.root_state
             .values()
             .filter_map(|state| state.diagnostics_due)
+            .chain(
+                self.initialized_sessions()
+                    .filter_map(|(_, state)| state.rainbow.next_deadline()),
+            )
             .min()
     }
 
     /// Fire every tail whose deadline has passed by posting its event.
     pub fn on_tick(&mut self, now: Instant) {
+        for state in self.sessions.values_mut() {
+            if state.lifecycle == SessionLifecycle::Initialized
+                && let Some(request) = state.rainbow.tick(now)
+                && let Err(error) = state.sender.send_request(request)
+            {
+                tracing::debug!(%error, "rainbow refresh was not delivered");
+            }
+        }
         let due: Vec<SourceRoot> = self
             .root_state
             .iter()

--- a/baml_language/crates/baml_lsp/tests/protocol.rs
+++ b/baml_language/crates/baml_lsp/tests/protocol.rs
@@ -27,6 +27,14 @@ struct RecordingSender {
 }
 
 impl ClientSender for RecordingSender {
+    fn send_request(&self, request: lsp_server::Request) -> Result<(), LspError> {
+        self.sent
+            .lock()
+            .unwrap()
+            .push((request.method, request.params));
+        Ok(())
+    }
+
     fn send_notification(&self, method: &str, params: Value) -> Result<(), LspError> {
         self.sent.lock().unwrap().push((method.to_owned(), params));
         Ok(())
@@ -1838,4 +1846,89 @@ fn a_propagated_panic_retries_diagnostics_but_a_real_panic_does_not() {
         "a real panic waits for the next edit rather than re-running the \
          query that panicked"
     );
+}
+
+#[test]
+fn rainbow_range_starts_once_and_finishes_with_a_final_refresh() {
+    let mut h = Harness::new();
+    let session = SessionKey(1);
+    let sender = Arc::new(RecordingSender::default());
+    h.senders.insert(session, Arc::clone(&sender));
+    h.state.open_session(session, sender);
+    h.request(
+        session,
+        "initialize",
+        json!({
+            "capabilities": { "workspace": { "semanticTokens": { "refreshSupport": true } } },
+            "initializationOptions": { "rustFunctionRainbow": true },
+        }),
+    )
+    .unwrap();
+    h.notify(session, "initialized", json!({})).unwrap();
+    let uri = Url::parse("baml-stdlib:/baml/ns_fs/fs.baml").unwrap();
+    let source = h
+        .request(session, "baml/stdlibSource", json!({ "uri": uri }))
+        .unwrap();
+    let content = source["content"].as_str().unwrap();
+    let codec = baml_lsp::position_codec::PositionCodec::new(
+        content,
+        baml_lsp::position_codec::PositionEncoding::UTF16,
+    );
+    let params = json!({
+        "textDocument": { "uri": uri },
+        "range": { "start": { "line": 0, "character": 0 }, "end": codec.offset_to_position(u32::try_from(content.len()).unwrap()) },
+    });
+    h.request(session, "textDocument/semanticTokens/range", params.clone())
+        .unwrap();
+    assert!(h.state.next_deadline().is_some());
+    let full = h
+        .request(
+            session,
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        )
+        .unwrap();
+    let tokens = full["data"].as_array().unwrap();
+    assert!(
+        tokens
+            .as_chunks::<5>()
+            .0
+            .iter()
+            .any(|token| token[3].as_u64().unwrap() >= baml_ide::TOKEN_TYPES.len() as u64)
+    );
+    assert!(h.state.next_deadline().is_some());
+    h.state.on_tick(Instant::now() + Duration::from_secs(2));
+    assert!(
+        h.sender(session)
+            .methods()
+            .contains(&"workspace/semanticTokens/refresh".to_owned())
+    );
+    assert!(h.state.next_deadline().is_none());
+    let settled = h
+        .request(
+            session,
+            "textDocument/semanticTokens/full/delta",
+            json!({
+                "textDocument": { "uri": uri }, "previousResultId": full["resultId"],
+            }),
+        )
+        .unwrap();
+    let mut replayed = tokens.clone();
+    for edit in settled["edits"].as_array().unwrap().iter().rev() {
+        let start = usize::try_from(edit["start"].as_u64().unwrap()).unwrap();
+        let end = start + usize::try_from(edit["deleteCount"].as_u64().unwrap()).unwrap();
+        replayed.splice(start..end, edit["data"].as_array().unwrap().clone());
+    }
+    let current = h
+        .request(
+            session,
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        )
+        .unwrap();
+    assert_eq!(Value::Array(replayed), current["data"]);
+    h.close(session, &uri);
+    h.request(session, "textDocument/semanticTokens/range", params)
+        .unwrap();
+    assert!(h.state.next_deadline().is_none());
 }

--- a/baml_language/crates/baml_lsp_server/src/lsp_runtime.rs
+++ b/baml_language/crates/baml_lsp_server/src/lsp_runtime.rs
@@ -80,12 +80,14 @@ fn session_key(session_id: SessionId) -> SessionKey {
 /// browser takeover or transport close.
 pub struct RevocableSessionSender {
     sink: Mutex<Option<Sink>>,
+    requests: Option<(SessionId, Weak<LspRuntime>)>,
 }
 
 impl RevocableSessionSender {
     fn new(sink: Sink) -> Self {
         Self {
             sink: Mutex::new(Some(sink)),
+            requests: None,
         }
     }
 
@@ -116,6 +118,18 @@ impl RevocableSessionSender {
 }
 
 impl ClientSender for RevocableSessionSender {
+    fn send_request(&self, request: lsp_server::Request) -> Result<(), LspError> {
+        let (session, runtime) = self.requests.as_ref().ok_or(LspError::ClientClosed)?;
+        let runtime = runtime.upgrade().ok_or(LspError::ClientClosed)?;
+        let id = request.id.clone();
+        runtime.register_server_request(*session, id.clone(), Box::new(|_| {}));
+        if let Err(error) = self.send(lsp_server::Message::Request(request)) {
+            runtime.server_requests.lock().remove(&(*session, id));
+            return Err(error);
+        }
+        Ok(())
+    }
+
     fn send_notification(&self, method: &str, params: serde_json::Value) -> Result<(), LspError> {
         self.send(lsp_server::Message::Notification(
             lsp_server::Notification::new(method.to_owned(), params),
@@ -161,11 +175,7 @@ pub struct LspRuntime {
     endpoints: Mutex<HashMap<SessionId, Endpoint>>,
     document_overlays: Mutex<HashMap<(SessionId, PathBuf), lsp_types::TextDocumentItem>>,
     pending_responses: Mutex<VecDeque<PendingResponse>>,
-    /// Correlation seam for server-initiated requests (workspace/
-    /// configuration and friends). This server currently never issues such
-    /// requests, so no dispatch path populates the map today; it exists so
-    /// client→server responses have a real route instead of being admitted
-    /// and then silently lost. Uncorrelated responses are logged and dropped.
+    /// Correlates client responses with server-initiated requests.
     server_requests: Mutex<HashMap<(SessionId, lsp_server::RequestId), ServerRequestResponder>>,
     delivery_gate: Mutex<()>,
     wake_tx: Sender<()>,
@@ -237,7 +247,9 @@ impl LspRuntime {
             // restored instead of being erased by the synthetic didClose.
             self.finish_termination(takeover);
         }
-        let outbound = Arc::new(RevocableSessionSender::new(sink.clone()));
+        let mut outbound = RevocableSessionSender::new(sink.clone());
+        outbound.requests = Some((opened.session_id, self.weak_self.clone()));
+        let outbound = Arc::new(outbound);
         self.endpoints.lock().insert(
             opened.session_id,
             Endpoint {
@@ -344,8 +356,6 @@ impl LspRuntime {
     /// Registers interest in the client's response to a server-initiated
     /// request. Call this *before* writing the request to the session sink;
     /// the responder runs on the owner thread when the response arrives.
-    /// (Correlation seam for a server that starts issuing
-    /// `workspace/configuration`-style requests — currently unused.)
     pub fn register_server_request(
         &self,
         session_id: SessionId,
@@ -1411,6 +1421,49 @@ mod tests {
     /// Defect containment: client responses to server-initiated requests
     /// route through the correlation seam instead of being admitted and then
     /// silently dropped.
+    #[test]
+    fn refresh_requests_register_and_release_their_response() {
+        let (runtime, mut state) = runtime_without_worker();
+        let messages = Arc::new(Mutex::new(Vec::new()));
+        let opened = runtime.open_session(
+            TransportKind::Stdio,
+            capturing_sink(Arc::clone(&messages)),
+            Arc::new(|| {}),
+            None,
+        );
+        initialize(&runtime, opened.session_id);
+        runtime.drain(&mut state);
+        let sender = runtime.endpoints.lock()[&opened.session_id]
+            .outbound
+            .clone();
+        let id = RequestId::from("rainbow-test".to_owned());
+        sender
+            .send_request(lsp_server::Request::new(
+                id.clone(),
+                "workspace/semanticTokens/refresh".to_owned(),
+                (),
+            ))
+            .unwrap();
+        assert!(
+            runtime
+                .server_requests
+                .lock()
+                .contains_key(&(opened.session_id, id.clone()))
+        );
+        assert!(
+            messages
+                .lock()
+                .iter()
+                .any(|message| matches!(message, Message::Request(request) if request.id == id))
+        );
+        runtime.submit(
+            opened.session_id,
+            Message::Response(lsp_server::Response::new_ok(id, ())),
+        );
+        runtime.drain(&mut state);
+        assert!(runtime.server_requests.lock().is_empty());
+    }
+
     #[test]
     fn client_response_routes_through_the_server_request_seam() {
         let (runtime, mut state) = runtime_without_worker();

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -116,6 +116,7 @@ extern "C" {
         exec: (command: string, args: string[]) => Promise<any>;
         shell: (command: string) => Promise<any>;
         host_dispatch: (call: any) => void;
+        lsp_make_request: (request: LspRequest) => void;
         lsp_send_notification: (notification: LspNotification) => void;
         lsp_send_response: (response: LspResponse) => void;
         playground_send_notification: (notification: PlaygroundNotification) => void;
@@ -142,6 +143,9 @@ extern "C" {
 
     #[wasm_bindgen(method, getter, structural, js_name = "lsp_send_notification")]
     fn lsp_send_notification(this: &WasmCallbacks) -> Function;
+
+    #[wasm_bindgen(method, getter, structural, js_name = "lsp_make_request")]
+    fn lsp_make_request(this: &WasmCallbacks) -> Function;
 
     #[wasm_bindgen(method, getter, structural, js_name = "lsp_send_response")]
     fn lsp_send_response(this: &WasmCallbacks) -> Function;
@@ -258,6 +262,7 @@ impl BamlWasmRuntime {
         let sender = Arc::new(WasmClientSender::new(
             callbacks.lsp_send_notification(),
             callbacks.lsp_send_response(),
+            callbacks.lsp_make_request(),
         ));
         let playground_sender =
             playground_notify::WasmPlaygroundSender::new(callbacks.playground_send_notification());

--- a/baml_language/crates/bridge_wasm/src/lsp_wire.rs
+++ b/baml_language/crates/bridge_wasm/src/lsp_wire.rs
@@ -97,19 +97,22 @@ impl From<lsp_server::ResponseError> for LspResponseError {
     }
 }
 
-/// The host's outbound half: one JS callback for notifications, one for
-/// responses. There is no request callback — this server never issues
-/// client-bound requests (the native host's equivalent plumbing was dead
-/// too), so a `lsp_make_request` the host supplies is simply unused.
+/// The host's outbound LSP callbacks.
 pub(crate) struct WasmClientSender {
     send_notification: SendWrapper<Function>,
+    make_request: SendWrapper<Function>,
     send_response: SendWrapper<Function>,
 }
 
 impl WasmClientSender {
-    pub(crate) fn new(send_notification: Function, send_response: Function) -> Self {
+    pub(crate) fn new(
+        send_notification: Function,
+        send_response: Function,
+        make_request: Function,
+    ) -> Self {
         Self {
             send_notification: SendWrapper::new(send_notification),
+            make_request: SendWrapper::new(make_request),
             send_response: SendWrapper::new(send_response),
         }
     }
@@ -145,6 +148,17 @@ impl WasmClientSender {
 }
 
 impl baml_lsp::ClientSender for WasmClientSender {
+    fn send_request(&self, request: lsp_server::Request) -> Result<(), LspError> {
+        let payload = to_json_jsvalue(&request, "LSP request")?;
+        self.make_request
+            .inner()
+            .call1(&JsValue::NULL, &payload)
+            .map(|_| ())
+            .map_err(|error| {
+                LspError::Internal(format!("failed to deliver an LSP request: {error:?}"))
+            })
+    }
+
     fn send_notification(&self, method: &str, params: serde_json::Value) -> Result<(), LspError> {
         let notification = LspNotification {
             method: method.to_owned(),

--- a/typescript2/app-vscode-ext/package.json
+++ b/typescript2/app-vscode-ext/package.json
@@ -65,6 +65,30 @@
       },
       "editor.semanticTokenColorCustomizations": {
         "rules": {
+          "bamlRainbow0:baml": "#f25c5c",
+          "bamlRainbow1:baml": "#f2825c",
+          "bamlRainbow2:baml": "#f2a75c",
+          "bamlRainbow3:baml": "#f2cd5c",
+          "bamlRainbow4:baml": "#f2f25c",
+          "bamlRainbow5:baml": "#cdf25c",
+          "bamlRainbow6:baml": "#a7f25c",
+          "bamlRainbow7:baml": "#82f25c",
+          "bamlRainbow8:baml": "#5cf25c",
+          "bamlRainbow9:baml": "#5cf282",
+          "bamlRainbow10:baml": "#5cf2a7",
+          "bamlRainbow11:baml": "#5cf2cd",
+          "bamlRainbow12:baml": "#5cf2f2",
+          "bamlRainbow13:baml": "#5ccdf2",
+          "bamlRainbow14:baml": "#5ca7f2",
+          "bamlRainbow15:baml": "#5c82f2",
+          "bamlRainbow16:baml": "#5c5cf2",
+          "bamlRainbow17:baml": "#825cf2",
+          "bamlRainbow18:baml": "#a75cf2",
+          "bamlRainbow19:baml": "#cd5cf2",
+          "bamlRainbow20:baml": "#f25cf2",
+          "bamlRainbow21:baml": "#f25ccd",
+          "bamlRainbow22:baml": "#f25ca7",
+          "bamlRainbow23:baml": "#f25c82",
           "namespace:baml": "#808080CC"
         }
       }
@@ -91,6 +115,128 @@
           "light": "./baml-lamb-light.svg"
         },
         "id": "baml"
+      }
+    ],
+    "semanticTokenTypes": [
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow0",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow1",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow2",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow3",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow4",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow5",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow6",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow7",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow8",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow9",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow10",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow11",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow12",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow13",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow14",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow15",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow16",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow17",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow18",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow19",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow20",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow21",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow22",
+        "superType": "macro"
+      },
+      {
+        "description": "Native Rust sigil rainbow color.",
+        "id": "bamlRainbow23",
+        "superType": "macro"
       }
     ]
   },
@@ -120,9 +266,10 @@
     "build": "pnpm run typecheck && tsup",
     "build:cli": "cargo build -p baml_cli --manifest-path ../../baml_language/Cargo.toml",
     "dev": "tsup --watch --sourcemap",
-    "prebuild": "pnpm run sync:grammar",
-    "predev": "pnpm run sync:grammar",
+    "prebuild": "pnpm run sync:grammar && pnpm run sync:rainbow",
+    "predev": "pnpm run sync:grammar && pnpm run sync:rainbow",
     "sync:grammar": "pnpm --filter @b/pkg-grammar build",
+    "sync:rainbow": "node ../pkg-lsp/sync-rainbow.mjs",
     "test": "vitest",
     "test:run": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/typescript2/app-vscode-ext/src/extension.ts
+++ b/typescript2/app-vscode-ext/src/extension.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+  rainbowInitializationOptions,
   STDLIB_SCHEME,
   STDLIB_SOURCE_METHOD,
   StdlibDocuments,
@@ -215,6 +216,7 @@ function createClient(context: vscode.ExtensionContext): LanguageClient {
       { language: 'baml', scheme: STDLIB_SCHEME },
     ],
     initializationOptions: {
+      ...rainbowInitializationOptions,
       bamlClient: {
         capabilities: [
           'openPlayground.v1',

--- a/typescript2/pkg-editor/src/MonacoEditor.tsx
+++ b/typescript2/pkg-editor/src/MonacoEditor.tsx
@@ -20,6 +20,9 @@
  */
 
 import {
+  rainbowInitializationOptions,
+  rainbowTokenColors,
+  rainbowTokenTypes,
   STDLIB_SOURCE_METHOD,
   StdlibDocuments,
   type StdlibSourceResult,
@@ -568,6 +571,7 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
                     id: 'baml',
                   },
                 ],
+                semanticTokenTypes: rainbowTokenTypes,
                 themes: [
                   {
                     id: 'monospace-dark',
@@ -672,6 +676,7 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
             'editor.semanticTokenColorCustomizations': {
               rules: {
                 'namespace:baml': '#808080CC',
+                ...rainbowTokenColors,
               },
             },
             'editor.tabSize': 2,
@@ -1166,6 +1171,7 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
         const lcWrapper = new LanguageClientWrapper({
           clientOptions: {
             documentSelector: ['baml'],
+            initializationOptions: rainbowInitializationOptions,
           },
           connection: conn.lcConnection,
           languageId: 'baml',

--- a/typescript2/pkg-lsp/package.json
+++ b/typescript2/pkg-lsp/package.json
@@ -4,7 +4,7 @@
     "typescript": "^5.9.3",
     "vitest": "^4.0.16"
   },
-  "main": "src/stdlib-documents.ts",
+  "main": "src/index.ts",
   "name": "@b/pkg-lsp",
   "private": true,
   "scripts": {
@@ -12,6 +12,6 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "types": "src/stdlib-documents.ts",
+  "types": "src/index.ts",
   "version": "0.1.0"
 }

--- a/typescript2/pkg-lsp/src/index.ts
+++ b/typescript2/pkg-lsp/src/index.ts
@@ -1,0 +1,2 @@
+export * from './rainbow';
+export * from './stdlib-documents';

--- a/typescript2/pkg-lsp/src/rainbow.ts
+++ b/typescript2/pkg-lsp/src/rainbow.ts
@@ -1,0 +1,13 @@
+import palette from '../../../baml_language/crates/baml_lsp/src/rainbow.json';
+
+export const rainbowInitializationOptions = { rustFunctionRainbow: true };
+
+export const rainbowTokenTypes = palette.map(({ token }) => ({
+  description: 'Native Rust sigil rainbow color.',
+  id: token,
+  superType: 'macro',
+}));
+
+export const rainbowTokenColors = Object.fromEntries(
+  palette.map(({ token, color }) => [`${token}:baml`, color]),
+);

--- a/typescript2/pkg-lsp/sync-rainbow.mjs
+++ b/typescript2/pkg-lsp/sync-rainbow.mjs
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const palette = JSON.parse(
+  readFileSync(
+    new URL(
+      '../../baml_language/crates/baml_lsp/src/rainbow.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+);
+const manifestPath = new URL('../app-vscode-ext/package.json', import.meta.url);
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+manifest.contributes.semanticTokenTypes = palette.map(({ token }) => ({
+  description: 'Native Rust sigil rainbow color.',
+  id: token,
+  superType: 'macro',
+}));
+const rules =
+  manifest.contributes.configurationDefaults[
+    'editor.semanticTokenColorCustomizations'
+  ].rules;
+for (const name of Object.keys(rules)) {
+  if (/^bamlRainbow\d+:baml$/.test(name)) delete rules[name];
+}
+Object.assign(
+  rules,
+  Object.fromEntries(
+    palette.map(({ token, color }) => [`${token}:baml`, color]),
+  ),
+);
+manifest.contributes.configurationDefaults[
+  'editor.semanticTokenColorCustomizations'
+].rules = Object.fromEntries(
+  Object.keys(rules)
+    .sort(new Intl.Collator('en', { numeric: true }).compare)
+    .map((key) => [key, rules[key]]),
+);
+writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);


### PR DESCRIPTION
Native Rust sigils now scroll through a rainbow for about one second when first seen, then keep a stable rainbow. This covers `$rust_function`, `$rust_io_function`, and `$rust_type` in VS Code and PromptFiddle's Monaco editor.

The shared LSP owns animation timing, semantic-token encoding, and refreshes. Both editors use one palette; clients without the color mapping keep normal theme colors, and clients without refresh support get a static rainbow. Reopening a document does not replay the animation.

Also fixes qualified type navigation: `baml.fs.File` resolves through its namespace before considering bare names, including when a local `File` exists. Hover and go-to-definition share that resolver.

Validation:
- IDE tests, LSP unit/protocol/substrate tests, and native refresh-response routing tests pass.
- WASM bridge check passes.
- Shared editor, extension, and LSP package typechecks pass.
- Extension and playground frontend production builds pass.
- Regression coverage for sigil classification, animation timing/direction, range requests, delta replay, reopening, fallback colors, and qualified navigation.
