### PR TITLE
docs: backtest 0.18.0 and prepare 0.19.0 changelogs

### DIFF
--- a/docs/changelog-backtests/0.18.0/README.md
+++ b/docs/changelog-backtests/0.18.0/README.md
@@ -1,0 +1,114 @@
+# BAML 0.18.0 changelog backtest
+
+The original procedure produces useful release notes, but the backtest established two additional safeguards: inspect release-relevant changes outside `baml_language/`, and verify every advertised API at the final tag. This backtest found one workflow-only runtime fix that the prescribed filter misses, one advertised reflection feature that was removed before release, and substantial missing migration guidance.
+
+The [unpublished draft](../../../typescript2/app-website/blog-releases/2026-08-27-baml-0.18.0-backtest.md) is separate from the [historical post](../../../typescript2/app-website/blog-releases/2026-08-27-baml-0.18.0.md). It has a unique slug and `isPublished: false`; the website loader excludes such posts. No release was published and no followup was sent.
+
+## Scope and artifacts
+
+This applies the originally provided procedure (now [updated with the findings in PR #4784](https://github.com/BoundaryML/baml/pull/4784)) to `baml-language-0.17.0..baml-language-0.18.0`, with the lower tag excluded and upper tag included. The lower commit is `36545fde3913aa3699a27aed11365541c8123821`; the upper commit is `7622555396a99db466afaea09dea2cad259d4033`. Current canary was not substituted for the upper bound. Tags were fetched before inventorying.
+
+| Measure | Result |
+| --- | ---: |
+| Commits / PRs in the full range | 114 |
+| PRs in the prescribed `baml_language/` log | 89 |
+| V0-only PRs excluded from followups | 4 |
+| Non-v0 PRs screened for followups | 110 |
+| PRs with retained user-facing effects | 64 |
+| Aggregated effects | 69 |
+| Classification | 1 headline, 18 features, 12 breaking changes, 38 bug fixes |
+| External notification drafts | 17 destinations: 9 PRs, 8 issues |
+
+The 64-PR draft includes #4502 as an explicit correction to the literal path/workflow filters. Following those filters exactly would leave 63 retained PRs. Non-release website copy and internal product metrics were screened for followups but excluded from the language changelog.
+
+- [Complete inventory and exclusion reasons](step1a-all-prs.md)
+- [Step 1b: user-visible PRs](step1b-prs-only-user-visible.md)
+- [Step 2a: effects for each PR](step2a-pr-user-effects.md)
+- [Step 2b: aggregated effects and classifications](step2b-pr-user-effects-reaggregated.md)
+- [Step 3: followup drafts](step3-followup-actions.md)
+- [Additional source coverage](source-coverage.md)
+- [Validation evidence and limits](validation.md)
+
+## Findings against the historical changelog
+
+### The path and workflow filters lose a shipped fix
+
+[#4502](https://github.com/BoundaryML/baml/pull/4502) fixes the v1 Node bridge on Alpine for x86_64 and aarch64. Its only changed file is `.github/workflows/build2-nodejs-sdk.reusable.yaml`. The prescribed path-limited log misses it, and the blanket exclusion of workflow-only PRs also removes it. The workflow builds `baml_language/sdks/typescript/bridge_typescript`; this is not a v0 change. The PR records a four-cell Alpine validation with unfixed controls and fixed builds.
+
+Recommendation: inventory the entire range first. Classify files by the product they build or ship. Exclude workflow changes only when they have no end-user artifact or behavior effect.
+
+### A merged feature was removed before the release
+
+[#4519](https://github.com/BoundaryML/baml/pull/4519) added generic function descriptors with `is_generic`, `generic_params`, `specialize`, and `get`. [#4560](https://github.com/BoundaryML/baml/pull/4560) removed those methods and the descriptor surface before the upper tag. The historical post still cites #4519 under expanded reflection.
+
+The released 0.18.0 CLI reports E0007 for `descriptor.specialize(...)`. The [final-tag function reflection source](https://github.com/BoundaryML/baml/blob/baml-language-0.18.0/baml_language/crates/baml_builtins2/baml_std/reflect/ns_function/function.baml) exposes `as_type`, `params`, and `return_type`, without specialization. The backtest excludes #4519. It also excludes the simpler add/revert pair [#4464](https://github.com/BoundaryML/baml/pull/4464) and [#4469](https://github.com/BoundaryML/baml/pull/4469).
+
+Recommendation: compute net effects at the upper tag. Inspect later edits to each advertised surface, even when the later PR is labeled as an internal refactor. Validate examples with the released artifact when available.
+
+### Commit subjects and PR descriptions are insufficient
+
+The current description of [#4493](https://github.com/BoundaryML/baml/pull/4493) describes optional-chain generic lowering, but its merged diff changes AnyClass rulings, field handles, and diagnostics. Optional-call lowering belongs to [#4495](https://github.com/BoundaryML/baml/pull/4495). The draft uses the merged diff and final source.
+
+Other broad PRs contain several effects that the historical post omits:
+
+| PR | Missing or underspecified effect |
+| --- | --- |
+| [#4135](https://github.com/BoundaryML/baml/pull/4135) | `bool.random()` is newly introduced. Integer left-shift overflow now truncates. |
+| [#4541](https://github.com/BoundaryML/baml/pull/4541) | Tests gain a five-minute deadline. Shutdown gains a 15-second grace period. Both have environment overrides. There are also compiler, lambda-inference, diagnostic-rendering, and cleanup fixes beyond formatting. |
+| [#4570](https://github.com/BoundaryML/baml/pull/4570) | Remove the output type parameter from `ai.Agent`; restore streamed usage events. |
+| [#4604](https://github.com/BoundaryML/baml/pull/4604) | `TurnStream.next()` changes from a string to an array of strings. `Runner` changes its method contract. Prompt interpolation may throw. Host media and renderer parity are fixed. |
+| [#4606](https://github.com/BoundaryML/baml/pull/4606) | Existing file, socket, and process-pipe APIs change. EOF becomes null on the shared read contract. TCP per-call timeout parameters are replaced with a timeout wrapper. |
+| [#4601](https://github.com/BoundaryML/baml/pull/4601) | Explicit type arguments must be removed from `to_string` and `to_json`. The historical `to_string<unknown>()` replacement advice is already stale. |
+
+Recommendation: enumerate effects per PR before aggregation. Treat descriptions as leads and merged code as the authority, especially for broad or stacked PRs.
+
+### Ten additional PRs have user-facing effects
+
+The historical post cites 56 distinct PRs. The backtest retains 54 of those, excludes #4461 and #4519, and adds these ten:
+
+| PR | User-facing effect |
+| --- | --- |
+| [#4460](https://github.com/BoundaryML/baml/pull/4460) | Diagnose unsupported indirect runtime checks and preserve useful mounted-package diagnostics. |
+| [#4502](https://github.com/BoundaryML/baml/pull/4502) | Correct musl Node bridge artifacts. |
+| [#4529](https://github.com/BoundaryML/baml/pull/4529) | Correct method dispatch on top-level bindings and preserve Session-call errors. |
+| [#4531](https://github.com/BoundaryML/baml/pull/4531) | Type-check Session assignments. |
+| [#4568](https://github.com/BoundaryML/baml/pull/4568) | Reject incompatible/corrupt compiler artifacts before decoding. |
+| [#4571](https://github.com/BoundaryML/baml/pull/4571) | Prevent Session helper-name collisions. |
+| [#4581](https://github.com/BoundaryML/baml/pull/4581) | Tie editor results to current buffers and project revisions. |
+| [#4593](https://github.com/BoundaryML/baml/pull/4593) | Reject imprecise `throws unknown` declarations. |
+| [#4619](https://github.com/BoundaryML/baml/pull/4619) | Reject missing required fields in class construction. |
+| [#4621](https://github.com/BoundaryML/baml/pull/4621) | Reject unspecialized generic function values without a concrete contextual signature. |
+
+These are editorial findings, not recall/precision scores against an assumed perfect historical changelog. The old post was consulted during the backtest; this was not a blinded evaluation.
+
+### Performance claims need their own evidence
+
+[#4461](https://github.com/BoundaryML/baml/pull/4461) explicitly says its end-to-end result is neutral/noisy. Its reported medians are slightly slower. It should not be cited as proof that compilation became faster.
+
+The draft classifies supported performance improvements as FEATURE, as requested. It includes the PR measurements for [#4453](https://github.com/BoundaryML/baml/pull/4453), [#4458](https://github.com/BoundaryML/baml/pull/4458), [#4463](https://github.com/BoundaryML/baml/pull/4463), and [#4604](https://github.com/BoundaryML/baml/pull/4604). These are author-reported A/B results from intermediate commits. They are not newly measured 0.17.0-versus-0.18.0 benchmarks, and their percentage changes are not additive.
+
+### The historical format does not meet the procedure
+
+The historical post has no fenced code examples. It groups five reflection PRs into one feature and four PRs into each of two fix entries. It puts compilation and stream-parsing speedups under fixes. The new draft splits effects into groups of at most three PRs, gives each effect one classification, includes syntax/library examples, and supplies before/after migration guidance. Closely related features and breaking effects from a single PR are separate entries where the user action differs.
+
+### Followups require a broader inventory and partial-fix language
+
+The nine external-authored PR destinations include Ruby groundwork and CI/test-only contributions. Those would be lost if notification planning reused only step 1b. GitHub association metadata identifies seven candidate external handles, with both Ruby accounts preserved rather than presumed identical.
+
+[#4429](https://github.com/BoundaryML/baml/issues/4429) deserves a partial update: CLI logging is verified, while packed-binary logging and `--log-file` are not established as fixed. [#4588](https://github.com/BoundaryML/baml/issues/4588) has an author-confirmed nightly fix and a passing 0.18.0 dead-endpoint reproduction; its separate stderr-content policy question remains open. [#4506](https://github.com/BoundaryML/baml/issues/4506) still reproduces on 0.18.0 and must not receive a “fixed” notification just because the related iterator PR merged.
+
+Recommendation: keep release-note inclusion and contributor notification eligibility separate. Resolve linked issue and source-thread context before drafting a response. Preserve partial scope and deduplicate destinations.
+
+## Procedure improvements from the backtest
+
+The preparation guide now incorporates the range, filtering, final-source, migration, and validation safeguards below.
+
+1. Accept explicit lower and upper revision bounds. Resolve both to commit IDs before scanning. Use current release discovery only when bounds are absent.
+2. Inventory every commit in the range before filtering. Include packaging/workflow fixes that affect shipped artifacts. Keep this complete inventory for followups.
+3. Record every exclusion with a reason. Resolve reverted and superseded changes against the upper tag, not merge titles alone.
+4. Inspect merged diffs for each public surface and all broad PRs. Verify example API names, return types, configuration keys, and imports against the final tag.
+5. Include migration guidance for removed arguments, changed return types, EOF behavior, deadlines, and renamed output paths. A bug-fix classification does not eliminate the need to state required user action.
+6. Require benchmark evidence before calling a refactor a performance improvement. Label the measured revision, workload, build profile, and baseline.
+7. Validate code examples with the target release. Keep compile-only checks distinct from execution: #4506 passes `baml check` but still fails when run.
+8. Keep notification drafts local until publishing is authorized. Track source coverage, account-attribution rules, unavailable sources, and partial fixes explicitly.
+9. Preserve the original post during a backtest. Mark any website draft with `isPublished: false` and a unique slug.

--- a/docs/changelog-backtests/0.18.0/source-coverage.md
+++ b/docs/changelog-backtests/0.18.0/source-coverage.md
@@ -1,0 +1,73 @@
+# Followup source coverage
+
+The PR inventory is [step1a-all-prs.md](step1a-all-prs.md). This file records the additional issue sources inspected. Source links are evidence, not instructions to post.
+
+## Linear
+
+| Issue | Source title | Attribution / followup disposition |
+| --- | --- | --- |
+| [B-1059](https://linear.app/boundaryml2/issue/B-1059/c-canceltokenany-intermittently-loses-native-state) | C# CancelToken.any intermittently loses native state | Internal/automated source; inspect linked external reports separately. |
+| [B-1071](https://linear.app/boundaryml2/issue/B-1071/logical-operators-and-conditions-never-require-bool) | Logical operators and conditions never require `bool` | Internal/automated source; inspect linked external reports separately. |
+| [B-1073](https://linear.app/boundaryml2/issue/B-1073/literal-patterns-compare-with-which-coerces-across-the-numeric-tower) | Literal patterns compare with `==`, which coerces across the numeric tower | Internal/automated source; inspect linked external reports separately. |
+| [B-1074](https://linear.app/boundaryml2/issue/B-1074/plain-field-access-on-a-nullable-intermediate-is-permitted-inside-an) | Plain field access on a nullable intermediate is permitted inside an optional chain | Internal/automated source; inspect linked external reports separately. |
+| [B-1148](https://linear.app/boundaryml2/issue/B-1148/bamljsonto-stringt-fails-at-runtime-when-t-unknown) | baml.json.to_string<T> fails at runtime when T = unknown | Internal/automated source; inspect linked external reports separately. |
+| [B-1167](https://linear.app/boundaryml2/issue/B-1167/ban-throws-unknown) | Ban `throws unknown` | Internal/automated source; inspect linked external reports separately. |
+| [B-1180](https://linear.app/boundaryml2/issue/B-1180/vm-internal-error-method-call-on-an-interface-typed-optional) | VM internal error: ?. method call on an interface-typed optional | Internal/automated source; inspect linked external reports separately. |
+| [B-1480](https://linear.app/boundaryml2/issue/B-1480/implement-first-class-bamlerrorsunknownerror-wrapping-for-untyped) | Implement first-class `baml.errors.UnknownError` wrapping for untyped throws | Internal/automated source; inspect linked external reports separately. |
+| [B-1512](https://linear.app/boundaryml2/issue/B-1512/vm-internal-error-should-never-reach-users-audit-all-sites-and-panic) | `VM internal error` should never reach users — audit all sites and panic instead | Internal/automated source; inspect linked external reports separately. |
+| [B-1545](https://linear.app/boundaryml2/issue/B-1545/restore-disabled-macos-ci-jobs) | Restore disabled macOS CI jobs | Internal/automated source; inspect linked external reports separately. |
+| [B-1559](https://linear.app/boundaryml2/issue/B-1559/remove-hashtag-raw-string-transcripts-from-compiler) | Remove hashtag raw string transcripts from compiler | Internal/automated source; inspect linked external reports separately. |
+| [B-1562](https://linear.app/boundaryml2/issue/B-1562/format-test-assertion-for-readability) | Format test assertion for readability | Internal/automated source; inspect linked external reports separately. |
+| [B-1563](https://linear.app/boundaryml2/issue/B-1563/allow-string-null-truthiness-in-if-conditions) | Allow `string \| null` truthiness in `if` conditions | Internal/automated source; inspect linked external reports separately. |
+| [B-1572](https://linear.app/boundaryml2/issue/B-1572/baml-language-0170-release-issues) | baml_language 0.17.0 release issues | Internal/automated source; inspect linked external reports separately. |
+| [B-1576](https://linear.app/boundaryml2/issue/B-1576/fix-compiler-abort-for-inferred-arraymap-result) | Fix compiler abort for inferred Array.map result | Internal/automated source; inspect linked external reports separately. |
+| [B-1580](https://linear.app/boundaryml2/issue/B-1580/infer-callback-throws-effects-through-optional-callback-parameters) | Infer callback throws effects through optional callback parameters | Internal/automated source; inspect linked external reports separately. |
+| [B-1582](https://linear.app/boundaryml2/issue/B-1582/fix-remaining-runtime-reflection-and-dynamic-type-failures-found-by) | Fix remaining runtime reflection and dynamic-type failures found by VetRec | Internal/automated source; inspect linked external reports separately. |
+| [B-1591](https://linear.app/boundaryml2/issue/B-1591/standardize-c-sdk-generator-output-directory-on-baml-sdk) | Standardize C# SDK generator output directory on baml_sdk | Internal/automated source; inspect linked external reports separately. |
+| [B-1592](https://linear.app/boundaryml2/issue/B-1592/ctxoutput-format-options) | ctx.output_format options | Internal/automated source; inspect linked external reports separately. |
+| [B-1605](https://linear.app/boundaryml2/issue/B-1605/reflection-bug-fixes-batch-1) | Reflection bug fixes (Batch #1) | Internal/automated source; inspect linked external reports separately. |
+| [B-1607](https://linear.app/boundaryml2/issue/B-1607/baml-check-panics-on-unresolved-type-in-a-throws-clause) | `baml check` panics on unresolved type in a throws clause | Internal/automated source; inspect linked external reports separately. |
+| [B-1612](https://linear.app/boundaryml2/issue/B-1612/untyped-in-catch-arm-panics) | untyped [] in catch arm panics | Internal/automated source; inspect linked external reports separately. |
+| [B-1627](https://linear.app/boundaryml2/issue/B-1627/fix-reflectcall-any-inferred-generics-runtime-failure) | Fix reflect.call_any inferred generics runtime failure | Internal/automated source; inspect linked external reports separately. |
+| [B-1630](https://linear.app/boundaryml2/issue/B-1630/keep-legacy-declarative-tests-valid-after-baml-fmt) | Keep legacy declarative tests valid after baml fmt | Internal/automated source; inspect linked external reports separately. |
+| [B-1649](https://linear.app/boundaryml2/issue/B-1649/optional-job-fields-return-null) | Optional Job fields return null | Internal/automated source; inspect linked external reports separately. |
+| [B-207](https://linear.app/boundaryml2/issue/B-207/read-write-interface-stdin) | read / write interface (stdin) | Internal/automated source; inspect linked external reports separately. |
+| [B-236](https://linear.app/boundaryml2/issue/B-236/empty-in-ifelse-else-branch-causes-vm-crash-expected-map-got-array) | Empty `[]` in if/else else-branch causes VM crash: `expected map, got array` | Internal/automated source; inspect linked external reports separately. |
+| [B-441](https://linear.app/boundaryml2/issue/B-441/log-events-never-surfaced-by-baml-test-or-baml-run) | `log.*` events never surfaced by `baml test` or `baml run` | Internal/automated source; inspect linked external reports separately. |
+| [B-469](https://linear.app/boundaryml2/issue/B-469/t-type-annotation-in-array-match-arm-is-silently-ignored-at-runtime) | `[..]: T[]` type annotation in array match arm is silently ignored at runtime | Internal/automated source; inspect linked external reports separately. |
+| [B-569](https://linear.app/boundaryml2/issue/B-569/mapint-type-checks-but-crashes-at-runtime-expected-string-got-int) | map<int, ...> type-checks but crashes at runtime: 'expected string, got int' | Internal/automated source; inspect linked external reports separately. |
+| [B-633](https://linear.app/boundaryml2/issue/B-633/generic-tpop-erases-the-typed-t-not-t-null-leaks-into-a-non-nullable-t) | Generic `T[].pop()` erases the `?` (typed `T`, not `T?`) — `null` leaks into a non-nullable `T` | Internal/automated source; inspect linked external reports separately. |
+| [B-693](https://linear.app/boundaryml2/issue/B-693/symbolic-bytecode-format-load-time-linker-relocatable-units-v2) | Symbolic bytecode format + load-time linker (relocatable units v2) | Internal/automated source; inspect linked external reports separately. |
+| [B-694](https://linear.app/boundaryml2/issue/B-694/persist-typed-stdlib-interface-export-data-remove-the-per-process-cold) | Persist typed stdlib interface (export data) — remove the per-process cold-typecheck floor | Internal/automated source; inspect linked external reports separately. |
+| [B-722](https://linear.app/boundaryml2/issue/B-722/skill-unknownerror-pattern-for-interfaces) | skill: UnknownError pattern for interfaces | Internal/automated source; inspect linked external reports separately. |
+| [B-805](https://linear.app/boundaryml2/issue/B-805/log-when-shutdown-is-waiting-on-remaining-threads) | Log when shutdown is waiting on remaining threads | Internal/automated source; inspect linked external reports separately. |
+| [B-841](https://linear.app/boundaryml2/issue/B-841/create-one-liner-to-install-local-baml-extension-in-vs-code) | Create one-liner to install local BAML extension in VS Code | Internal/automated source; inspect linked external reports separately. |
+| [B-883](https://linear.app/boundaryml2/issue/B-883/codegen-type-for-never) | Codegen type for `never` | Internal/automated source; inspect linked external reports separately. |
+| [B-987](https://linear.app/boundaryml2/issue/B-987/type-checker-accepts-float-string-causing-vm-internal-error-at-runtime) | Type checker accepts `float += string`, causing VM internal error at runtime | Internal/automated source; inspect linked external reports separately. |
+| [BAMLGH-62](https://linear.app/boundaryml2/issue/BAMLGH-62/baml-run-on-0170-swallows-every-thrown-error-and-prints-a-type-checker) | `baml run` on 0.17.0 swallows every thrown error and prints a type-checker union dump instead (0.15.0 reported the real error) | GitHub report; use the corresponding issue destination. |
+| [BAMLGH-63](https://linear.app/boundaryml2/issue/BAMLGH-63/sap-017-an-optional-class-typed-field-is-silently-coerced-to-null) | SAP 0.17: an optional class-typed field is silently coerced to `null` — discarding a well-formed value — when the answer omits an optional class-typed member nested inside it | GitHub report; use the corresponding issue destination. |
+
+## GitHub issues
+
+- [#4154](https://github.com/BoundaryML/baml/issues/4154): screened; see step 3 for exclusion.
+- [#4279](https://github.com/BoundaryML/baml/issues/4279): screened; see step 3 for exclusion.
+- [#4335](https://github.com/BoundaryML/baml/issues/4335): notification drafted.
+- [#4355](https://github.com/BoundaryML/baml/issues/4355): notification drafted.
+- [#4371](https://github.com/BoundaryML/baml/issues/4371): screened; see step 3 for exclusion.
+- [#4376](https://github.com/BoundaryML/baml/issues/4376): notification drafted.
+- [#4421](https://github.com/BoundaryML/baml/issues/4421): notification drafted.
+- [#4422](https://github.com/BoundaryML/baml/issues/4422): screened; see step 3 for exclusion.
+- [#4429](https://github.com/BoundaryML/baml/issues/4429): notification drafted.
+- [#4468](https://github.com/BoundaryML/baml/issues/4468): notification drafted.
+- [#4506](https://github.com/BoundaryML/baml/issues/4506): screened; see step 3 for exclusion.
+- [#4588](https://github.com/BoundaryML/baml/issues/4588): notification drafted.
+- [#4589](https://github.com/BoundaryML/baml/issues/4589): notification drafted.
+
+## Slack source threads
+
+- [B-1649](https://gloo-global.slack.com/archives/C06P60YREAC/p1787877736697639): thread read in full; internal participants.
+- [B-1627](https://gloo-global.slack.com/archives/C0958DV7YPL/p1787601591163179): thread read in full; internal participants.
+- [B-805](https://gloo-global.slack.com/archives/C093PJAFHCZ/p1783612804212919): thread read in full; internal participants.
+- [B-805 earlier design](https://gloo-global.slack.com/archives/C0A66240YFJ/p1783092939143909): thread read in full; internal participants.
+- [B-1576](https://gloo-global.slack.com/archives/C03KV1PJ6EM/p1787006870218669): thread read in full; internal participants.
+- [B-841](https://gloo-global.slack.com/archives/C06P60YREAC/p1783723358205209): thread read in full; internal participants.

--- a/docs/changelog-backtests/0.18.0/step1a-all-prs.md
+++ b/docs/changelog-backtests/0.18.0/step1a-all-prs.md
@@ -1,0 +1,122 @@
+# Complete release-range inventory
+
+Range: `baml-language-0.17.0..baml-language-0.18.0` (lower tag excluded; upper tag included). Sources were inspected at the upper tag, not current canary.
+
+The range contains 114 commits/PRs. The procedure’s path-filtered log returns 89. Only four PRs are BAML v0-only; the followup inventory therefore includes 110 PRs. `Keep` means a net user-visible effect in this draft. The workflow-only musl fix #4502 is an explicitly documented correction to the procedure’s filter.
+
+| PR | Language path? | Decision | Evidence / reason |
+| --- | --- | --- | --- |
+| [#4455](https://github.com/BoundaryML/baml/pull/4455) | Yes | Exclude | Documentation for the preceding release. |
+| [#4453](https://github.com/BoundaryML/baml/pull/4453) | Yes | Keep | C02 |
+| [#4458](https://github.com/BoundaryML/baml/pull/4458) | Yes | Keep | C03 |
+| [#4460](https://github.com/BoundaryML/baml/pull/4460) | Yes | Keep | C33 |
+| [#4461](https://github.com/BoundaryML/baml/pull/4461) | Yes | Exclude | Internal cache reuse; its own benchmarks explicitly claim no end-to-end speedup. |
+| [#4462](https://github.com/BoundaryML/baml/pull/4462) | Yes | Exclude | CI fixture scheduling only. |
+| [#4463](https://github.com/BoundaryML/baml/pull/4463) | Yes | Keep | C03 |
+| [#4464](https://github.com/BoundaryML/baml/pull/4464) | Yes | Exclude | Entire change reverted by #4469 before the upper tag. |
+| [#4469](https://github.com/BoundaryML/baml/pull/4469) | Yes | Exclude | Cancels #4464; no net release change. |
+| [#4456](https://github.com/BoundaryML/baml/pull/4456) | Yes | Exclude | Changelog cleanup and release notifications. |
+| [#4202](https://github.com/BoundaryML/baml/pull/4202) | No | Exclude | BAML v0 audio provider in engine/. |
+| [#4407](https://github.com/BoundaryML/baml/pull/4407) | No | Exclude | Contributor command for installing a locally built VS Code extension. |
+| [#4408](https://github.com/BoundaryML/baml/pull/4408) | Yes | Keep | C32 |
+| [#4472](https://github.com/BoundaryML/baml/pull/4472) | Yes | Exclude | C# release size-gate policy only. |
+| [#4409](https://github.com/BoundaryML/baml/pull/4409) | Yes | Keep | C31 |
+| [#4474](https://github.com/BoundaryML/baml/pull/4474) | No | Exclude | BAML v0 version bump. |
+| [#4471](https://github.com/BoundaryML/baml/pull/4471) | No | Exclude | CI baseline automation only. |
+| [#4378](https://github.com/BoundaryML/baml/pull/4378) | Yes | Exclude | Private Ruby loader groundwork; no callable end-user Ruby SDK introduced. |
+| [#4466](https://github.com/BoundaryML/baml/pull/4466) | Yes | Keep | C34 |
+| [#4465](https://github.com/BoundaryML/baml/pull/4465) | Yes | Exclude | Binary-size baseline refresh only. |
+| [#4478](https://github.com/BoundaryML/baml/pull/4478) | Yes | Keep | C35 |
+| [#4489](https://github.com/BoundaryML/baml/pull/4489) | Yes | Keep | C36 |
+| [#4467](https://github.com/BoundaryML/baml/pull/4467) | Yes | Keep | C37 |
+| [#4470](https://github.com/BoundaryML/baml/pull/4470) | Yes | Keep | C38 |
+| [#4473](https://github.com/BoundaryML/baml/pull/4473) | Yes | Keep | C39 |
+| [#4491](https://github.com/BoundaryML/baml/pull/4491) | Yes | Keep | C10 C40 |
+| [#4494](https://github.com/BoundaryML/baml/pull/4494) | No | Exclude | Repository editor preference only. |
+| [#4493](https://github.com/BoundaryML/baml/pull/4493) | Yes | Keep | C10 C40 |
+| [#4490](https://github.com/BoundaryML/baml/pull/4490) | Yes | Keep | C41 |
+| [#4495](https://github.com/BoundaryML/baml/pull/4495) | Yes | Keep | C42 |
+| [#4499](https://github.com/BoundaryML/baml/pull/4499) | Yes | Exclude | Test timing and hermeticity only. |
+| [#4501](https://github.com/BoundaryML/baml/pull/4501) | Yes | Keep | C43 |
+| [#4498](https://github.com/BoundaryML/baml/pull/4498) | Yes | Keep | C12 |
+| [#4503](https://github.com/BoundaryML/baml/pull/4503) | No | Exclude | BAML v0 OpenAI token-detail fix in engine/. |
+| [#4518](https://github.com/BoundaryML/baml/pull/4518) | Yes | Keep | C45 |
+| [#4524](https://github.com/BoundaryML/baml/pull/4524) | No | Exclude | BAML v0 version bump. |
+| [#4516](https://github.com/BoundaryML/baml/pull/4516) | Yes | Keep | C44 |
+| [#4528](https://github.com/BoundaryML/baml/pull/4528) | No | Exclude | CI protoc installation only. |
+| [#4519](https://github.com/BoundaryML/baml/pull/4519) | Yes | Exclude | Generic-function descriptor listing and specialize/get APIs were removed by #4560 before the upper tag; no shipped feature. |
+| [#4529](https://github.com/BoundaryML/baml/pull/4529) | Yes | Keep | C46 |
+| [#4479](https://github.com/BoundaryML/baml/pull/4479) | No | Exclude | Contributor/CI sccache logging configuration. |
+| [#4517](https://github.com/BoundaryML/baml/pull/4517) | Yes | Exclude | Test cleanup only. |
+| [#4481](https://github.com/BoundaryML/baml/pull/4481) | Yes | Exclude | TypeScript declaration-test harness speed only. |
+| [#4533](https://github.com/BoundaryML/baml/pull/4533) | Yes | Exclude | Python test setup build deduplication only. |
+| [#4531](https://github.com/BoundaryML/baml/pull/4531) | Yes | Keep | C47 |
+| [#4530](https://github.com/BoundaryML/baml/pull/4530) | Yes | Keep | C45 |
+| [#4441](https://github.com/BoundaryML/baml/pull/4441) | Yes | Keep | C15 |
+| [#4502](https://github.com/BoundaryML/baml/pull/4502) | No | Keep | C30 |
+| [#4535](https://github.com/BoundaryML/baml/pull/4535) | Yes | Keep | C28 |
+| [#4459](https://github.com/BoundaryML/baml/pull/4459) | Yes | Keep | C07 C08 C09 C38 C66 |
+| [#4526](https://github.com/BoundaryML/baml/pull/4526) | Yes | Keep | C48 |
+| [#4537](https://github.com/BoundaryML/baml/pull/4537) | No | Exclude | Non-gating CI runner preview only. |
+| [#4539](https://github.com/BoundaryML/baml/pull/4539) | No | Exclude | CI runner/cache isolation only. |
+| [#4510](https://github.com/BoundaryML/baml/pull/4510) | Yes | Keep | C16 |
+| [#4536](https://github.com/BoundaryML/baml/pull/4536) | Yes | Keep | C44 |
+| [#4500](https://github.com/BoundaryML/baml/pull/4500) | Yes | Keep | C13 |
+| [#4508](https://github.com/BoundaryML/baml/pull/4508) | Yes | Keep | C49 |
+| [#4544](https://github.com/BoundaryML/baml/pull/4544) | Yes | Keep | C49 |
+| [#4522](https://github.com/BoundaryML/baml/pull/4522) | Yes | Keep | C28 |
+| [#4547](https://github.com/BoundaryML/baml/pull/4547) | Yes | Keep | C50 |
+| [#4548](https://github.com/BoundaryML/baml/pull/4548) | Yes | Keep | C01 |
+| [#4541](https://github.com/BoundaryML/baml/pull/4541) | Yes | Keep | C29 C32 C36 C51 C69 |
+| [#4552](https://github.com/BoundaryML/baml/pull/4552) | No | Exclude | CI runner provisioning only. |
+| [#4555](https://github.com/BoundaryML/baml/pull/4555) | No | Exclude | Internal oncall schedule only. |
+| [#4543](https://github.com/BoundaryML/baml/pull/4543) | Yes | Keep | C22 |
+| [#4554](https://github.com/BoundaryML/baml/pull/4554) | Yes | Exclude | Binary-size baseline refresh only. |
+| [#4560](https://github.com/BoundaryML/baml/pull/4560) | Yes | Exclude | Runtime representation rewrite also removes the unreleased #4519 API; final reflection behavior is documented under the surviving fixes, not as a separate feature. |
+| [#4562](https://github.com/BoundaryML/baml/pull/4562) | Yes | Exclude | Test snapshot rendering only; verified from the merged diff. |
+| [#4564](https://github.com/BoundaryML/baml/pull/4564) | Yes | Exclude | Release verification checks and C# smoke-call adjustment; the shipped musl fix is #4502. |
+| [#4558](https://github.com/BoundaryML/baml/pull/4558) | No | Exclude | CI runner cache access only. |
+| [#4565](https://github.com/BoundaryML/baml/pull/4565) | Yes | Keep | C25 |
+| [#4569](https://github.com/BoundaryML/baml/pull/4569) | Yes | Exclude | Removal of an already obsolete protocol and debug-only verifier; no additional user effect established. |
+| [#4566](https://github.com/BoundaryML/baml/pull/4566) | Yes | Keep | C52 |
+| [#4135](https://github.com/BoundaryML/baml/pull/4135) | Yes | Keep | C17 C53 |
+| [#4572](https://github.com/BoundaryML/baml/pull/4572) | Yes | Exclude | Internal test compilation acceleration only. |
+| [#4575](https://github.com/BoundaryML/baml/pull/4575) | Yes | Exclude | C# verification fixture refactor only. |
+| [#4580](https://github.com/BoundaryML/baml/pull/4580) | Yes | Keep | C22 C23 |
+| [#4570](https://github.com/BoundaryML/baml/pull/4570) | Yes | Keep | C04 C20 |
+| [#4563](https://github.com/BoundaryML/baml/pull/4563) | Yes | Keep | C01 |
+| [#4578](https://github.com/BoundaryML/baml/pull/4578) | Yes | Keep | C01 |
+| [#4573](https://github.com/BoundaryML/baml/pull/4573) | Yes | Keep | C54 |
+| [#4567](https://github.com/BoundaryML/baml/pull/4567) | Yes | Keep | C27 |
+| [#4582](https://github.com/BoundaryML/baml/pull/4582) | Yes | Exclude | C# CI cache and test scheduling only. |
+| [#4581](https://github.com/BoundaryML/baml/pull/4581) | Yes | Keep | C55 |
+| [#4597](https://github.com/BoundaryML/baml/pull/4597) | No | Exclude | Website navigation edit independent of the language release. |
+| [#4568](https://github.com/BoundaryML/baml/pull/4568) | Yes | Keep | C56 |
+| [#4571](https://github.com/BoundaryML/baml/pull/4571) | Yes | Keep | C57 |
+| [#4577](https://github.com/BoundaryML/baml/pull/4577) | Yes | Keep | C58 |
+| [#4574](https://github.com/BoundaryML/baml/pull/4574) | Yes | Keep | C11 |
+| [#4583](https://github.com/BoundaryML/baml/pull/4583) | Yes | Keep | C43 C59 |
+| [#4601](https://github.com/BoundaryML/baml/pull/4601) | Yes | Keep | C24 |
+| [#4600](https://github.com/BoundaryML/baml/pull/4600) | Yes | Keep | C60 |
+| [#4579](https://github.com/BoundaryML/baml/pull/4579) | No | Exclude | Internal feedback triage tooling. |
+| [#4603](https://github.com/BoundaryML/baml/pull/4603) | Yes | Exclude | Compiler type representation cleanup; no separate user effect established. |
+| [#4605](https://github.com/BoundaryML/baml/pull/4605) | No | Exclude | Website onboarding copy independent of the language release. |
+| [#4607](https://github.com/BoundaryML/baml/pull/4607) | No | Exclude | Website deployment configuration independent of the language release. |
+| [#4602](https://github.com/BoundaryML/baml/pull/4602) | Yes | Keep | C26 |
+| [#4604](https://github.com/BoundaryML/baml/pull/4604) | Yes | Keep | C05 C06 C19 C20 C21 C61 |
+| [#4606](https://github.com/BoundaryML/baml/pull/4606) | Yes | Keep | C18 C68 |
+| [#4599](https://github.com/BoundaryML/baml/pull/4599) | Yes | Keep | C14 |
+| [#4609](https://github.com/BoundaryML/baml/pull/4609) | Yes | Keep | C67 |
+| [#4613](https://github.com/BoundaryML/baml/pull/4613) | No | Exclude | Internal metrics and Slack reporting. |
+| [#4614](https://github.com/BoundaryML/baml/pull/4614) | No | Exclude | Internal metrics screenshot readiness. |
+| [#4615](https://github.com/BoundaryML/baml/pull/4615) | No | Exclude | Internal metrics screenshot readiness. |
+| [#4612](https://github.com/BoundaryML/baml/pull/4612) | Yes | Keep | C62 |
+| [#4617](https://github.com/BoundaryML/baml/pull/4617) | No | Exclude | Internal metrics Slack destination. |
+| [#4618](https://github.com/BoundaryML/baml/pull/4618) | No | Exclude | Internal metrics report link. |
+| [#4608](https://github.com/BoundaryML/baml/pull/4608) | No | Exclude | Internal issue triage tooling. |
+| [#4619](https://github.com/BoundaryML/baml/pull/4619) | Yes | Keep | C63 |
+| [#4621](https://github.com/BoundaryML/baml/pull/4621) | Yes | Keep | C64 |
+| [#4626](https://github.com/BoundaryML/baml/pull/4626) | Yes | Exclude | Test scheduling determinism; production LSP unchanged. |
+| [#4593](https://github.com/BoundaryML/baml/pull/4593) | Yes | Keep | C65 |
+| [#4628](https://github.com/BoundaryML/baml/pull/4628) | Yes | Exclude | The historical changelog itself; comparison target, not a product change. |
+| [#4629](https://github.com/BoundaryML/baml/pull/4629) | Yes | Exclude | Version synchronization for this release. |

--- a/docs/changelog-backtests/0.18.0/step1b-prs-only-user-visible.md
+++ b/docs/changelog-backtests/0.18.0/step1b-prs-only-user-visible.md
@@ -1,0 +1,70 @@
+# PRs with user-visible effects
+
+Range: `baml-language-0.17.0..baml-language-0.18.0` (lower tag excluded; upper tag included). Sources were inspected at the upper tag, not current canary.
+
+64 PRs retained after checking the net result at the release tag. #4502 is outside the procedure’s literal path/workflow filters but changes the installed v1 Node bridge. See the backtest report for this exception.
+
+- [#4453](https://github.com/BoundaryML/baml/pull/4453): perf(runtime): precompile stdlib prefix for Package.compile
+- [#4458](https://github.com/BoundaryML/baml/pull/4458): perf(compiler): memoize canonical body inference facts
+- [#4460](https://github.com/BoundaryML/baml/pull/4460): fix: harden runtime compilation boundaries
+- [#4463](https://github.com/BoundaryML/baml/pull/4463): perf(compiler): restore alias memos for impl scans
+- [#4408](https://github.com/BoundaryML/baml/pull/4408): feat: log when shutdown waits for active futures
+- [#4409](https://github.com/BoundaryML/baml/pull/4409): fix(cli): surface log events from baml run
+- [#4466](https://github.com/BoundaryML/baml/pull/4466): fix: restore E0007 for member access on unknown receivers
+- [#4478](https://github.com/BoundaryML/baml/pull/4478): fix(compiler): literal patterns are membership tests, not `==` (B-1073)
+- [#4489](https://github.com/BoundaryML/baml/pull/4489): fmt: strip redundant same-precedence parens in binary chains and call args (B-1562)
+- [#4467](https://github.com/BoundaryML/baml/pull/4467): fix: preserve mutable identities across loop calls
+- [#4470](https://github.com/BoundaryML/baml/pull/4470): fix: reject non-data LLM output schemas
+- [#4473](https://github.com/BoundaryML/baml/pull/4473): fix: diagnose unspecialized reflected generics
+- [#4491](https://github.com/BoundaryML/baml/pull/4491): feat(reflect): add read-only AnyClass reflection
+- [#4493](https://github.com/BoundaryML/baml/pull/4493): feat(reflect): apply the AnyClass follow-up rulings
+- [#4490](https://github.com/BoundaryML/baml/pull/4490): fix(hir_ty): compiler abort on for-loops over joined map arms and Iterable-bounded generics
+- [#4495](https://github.com/BoundaryML/baml/pull/4495): fix: thread type arguments through optional-chained calls
+- [#4501](https://github.com/BoundaryML/baml/pull/4501): fix(reflect): runtime type definitions through dispatch, nested views, and pending-field metadata (B-1582)
+- [#4498](https://github.com/BoundaryML/baml/pull/4498): feat(language): truthiness in condition positions (B-1563)
+- [#4518](https://github.com/BoundaryML/baml/pull/4518): Diagnose inline unreflect type arguments that escape their call
+- [#4516](https://github.com/BoundaryML/baml/pull/4516): Carry minted type identity through interface dispatch
+- [#4529](https://github.com/BoundaryML/baml/pull/4529): Make a let binding that lives in a global behave like an ordinary binding
+- [#4531](https://github.com/BoundaryML/baml/pull/4531): Type-check a Session assignment against its binding
+- [#4530](https://github.com/BoundaryML/baml/pull/4530): Extend the runtime-type escape rule to throws and optional chains
+- [#4441](https://github.com/BoundaryML/baml/pull/4441): feat: first-class UnknownError wrapping
+- [#4502](https://github.com/BoundaryML/baml/pull/4502): fix: make sure Node SDK musl runtime works on alpine
+- [#4535](https://github.com/BoundaryML/baml/pull/4535): fix: c# now always generates as baml_sdk, not baml_client
+- [#4459](https://github.com/BoundaryML/baml/pull/4459): Enable the Python SDK migration primitives used by VetRec
+- [#4526](https://github.com/BoundaryML/baml/pull/4526): fix: return a well-formed error, not a panic, when `naming_convention = "language"` is used for SDKs
+- [#4510](https://github.com/BoundaryML/baml/pull/4510): feat(stdlib): add take/skip/take_while/skip_while iterator adapters to baml.iter
+- [#4536](https://github.com/BoundaryML/baml/pull/4536): Keep a compiled package's types identical through interface dispatch
+- [#4500](https://github.com/BoundaryML/baml/pull/4500): Interface member projections
+- [#4508](https://github.com/BoundaryML/baml/pull/4508): fix: materialize reassigned short-circuit locals
+- [#4544](https://github.com/BoundaryML/baml/pull/4544): fix: prove stack-carried locals by predecessor coverage
+- [#4522](https://github.com/BoundaryML/baml/pull/4522): fix: generate baml_sdk in next to `baml.toml` by default
+- [#4547](https://github.com/BoundaryML/baml/pull/4547): fix: preserve array ascriptions in match coverage
+- [#4548](https://github.com/BoundaryML/baml/pull/4548): feat(profiling): segmented local backend (CCT + exact evidence + CAS)
+- [#4541](https://github.com/BoundaryML/baml/pull/4541): fmt: strip redundant receiver parens; fix unreflect MIR ICE
+- [#4543](https://github.com/BoundaryML/baml/pull/4543): Make reflect a root package
+- [#4565](https://github.com/BoundaryML/baml/pull/4565): B-1559: Reject hash string literals
+- [#4566](https://github.com/BoundaryML/baml/pull/4566): fix(compiler2): preserve type-ref diagnostic ownership
+- [#4135](https://github.com/BoundaryML/baml/pull/4135): Use `Rng` for all primitive random methods
+- [#4580](https://github.com/BoundaryML/baml/pull/4580): Type views should not be subtypes of `reflect.Type`
+- [#4570](https://github.com/BoundaryML/baml/pull/4570): Agent de-generification + unified on_event across Agent, direct calls, and streams
+- [#4563](https://github.com/BoundaryML/baml/pull/4563): baml query: SQL over local execution profiles (P0 store, query core, provider, CLI)
+- [#4578](https://github.com/BoundaryML/baml/pull/4578): playground: Telemetry tab over the canonical profile store
+- [#4573](https://github.com/BoundaryML/baml/pull/4573): fix(compiler2): diagnose untyped empty containers
+- [#4567](https://github.com/BoundaryML/baml/pull/4567): B-1592: restore ctx.output_format options
+- [#4581](https://github.com/BoundaryML/baml/pull/4581): LSP
+- [#4568](https://github.com/BoundaryML/baml/pull/4568): Version compiler artifact envelopes
+- [#4571](https://github.com/BoundaryML/baml/pull/4571): Represent reflection runtime state with enums
+- [#4577](https://github.com/BoundaryML/baml/pull/4577): Preserve runtime type identity across reflection seams
+- [#4574](https://github.com/BoundaryML/baml/pull/4574): Allow unreflect in any type position
+- [#4583](https://github.com/BoundaryML/baml/pull/4583): Preserve runtime diagnostics and reflected schemas
+- [#4601](https://github.com/BoundaryML/baml/pull/4601): Make baml.json.to_string and to_json non-generic
+- [#4600](https://github.com/BoundaryML/baml/pull/4600): Validate reflect.call_any return values against R
+- [#4602](https://github.com/BoundaryML/baml/pull/4602): [B-1630] Remove legacy test declarations
+- [#4604](https://github.com/BoundaryML/baml/pull/4604): Runner interface, async-iterable Python streams, and drain-ready TurnStream batching
+- [#4606](https://github.com/BoundaryML/baml/pull/4606): B-207: implement BEP-069 Read and Write interfaces
+- [#4599](https://github.com/BoundaryML/baml/pull/4599): Infer stored lambda parameters from later uses
+- [#4609](https://github.com/BoundaryML/baml/pull/4609): fix(cli): enable bundle-http for HTTP support in baml run and playground
+- [#4612](https://github.com/BoundaryML/baml/pull/4612): fix(sap): preserve optional classes with omitted fields
+- [#4619](https://github.com/BoundaryML/baml/pull/4619): fix(compiler): reject missing required class fields
+- [#4621](https://github.com/BoundaryML/baml/pull/4621): fix(compiler): reject unspecialized generic function values
+- [#4593](https://github.com/BoundaryML/baml/pull/4593): fix(compiler): reject imprecise throws unknown declarations

--- a/docs/changelog-backtests/0.18.0/step2a-pr-user-effects.md
+++ b/docs/changelog-backtests/0.18.0/step2a-pr-user-effects.md
@@ -1,0 +1,281 @@
+# User effects by PR
+
+Range: `baml-language-0.17.0..baml-language-0.18.0` (lower tag excluded; upper tag included). Sources were inspected at the upper tag, not current canary.
+
+A PR can contain several independently classified effects. Intermediate API names are replaced with the names present in 0.18.0.
+
+## [#4453](https://github.com/BoundaryML/baml/pull/4453)
+
+- **C02 · FEATURE:** Runtime package compilation reuses a precompiled standard library. The PR’s five-sample cold-path median fell from approximately 4–5 seconds to 20.6 milliseconds for a small package. These measurements describe that workload and host.
+
+## [#4458](https://github.com/BoundaryML/baml/pull/4458)
+
+- **C03 · FEATURE:** PR #4458 reports an empty-project median of 530.2 → 489.1 ms and a full-test-project median of 2.333 → 2.120 s. PR #4463 reports 497.5 → 485.6 ms and 2.180 → 2.133 s against its own immediate baseline. These are separate A/B measurements; their percentages must not be added.
+
+## [#4460](https://github.com/BoundaryML/baml/pull/4460)
+
+- **C33 · BUGFIX:** Indirect calls that need unsupported runtime type checks now produce E0010. Runtime-created types no longer leak hidden synthetic names into source diagnostics.
+
+## [#4463](https://github.com/BoundaryML/baml/pull/4463)
+
+- **C03 · FEATURE:** PR #4458 reports an empty-project median of 530.2 → 489.1 ms and a full-test-project median of 2.333 → 2.120 s. PR #4463 reports 497.5 → 485.6 ms and 2.180 → 2.133 s against its own immediate baseline. These are separate A/B measurements; their percentages must not be added.
+
+## [#4408](https://github.com/BoundaryML/baml/pull/4408)
+
+- **C32 · BUGFIX:** CLI shutdown reports active futures and supports cancellation. Leaked-future cleanup no longer leaves completed tests waiting indefinitely.
+
+## [#4409](https://github.com/BoundaryML/baml/pull/4409)
+
+- **C31 · BUGFIX:** `baml run` surfaces `log.*` events and respects `--log` and `BAML_LOG`. The test command accepts the unified log option. This does not establish that packed-binary logging or `--log-file` is fixed.
+
+## [#4466](https://github.com/BoundaryML/baml/pull/4466)
+
+- **C34 · BUGFIX:** Calling a nonexistent member on an `unknown` receiver produces E0007 before execution.
+
+## [#4478](https://github.com/BoundaryML/baml/pull/4478)
+
+- **C35 · BUGFIX:** Literal patterns distinguish `1`, `1.0`, and `1n`. Dense integer matches no longer crash on a float. Literal aliases match their value instead of every value of the base type.
+
+## [#4489](https://github.com/BoundaryML/baml/pull/4489)
+
+- **C36 · BUGFIX:** `baml fmt` removes unnecessary parentheses in binary chains, call arguments, postfix receivers, and unary operands. It keeps parentheses needed for meaning or comments.
+
+## [#4467](https://github.com/BoundaryML/baml/pull/4467)
+
+- **C37 · BUGFIX:** A map created before a loop retains changes made by callees in successive iterations.
+
+## [#4470](https://github.com/BoundaryML/baml/pull/4470)
+
+- **C38 · BUGFIX:** Non-data output schemas produce structured errors rather than crashes or silently incomplete schemas. Realized generic output planning is finite and preserves supported schemas.
+
+## [#4473](https://github.com/BoundaryML/baml/pull/4473)
+
+- **C39 · BUGFIX:** Extracting an unspecialized generic function reports a diagnostic instead of returning null silently. Generic specialization is not available in the final release.
+
+## [#4491](https://github.com/BoundaryML/baml/pull/4491)
+
+- **C10 · FEATURE:** Narrow an opaque class value to `reflect.AnyClass`. Read fields and inspect their metadata without knowing the class at compile time. The API is read-only. Bound field handles expose `value<T>()`.
+- **C40 · BUGFIX:** A `let ... else` branch must diverge. Invalid branches produce E0113, including loops that can break back into the surrounding function. Invalid primitive companion types also receive source diagnostics.
+
+## [#4493](https://github.com/BoundaryML/baml/pull/4493)
+
+- **C10 · FEATURE:** Narrow an opaque class value to `reflect.AnyClass`. Read fields and inspect their metadata without knowing the class at compile time. The API is read-only. Bound field handles expose `value<T>()`.
+- **C40 · BUGFIX:** A `let ... else` branch must diverge. Invalid branches produce E0113, including loops that can break back into the surrounding function. Invalid primitive companion types also receive source diagnostics.
+
+## [#4490](https://github.com/BoundaryML/baml/pull/4490)
+
+- **C41 · BUGFIX:** Loops over joined map results and `Iterable`-bounded generics no longer abort compilation.
+
+## [#4495](https://github.com/BoundaryML/baml/pull/4495)
+
+- **C42 · BUGFIX:** `x?.method<T>()` carries its type arguments to the method and no longer fails inside the VM.
+
+## [#4501](https://github.com/BoundaryML/baml/pull/4501)
+
+- **C43 · BUGFIX:** Runtime class and enum definitions survive interface dispatch and nested reflection views. Reflected declarations preserve field metadata, docstrings, and declaration order.
+
+## [#4498](https://github.com/BoundaryML/baml/pull/4498)
+
+- **C12 · FEATURE:** Conditions and logical operators accept truthy and falsy values. Null, false, numeric zero, empty strings, empty containers, and empty bytes are falsy. Logical operators still return bool. A truthy nullable-string condition narrows the value to string. Strings also gain `is_empty()`.
+
+## [#4518](https://github.com/BoundaryML/baml/pull/4518)
+
+- **C45 · BUGFIX:** Inline runtime type arguments that escape through constructed result types, thrown types, or optional chains produce E0168 with guidance to name the type first.
+
+## [#4516](https://github.com/BoundaryML/baml/pull/4516)
+
+- **C44 · BUGFIX:** Runtime-created and runtime-compiled types keep their identity inside interface implementations. Equality checks and maps keyed by these types remain consistent.
+
+## [#4529](https://github.com/BoundaryML/baml/pull/4529)
+
+- **C46 · BUGFIX:** Methods on top-level `let` and `client` bindings receive the correct receiver. Session-bound calls keep their structured errors instead of replacing them with VM failures.
+
+## [#4531](https://github.com/BoundaryML/baml/pull/4531)
+
+- **C47 · BUGFIX:** Assigning to a Session binding must match its declared type. Invalid assignments fail during compilation. Redeclaring a binding can establish a new type.
+
+## [#4530](https://github.com/BoundaryML/baml/pull/4530)
+
+- **C45 · BUGFIX:** Inline runtime type arguments that escape through constructed result types, thrown types, or optional chains produce E0168 with guidance to name the type first.
+
+## [#4441](https://github.com/BoundaryML/baml/pull/4441)
+
+- **C15 · FEATURE:** `UnknownError.from<T>()` preserves known errors and avoids wrapping an error twice. `with_message<T>()` adds context while retaining the original cause and stack trace.
+
+## [#4502](https://github.com/BoundaryML/baml/pull/4502)
+
+- **C30 · BUGFIX:** The x86_64 and aarch64 musl Node addons now link against musl and load on Alpine. The PR verified both architectures with fixed and unfixed builds. This user-visible fix is implemented entirely in a GitHub workflow.
+
+## [#4535](https://github.com/BoundaryML/baml/pull/4535)
+
+- **C28 · BREAKING_CHANGE:** With no `output_dir`, generators write `baml_sdk` next to `baml.toml`. C# now uses the same `baml_sdk` directory name. Update build includes and scripts. An explicit manifest `output_dir` still names the parent directory.
+
+## [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+- **C07 · FEATURE:** Build a provider request for inspection without making an LLM call or requiring API credentials. Preview authentication uses placeholders. A preview that would require file reads or URL fetches reports `PreviewUnsupported`.
+- **C08 · FEATURE:** OpenAI, Anthropic, and Vertex clients support total-request and time-to-first-token deadlines on the native runtime. Configure schema repair attempts on `ai.Agent`. Browser SSE deadlines are not enforced by this change.
+- **C09 · FEATURE:** Generated Python models default nullable class fields to None and ignore unknown fields. Nullable function parameters still require an argument unless the BAML function declares a default.
+- **C38 · BUGFIX:** Non-data output schemas produce structured errors rather than crashes or silently incomplete schemas. Realized generic output planning is finite and preserves supported schemas.
+- **C66 · BUGFIX:** Generated Python models preserve concrete union values and stream cancellation. Provider errors retain typed failure information, including `FinishReasonError`. Streaming retry, fallback, and round-robin clients can recover before the first text delta.
+
+## [#4526](https://github.com/BoundaryML/baml/pull/4526)
+
+- **C48 · BUGFIX:** Unsupported generator naming conventions produce E0019 at `baml.toml`. Go and C# require `language`; other targets require `preserve-case`.
+
+## [#4510](https://github.com/BoundaryML/baml/pull/4510)
+
+- **C16 · FEATURE:** Iterators gain `take`, `skip`, `take_while`, and `skip_while`. These adapters are lazy. `take` can bound an infinite iterator before collection.
+
+## [#4536](https://github.com/BoundaryML/baml/pull/4536)
+
+- **C44 · BUGFIX:** Runtime-created and runtime-compiled types keep their identity inside interface implementations. Equality checks and maps keyed by these types remain consistent.
+
+## [#4500](https://github.com/BoundaryML/baml/pull/4500)
+
+- **C13 · FEATURE:** Use `(Type as Interface).member` to select an implementation. `Interface.instance_method(instance)` infers the implementing type.
+
+## [#4508](https://github.com/BoundaryML/baml/pull/4508)
+
+- **C49 · BUGFIX:** Short-circuit expressions and branch-assigned locals retain their values without leaking operands or hanging later loop iterations.
+
+## [#4544](https://github.com/BoundaryML/baml/pull/4544)
+
+- **C49 · BUGFIX:** Short-circuit expressions and branch-assigned locals retain their values without leaking operands or hanging later loop iterations.
+
+## [#4522](https://github.com/BoundaryML/baml/pull/4522)
+
+- **C28 · BREAKING_CHANGE:** With no `output_dir`, generators write `baml_sdk` next to `baml.toml`. C# now uses the same `baml_sdk` directory name. Update build includes and scripts. An explicit manifest `output_dir` still names the parent directory.
+
+## [#4547](https://github.com/BoundaryML/baml/pull/4547)
+
+- **C50 · BUGFIX:** Match arms annotated with `int[]` or `string[]` correctly refine a union of arrays.
+
+## [#4548](https://github.com/BoundaryML/baml/pull/4548)
+
+- **C01 · HEADLINE_CHANGE:** Use `baml query` to explore locally recorded executions with SQL. The playground’s Telemetry tab shows executions, call paths, retained spans, errors, and captured values. Profiling data lives in `.baml/profiles-v1`.
+
+## [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+- **C29 · BREAKING_CHANGE:** Tests now time out after 300,000 ms by default. Raise `BAML_TEST_TIMEOUT_MS` for tests that intentionally take longer.
+- **C32 · BUGFIX:** CLI shutdown reports active futures and supports cancellation. Leaked-future cleanup no longer leaves completed tests waiting indefinitely.
+- **C36 · BUGFIX:** `baml fmt` removes unnecessary parentheses in binary chains, call arguments, postfix receivers, and unary operands. It keeps parentheses needed for meaning or comments.
+- **C51 · BUGFIX:** Generic calls involving local runtime type bindings lower without the previous internal compiler failure. Context-typed lambda signatures also infer correctly. Malformed diagnostic fragments fall back to plain text.
+- **C69 · BREAKING_CHANGE:** CLI shutdown now allows 15 seconds for remaining background futures before cancelling and abandoning them. Set BAML_SHUTDOWN_GRACE_MS=0 to restore an unlimited wait. Explicitly await or clean up background work when it must complete.
+
+## [#4543](https://github.com/BoundaryML/baml/pull/4543)
+
+- **C22 · BREAKING_CHANGE:** Replace `baml.reflect.*` with `reflect.*`. Replace the bare runtime `type` value type with `reflect.Type`. `AnyClass` and `AnyFunction` also move from `baml` into `reflect`.
+
+## [#4565](https://github.com/BoundaryML/baml/pull/4565)
+
+- **C25 · BREAKING_CHANGE:** Hash-delimited strings are rejected throughout BAML. Use quoted strings for plain text or backticks for interpolation. Rewrite Jinja expressions as BAML expressions.
+
+## [#4566](https://github.com/BoundaryML/baml/pull/4566)
+
+- **C52 · BUGFIX:** Undefined types produce diagnostics anchored to the owning signature or body. Diagnostic rendering no longer panics or points at an unrelated expression.
+
+## [#4135](https://github.com/BoundaryML/baml/pull/4135)
+
+- **C17 · FEATURE:** `int.random()`, `float.random()`, and `bigint.random()` accept an optional `rng`. `bool.random()` is new and accepts the same option.
+- **C53 · BUGFIX:** Integer left shifts truncate at the 63-bit integer width instead of panicking on overflow.
+
+## [#4580](https://github.com/BoundaryML/baml/pull/4580)
+
+- **C22 · BREAKING_CHANGE:** Replace `baml.reflect.*` with `reflect.*`. Replace the bare runtime `type` value type with `reflect.Type`. `AnyClass` and `AnyFunction` also move from `baml` into `reflect`.
+- **C23 · BREAKING_CHANGE:** Reflection kind views are wrappers. They are no longer subtypes of `reflect.Type`. Use `as_type()` when an API needs the underlying type.
+
+## [#4570](https://github.com/BoundaryML/baml/pull/4570)
+
+- **C04 · FEATURE:** Direct calls, explicit agents, and streams accept the same optional event listener. Events expose usage and request/response information. Errors thrown by a listener do not fail the LLM run. Streams report usage when they settle.
+- **C20 · BREAKING_CHANGE:** `ai.Agent` is no longer generic. `ai.Runner` now puts `Out` on its `run` method and returns `ai.RunResult<Out>`. Custom runner implementations must move their output type parameter to the method and declare their associated `Error`.
+
+## [#4563](https://github.com/BoundaryML/baml/pull/4563)
+
+- **C01 · HEADLINE_CHANGE:** Use `baml query` to explore locally recorded executions with SQL. The playground’s Telemetry tab shows executions, call paths, retained spans, errors, and captured values. Profiling data lives in `.baml/profiles-v1`.
+
+## [#4578](https://github.com/BoundaryML/baml/pull/4578)
+
+- **C01 · HEADLINE_CHANGE:** Use `baml query` to explore locally recorded executions with SQL. The playground’s Telemetry tab shows executions, call paths, retained spans, errors, and captured values. Profiling data lives in `.baml/profiles-v1`.
+
+## [#4573](https://github.com/BoundaryML/baml/pull/4573)
+
+- **C54 · BUGFIX:** Empty arrays and maps with no inferable element type produce E0155. Add a type annotation or supply contextual typing.
+
+## [#4567](https://github.com/BoundaryML/baml/pull/4567)
+
+- **C27 · BREAKING_CHANGE:** Use `ctx.output_format()` in prompts. It also accepts output-format options such as prefixes, class hoisting, enum formatting, map style, and the null spelling.
+
+## [#4581](https://github.com/BoundaryML/baml/pull/4581)
+
+- **C55 · BUGFIX:** The language server rejects stale background results and uses unsaved editor buffers during project discovery. File and workspace changes update project ownership and diagnostics.
+
+## [#4568](https://github.com/BoundaryML/baml/pull/4568)
+
+- **C56 · BUGFIX:** Versioned bytecode and package artifacts validate their format, compiler fingerprint, and checksum before decoding. Canary or development builds with mismatched fingerprints report an actionable error. Regenerate the SDK and use a matching bridge.
+
+## [#4571](https://github.com/BoundaryML/baml/pull/4571)
+
+- **C57 · BUGFIX:** Generated Session evaluation helpers no longer collide with user-defined binding names.
+
+## [#4577](https://github.com/BoundaryML/baml/pull/4577)
+
+- **C58 · BUGFIX:** Empty runtime containers preserve their original type identity. Standalone rendered schemas include required static dependencies. Conflicting same-name declarations produce an error; equivalent ones fold together.
+
+## [#4574](https://github.com/BoundaryML/baml/pull/4574)
+
+- **C11 · FEATURE:** `unreflect(expr)` can appear inside local type expressions. Item signatures still reject it because they have no body scope to own the runtime type. Name the runtime type first when it would escape through a result or thrown value.
+
+## [#4583](https://github.com/BoundaryML/baml/pull/4583)
+
+- **C43 · BUGFIX:** Runtime class and enum definitions survive interface dispatch and nested reflection views. Reflected declarations preserve field metadata, docstrings, and declaration order.
+- **C59 · BUGFIX:** Session evaluation and runtime compilation preserve original diagnostics and structured causes.
+
+## [#4601](https://github.com/BoundaryML/baml/pull/4601)
+
+- **C24 · BREAKING_CHANGE:** `to_string` and `to_json` now inspect the runtime value, including values typed as `unknown`. Remove explicit type arguments. Replace `encode` with `to_string`. `from_string<T>` remains generic.
+
+## [#4600](https://github.com/BoundaryML/baml/pull/4600)
+
+- **C60 · BUGFIX:** `reflect.call_any` checks the returned value against the requested result type. A mismatch raises `reflect.InvalidArgumentError` at the call boundary.
+
+## [#4602](https://github.com/BoundaryML/baml/pull/4602)
+
+- **C26 · BREAKING_CHANGE:** Write tests as expression bodies. Call the function and assert on its result inside the test.
+
+## [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+- **C05 · FEATURE:** Python streams support `async for`. Each iteration yields a non-null partial result. Read the completed value with `final_async()`.
+- **C06 · FEATURE:** The PR’s debug-profile benchmark measured 27.2 seconds of per-delta parsing for approximately 99 KB across 2,550 deltas. Parsing 32-delta backlogs took 0.9 seconds; 128-delta backlogs took 0.23 seconds. At approximately 33 KB, the corresponding measurements were 2.9 seconds, 393 ms, and 40 ms. This is parser work under backlogs, not end-to-end provider latency.
+- **C19 · FEATURE:** Prompt interpolation can call functions that throw. Rendering failures surface as `ai.errors.PromptRenderError`.
+- **C20 · BREAKING_CHANGE:** `ai.Agent` is no longer generic. `ai.Runner` now puts `Out` on its `run` method and returns `ai.RunResult<Out>`. Custom runner implementations must move their output type parameter to the method and declare their associated `Error`.
+- **C21 · BREAKING_CHANGE:** Low-level `ai.stream.TurnStream.next()` returns `string[] | ai.stream.Done`. Iterate the returned array to process individual deltas. High-level streams continue to return parsed partial values.
+- **C61 · BUGFIX:** Optional media arrays cross the host boundary correctly. Host-provided media appears in rendered requests. Output-format layout and role-edge whitespace match the migration parity fixtures.
+
+## [#4606](https://github.com/BoundaryML/baml/pull/4606)
+
+- **C18 · FEATURE:** Files, TCP streams, and process pipes implement `baml.io.Read` and `baml.io.Write`. Readers share `bytes()` and `text()`. Writers share `write()`, which retries partial writes until all bytes are accepted. Byte buffers gain `index_of()` for locating a byte.
+- **C68 · BREAKING_CHANGE:** Reads now take a byte limit and return null at EOF. Replace file.read_bytes with file.read and file.write_bytes with file.write. Process stdin is a WritePipe: replace write_stdin and close_stdin with stdin.write and stdin.close. TCP read/write no longer accept per-call timeout parameters; use baml.future.with_timeout.
+
+## [#4599](https://github.com/BoundaryML/baml/pull/4599)
+
+- **C14 · FEATURE:** A stored lambda can infer an omitted parameter type from its uses.
+
+## [#4609](https://github.com/BoundaryML/baml/pull/4609)
+
+- **C67 · BUGFIX:** HTTP operations work again in baml run and the playground because their runtime includes the HTTP implementation.
+
+## [#4612](https://github.com/BoundaryML/baml/pull/4612)
+
+- **C62 · BUGFIX:** Omitting an optional nested class field no longer causes a valid containing optional object to become null. Regression coverage exercises both OpenAI Chat and Responses ingestion.
+
+## [#4619](https://github.com/BoundaryML/baml/pull/4619)
+
+- **C63 · BUGFIX:** Class constructors report E0001 for omitted required fields. Supply every required value or make the field nullable. An `unknown` field still requires an explicit value.
+
+## [#4621](https://github.com/BoundaryML/baml/pull/4621)
+
+- **C64 · BUGFIX:** A stored function value needs a concrete signature. Use `identity<string>` or annotate the binding with a concrete function type. Direct generic calls can still infer arguments independently.
+
+## [#4593](https://github.com/BoundaryML/baml/pull/4593)
+
+- **C65 · BUGFIX:** Functions that do not throw, or only throw a narrower type, report E0097 for `throws unknown`. Remove the clause or give a precise bound. Real unknown error boundaries remain supported.

--- a/docs/changelog-backtests/0.18.0/step2b-pr-user-effects-reaggregated.md
+++ b/docs/changelog-backtests/0.18.0/step2b-pr-user-effects-reaggregated.md
@@ -1,0 +1,419 @@
+# Aggregated and classified user effects
+
+Range: `baml-language-0.17.0..baml-language-0.18.0` (lower tag excluded; upper tag included). Sources were inspected at the upper tag, not current canary.
+
+Each entry has exactly one classification and at most three source PRs. Compatibility changes that repair invalid behavior are classified as BUGFIX; their required user actions remain explicit. There is one headline: local execution queries. Performance improvements are FEATURE and retain the PR measurements.
+
+## C01: Query local execution traces
+
+**HEADLINE_CHANGE** · [#4548](https://github.com/BoundaryML/baml/pull/4548), [#4563](https://github.com/BoundaryML/baml/pull/4563), [#4578](https://github.com/BoundaryML/baml/pull/4578)
+
+Use `baml query` to explore locally recorded executions with SQL. The playground’s Telemetry tab shows executions, call paths, retained spans, errors, and captured values. Profiling data lives in `.baml/profiles-v1`.
+
+## C02: Compile runtime packages faster
+
+**FEATURE** · [#4453](https://github.com/BoundaryML/baml/pull/4453)
+
+Runtime package compilation reuses a precompiled standard library. The PR’s five-sample cold-path median fell from approximately 4–5 seconds to 20.6 milliseconds for a small package. These measurements describe that workload and host.
+
+## C03: Reduce compiler inference work
+
+**FEATURE** · [#4458](https://github.com/BoundaryML/baml/pull/4458), [#4463](https://github.com/BoundaryML/baml/pull/4463)
+
+PR #4458 reports an empty-project median of 530.2 → 489.1 ms and a full-test-project median of 2.333 → 2.120 s. PR #4463 reports 497.5 → 485.6 ms and 2.180 → 2.133 s against its own immediate baseline. These are separate A/B measurements; their percentages must not be added.
+
+## C04: Observe LLM calls with on_event
+
+**FEATURE** · [#4570](https://github.com/BoundaryML/baml/pull/4570)
+
+Direct calls, explicit agents, and streams accept the same optional event listener. Events expose usage and request/response information. Errors thrown by a listener do not fail the LLM run. Streams report usage when they settle.
+
+## C05: Iterate over Python streams
+
+**FEATURE** · [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+Python streams support `async for`. Each iteration yields a non-null partial result. Read the completed value with `final_async()`.
+
+## C06: Parse streamed backlogs in batches
+
+**FEATURE** · [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+The PR’s debug-profile benchmark measured 27.2 seconds of per-delta parsing for approximately 99 KB across 2,550 deltas. Parsing 32-delta backlogs took 0.9 seconds; 128-delta backlogs took 0.23 seconds. At approximately 33 KB, the corresponding measurements were 2.9 seconds, 393 ms, and 40 ms. This is parser work under backlogs, not end-to-end provider latency.
+
+## C07: Preview requests without credentials
+
+**FEATURE** · [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+Build a provider request for inspection without making an LLM call or requiring API credentials. Preview authentication uses placeholders. A preview that would require file reads or URL fetches reports `PreviewUnsupported`.
+
+## C08: Configure native request deadlines and schema attempts
+
+**FEATURE** · [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+OpenAI, Anthropic, and Vertex clients support total-request and time-to-first-token deadlines on the native runtime. Configure schema repair attempts on `ai.Agent`. Browser SSE deadlines are not enforced by this change.
+
+## C09: Default nullable Python model fields to None
+
+**FEATURE** · [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+Generated Python models default nullable class fields to None and ignore unknown fields. Nullable function parameters still require an argument unless the BAML function declares a default.
+
+## C10: Inspect class values through reflection
+
+**FEATURE** · [#4491](https://github.com/BoundaryML/baml/pull/4491), [#4493](https://github.com/BoundaryML/baml/pull/4493)
+
+Narrow an opaque class value to `reflect.AnyClass`. Read fields and inspect their metadata without knowing the class at compile time. The API is read-only. Bound field handles expose `value<T>()`.
+
+## C11: Use unreflect in nested type expressions
+
+**FEATURE** · [#4574](https://github.com/BoundaryML/baml/pull/4574)
+
+`unreflect(expr)` can appear inside local type expressions. Item signatures still reject it because they have no body scope to own the runtime type. Name the runtime type first when it would escape through a result or thrown value.
+
+## C12: Use truthiness in conditions
+
+**FEATURE** · [#4498](https://github.com/BoundaryML/baml/pull/4498)
+
+Conditions and logical operators accept truthy and falsy values. Null, false, numeric zero, empty strings, empty containers, and empty bytes are falsy. Logical operators still return bool. A truthy nullable-string condition narrows the value to string. Strings also gain `is_empty()`.
+
+## C13: Call interface members explicitly
+
+**FEATURE** · [#4500](https://github.com/BoundaryML/baml/pull/4500)
+
+Use `(Type as Interface).member` to select an implementation. `Interface.instance_method(instance)` infers the implementing type.
+
+## C14: Infer stored lambda parameters from later calls
+
+**FEATURE** · [#4599](https://github.com/BoundaryML/baml/pull/4599)
+
+A stored lambda can infer an omitted parameter type from its uses.
+
+## C15: Wrap unknown errors while retaining their cause
+
+**FEATURE** · [#4441](https://github.com/BoundaryML/baml/pull/4441)
+
+`UnknownError.from<T>()` preserves known errors and avoids wrapping an error twice. `with_message<T>()` adds context while retaining the original cause and stack trace.
+
+## C16: Limit and skip iterator elements
+
+**FEATURE** · [#4510](https://github.com/BoundaryML/baml/pull/4510)
+
+Iterators gain `take`, `skip`, `take_while`, and `skip_while`. These adapters are lazy. `take` can bound an infinite iterator before collection.
+
+## C17: Choose the random generator for primitive values
+
+**FEATURE** · [#4135](https://github.com/BoundaryML/baml/pull/4135)
+
+`int.random()`, `float.random()`, and `bigint.random()` accept an optional `rng`. `bool.random()` is new and accepts the same option.
+
+## C18: Share I/O code across readers and writers
+
+**FEATURE** · [#4606](https://github.com/BoundaryML/baml/pull/4606)
+
+Files, TCP streams, and process pipes implement `baml.io.Read` and `baml.io.Write`. Readers share `bytes()` and `text()`. Writers share `write()`, which retries partial writes until all bytes are accepted. Byte buffers gain `index_of()` for locating a byte.
+
+## C19: Use throwing expressions in prompts
+
+**FEATURE** · [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+Prompt interpolation can call functions that throw. Rendering failures surface as `ai.errors.PromptRenderError`.
+
+## C20: Remove output types from Agent and Runner
+
+**BREAKING_CHANGE** · [#4570](https://github.com/BoundaryML/baml/pull/4570), [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+`ai.Agent` is no longer generic. `ai.Runner` now puts `Out` on its `run` method and returns `ai.RunResult<Out>`. Custom runner implementations must move their output type parameter to the method and declare their associated `Error`.
+
+## C21: Handle batches from TurnStream.next()
+
+**BREAKING_CHANGE** · [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+Low-level `ai.stream.TurnStream.next()` returns `string[] | ai.stream.Done`. Iterate the returned array to process individual deltas. High-level streams continue to return parsed partial values.
+
+## C22: Use the reflect root package
+
+**BREAKING_CHANGE** · [#4543](https://github.com/BoundaryML/baml/pull/4543), [#4580](https://github.com/BoundaryML/baml/pull/4580)
+
+Replace `baml.reflect.*` with `reflect.*`. Replace the bare runtime `type` value type with `reflect.Type`. `AnyClass` and `AnyFunction` also move from `baml` into `reflect`.
+
+## C23: Convert reflection views explicitly
+
+**BREAKING_CHANGE** · [#4580](https://github.com/BoundaryML/baml/pull/4580)
+
+Reflection kind views are wrappers. They are no longer subtypes of `reflect.Type`. Use `as_type()` when an API needs the underlying type.
+
+## C24: Remove generic arguments from JSON serialization
+
+**BREAKING_CHANGE** · [#4601](https://github.com/BoundaryML/baml/pull/4601)
+
+`to_string` and `to_json` now inspect the runtime value, including values typed as `unknown`. Remove explicit type arguments. Replace `encode` with `to_string`. `from_string<T>` remains generic.
+
+## C25: Replace hash string literals
+
+**BREAKING_CHANGE** · [#4565](https://github.com/BoundaryML/baml/pull/4565)
+
+Hash-delimited strings are rejected throughout BAML. Use quoted strings for plain text or backticks for interpolation. Rewrite Jinja expressions as BAML expressions.
+
+## C26: Replace legacy declarative test blocks
+
+**BREAKING_CHANGE** · [#4602](https://github.com/BoundaryML/baml/pull/4602)
+
+Write tests as expression bodies. Call the function and assert on its result inside the test.
+
+## C27: Call ctx.output_format()
+
+**BREAKING_CHANGE** · [#4567](https://github.com/BoundaryML/baml/pull/4567)
+
+Use `ctx.output_format()` in prompts. It also accepts output-format options such as prefixes, class hoisting, enum formatting, map style, and the null spelling.
+
+## C28: Update generated SDK paths
+
+**BREAKING_CHANGE** · [#4522](https://github.com/BoundaryML/baml/pull/4522), [#4535](https://github.com/BoundaryML/baml/pull/4535)
+
+With no `output_dir`, generators write `baml_sdk` next to `baml.toml`. C# now uses the same `baml_sdk` directory name. Update build includes and scripts. An explicit manifest `output_dir` still names the parent directory.
+
+## C29: Set the test timeout explicitly for long tests
+
+**BREAKING_CHANGE** · [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+Tests now time out after 300,000 ms by default. Raise `BAML_TEST_TIMEOUT_MS` for tests that intentionally take longer.
+
+## C30: Load the Node bridge on Alpine Linux
+
+**BUGFIX** · [#4502](https://github.com/BoundaryML/baml/pull/4502)
+
+The x86_64 and aarch64 musl Node addons now link against musl and load on Alpine. The PR verified both architectures with fixed and unfixed builds. This user-visible fix is implemented entirely in a GitHub workflow.
+
+## C31: Show BAML logs during CLI execution
+
+**BUGFIX** · [#4409](https://github.com/BoundaryML/baml/pull/4409)
+
+`baml run` surfaces `log.*` events and respects `--log` and `BAML_LOG`. The test command accepts the unified log option. This does not establish that packed-binary logging or `--log-file` is fixed.
+
+## C32: Explain waits during shutdown
+
+**BUGFIX** · [#4408](https://github.com/BoundaryML/baml/pull/4408), [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+CLI shutdown reports active futures and supports cancellation. Leaked-future cleanup no longer leaves completed tests waiting indefinitely.
+
+## C33: Reject invalid runtime compilation boundaries
+
+**BUGFIX** · [#4460](https://github.com/BoundaryML/baml/pull/4460)
+
+Indirect calls that need unsupported runtime type checks now produce E0010. Runtime-created types no longer leak hidden synthetic names into source diagnostics.
+
+## C34: Diagnose unknown member access
+
+**BUGFIX** · [#4466](https://github.com/BoundaryML/baml/pull/4466)
+
+Calling a nonexistent member on an `unknown` receiver produces E0007 before execution.
+
+## C35: Match numeric literal patterns by membership
+
+**BUGFIX** · [#4478](https://github.com/BoundaryML/baml/pull/4478)
+
+Literal patterns distinguish `1`, `1.0`, and `1n`. Dense integer matches no longer crash on a float. Literal aliases match their value instead of every value of the base type.
+
+## C36: Remove redundant formatter parentheses
+
+**BUGFIX** · [#4489](https://github.com/BoundaryML/baml/pull/4489), [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+`baml fmt` removes unnecessary parentheses in binary chains, call arguments, postfix receivers, and unary operands. It keeps parentheses needed for meaning or comments.
+
+## C37: Preserve map mutations across loop calls
+
+**BUGFIX** · [#4467](https://github.com/BoundaryML/baml/pull/4467)
+
+A map created before a loop retains changes made by callees in successive iterations.
+
+## C38: Report unsupported LLM output schemas
+
+**BUGFIX** · [#4470](https://github.com/BoundaryML/baml/pull/4470), [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+Non-data output schemas produce structured errors rather than crashes or silently incomplete schemas. Realized generic output planning is finite and preserves supported schemas.
+
+## C39: Diagnose invalid reflected generic extraction
+
+**BUGFIX** · [#4473](https://github.com/BoundaryML/baml/pull/4473)
+
+Extracting an unspecialized generic function reports a diagnostic instead of returning null silently. Generic specialization is not available in the final release.
+
+## C40: Reject falling-through let-else branches
+
+**BUGFIX** · [#4491](https://github.com/BoundaryML/baml/pull/4491), [#4493](https://github.com/BoundaryML/baml/pull/4493)
+
+A `let ... else` branch must diverge. Invalid branches produce E0113, including loops that can break back into the surrounding function. Invalid primitive companion types also receive source diagnostics.
+
+## C41: Compile loops over inferred iterator results
+
+**BUGFIX** · [#4490](https://github.com/BoundaryML/baml/pull/4490)
+
+Loops over joined map results and `Iterable`-bounded generics no longer abort compilation.
+
+## C42: Retain generic arguments in optional calls
+
+**BUGFIX** · [#4495](https://github.com/BoundaryML/baml/pull/4495)
+
+`x?.method<T>()` carries its type arguments to the method and no longer fails inside the VM.
+
+## C43: Preserve runtime definitions and reflected metadata
+
+**BUGFIX** · [#4501](https://github.com/BoundaryML/baml/pull/4501), [#4583](https://github.com/BoundaryML/baml/pull/4583)
+
+Runtime class and enum definitions survive interface dispatch and nested reflection views. Reflected declarations preserve field metadata, docstrings, and declaration order.
+
+## C44: Preserve runtime type identity through dispatch
+
+**BUGFIX** · [#4516](https://github.com/BoundaryML/baml/pull/4516), [#4536](https://github.com/BoundaryML/baml/pull/4536)
+
+Runtime-created and runtime-compiled types keep their identity inside interface implementations. Equality checks and maps keyed by these types remain consistent.
+
+## C45: Prevent runtime types from escaping unnamed
+
+**BUGFIX** · [#4518](https://github.com/BoundaryML/baml/pull/4518), [#4530](https://github.com/BoundaryML/baml/pull/4530)
+
+Inline runtime type arguments that escape through constructed result types, thrown types, or optional chains produce E0168 with guidance to name the type first.
+
+## C46: Call methods on top-level bindings
+
+**BUGFIX** · [#4529](https://github.com/BoundaryML/baml/pull/4529)
+
+Methods on top-level `let` and `client` bindings receive the correct receiver. Session-bound calls keep their structured errors instead of replacing them with VM failures.
+
+## C47: Type-check Session assignments
+
+**BUGFIX** · [#4531](https://github.com/BoundaryML/baml/pull/4531)
+
+Assigning to a Session binding must match its declared type. Invalid assignments fail during compilation. Redeclaring a binding can establish a new type.
+
+## C48: Validate generator naming conventions
+
+**BUGFIX** · [#4526](https://github.com/BoundaryML/baml/pull/4526)
+
+Unsupported generator naming conventions produce E0019 at `baml.toml`. Go and C# require `language`; other targets require `preserve-case`.
+
+## C49: Preserve reassigned values across branches and loops
+
+**BUGFIX** · [#4508](https://github.com/BoundaryML/baml/pull/4508), [#4544](https://github.com/BoundaryML/baml/pull/4544)
+
+Short-circuit expressions and branch-assigned locals retain their values without leaking operands or hanging later loop iterations.
+
+## C50: Honor array annotations in match coverage
+
+**BUGFIX** · [#4547](https://github.com/BoundaryML/baml/pull/4547)
+
+Match arms annotated with `int[]` or `string[]` correctly refine a union of arrays.
+
+## C51: Avoid compiler failures in local runtime-type calls
+
+**BUGFIX** · [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+Generic calls involving local runtime type bindings lower without the previous internal compiler failure. Context-typed lambda signatures also infer correctly. Malformed diagnostic fragments fall back to plain text.
+
+## C52: Locate unresolved-type diagnostics correctly
+
+**BUGFIX** · [#4566](https://github.com/BoundaryML/baml/pull/4566)
+
+Undefined types produce diagnostics anchored to the owning signature or body. Diagnostic rendering no longer panics or points at an unrelated expression.
+
+## C53: Truncate overflowing integer left shifts
+
+**BUGFIX** · [#4135](https://github.com/BoundaryML/baml/pull/4135)
+
+Integer left shifts truncate at the 63-bit integer width instead of panicking on overflow.
+
+## C54: Diagnose untyped empty containers
+
+**BUGFIX** · [#4573](https://github.com/BoundaryML/baml/pull/4573)
+
+Empty arrays and maps with no inferable element type produce E0155. Add a type annotation or supply contextual typing.
+
+## C55: Keep editor results tied to the current document
+
+**BUGFIX** · [#4581](https://github.com/BoundaryML/baml/pull/4581)
+
+The language server rejects stale background results and uses unsaved editor buffers during project discovery. File and workspace changes update project ownership and diagnostics.
+
+## C56: Reject incompatible compiler artifacts early
+
+**BUGFIX** · [#4568](https://github.com/BoundaryML/baml/pull/4568)
+
+Versioned bytecode and package artifacts validate their format, compiler fingerprint, and checksum before decoding. Canary or development builds with mismatched fingerprints report an actionable error. Regenerate the SDK and use a matching bridge.
+
+## C57: Avoid Session helper-name collisions
+
+**BUGFIX** · [#4571](https://github.com/BoundaryML/baml/pull/4571)
+
+Generated Session evaluation helpers no longer collide with user-defined binding names.
+
+## C58: Keep reflected container and schema identities intact
+
+**BUGFIX** · [#4577](https://github.com/BoundaryML/baml/pull/4577)
+
+Empty runtime containers preserve their original type identity. Standalone rendered schemas include required static dependencies. Conflicting same-name declarations produce an error; equivalent ones fold together.
+
+## C59: Retain runtime evaluation errors
+
+**BUGFIX** · [#4583](https://github.com/BoundaryML/baml/pull/4583)
+
+Session evaluation and runtime compilation preserve original diagnostics and structured causes.
+
+## C60: Validate reflect.call_any results
+
+**BUGFIX** · [#4600](https://github.com/BoundaryML/baml/pull/4600)
+
+`reflect.call_any` checks the returned value against the requested result type. A mismatch raises `reflect.InvalidArgumentError` at the call boundary.
+
+## C61: Preserve host media and prompt rendering
+
+**BUGFIX** · [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+Optional media arrays cross the host boundary correctly. Host-provided media appears in rendered requests. Output-format layout and role-edge whitespace match the migration parity fixtures.
+
+## C62: Preserve valid optional class responses
+
+**BUGFIX** · [#4612](https://github.com/BoundaryML/baml/pull/4612)
+
+Omitting an optional nested class field no longer causes a valid containing optional object to become null. Regression coverage exercises both OpenAI Chat and Responses ingestion.
+
+## C63: Require values for required class fields
+
+**BUGFIX** · [#4619](https://github.com/BoundaryML/baml/pull/4619)
+
+Class constructors report E0001 for omitted required fields. Supply every required value or make the field nullable. An `unknown` field still requires an explicit value.
+
+## C64: Specialize generic function values before storing them
+
+**BUGFIX** · [#4621](https://github.com/BoundaryML/baml/pull/4621)
+
+A stored function value needs a concrete signature. Use `identity<string>` or annotate the binding with a concrete function type. Direct generic calls can still infer arguments independently.
+
+## C65: Reject imprecise throws unknown declarations
+
+**BUGFIX** · [#4593](https://github.com/BoundaryML/baml/pull/4593)
+
+Functions that do not throw, or only throw a narrower type, report E0097 for `throws unknown`. Remove the clause or give a precise bound. Real unknown error boundaries remain supported.
+
+## C66: Preserve Python values, cancellation, and typed provider errors
+
+**BUGFIX** · [#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+Generated Python models preserve concrete union values and stream cancellation. Provider errors retain typed failure information, including `FinishReasonError`. Streaming retry, fallback, and round-robin clients can recover before the first text delta.
+
+## C67: Restore HTTP in CLI and playground execution
+
+**BUGFIX** · [#4609](https://github.com/BoundaryML/baml/pull/4609)
+
+HTTP operations work again in baml run and the playground because their runtime includes the HTTP implementation.
+
+## C68: Migrate file, socket, and process-pipe I/O
+
+**BREAKING_CHANGE** · [#4606](https://github.com/BoundaryML/baml/pull/4606)
+
+Reads now take a byte limit and return null at EOF. Replace file.read_bytes with file.read and file.write_bytes with file.write. Process stdin is a WritePipe: replace write_stdin and close_stdin with stdin.write and stdin.close. TCP read/write no longer accept per-call timeout parameters; use baml.future.with_timeout.
+
+## C69: Configure shutdown waits for background work
+
+**BREAKING_CHANGE** · [#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+CLI shutdown now allows 15 seconds for remaining background futures before cancelling and abandoning them. Set BAML_SHUTDOWN_GRACE_MS=0 to restore an unlimited wait. Explicitly await or clean up background work when it must complete.

--- a/docs/changelog-backtests/0.18.0/step3-followup-actions.md
+++ b/docs/changelog-backtests/0.18.0/step3-followup-actions.md
@@ -1,0 +1,212 @@
+# Release followup drafts
+
+Backtest only: nothing has been posted. These drafts refer to the already-published BAML 0.18.0 release. There are 17 destinations: nine external-authored PRs and eight external-authored issues. Seven distinct GitHub handles are represented; `ryanmazzolini` and `rmazzolini` are retained separately because account identity was not assumed.
+
+All 110 non-v0 PRs were screened, including CI-only changes, reverted changes, and internal refactors. GitHub PR bodies, issue comments, reviews, and inline review comments were read. Directly referenced GitHub issues and their comments were read. Forty Linear issues were retrieved from release references and linked source context, including comments and attachments. Six linked Slack source threads were also read; they contain internal discussion or point back to the GitHub reports listed here.
+
+The only Discord link in the original 114-PR inventory belongs to v0-only #4202. No Discord thread was linked from the in-scope PR/issue/Linear source records inspected. There is therefore no verified Discord destination to notify. This is a reference-graph audit, not a search of every Discord message for unlinked reports.
+
+GitHub `MEMBER`, `OWNER`, and `COLLABORATOR` associations were treated as internal, and bot accounts were removed. `CONTRIBUTOR` and `NONE` human accounts were retained. This is the observed repository-association rule, not an employment directory. CI-only contributors receive contribution acknowledgments without inventing a user-facing release feature.
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4378
+
+> Ruby needs a safe process-wide loader before the Ruby/Sorbet SDK can call the BAML 1.0 runtime.
+
+```text
+Thanks @ryanmazzolini and @rmazzolini for the private Ruby bridge loader and ABI validation groundwork. Your contribution is included in the changes leading to BAML 0.18.0. This is groundwork for Ruby support; it does not announce a complete callable Ruby SDK.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4499
+
+> Timing-sensitive tests currently encode idle-16-vCPU behavior as correctness: the cancellation suites assert sub-second wall-clock bounds, the prof soak bounds a
+
+```text
+Thanks @harivansh-afk for machine-independent timing bounds and hermetic test setup. Your contribution is included in the changes leading to BAML 0.18.0. These are test-infrastructure changes included in the release range.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4479
+
+> Two small changes that cost nothing on your runners and unbreak CI for anyone running this repo's workflows outside it.
+
+```text
+Thanks @harivansh-afk for the sccache log-path fix that respects TMPDIR. Your contribution is included in the changes leading to BAML 0.18.0. This acknowledgment is for the development and CI environment improvement.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4481
+
+> The attw gate packs the working tree verbatim, so the tarball it checks carries the debug `.node` binary: **630MB, 99.7%
+
+```text
+Thanks @harivansh-afk for the faster TypeScript declaration gate that excludes the unused native binary. Your contribution is included in the changes leading to BAML 0.18.0. This improves our checks; it is not a runtime performance claim.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4537
+
+> Copies of the Linux CI lanes pointed at ix machines, running side by side with the gating Blacksmith checks, plus
+
+```text
+Thanks @harivansh-afk for the Linux CI runner preview. Your contribution is included in the changes leading to BAML 0.18.0. This acknowledges the CI contribution included in the release range.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4539
+
+> Nothing outside the `ix-*` files.
+
+```text
+Thanks @harivansh-afk for the Linux-only scope and cache isolation fixes for the CI preview. Your contribution is included in the changes leading to BAML 0.18.0. This acknowledges the CI contribution included in the release range.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4510
+
+> Related to #4506 — discovered while investigating that compiler crash.
+
+```text
+Thanks @ritunjaym for the lazy take, skip, take_while, and skip_while iterator adapters. Your contribution is included in the changes leading to BAML 0.18.0. The separate unknown-method compiler defect in #4506 is still reproducible on 0.18.0; this release does not close that report.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4552
+
+> Runner provisioning for the ix preview lanes now lives in the ix GitHub App it watches
+
+```text
+Thanks @harivansh-afk for the GitHub App integration for CI runner provisioning. Your contribution is included in the changes leading to BAML 0.18.0. This acknowledges the CI contribution included in the release range.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub PR: https://github.com/BoundaryML/baml/pull/4558
+
+> Nothing outside the `ix-*` workflow files.
+
+```text
+Thanks @harivansh-afk for shared compiler-cache support for the Linux CI runners. Your contribution is included in the changes leading to BAML 0.18.0. This acknowledges the CI contribution included in the release range.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4335
+
+Source PRs: [#4526](https://github.com/BoundaryML/baml/pull/4526).
+
+> rust codegen panics on `naming_convention = "language"` instead of emitting a diagnostic
+
+```text
+Thanks @BenSpex for the report. BAML 0.18.0 now reports an E0019 diagnostic for unsupported generator naming conventions instead of panicking. For Rust, use naming_convention = "preserve-case".
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4355
+
+Source PRs: [#4502](https://github.com/BoundaryML/baml/pull/4502).
+
+> addon fails to load on Alpine
+
+```text
+Thanks @tha-hammer for the report. BAML 0.18.0 includes the musl Node bridge build fix for x86_64 and aarch64. The PR verified that both addons link against musl and load on Alpine.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4376
+
+Source PRs: [#4522](https://github.com/BoundaryML/baml/pull/4522).
+
+> default output_dir writes OUTSIDE the project directory
+
+```text
+Thanks @BenSpex for the report. With BAML 0.18.0, an omitted output_dir generates baml_sdk next to baml.toml. Explicit output_dir values still select the parent directory for baml_sdk.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4421
+
+Source PRs: [#4508](https://github.com/BoundaryML/baml/pull/4508), [#4544](https://github.com/BoundaryML/baml/pull/4544).
+
+> for loop with multi-variable reassignment + array push hangs
+
+```text
+Thanks @tha-hammer for the report. BAML 0.18.0 includes the compiler fixes for reassigned locals and short-circuit expressions across loops. The reported multi-variable/array-push case is covered by the regression tests.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4468
+
+Source PRs: [#4490](https://github.com/BoundaryML/baml/pull/4490).
+
+> compiler ABORTS (SIGABRT) instead of reporting
+
+```text
+Thanks @briancripe for the report. BAML 0.18.0 fixes compilation of loops over joined Array.map results and Iterable-bounded generics. The inferred-result shape in this report is covered by the regression tests.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4589
+
+Source PRs: [#4612](https://github.com/BoundaryML/baml/pull/4612).
+
+> Only "optional field + omitted optional class-typed sub-key" loses the data.
+
+```text
+Thanks @BenSpex for the report. BAML 0.18.0 fixes the omitted-optional-member scoring issue. A valid optional object is retained when a nested optional member is omitted. The fix has deterministic regression coverage through both OpenAI Chat Completions and Responses.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4429
+
+Status: partial followup. Source PRs: [#4409](https://github.com/BoundaryML/baml/pull/4409).
+
+> produce **zero output**
+
+```text
+Thanks @tha-hammer for the report. BAML 0.18.0 addresses the baml run part of this report: log.* events appear with --log <LEVEL> or BAML_LOG. We verified the error-level example on the released 0.18.0 binary. Packed-binary logging and --log-file are not established as fixed by this change, so this is a partial update.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# GitHub issue: https://github.com/BoundaryML/baml/issues/4588
+
+Status: partial followup. Source PRs: [#4459](https://github.com/BoundaryML/baml/pull/4459), [#4583](https://github.com/BoundaryML/baml/pull/4583).
+
+> All four scenarios now produce distinct, typed throws with a full traceback
+
+```text
+Thanks @BenSpex for the report. The runtime/error-boundary updates are now in BAML 0.18.0. Your confirmation on the August 24 nightly is consistent with a fresh 0.18.0 check: the dead-endpoint repro reports ai.errors.NetworkFailure with a traceback instead of the union dump. This does not resolve your separate stderr-content policy question. The release also requires ctx.output_format() and removes hash string literals; migration examples are in the changelog.
+
+Release notes: https://boundaryml.com/changelog
+```
+
+# Screened reports with no release notification
+
+| Source | Decision |
+| --- | --- |
+| [#4506](https://github.com/BoundaryML/baml/issues/4506) | Do not claim the compiler crash is fixed. The 0.18.0 binary still throws an internal compiler error for the inferred generic receiver. #4510 adds iterator adapters and explicitly disclaims fixing this report. |
+| [#4371](https://github.com/BoundaryML/baml/issues/4371) | No in-range fix for Rust code generation of non-identifier literal union arms was established. |
+| [#4422](https://github.com/BoundaryML/baml/issues/4422) | Multi-part documentation/DX report. It is referenced context, not a verified fixed issue in this release. |
+| [#4279](https://github.com/BoundaryML/baml/issues/4279) | Musl packing fix predates the lower tag; distinct from #4355’s Node addon fix. |
+| [#4154](https://github.com/BoundaryML/baml/issues/4154) | V0 provider metadata issue. Its thread already records release 0.224.0 as the fix. |
+| [#1724](https://github.com/BoundaryML/baml/issues/1724), [#4497](https://github.com/BoundaryML/baml/issues/4497) | Closed by v0-only PRs #4202 and #4503. No v1 followup. |
+
+# Retrieval and coverage notes
+
+All 110 non-v0 PR comment connections and all 110 review connections reported `pageInfo.hasNextPage=false` on the fetched page; none required a second GraphQL page. REST inline review and issue-comment collections were fetched with pagination. The GitHub reference scan also inspected linked out-of-range PR metadata to distinguish PR links from issues; those PRs are context, not additions to the release inventory. Two regex matches (`#0` and `#55062759600785`) returned 404 and were rejected as non-issue numeric text.
+
+The Ruby PR also links an external Shortcut story. No Shortcut credential was provided or used; its private contents were not verified. The GitHub PR author and reviewer are both included above, so this does not block their contribution acknowledgment. Historical comments and issue state were read at backtest time; they are not a snapshot of what was visible on release day.

--- a/docs/changelog-backtests/0.18.0/validation.md
+++ b/docs/changelog-backtests/0.18.0/validation.md
@@ -1,0 +1,59 @@
+# Validation evidence
+
+Validation used the published macOS ARM64 BAML 0.18.0 artifact, not the worktree’s current compiler. Its version command reports `baml-cli 0.18.0`. The downloaded archive’s SHA-256 matched the release checksum: `dad86121702f9f6c10ade1b5cd834379848d16910613f96fe398c875556dc67e`.
+
+Release asset: [baml-language-0.18.0-aarch64-apple-darwin.tar.gz](https://github.com/BoundaryML/baml/releases/download/baml-language-0.18.0/baml-language-0.18.0-aarch64-apple-darwin.tar.gz). The matching `.sha256` release asset was checked before extraction. Source inspection used `git show baml-language-0.18.0:<path>` and immutable merge diffs, so later canary changes could not change the API examples. Temporary test projects and downloaded artifacts were kept outside the repository.
+
+## Examples
+
+All 22 positive BAML snippets compile with the released CLI. Each was checked in its own project with `[package] name = "root"` and a single `baml_src/main.baml`. Historical “before” snippets are migration illustrations and are not expected to compile under 0.18.0.
+
+| Entry | Example | `baml check` | Pure execution |
+| --- | --- | --- | --- |
+| C04 | Observe LLM calls with on_event | Pass | Compile only |
+| C07 | Preview requests without credentials | Pass | Compile only |
+| C08 | Configure native request deadlines and schema attempts | Pass | Compile only |
+| C10 | Inspect class values through reflection | Pass | Pass |
+| C11 | Use unreflect in nested type expressions | Pass | Pass |
+| C12 | Use truthiness in conditions | Pass | Pass |
+| C13 | Call interface members explicitly | Pass | Pass |
+| C14 | Infer stored lambda parameters from later calls | Pass | Pass |
+| C15 | Wrap unknown errors while retaining their cause | Pass | Compile only |
+| C16 | Limit and skip iterator elements | Pass | Pass |
+| C17 | Choose the random generator for primitive values | Pass | Pass |
+| C18 | Share I/O code across readers and writers | Pass | Compile only |
+| C19 | Use throwing expressions in prompts | Pass | Compile only |
+| C20 | Remove output types from Agent and Runner | Pass | Compile only |
+| C21 | Handle batches from TurnStream.next() | Pass | Compile only |
+| C22 | Use the reflect root package | Pass | Compile only |
+| C23 | Convert reflection views explicitly | Pass | Pass |
+| C24 | Remove generic arguments from JSON serialization | Pass | Pass |
+| C25 | Replace hash string literals | Pass | Compile only |
+| C26 | Replace legacy declarative test blocks | Pass | Compile only |
+| C27 | Call ctx.output_format() | Pass | Compile only |
+| C68 | Migrate file, socket, and process-pipe I/O | Pass | Compile only |
+
+Nine pure examples were also executed successfully: class field reflection, nested runtime types, truthiness, interface calls, stored lambdas, iterator adapters, random-generator selection, type-view conversion, and JSON serialization. LLM examples were not sent to providers. Source-level compilation validates their BAML surface, not provider integration.
+
+Both Python snippets pass Python syntax parsing. The 0.18.0 generator was also run on a `Record { label: string? }` schema. Its Python model and stub contain `label: typing.Optional[str] = None`, and the model declares `extra="ignore"`. The async-stream example’s exported function name exists in that generated SDK. Python bridge iteration was checked against the final-tag `_stream.py` implementation; it was not executed against a live provider.
+
+The explicit `output_dir = ".."` example uses the release manifest’s `[generator.python]` table with `naming_convention = "preserve-case"`. The generator’s default path was observed when generating the model fixture: it created `<project>/baml_sdk`.
+
+The query example was executed after recording a local `main` run with `BAML_PROFILE=1`. `SELECT * FROM threads WHERE parent_thread_id IS NULL LIMIT 10` returned one execution root with `status=succeeded` and terminal `result=complete`. `baml query --schema` also succeeded. The catalog has no `executions` table; the draft uses the actual `threads` relation.
+
+## Targeted historical checks
+
+| Claim / source | Released 0.18.0 result | Consequence |
+| --- | --- | --- |
+| `reflect.function.Type.specialize` from #4519 | E0007: no member `specialize` | Exclude the removed feature. The deletion is visible in #4560. |
+| #4429 CLI logging | `baml run --log error main` prints the expected error-level marker; exit 0 | Draft a partial issue update. |
+| #4588 lost runtime errors | A closed localhost endpoint produces `ai.errors.NetworkFailure` with traceback; exit 1 | Confirm that specific failure path. Other scenarios rely on the reporter’s nightly confirmation, not a fresh replay here. |
+| #4506 inferred generic missing method | `baml check` exits 0; running the function produces the reported internal compiler error; exit 1 | Do not mark the issue fixed. The repro omits its old `throws unknown` declaration so the new precision diagnostic cannot mask the defect. |
+
+## Document checks
+
+The artifact checks cover all 114 PR decisions, at most three source PRs per aggregated effect, one classification per effect, example or benchmark evidence for every feature/headline, unique notification destinations, source-quote lengths, balanced code fences, and relative links. They also verify `isPublished: false` and that the historical blog post has no diff. Whitespace and applicable repository hooks are checked before committing.
+
+## Limits
+
+This is a documentation backtest, not a full release certification. It does not rerun Rust/SDK CI for the historical toolchain, reproduce author benchmarks, exercise provider calls, or validate every migration against the old binary. Performance tables retain their PR-specific baselines and build-profile qualifications. Current GitHub/Linear source records can include edits and comments made after release day. All direct non-v0 PRs were checked for notification candidates; unlinked Discord conversations and the external Shortcut story were not searched. No private issue bodies, credentials, or downloaded binaries are committed.

--- a/docs/changelog-preparation/0.19.0/README.md
+++ b/docs/changelog-preparation/0.19.0/README.md
@@ -4,7 +4,7 @@ Prepared using the procedure in [docs/prepare-changelog.md from PR #4784](https:
 
 Assumed cut: September 8, 2026, America/Los_Angeles. Base: `baml-language-0.18.0` (`7622555396a99db466afaea09dea2cad259d4033`). Candidate: canary `5b398f2b60cfa78258ac9534e8322d056564e85f`. The candidate timestamp falls on September 9 UTC; “today” here is the user’s Pacific date. Later canary changes are not included.
 
-The [release draft](../../../typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md) is unpublished. This preparation does not bump versions, tag a release, or send notifications. Before publication, compare the actual release SHA with this pinned cut, reconcile any extra changes, update the publication date if needed, and enable the post only after the release is available.
+The [release post](../../../typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md) has `isPublished: true` so it can be reviewed in the PR’s website preview. Merging it into `canary` also makes it eligible for production publication. This preparation does not bump versions, tag a release, or send notifications. Before merging, compare the actual release SHA with this pinned cut, reconcile any extra changes, update the publication date if needed, and confirm the release is available.
 
 - [Full inventory](step1a-all-prs.md): all 74 PRs, including inclusion/exclusion decisions.
 - [User-visible PRs](step1b-prs-only-user-visible.md): 25 retained PRs.

--- a/docs/changelog-preparation/0.19.0/README.md
+++ b/docs/changelog-preparation/0.19.0/README.md
@@ -1,0 +1,16 @@
+# BAML 0.19.0 changelog preparation
+
+Prepared using the procedure in [docs/prepare-changelog.md from PR #4784](https://github.com/BoundaryML/baml/blob/15d6400d2e/docs/prepare-changelog.md), including the full-range and final-source checks established by the 0.18.0 backtest.
+
+Assumed cut: September 8, 2026, America/Los_Angeles. Base: `baml-language-0.18.0` (`7622555396a99db466afaea09dea2cad259d4033`). Candidate: canary `5b398f2b60cfa78258ac9534e8322d056564e85f`. The candidate timestamp falls on September 9 UTC; “today” here is the user’s Pacific date. Later canary changes are not included.
+
+The [release draft](../../../typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md) is unpublished. This preparation does not bump versions, tag a release, or send notifications. Before publication, compare the actual release SHA with this pinned cut, reconcile any extra changes, update the publication date if needed, and enable the post only after the release is available.
+
+- [Full inventory](step1a-all-prs.md): all 74 PRs, including inclusion/exclusion decisions.
+- [User-visible PRs](step1b-prs-only-user-visible.md): 25 retained PRs.
+- [Effects by PR](step2a-pr-user-effects.md) and [aggregated effects](step2b-pr-user-effects-reaggregated.md): 34 entries, each classified once.
+- [Followup drafts](step3-followup-actions.md): three replies for two external users, plus exclusions and an unresolved Discord-thread reference.
+- [Source coverage](source-coverage.md): 65 non-v0 PR discussions, referenced issues, and source-thread coverage.
+- [Validation](validation.md): candidate compiler checks, 0.18.0 comparisons, execution probes, and remaining release-time checks.
+
+The wrapper fix is independently delivered: verify the current installer and compatible wrapper before posting that issue response. The float PR mentions a Discord proposal without a link; the PR reply is prepared, but a separate Discord draft needs a verified destination.

--- a/docs/changelog-preparation/0.19.0/source-coverage.md
+++ b/docs/changelog-preparation/0.19.0/source-coverage.md
@@ -1,0 +1,319 @@
+# Source coverage
+
+The release cut is `baml-language-0.18.0` (`7622555396a99db466afaea09dea2cad259d4033`) through canary `5b398f2b60cfa78258ac9534e8322d056564e85f`, pinned on September 8, 2026 in America/Los_Angeles. The upper commit is September 9 in UTC. Later canary commits are outside this draft.
+
+The full Git range contains 74 commits, each associated with one merged PR. The path-filtered range contains 23 PRs. All PR bodies were read; all 65 non-v0 PRs additionally have fetched issue comments, reviews, inline review comments, and closing-issue references. The nine v0-only exclusions are #4643, #4642, #4645, #4659, #4663, #4669, #4670, #4710, and #4711. Mixed root/workspace changes remain in the followup inventory even if not release-note material.
+
+## GitHub discussion coverage
+
+Counts are as fetched during preparation. GraphQL collections have no next page. REST inline review comments were fetched with pagination.
+
+| PR | Author | Comments | Reviews | Inline comments |
+| --- | --- | ---: | ---: | ---: |
+| [#4625](https://github.com/BoundaryML/baml/pull/4625) | codeshaunted | 4 | 1 | 0 |
+| [#4630](https://github.com/BoundaryML/baml/pull/4630) | 2kai2kai2 | 4 | 2 | 5 |
+| [#4633](https://github.com/BoundaryML/baml/pull/4633) | antoniosarosi | 4 | 1 | 0 |
+| [#4623](https://github.com/BoundaryML/baml/pull/4623) | aaronvg | 14 | 42 | 61 |
+| [#4616](https://github.com/BoundaryML/baml/pull/4616) | sxlijin | 4 | 4 | 4 |
+| [#4644](https://github.com/BoundaryML/baml/pull/4644) | sxlijin | 4 | 4 | 2 |
+| [#4646](https://github.com/BoundaryML/baml/pull/4646) | hellovai | 4 | 6 | 5 |
+| [#4632](https://github.com/BoundaryML/baml/pull/4632) | sxlijin | 8 | 1 | 0 |
+| [#4680](https://github.com/BoundaryML/baml/pull/4680) | sxlijin | 3 | 0 | 0 |
+| [#4687](https://github.com/BoundaryML/baml/pull/4687) | sxlijin | 5 | 1 | 0 |
+| [#4686](https://github.com/BoundaryML/baml/pull/4686) | 2kai2kai2 | 4 | 2 | 1 |
+| [#4684](https://github.com/BoundaryML/baml/pull/4684) | sxlijin | 5 | 1 | 0 |
+| [#4688](https://github.com/BoundaryML/baml/pull/4688) | sxlijin | 5 | 4 | 4 |
+| [#4692](https://github.com/BoundaryML/baml/pull/4692) | sxlijin | 6 | 5 | 3 |
+| [#4693](https://github.com/BoundaryML/baml/pull/4693) | sxlijin | 8 | 1 | 1 |
+| [#4698](https://github.com/BoundaryML/baml/pull/4698) | sxlijin | 5 | 8 | 6 |
+| [#4685](https://github.com/BoundaryML/baml/pull/4685) | sxlijin | 14 | 8 | 6 |
+| [#4701](https://github.com/BoundaryML/baml/pull/4701) | sxlijin | 4 | 1 | 0 |
+| [#4714](https://github.com/BoundaryML/baml/pull/4714) | antoniosarosi | 4 | 2 | 0 |
+| [#4713](https://github.com/BoundaryML/baml/pull/4713) | antoniosarosi | 4 | 1 | 0 |
+| [#4718](https://github.com/BoundaryML/baml/pull/4718) | sxlijin | 4 | 1 | 0 |
+| [#4611](https://github.com/BoundaryML/baml/pull/4611) | codeshaunted | 6 | 2 | 0 |
+| [#4702](https://github.com/BoundaryML/baml/pull/4702) | sxlijin | 4 | 4 | 3 |
+| [#4703](https://github.com/BoundaryML/baml/pull/4703) | sxlijin | 4 | 1 | 0 |
+| [#4704](https://github.com/BoundaryML/baml/pull/4704) | sxlijin | 5 | 0 | 0 |
+| [#4705](https://github.com/BoundaryML/baml/pull/4705) | sxlijin | 5 | 0 | 0 |
+| [#4706](https://github.com/BoundaryML/baml/pull/4706) | sxlijin | 5 | 0 | 0 |
+| [#4707](https://github.com/BoundaryML/baml/pull/4707) | sxlijin | 6 | 0 | 0 |
+| [#4708](https://github.com/BoundaryML/baml/pull/4708) | sxlijin | 5 | 0 | 0 |
+| [#4709](https://github.com/BoundaryML/baml/pull/4709) | sxlijin | 6 | 0 | 0 |
+| [#4634](https://github.com/BoundaryML/baml/pull/4634) | ATX24 | 4 | 8 | 6 |
+| [#4635](https://github.com/BoundaryML/baml/pull/4635) | ATX24 | 5 | 1 | 2 |
+| [#4636](https://github.com/BoundaryML/baml/pull/4636) | ATX24 | 5 | 0 | 0 |
+| [#4637](https://github.com/BoundaryML/baml/pull/4637) | ATX24 | 5 | 1 | 3 |
+| [#4720](https://github.com/BoundaryML/baml/pull/4720) | 2kai2kai2 | 4 | 3 | 3 |
+| [#4723](https://github.com/BoundaryML/baml/pull/4723) | codeshaunted | 5 | 2 | 2 |
+| [#4725](https://github.com/BoundaryML/baml/pull/4725) | 2kai2kai2 | 4 | 2 | 20 |
+| [#4639](https://github.com/BoundaryML/baml/pull/4639) | ATX24 | 5 | 3 | 9 |
+| [#4735](https://github.com/BoundaryML/baml/pull/4735) | sxlijin | 4 | 1 | 0 |
+| [#4721](https://github.com/BoundaryML/baml/pull/4721) | codeshaunted | 6 | 2 | 1 |
+| [#4715](https://github.com/BoundaryML/baml/pull/4715) | ATX24 | 3 | 2 | 1 |
+| [#4738](https://github.com/BoundaryML/baml/pull/4738) | sxlijin | 5 | 6 | 3 |
+| [#4739](https://github.com/BoundaryML/baml/pull/4739) | 2kai2kai2 | 4 | 3 | 2 |
+| [#4727](https://github.com/BoundaryML/baml/pull/4727) | hellovai | 3 | 1 | 6 |
+| [#4730](https://github.com/BoundaryML/baml/pull/4730) | hellovai | 3 | 0 | 0 |
+| [#4732](https://github.com/BoundaryML/baml/pull/4732) | hellovai | 3 | 0 | 0 |
+| [#4733](https://github.com/BoundaryML/baml/pull/4733) | hellovai | 3 | 0 | 0 |
+| [#4734](https://github.com/BoundaryML/baml/pull/4734) | hellovai | 3 | 0 | 0 |
+| [#4742](https://github.com/BoundaryML/baml/pull/4742) | sxlijin | 4 | 3 | 2 |
+| [#4743](https://github.com/BoundaryML/baml/pull/4743) | sxlijin | 5 | 0 | 0 |
+| [#4745](https://github.com/BoundaryML/baml/pull/4745) | sxlijin | 4 | 5 | 5 |
+| [#4755](https://github.com/BoundaryML/baml/pull/4755) | sxlijin | 6 | 2 | 1 |
+| [#4757](https://github.com/BoundaryML/baml/pull/4757) | sxlijin | 5 | 3 | 0 |
+| [#4756](https://github.com/BoundaryML/baml/pull/4756) | sxlijin | 5 | 11 | 12 |
+| [#4752](https://github.com/BoundaryML/baml/pull/4752) | ritunjaym | 4 | 2 | 2 |
+| [#4729](https://github.com/BoundaryML/baml/pull/4729) | ATX24 | 16 | 7 | 34 |
+| [#4759](https://github.com/BoundaryML/baml/pull/4759) | antoniosarosi | 16 | 10 | 6 |
+| [#4762](https://github.com/BoundaryML/baml/pull/4762) | hellovai | 4 | 2 | 1 |
+| [#4764](https://github.com/BoundaryML/baml/pull/4764) | hellovai | 4 | 17 | 21 |
+| [#4777](https://github.com/BoundaryML/baml/pull/4777) | codeshaunted | 4 | 2 | 0 |
+| [#4778](https://github.com/BoundaryML/baml/pull/4778) | sxlijin | 5 | 5 | 4 |
+| [#4751](https://github.com/BoundaryML/baml/pull/4751) | ritunjaym | 3 | 9 | 9 |
+| [#4779](https://github.com/BoundaryML/baml/pull/4779) | sxlijin | 5 | 9 | 8 |
+| [#4780](https://github.com/BoundaryML/baml/pull/4780) | sxlijin | 5 | 3 | 1 |
+| [#4783](https://github.com/BoundaryML/baml/pull/4783) | hellovai | 3 | 4 | 2 |
+
+## Referenced issues and contextual PRs
+
+- `#0`: HTTP 404. Numeric false positive, not an issue.
+- [#1259](https://github.com/BoundaryML/baml/issues/1259): Issue body and all comments read; disposition recorded in followups.
+- [#2736](https://github.com/BoundaryML/baml/issues/2736): Issue body and all comments read; disposition recorded in followups.
+- [#3247](https://github.com/BoundaryML/baml/pull/3247): Contextual PR, outside the cut.
+- [#3616](https://github.com/BoundaryML/baml/pull/3616): Contextual PR, outside the cut.
+- [#3887](https://github.com/BoundaryML/baml/pull/3887): Contextual PR, outside the cut.
+- [#3896](https://github.com/BoundaryML/baml/pull/3896): Contextual PR, outside the cut.
+- [#4046](https://github.com/BoundaryML/baml/pull/4046): Contextual PR, outside the cut.
+- [#4185](https://github.com/BoundaryML/baml/pull/4185): Contextual PR, outside the cut.
+- [#4251](https://github.com/BoundaryML/baml/pull/4251): Contextual PR, outside the cut.
+- [#4301](https://github.com/BoundaryML/baml/pull/4301): Contextual PR, outside the cut.
+- [#4370](https://github.com/BoundaryML/baml/issues/4370): Issue body and all comments read; disposition recorded in followups.
+- [#4468](https://github.com/BoundaryML/baml/issues/4468): Issue body and all comments read; disposition recorded in followups.
+- [#4541](https://github.com/BoundaryML/baml/pull/4541): Contextual PR, outside the cut.
+- [#4587](https://github.com/BoundaryML/baml/issues/4587): Issue body and all comments read; disposition recorded in followups.
+- [#4624](https://github.com/BoundaryML/baml/issues/4624): Issue body and all comments read; disposition recorded in followups.
+- [#4629](https://github.com/BoundaryML/baml/pull/4629): Contextual PR, outside the cut.
+- [#4694](https://github.com/BoundaryML/baml/pull/4694): Contextual PR, outside the cut.
+- [#4728](https://github.com/BoundaryML/baml/pull/4728): Contextual PR, outside the cut.
+- `#4731`: HTTP 404. GitHub Stacks identifier, not an accessible issue/PR.
+- [#4749](https://github.com/BoundaryML/baml/pull/4749): Contextual PR, outside the cut.
+- [#4750](https://github.com/BoundaryML/baml/issues/4750): Issue body and all comments read; disposition recorded in followups.
+- `#33575286667`: HTTP 404. Actions run identifier, not an issue.
+
+## Linear coverage
+
+Direct references and one-hop contextual references were read, including descriptions, comments, attachments, and relation metadata. All fetched collections report no next page. Unrelated historical relation graphs are not recursively expanded. Secrets were obtained from the specified Infisical environment in memory; no credentials or raw private issue bodies are committed.
+
+- [B-1123](https://linear.app/boundaryml2/issue/B-1123/bytecode-version-skew-errors): bytecode version skew errors.
+- [B-1610](https://linear.app/boundaryml2/issue/B-1610/require-baml-skill-when-running-in-agent-mode): Require BAML skill when running in agent mode.
+- [B-1646](https://linear.app/boundaryml2/issue/B-1646/reject-unsafe-union-member-access-with-conflicting-types): Reject unsafe union member access with conflicting types.
+- [B-1655](https://linear.app/boundaryml2/issue/B-1655/open-question-opt-in-integration-tests-and-shared-fixture-lifecycle): Open question: opt-in integration tests and shared fixture lifecycle.
+- [B-1656](https://linear.app/boundaryml2/issue/B-1656/bridge-web-generated-bytecode-traps-during-initialization-under): bridge-web: generated bytecode traps during initialization under Cloudflare workerd.
+- [B-1672](https://linear.app/boundaryml2/issue/B-1672/incident-reissue-accidentally-deleted-boundarymlbaml-actions-secrets): Internal release operations.
+- [B-1675](https://linear.app/boundaryml2/issue/B-1675/populate-maven-central-and-gradle-release-secrets-in-infisical): Internal release operations.
+- [B-1680](https://linear.app/boundaryml2/issue/B-1680/unreflect-as-rigid-typevar-only): `unreflect` as rigid typevar only.
+- [B-1682](https://linear.app/boundaryml2/issue/B-1682/return-inside-a-closure-is-type-checked-against-the-enclosing-function): `return` inside a closure is type-checked against the enclosing function.
+- [B-859](https://linear.app/boundaryml2/issue/B-859/implement-bridge-web-typescript-for-wasmweb): Implement bridge-web (TypeScript for WASM/web).
+- [BAMLGH-4](https://linear.app/boundaryml2/issue/BAMLGH-4/feat-support-cloudflare-workers): feat: support cloudflare workers.
+- [BAMLGH-44](https://linear.app/boundaryml2/issue/BAMLGH-44/sdkgen-rust-016-every-llm-function-is-skipped-implicit-aierrorsfailure): sdkgen_rust 0.16: every LLM function is skipped (implicit ai.errors.Failure throws contract is an interface) — empty client at exit 0.
+- [BAMLGH-61](https://linear.app/boundaryml2/issue/BAMLGH-61/0170-throws-clause-with-an-unresolved-type-panics-the-compiler-index): 0.17.0: `throws` clause with an unresolved type panics the compiler (index out of bounds, type_ref.rs:346, exit 134) — 0.16.0 gives a clean E0002.
+- [BAMLGH-70](https://linear.app/boundaryml2/issue/BAMLGH-70/official-installer-wrapper-requires-glibc-239-and-cannot-bootstrap-on): Official installer wrapper requires GLIBC 2.39 and cannot bootstrap on Debian bookworm.
+- [BAMLGH-73](https://linear.app/boundaryml2/issue/BAMLGH-73/bug-0170-canary-00-and-00-literals-in-the-same-function-body-alias-to): [bug] 0.17.0 canary: `0.0` and `-0.0` literals in the same function body alias to whichever is written first.
+
+## Source threads
+
+- B-1610: [internal skill discussion](https://gloo-global.slack.com/archives/C03KV1PJ6EM/p1787608667492599), complete thread read.
+- B-1646: [internal union-member discussion](https://gloo-global.slack.com/archives/C0BMY6H06HM/p1787852687522039), complete thread read.
+- B-1123 context: [forwarded historical user reports](https://gloo-global.slack.com/archives/C06P60YREAC/p1786405133641699) and [internal version-skew discussion](https://gloo-global.slack.com/archives/C06P60YREAC/p1786036998000449), complete threads read.
+- Discord: no addressable Discord links were present in fetched sources. #4751 mentions an unlinked proposal discussion; destination unresolved, explicitly carried forward in the notification draft.
+
+## Reproduction
+
+```sh
+git log --reverse --format='%H %s' baml-language-0.18.0..5b398f2b60cfa78258ac9534e8322d056564e85f
+git log --reverse --format='%H %s' baml-language-0.18.0..5b398f2b60cfa78258ac9534e8322d056564e85f -- baml_language/
+```
+
+GitHub data was fetched using authenticated `gh api graphql` and paginated REST endpoints. Linear was fetched via its GraphQL API. The hashes below identify the fetched metadata without publishing raw discussions; later edits to PR descriptions or comments will change these hashes.
+
+| Source | SHA-256 |
+| --- | --- |
+| `issue-0.json` | `ead84e21ff04f0d8fc2ab5916c96153c9117ae49e0b80aabf8dee6561168a7dd` |
+| `issue-1259.json` | `e7f1fcbc912fed767372b66a063228bf30b00bc698346ac8826b47ec998f9d3b` |
+| `issue-2736.json` | `917d6f77bdbad74fbebaf839a3f45725d3f47c5d5ed6322fa2b942aec21f1e47` |
+| `issue-3247.json` | `928a7cc3075d065c9ed64672983e0ecf3601264650a97ad1b3ebace04d058c40` |
+| `issue-33575286667.json` | `ead84e21ff04f0d8fc2ab5916c96153c9117ae49e0b80aabf8dee6561168a7dd` |
+| `issue-3616.json` | `eeff093d7d0b4cbaf4923733b354db1c27f1980f3135079ead90d1b125cf874c` |
+| `issue-3887.json` | `b1ee4a6f536298d29d5c5f51dbe23b82b075c7063a911918f27f8ad579a05964` |
+| `issue-3896.json` | `4cd0a32fdcb57ee350bc9925573495f88e606d3f11faf4e68f77d8fefb85554d` |
+| `issue-4046.json` | `60713dace15fb830252aa594240a092275d4ccb3f758be9cc4399ffa2714b535` |
+| `issue-4185.json` | `0c2b7981fd16cbeb4ad854566fd0fa6a45720481ef6eb6bcaca5393532cf61bf` |
+| `issue-4251.json` | `b41da1eb4bbe1e3a71ce289a7352640e68af548b5d7268ca4df35a52b37fe475` |
+| `issue-4301.json` | `622b4db88620c15d311038023d7c5f40e75aabc63455eb115ce25b8d28e4c64a` |
+| `issue-4370.json` | `aa58b2bab2aa375a905bea79c3583e8878b588c4d5ec99df84531ff4a052b1fb` |
+| `issue-4468.json` | `b2ef661238c210df217bc25dc84aca28f544f4a20f26b1c1ec89ea70a3ad1a60` |
+| `issue-4541.json` | `3692e619281ce133d607e7bdbb63952bb3ddacfa40615ac4c12342ff53238ddb` |
+| `issue-4587.json` | `5f74b576539d20a546b34ee712a2b1a6464c8e696490873b61aac5cb785fac4f` |
+| `issue-4624.json` | `c7d47dfbcdbb98333a7d04a729d9c55761700ff7a3539a2c30bb0152423e0e2d` |
+| `issue-4629.json` | `714b1000f22795f441a11b6d8dc96546794a23635a9f34584328ed9e8b5377a8` |
+| `issue-4694.json` | `9ce6379274e52e05bd2ce503f489389b82f60a850a7b6838368a7df5709b8c26` |
+| `issue-4728.json` | `1f94c7a44f0ae11dca1ca430c4f52238f5ea182d6e3688203dbba85aa3e17f5b` |
+| `issue-4731.json` | `ead84e21ff04f0d8fc2ab5916c96153c9117ae49e0b80aabf8dee6561168a7dd` |
+| `issue-4749.json` | `bdcbc3f8c5b2a1f448575841539a450daabeda171d5c59c88c0f7c19a8824760` |
+| `issue-4750.json` | `e49ec0dd95c7288fbb7f24445ea7656bd855a51b17dfd6f98a7c925f03b81ea8` |
+| `linear-B-1123.json` | `3dba0ae6c265f8e1afb953f9656d403ee83f2571a999bc1c024647aff2010aff` |
+| `linear-B-1610.json` | `9ae8e0f18e995aab7b3e6306311d1e9aefed4b28a4a90ef8245cc0cf18d85e80` |
+| `linear-B-1646.json` | `7bc37130a5607f3c704f07d5c4b38c9e6d3da49291523416b2f8b12f382f23fc` |
+| `linear-B-1655.json` | `b213be2863baf5dc68bc0f6d74b43efe705f4c35d075da76fe57d3548ee054bb` |
+| `linear-B-1656.json` | `780fb9b6978debf530770787f09c8b52f7a20b0a03a065d00bc49b8df66d4cf9` |
+| `linear-B-1672.json` | `48912201cea8c47960bdd43f66adcbefb7a8d46540aa4c36bdc03ceffa15c2b4` |
+| `linear-B-1675.json` | `5419a86ed6b9e7d05b6c47c5da4c826737d316860ab0b213517dcd782381725a` |
+| `linear-B-1680.json` | `105099708e7eac506496cc7ef300774647f63bf94ab3ebc4cd56802667ec76ec` |
+| `linear-B-1682.json` | `cb2669af5551c62243a8b5b966cddffb8439bc621c326558a2003fab3e405c3d` |
+| `linear-B-859.json` | `baee49394b7b4642b219405b20fa3eb76ac66218d0ddc23dfabf1e0d05ee03fd` |
+| `linear-BAMLGH-4.json` | `529467d9c539363e299b9cbe1424051dd253098655a384d5d8f193a9600f646c` |
+| `linear-BAMLGH-44.json` | `667d882f751105f1923e2c0fe616ad35624064853a9ab963bc99bcfd3ca75a57` |
+| `linear-BAMLGH-61.json` | `a3a5490e1438bb9c633d9f3744b5ac6d9ea0d6cc075b41765a9d72c6319711e6` |
+| `linear-BAMLGH-70.json` | `13dabe11e1905e7206752c7d7532b850aedc726a75c10178a0ac8064544ea9c7` |
+| `linear-BAMLGH-73.json` | `f13887b0a2f0b77b8d42e5fdebc2dff4716ae58a0c5a71790147a4d91892caf8` |
+| `pr-4611.json` | `88a0f3f477df4bc8c4ace61be97bf4d05e149a8dec5ca4da95a353b63d197867` |
+| `pr-4616.json` | `019c2f20e3c5cc25673782bb460c33938a496ed4b0e363f79f2177c448ffa7b0` |
+| `pr-4623.json` | `26eb05f3d0b7b682d152c3708969a7c1749f6d894e6523cc1e364246689b8808` |
+| `pr-4625.json` | `875228c77f661c9ef2a7ef6bc4e8c059eff66a6fca9345be8d0ec51e3ff1d5f0` |
+| `pr-4630.json` | `83ae94f2add0268d93454be9519e1a138f04b6e058e8462799c968689e32b605` |
+| `pr-4632.json` | `b4f6bffcef6b9e2fe3adbeaec7318637879fcd266b23cd3820df58f48cdeae92` |
+| `pr-4633.json` | `77ba0223c425ca6d7f2552dacc62189c9de429d00c3d64b27f16b555851fac2a` |
+| `pr-4634.json` | `4191d318f3910f50b96f6808e4b85f2cdc1039dfdb71763da5d5b61da1ab1bb1` |
+| `pr-4635.json` | `638662190d538e1992bd62d529a810a0753a93dcc7bdcc17bc9c774e9d1d8384` |
+| `pr-4636.json` | `10e81c6a7c5d6289779f04d28eb8f9ec1024d8fc8419cbc3b9beb98d9514fa10` |
+| `pr-4637.json` | `e42ab8053f244d4f57ee6a3a61c966f43a6399786057685ee8be331b037ec651` |
+| `pr-4639.json` | `583f7e0dcfcbbcd8320828c6873ffa65783ac8ba4054458461de7a989b0d8855` |
+| `pr-4642.json` | `994aa85b104160146decc4190583dd49d249ddbe8807bcc20e19e0d9f1fe8db7` |
+| `pr-4643.json` | `19c454d56f83e24cc4b14070597035cd71c5034d36129ce57001e2a7bc0d898b` |
+| `pr-4644.json` | `4f9ed336811519865e3128715b7112960870f301368e2ee91cf93d1b222f0292` |
+| `pr-4645.json` | `cd179a92368a098317a640a7af90e731382366c6c10e9583db7f26e0fb506d29` |
+| `pr-4646.json` | `1373e3fe6de46fa9cab6ed03bb5dae48c3d90954bd2082baf9d7ec772991fb9e` |
+| `pr-4659.json` | `3a91ac1b53a7a401593242d60fdefa5289841513da93a7e4cedfb1bfac81f5b0` |
+| `pr-4663.json` | `c251b6f980c6a54d6471e933dabf5837c8927b198a75aba9b24a84224c43b091` |
+| `pr-4669.json` | `8ca373f425603a5a430be8e67f87e5851a38c9778a88573d4c71dc411e3ae934` |
+| `pr-4670.json` | `4012047b2897e1d39850d490737e840c3770c7fb96d9cdc9a8a102ca15223955` |
+| `pr-4680.json` | `9cb67ba2707c8a1c35e24ca1ccb91a406c57a6f610db781cf8e16cd0f7d542dc` |
+| `pr-4684.json` | `89572541183cfb156397265924c99ef38ed118a832b94ef303da7f5a7258846b` |
+| `pr-4685.json` | `9df0fa2e0adac18c77ba98512a5dcc958023c33c0efb49a1f4f1ec5c274bd271` |
+| `pr-4686.json` | `0f2b91e1b4c70d76fef87a2bc8bd116ba50a006c970eb9e5f2e1cc0ef365a4cf` |
+| `pr-4687.json` | `d07f42c84b4851dd37ad4d70981b790956e5e4bb9fe6005f53987c7e0ed74dc3` |
+| `pr-4688.json` | `9fc729e9a8c05a12eb18c03930230e007ead1f3367a536ab6f4fdea69c1d460d` |
+| `pr-4692.json` | `198b5e52c7faf9c1932fceacf9e38b0215cacbee5b88b11e83da8bba034f2b33` |
+| `pr-4693.json` | `72ede1fe1f720e8706aa0bc5a7945279359fe093286ee239336d0fb8dab5a173` |
+| `pr-4698.json` | `8156e920f177f6797ffec571caa238bac0ee188a2dad427149c3d08c2a8561b3` |
+| `pr-4701.json` | `27804538276605ccd36170d634046199d9535782464f120053c4532f0a226167` |
+| `pr-4702.json` | `18d3bbc9f8aaefc6a4c0b11b4ca3b5e3590abb21efc1eda47bf619cd77fcaf9a` |
+| `pr-4703.json` | `9d7aa8298d4110a1f44d0c0f3eeaa97af9629580159b6564204410d267982201` |
+| `pr-4704.json` | `05eddb4ca39c94da9dca0595bfc14639729d26638c7188b35df98d652d4ea04b` |
+| `pr-4705.json` | `075ef70e003dc6e9c97eb36bc3899e13abb23584968b2664f3003c49011093d9` |
+| `pr-4706.json` | `d47aa1e02bbbd77c903a4e88b23d43a463da3f6f22cdb9e4877c4fe457a4cc41` |
+| `pr-4707.json` | `b776f174fac4357b7b9905d8e62f9fad903c269cea5d83d002cbd87d450320f6` |
+| `pr-4708.json` | `3647bf05d0c91cdfab73563e5aab157bdabc50e6acfc26c04e059b38e462e093` |
+| `pr-4709.json` | `daf7e58beb9a0ba038313aa39f358c49c4df51f8ccb2adcafa2b9e354488539a` |
+| `pr-4710.json` | `0721415b8be2aeee94e71aacf9f817e57f93c3dcaffdbd1e7e83023ce8357a69` |
+| `pr-4711.json` | `c77a0bef38bd3015e489c30691e9b8aa5f73aec831032ba01bd5042f1bc86437` |
+| `pr-4713.json` | `50da61db60698c8d3f2a06520c3725bce6acb0a3165866a659347c9fce5a56c6` |
+| `pr-4714.json` | `522846cc2918ab0d33edbdc7cc7eb3e5686479d6f021e003462fa53187fb5980` |
+| `pr-4715.json` | `7e01bcae3a32d6acfb6925a15df15d9cd6b31745a1e9eac0ea2dc882bf3320d0` |
+| `pr-4718.json` | `623a65fbe28e1139e37da98c780cc099ff290914627d2d15bc049e94d9f71723` |
+| `pr-4720.json` | `2bda12b0a92a11e0e7f52d9df231a1a30324db472a36554153f7489e1ac7c27a` |
+| `pr-4721.json` | `4eb3529df856f4946329c8c5508b82f77bd5b7e9e214372bcecadc1ea923dda5` |
+| `pr-4723.json` | `baa993b99348aace98a19dc214272607fba24e874ae9afd9df4a1d164a39811c` |
+| `pr-4725.json` | `ac54252c6b8870c1b05aa6ab1637f4879fed8c47120b8bc56798baf2feb796c1` |
+| `pr-4727.json` | `d2899092d6e4e02f5915719ed12f6b8fcb97acd82847726d962031b2e86fe39a` |
+| `pr-4729.json` | `518d262e31f0ba4e7390fd20f240a669dd90a60af2d9ad81f9f5305eb6e019d8` |
+| `pr-4730.json` | `f92dfde2f08f97d13405038ee595241ce487a55c52b1b3e77399df0cf439dfeb` |
+| `pr-4732.json` | `1474f054d85699fbc5f99a2fabe42693dda619fd581db938e3a8b5de0e163ae1` |
+| `pr-4733.json` | `3b8ba072cb70db59b4d69b6a22792e2db74d494ad840c848e68809aad28837ae` |
+| `pr-4734.json` | `02234e01f64af01c4c8e21247e3d5a69f8d5d7f144c4964f476235343bfa3eed` |
+| `pr-4735.json` | `3489bb45be14e3e645639184d8450e3f16863d3d645a88e759537a5d3b1b1fe6` |
+| `pr-4738.json` | `ac37a882690b857bcddb68f520ee593f2821f63d4a7f539daa5d3a954c49d398` |
+| `pr-4739.json` | `44af6cf31a2f66638bdab8d757580d0d062fd8a94a902bcb489f43fa8b3bd229` |
+| `pr-4742.json` | `2d930c09389ea6640f175a753605e6db89be4caefdbbad2b74b99b709384a2fc` |
+| `pr-4743.json` | `8a2b0f188a408ff76dc19e67e61894e923781bfb64bc0ab6a76f76aff31c749b` |
+| `pr-4745.json` | `85a507b660625a93bc2c600b60cfcc6b2075e7ca725fab905e38c66f86562262` |
+| `pr-4751.json` | `51525e8625dece79429395d49fcd0087c055230a5eb9bdf8c8c690f37c9572fd` |
+| `pr-4752.json` | `23cae79785076796160b5aaf6e52625c252a91ad0ed30975b4387ed172d0018f` |
+| `pr-4755.json` | `2776362b2c8a529a07c560621c2b3aa07ed9751d8eab94df5c233c5c00ac9a29` |
+| `pr-4756.json` | `cc896811f3f3b9b732826c360a890ea7153b392e65fb79220a55dcea46b72cb2` |
+| `pr-4757.json` | `ca3c9961f57a591252937753ecbe15c9a9c4989a1670c3bbfade66dd8f575b2a` |
+| `pr-4759.json` | `1d92c3ebdabf98eedd30ee0a463ef776f2a9d37b6e24df1aebb21c1207483e90` |
+| `pr-4762.json` | `2d207a26bd26e869a3ebe8eccfbfd304718d2304063578b1b238e408ab16a9a2` |
+| `pr-4764.json` | `8045902d75efbdb8cf907ff6e262832ecfb340a2d7c19a69cc5442695644932b` |
+| `pr-4777.json` | `f65d6ea3cb91c1d9a61b59d3a850caabe1ee65c9543e30a3bfde0acaf811fa57` |
+| `pr-4778.json` | `99ee2897a1f498061bfdc8ee1590bf1f791fdf6f2dac7f1d68559fe5c38e5fd2` |
+| `pr-4779.json` | `28acd1be5f61320180d6c96f85b71c95369b51c0980392f925413404fbe1e119` |
+| `pr-4780.json` | `1e8b2ba009ed0c8eba39ebe5ae312d62ec9cd31e602a34356169bece8cc1cd09` |
+| `pr-4783.json` | `39e4c666439d23cac6f45ec90ff8730847b479f6197026a293d37b7a6b4fd309` |
+| `review-comments-4611.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4616.json` | `899a7b992a0c373052658f5508a487fdcfe4a4fe2cee76655ee3e8909d119dbd` |
+| `review-comments-4623.json` | `e98c15c38f1c2b0ce11f8a8ba184531188f12221604c51b20485942fa3349748` |
+| `review-comments-4625.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4630.json` | `1c1dc40987ebebc36774a99e7ba3997719525e433647a39f84071ca786261fcf` |
+| `review-comments-4632.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4633.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4634.json` | `ab6da1f5408e3cc9c52020972f0596d907b9249b1fa790d5301496c25e036dab` |
+| `review-comments-4635.json` | `468278594297486dfcb3bccca69c9e686387b874a78103f49f533d930df57ce1` |
+| `review-comments-4636.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4637.json` | `09d9ff09e1a02d9711b91087d2ef3a5da90e3f91525c712cae8eb26b8b874d31` |
+| `review-comments-4639.json` | `ece9b428022a50e58da704a88f2947400dad8ea6d9169785235d1eddabf25862` |
+| `review-comments-4644.json` | `3f8a7bb54a2f349b9ab9fc74df5530cb52213f1de91369e5a54da68689e4ba16` |
+| `review-comments-4646.json` | `8c00565cb5ea2a51d39418765217dd40901773cb8d278f83901ef3b35093e7a1` |
+| `review-comments-4680.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4684.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4685.json` | `83a9cb1b461d6305b4f01d5d6bc0b5de3f281a59d221cd8154fd06f25dc84707` |
+| `review-comments-4686.json` | `6a4f5f7be8168c8ebe461163d975012d52a38a66f937ef3225df59f41e246d41` |
+| `review-comments-4687.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4688.json` | `86b454f5b7da7da0c4e5bdf3c540841a2f72d0a6b11c89b860ce71414be81564` |
+| `review-comments-4692.json` | `1bea2855258bbed0172813a635d421d00fef9ad86f5d894b62051d4c2c34be18` |
+| `review-comments-4693.json` | `f7321509a9ca399bf768d638db21a7d0ac74eb3c4751fc9d45c2347166bac4cf` |
+| `review-comments-4698.json` | `1cc4ffa912770117d4e9b86cabb87af26b7b300e86fa4356a74beb8820823277` |
+| `review-comments-4701.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4702.json` | `41b03e580c684ac93c9df2b86cba68bfe6325b07e56627a77b36677e1a74f30c` |
+| `review-comments-4703.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4704.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4705.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4706.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4707.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4708.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4709.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4713.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4714.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4715.json` | `249c75d163f0f22710f91bf9a8a150cfe0cb1f788c682d526ebd54cbfe825bc7` |
+| `review-comments-4718.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4720.json` | `d5ae3d992d3172df7d5a24c54eec936e6d99821b462fe8a5447fd14c957b345c` |
+| `review-comments-4721.json` | `822a91d5a51caee40fbb30eab0127e40ab724e90c2a429f17d57744a6883f37f` |
+| `review-comments-4723.json` | `cfd417d6499cd89dc840fa2e8d954b1f6f6e6d1aeb3bb52bb3fa00aa0a7dfe26` |
+| `review-comments-4725.json` | `3bd84d5896b203d6afba019b6ce1badf9d346a1d715b7521e6f2833b8c9e7233` |
+| `review-comments-4727.json` | `51542962b4187f272777cef508948ed3dced16419b504858cf0d68ed16a4b38d` |
+| `review-comments-4729.json` | `c4ff93725fb7f6cfa709a29fc280cd4ca1552797e73e42f068e9752e06928a87` |
+| `review-comments-4730.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4732.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4733.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4734.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4735.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4738.json` | `e2c053405ec2e7a91fbc7748cb4a2f9bfedd5990461c3c4804bcae85c0434b0a` |
+| `review-comments-4739.json` | `5b682d7da0dc1c5ef608bb1048460e170d976b359bcb4cbc141487943895c2dd` |
+| `review-comments-4742.json` | `0357221ff18e79e98f894de5dea06677e47a46c28109aae7ca392334eaf2ab4d` |
+| `review-comments-4743.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4745.json` | `6b8ff2cab287c9b9b10fca5c74880e5a62a8ca283c9d5a4343a4a989abe519cd` |
+| `review-comments-4751.json` | `aae14c2d5823b8422163c1ff2ae753ef1c767b13a7d702bbce5c11f637a451d1` |
+| `review-comments-4752.json` | `21c67c58c478464770360c7b9a3c040d72157a866a19c73ac0ec898cb3e6a387` |
+| `review-comments-4755.json` | `f34a955faeaade89d281062803fbae4499f7f7921bded834c61c00e65f5587e0` |
+| `review-comments-4756.json` | `0993acf785513b8ec706c8efa95f66aac1ccbb3a3bf43e5b8276bea4c95e7088` |
+| `review-comments-4757.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4759.json` | `3c0030aa2a63c7dea0f549f09abd2173e69294de9a31bd753a6b8b5f171bfb48` |
+| `review-comments-4762.json` | `baa3fadd230a123fef43288a10ff6b30dbfa9e61f5815760d4d3fc489c2c82b3` |
+| `review-comments-4764.json` | `41c8f6d8022f40c7428869982e1543690a0b054042b685605837a80d6922d361` |
+| `review-comments-4777.json` | `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945` |
+| `review-comments-4778.json` | `b1afc80f3d82aac118c70c5d11021c252c3c901179b348fd7c6d88fa37c8c73c` |
+| `review-comments-4779.json` | `1a727e551b2c9d458c64b9616339bfbdb3d4032cc404df568e11cbafa5c3d88c` |
+| `review-comments-4780.json` | `a6291f00f97640458bccc487f5f1b4fda0b96892b5076af6fab2dd42e98e34af` |
+| `review-comments-4783.json` | `2a5f6545beb76dee9a3f66aae65277215f2a8d7511ec650d01a7b44a69bdcbcc` |

--- a/docs/changelog-preparation/0.19.0/step1a-all-prs.md
+++ b/docs/changelog-preparation/0.19.0/step1a-all-prs.md
@@ -1,0 +1,80 @@
+# Complete release-range inventory
+
+Pinned range: `baml-language-0.18.0..5b398f2b60cfa78258ac9534e8322d056564e85f`. All 74 squash-merged PRs are accounted for. The `baml_language/` path filter finds only 23; the full-range review also covers the installer and developer-facing websites. Nine v0-only PRs are excluded from followups; all 65 remaining PRs were reviewed.
+
+| PR | Language path? | Changelog decision |
+| --- | --- | --- |
+| [#4625](https://github.com/BoundaryML/baml/pull/4625) feat(cli): embed the BAML agent skill | yes | Include: C04 |
+| [#4630](https://github.com/BoundaryML/baml/pull/4630) Interface dispatch bugfixes and unification | yes | Include: C27 |
+| [#4633](https://github.com/BoundaryML/baml/pull/4633) refactor(mir): remove dead visualization nodes from MIR | yes | MIR visualization cleanup; no user behavior. |
+| [#4623](https://github.com/BoundaryML/baml/pull/4623) Redesign FunctionSpec and streaming projections | yes | Include: C01, C10, C11 |
+| [#4643](https://github.com/BoundaryML/baml/pull/4643) fix: concurrent named-client cache lookup race | no | BAML v0 only. |
+| [#4642](https://github.com/BoundaryML/baml/pull/4642) engine: bump version to 0.226.2 | no | BAML v0 only. |
+| [#4645](https://github.com/BoundaryML/baml/pull/4645) engine: trigger releases manually, instead of by pushing two separate tags | no | BAML v0 only. |
+| [#4616](https://github.com/BoundaryML/baml/pull/4616) chore: notify Slack on successful nightly releases | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4644](https://github.com/BoundaryML/baml/pull/4644) chore: make app-product-metrics notifications self-documenting | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4646](https://github.com/BoundaryML/baml/pull/4646) fix(compiler): infer lambdas from callable union arms | yes | Include: C03 |
+| [#4632](https://github.com/BoundaryML/baml/pull/4632) fix(installer): bootstrap with compatible Linux wrappers | no | Include: C34 |
+| [#4659](https://github.com/BoundaryML/baml/pull/4659) engine: trigger releases from versioned source tags | no | BAML v0 only. |
+| [#4663](https://github.com/BoundaryML/baml/pull/4663) engine: fix release CI attestation pagination | no | BAML v0 only. |
+| [#4669](https://github.com/BoundaryML/baml/pull/4669) ci: add one-off crates.io 0.226.2 publisher | no | BAML v0 only. |
+| [#4670](https://github.com/BoundaryML/baml/pull/4670) engine: fix crates.io release from tag checkouts | no | BAML v0 only. |
+| [#4680](https://github.com/BoundaryML/baml/pull/4680) chore: disable ix preview CI, jobs are failing due to compute exhaustion | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4687](https://github.com/BoundaryML/baml/pull/4687) chore(release): move macos builds from gh to blacksmith | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4686](https://github.com/BoundaryML/baml/pull/4686) Fix LSP panic + diagnostic improvements | yes | Include: C28 |
+| [#4684](https://github.com/BoundaryML/baml/pull/4684) chore(release): workflow runs are now "canary release: 0.18.0" | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4688](https://github.com/BoundaryML/baml/pull/4688) ci: use shared Infisical credentials for release mirrors | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4692](https://github.com/BoundaryML/baml/pull/4692) fix: make baml_sdk work on cloudflare workers | yes | Include: C29 |
+| [#4693](https://github.com/BoundaryML/baml/pull/4693) ci: use shared Infisical token for Swift and Homebrew | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4698](https://github.com/BoundaryML/baml/pull/4698) fix(release): repair nightly toolchain builds | yes | Release-runner repair; no separately demonstrated user runtime effect. |
+| [#4685](https://github.com/BoundaryML/baml/pull/4685) ci: move sccache to baml-build3 R2 cache | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4701](https://github.com/BoundaryML/baml/pull/4701) fix(release): fix the x64 toolchain build, again | no | Release-runner repair; no separately demonstrated user runtime effect. |
+| [#4714](https://github.com/BoundaryML/baml/pull/4714) Let runtime-compiled code implement and call methods of mounted types | yes | Include: C30 |
+| [#4713](https://github.com/BoundaryML/baml/pull/4713) Bind Java publish jobs to the Infisical-synced release environment | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4718](https://github.com/BoundaryML/baml/pull/4718) chore: simplify c# sdk publication | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4611](https://github.com/BoundaryML/baml/pull/4611) [B-1646] Remove union field and method unification | yes | Include: C13 |
+| [#4702](https://github.com/BoundaryML/baml/pull/4702) chore: split BAML v1 setup actions from v0 | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4703](https://github.com/BoundaryML/baml/pull/4703) chore: scope the root Rust toolchain to engine | no | Root contributor toolchain configuration; not a v0-only exclusion. |
+| [#4704](https://github.com/BoundaryML/baml/pull/4704) chore: bump BAML Language Rust to 1.98.0 | yes | Repository Rust toolchain/CI update; no generated Rust SDK minimum-version change identified. |
+| [#4705](https://github.com/BoundaryML/baml/pull/4705) chore: upgrade BAML Language checkout to Node 24 | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4706](https://github.com/BoundaryML/baml/pull/4706) chore: upgrade BAML Language artifact actions to Node 24 | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4707](https://github.com/BoundaryML/baml/pull/4707) chore: upgrade remaining BAML Language actions to Node 24 | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4708](https://github.com/BoundaryML/baml/pull/4708) chore: upgrade BAML v1 on-call actions to Node 24 | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4709](https://github.com/BoundaryML/baml/pull/4709) chore: upgrade BAML v1 product-metrics actions to Node 24 | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4634](https://github.com/BoundaryML/baml/pull/4634) feat(atb2): sandbox for handle_issue: worktree lifecycle, allowlisted env, repro pre-check on canary | no | Internal agent-development pipeline. |
+| [#4635](https://github.com/BoundaryML/baml/pull/4635) feat(atb2): the gate: fmt, clippy, changed-crate tests, nextest, insta, the baml corpus; judged by exit code | no | Internal agent-development pipeline. |
+| [#4636](https://github.com/BoundaryML/baml/pull/4636) feat(atb2): handle_issue: a design pass, then a fix pass in the sandbox; PR body; outcome; agents run on Fable | no | Internal agent-development pipeline. |
+| [#4637](https://github.com/BoundaryML/baml/pull/4637) feat(atb2): handle_issue evals; run_tests.sh picks a pipeline stage; //# headers for the playground graph | no | Internal agent-development pipeline. |
+| [#4720](https://github.com/BoundaryML/baml/pull/4720) Invariant-holding type representations | yes | Include: C31 |
+| [#4723](https://github.com/BoundaryML/baml/pull/4723) [B-1610] Require matching BAML skill in agent mode | yes | Include: C15 |
+| [#4725](https://github.com/BoundaryML/baml/pull/4725) Standard Library conventions and cleanup | yes | Include: C16, C17, C18, C19, C20, C21, C22, C23, C35, C36 |
+| [#4639](https://github.com/BoundaryML/baml/pull/4639) feat(app-feedback): the feedback pipeline UI, reading the atb2 store | no | Internal agent-development pipeline. |
+| [#4735](https://github.com/BoundaryML/baml/pull/4735) ci: remove C# package availability smoke | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4721](https://github.com/BoundaryML/baml/pull/4721) [B-1682] Scope return type checking to closures | yes | Include: C32 |
+| [#4715](https://github.com/BoundaryML/baml/pull/4715) feat(atb2): merge_issue, the PR watcher; package written against canary's BAML | no | Internal agent-development pipeline. |
+| [#4738](https://github.com/BoundaryML/baml/pull/4738) ci: use repository secrets for sccache | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4710](https://github.com/BoundaryML/baml/pull/4710) chore(engine): bump engine Rust to 1.98.0 | no | BAML v0 only. |
+| [#4711](https://github.com/BoundaryML/baml/pull/4711) chore(engine): upgrade engine actions to Node 24 | no | BAML v0 only. |
+| [#4739](https://github.com/BoundaryML/baml/pull/4739) Comparison is total and reflexive | yes | Include: C24, C25 |
+| [#4727](https://github.com/BoundaryML/baml/pull/4727) feat(docs): add developer documentation portal | no | Include: C06 |
+| [#4730](https://github.com/BoundaryML/baml/pull/4730) feat(docs): publish and render generated references | no | Include: C07 |
+| [#4732](https://github.com/BoundaryML/baml/pull/4732) feat(docs): validate and render BAML snippets | no | Include: C06 |
+| [#4733](https://github.com/BoundaryML/baml/pull/4733) docs: load authored portal content from canonical sources | no | Include: C06 |
+| [#4734](https://github.com/BoundaryML/baml/pull/4734) ci(docs): split portal validation jobs | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4742](https://github.com/BoundaryML/baml/pull/4742) chore(web): remove public changelog | no | Intermediate changelog removal superseded by #4743 and #4783. |
+| [#4743](https://github.com/BoundaryML/baml/pull/4743) feat(web): publish releases as blog posts | yes | Include: C08 |
+| [#4745](https://github.com/BoundaryML/baml/pull/4745) style(web): apply inline code styling globally | no | Website inline-code styling only; no release-specific product capability. |
+| [#4755](https://github.com/BoundaryML/baml/pull/4755) fix(ci): validate nightly release CI run freshness | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4757](https://github.com/BoundaryML/baml/pull/4757) refactor(ci): run release verification after publishing | yes | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4756](https://github.com/BoundaryML/baml/pull/4756) ci: pull language release build images through GCP cache | yes | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4752](https://github.com/BoundaryML/baml/pull/4752) docs(setup): correct README-DEV.md's Rust toolchain instructions | no | Contributor README cleanup; external author is included in followups. |
+| [#4729](https://github.com/BoundaryML/baml/pull/4729) feat(atb2): part 5: Supabase store, Slack threads, PostHog intake, run_pipeline, @bammy babysit, a Fly runner deployed from CI | no | Internal agent-development pipeline. |
+| [#4759](https://github.com/BoundaryML/baml/pull/4759) Preserve discarded effects and optimize stackified bytecode | yes | Include: C09, C26, C33 |
+| [#4762](https://github.com/BoundaryML/baml/pull/4762) Improve generated developer reference discovery and readability | no | Include: C07 |
+| [#4764](https://github.com/BoundaryML/baml/pull/4764) Developer docs: render immutable records with live SSR | no | Include: C07 |
+| [#4777](https://github.com/BoundaryML/baml/pull/4777) Serve stdlib sources through read-only editor documents | yes | Include: C05 |
+| [#4778](https://github.com/BoundaryML/baml/pull/4778) chore(release): improve format of release slack notifications | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4751](https://github.com/BoundaryML/baml/pull/4751) feat(stdlib): add float exp, ln, log2, log10, cbrt, signum, and range constants | yes | Include: C02 |
+| [#4779](https://github.com/BoundaryML/baml/pull/4779) chore: document BAML language and wrapper releases | yes | Release/operator documentation, not a language behavior change. |
+| [#4780](https://github.com/BoundaryML/baml/pull/4780) chore(release): tag current oncall when a release fails | no | CI, publishing, infrastructure, or internal operational change; no separate user-facing effect. |
+| [#4783](https://github.com/BoundaryML/baml/pull/4783) Developer docs: redirect changelog to product release notes | no | Include: C08 |

--- a/docs/changelog-preparation/0.19.0/step1b-prs-only-user-visible.md
+++ b/docs/changelog-preparation/0.19.0/step1b-prs-only-user-visible.md
@@ -1,0 +1,29 @@
+# PRs with user-visible effects
+
+25 retained PRs. This includes installer and documentation surfaces outside `baml_language/`.
+
+- [#4625](https://github.com/BoundaryML/baml/pull/4625) feat(cli): embed the BAML agent skill
+- [#4630](https://github.com/BoundaryML/baml/pull/4630) Interface dispatch bugfixes and unification
+- [#4623](https://github.com/BoundaryML/baml/pull/4623) Redesign FunctionSpec and streaming projections
+- [#4646](https://github.com/BoundaryML/baml/pull/4646) fix(compiler): infer lambdas from callable union arms
+- [#4632](https://github.com/BoundaryML/baml/pull/4632) fix(installer): bootstrap with compatible Linux wrappers
+- [#4686](https://github.com/BoundaryML/baml/pull/4686) Fix LSP panic + diagnostic improvements
+- [#4692](https://github.com/BoundaryML/baml/pull/4692) fix: make baml_sdk work on cloudflare workers
+- [#4714](https://github.com/BoundaryML/baml/pull/4714) Let runtime-compiled code implement and call methods of mounted types
+- [#4611](https://github.com/BoundaryML/baml/pull/4611) [B-1646] Remove union field and method unification
+- [#4720](https://github.com/BoundaryML/baml/pull/4720) Invariant-holding type representations
+- [#4723](https://github.com/BoundaryML/baml/pull/4723) [B-1610] Require matching BAML skill in agent mode
+- [#4725](https://github.com/BoundaryML/baml/pull/4725) Standard Library conventions and cleanup
+- [#4721](https://github.com/BoundaryML/baml/pull/4721) [B-1682] Scope return type checking to closures
+- [#4739](https://github.com/BoundaryML/baml/pull/4739) Comparison is total and reflexive
+- [#4727](https://github.com/BoundaryML/baml/pull/4727) feat(docs): add developer documentation portal
+- [#4730](https://github.com/BoundaryML/baml/pull/4730) feat(docs): publish and render generated references
+- [#4732](https://github.com/BoundaryML/baml/pull/4732) feat(docs): validate and render BAML snippets
+- [#4733](https://github.com/BoundaryML/baml/pull/4733) docs: load authored portal content from canonical sources
+- [#4743](https://github.com/BoundaryML/baml/pull/4743) feat(web): publish releases as blog posts
+- [#4759](https://github.com/BoundaryML/baml/pull/4759) Preserve discarded effects and optimize stackified bytecode
+- [#4762](https://github.com/BoundaryML/baml/pull/4762) Improve generated developer reference discovery and readability
+- [#4764](https://github.com/BoundaryML/baml/pull/4764) Developer docs: render immutable records with live SSR
+- [#4777](https://github.com/BoundaryML/baml/pull/4777) Serve stdlib sources through read-only editor documents
+- [#4751](https://github.com/BoundaryML/baml/pull/4751) feat(stdlib): add float exp, ln, log2, log10, cbrt, signum, and range constants
+- [#4783](https://github.com/BoundaryML/baml/pull/4783) Developer docs: redirect changelog to product release notes

--- a/docs/changelog-preparation/0.19.0/step2a-pr-user-effects.md
+++ b/docs/changelog-preparation/0.19.0/step2a-pr-user-effects.md
@@ -11,7 +11,7 @@
 ## [#4623](https://github.com/BoundaryML/baml/pull/4623)
 
 - C01 — FEATURE: Call and parse bound LLM specifications. A bound `ai.FunctionSpec<Out>` now exposes `call()` and `parse()`. Use `call(client = ..., on_event = ...)` to run it. Use `parse()` to turn an existing model reply into its output type. The example parses locally without calling a model.
-- C10 — BREAKING_CHANGE: Use @ projections in BAML source. Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Stream directly from the function rather than calling `stream()` on a bound spec.
+- C10 — BREAKING_CHANGE: Use @ projections in BAML source. Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Generated spec and stream companions are also omitted from reflection and function listings.
 - C11 — BREAKING_CHANGE: Rename the request client override. The named argument on `FunctionSpec.build_request()` is now `client`, replacing `override_client`.
 
 ## [#4646](https://github.com/BoundaryML/baml/pull/4646)

--- a/docs/changelog-preparation/0.19.0/step2a-pr-user-effects.md
+++ b/docs/changelog-preparation/0.19.0/step2a-pr-user-effects.md
@@ -1,0 +1,115 @@
+# Effects by PR
+
+## [#4625](https://github.com/BoundaryML/baml/pull/4625)
+
+- C04 — FEATURE: Install the matching agent skill offline. `baml agent install` installs the skill bundled with the selected toolchain. It no longer fetches the skill from a separate GitHub repository. The skill records its exact toolchain version.
+
+## [#4630](https://github.com/BoundaryML/baml/pull/4630)
+
+- C27 — BUGFIX: Correct interface method dispatch. Fixed calls to interface default methods and out-of-body implementations, including methods involving associated types. Calls now use the correct implementation and type arguments.
+
+## [#4623](https://github.com/BoundaryML/baml/pull/4623)
+
+- C01 — FEATURE: Call and parse bound LLM specifications. A bound `ai.FunctionSpec<Out>` now exposes `call()` and `parse()`. Use `call(client = ..., on_event = ...)` to run it. Use `parse()` to turn an existing model reply into its output type. The example parses locally without calling a model.
+- C10 — BREAKING_CHANGE: Use @ projections in BAML source. Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Stream directly from the function rather than calling `stream()` on a bound spec.
+- C11 — BREAKING_CHANGE: Rename the request client override. The named argument on `FunctionSpec.build_request()` is now `client`, replacing `override_client`.
+
+## [#4646](https://github.com/BoundaryML/baml/pull/4646)
+
+- C03 — FEATURE: Infer lambda arguments through a union. A lambda can infer its parameter types from a union with exactly one callable alternative. For example, a parameter accepting either a string or a callback can supply the callback’s input type. Unions with multiple callable alternatives still need disambiguation.
+
+## [#4632](https://github.com/BoundaryML/baml/pull/4632)
+
+- C34 — BUGFIX: Bootstrap on older glibc and musl Linux systems. The Linux installer selects a compatible GNU wrapper and falls back to musl. Wrapper GNU builds target glibc 2.17 on x86_64 and 2.28 on ARM64; Debian Bookworm and Alpine were covered in the PR. This is an installer/wrapper update delivered alongside the language toolchain, with its own version.
+
+## [#4686](https://github.com/BoundaryML/baml/pull/4686)
+
+- C28 — BUGFIX: Diagnose invalid types without crashing the LSP. Unresolved types in required interface method signatures and invalid bounds now produce diagnostics instead of crashing the language server or reaching a later compiler panic. PromptFiddle also shows a clearer message if its language server panics.
+
+## [#4692](https://github.com/BoundaryML/baml/pull/4692)
+
+- C29 — BUGFIX: Initialize generated web SDKs in Cloudflare Workers. Generated TypeScript/web SDKs can initialize under workerd without trapping on module-scope random-number access.
+
+## [#4714](https://github.com/BoundaryML/baml/pull/4714)
+
+- C30 — BUGFIX: Call mounted methods from runtime-compiled packages. `reflect.Package.compile()` preserves mounted class methods and required/default interface methods. Runtime-compiled code can implement a mounted interface and call mounted methods without namespace-shadowing errors. Calling `to_string()` on reflected types in that code no longer triggers a compiler panic.
+
+## [#4611](https://github.com/BoundaryML/baml/pull/4611)
+
+- C13 — BREAKING_CHANGE: Make shared union members explicit. Same-named fields or methods on unrelated union arms no longer create a shared API, even when their types match. Narrow the union before access, or declare the shared member on one interface implemented by every arm.
+
+## [#4720](https://github.com/BoundaryML/baml/pull/4720)
+
+- C31 — BUGFIX: Respect inherited associated-type constraints. The type checker respects associated-type pins inherited through an interface’s `requires` constraints and consistently diagnoses invalid implementation targets.
+
+## [#4723](https://github.com/BoundaryML/baml/pull/4723)
+
+- C15 — BREAKING_CHANGE: Refresh the skill before agent authoring commands. Detected coding agents must have a BAML skill matching the selected toolchain before authoring commands run. Install the skill again after changing toolchains. Human sessions warn by default. `--agent-skill-check` and `BAML_AGENT_SKILL_CHECK` accept `auto`, `require`, `warn`, and `off`; installation and management commands remain available.
+
+## [#4725](https://github.com/BoundaryML/baml/pull/4725)
+
+- C16 — BREAKING_CHANGE: Use shorter standard-library type names. Update type annotations, constructors, catches, and generated-SDK references to the names below. Regenerate SDKs with the new toolchain.
+- C17 — BREAKING_CHANGE: Use public parsing and testing APIs. Parser caches and polling sentinels are now internal: `baml.sap.ParseCache`, `NoYield`, `baml.csv.CsvNeedData`, `CsvSkip`, and `CsvHeaders` gained underscore-prefixed names. Testing registry execution/selection helpers and pool types also became internal. Use `baml.sap.parse<T>()` or `parse_type()` for parsing, CSV readers for records, and authored `test`/`testset` blocks or the public testing runners. Provider implementation helpers under `*.internal` also dropped provider-name prefixes; those helpers are not stable public APIs.
+- C18 — BREAKING_CHANGE: Keep panics out of throws clauses. Explicitly throwing a `baml.panics.*` value raises a panic. It no longer contributes to inferred `throws`, and wildcard `catch` or `catch_all` arms skip it. Name a panic type explicitly if you intend to intercept it. Assertions now raise `baml.panics.AssertionFailed` instead of a generic user panic.
+- C19 — BREAKING_CHANGE: Handle the updated I/O error contracts. `baml.http.send()` and `fetch_sse()` include `baml.errors.InvalidArgument`. `baml.io.input()` can throw `baml.errors.Io`. Invalid glob patterns throw `ParseError`, while `Glob.matches()` is `throws never`. `File.close()` is idempotent and only declares `Io`; remove `InvalidArgument` from wrappers that declared it solely for close. CSV reader and writer close operations now propagate file-close failures.
+- C20 — BREAKING_CHANGE: Remove obsolete catchable runtime error types. `baml.errors.NotImplemented` and `baml.errors.DevOther` were removed. Unsupported runtime capabilities use a panic channel, and runtime invariant failures use internal errors. If your own code threw either removed class, define an application error. Handle only the documented errors from standard-library calls.
+- C21 — BREAKING_CHANGE: Check float division results explicitly. Float division by zero produces infinity or NaN. It no longer raises `DivisionByZero`; integer division still does. Validate the denominator when your application needs to reject zero.
+- C22 — BREAKING_CHANGE: Update integer overflow handling. `int.abs()` is now `throws never` and raises `baml.panics.IntegerOverflow` for `int.min_value()`. It no longer throws `InvalidArgument`. Integer left-shift interface calls now match the `<<` operator’s truncation: high bits are discarded, `1 << 62` is `int.min_value()`, and `1 << 63` is zero. Negative shifts still panic.
+- C23 — BREAKING_CHANGE: Omit the time argument to request midnight. `PlainDate.to_plain_datetime()` takes a non-null `PlainTime`. Omit the argument for midnight instead of passing `null`.
+- C35 — BUGFIX: Keep built-in frames out of user tracebacks. User-facing tracebacks omit standard-library frames, including built-ins implemented in BAML.
+- C36 — BUGFIX: Return empty buffers for non-positive reads. Native and web read operations return empty buffers for non-positive byte counts.
+
+## [#4721](https://github.com/BoundaryML/baml/pull/4721)
+
+- C32 — BUGFIX: Check closure returns against the closure. An early `return` inside a closure is checked against that closure’s return type, rather than the enclosing function’s type. Closure return inference also accounts for explicit and tail returns.
+
+## [#4739](https://github.com/BoundaryML/baml/pull/4739)
+
+- C24 — BREAKING_CHANGE: Use Compare and Ordering for sorting. `baml.ops.Compare.cmp()` returns `baml.ops.Ordering.Less`, `Equal`, or `Greater`. It replaces `baml.Comparable.compare()`. Implement `Equals` and `Compare` for custom naturally sorted types. `Compare` supplies `min`, `max`, and `clamp`. `Comparable.CompareError` and `Sortable.SortError` are gone; natural comparison and `sort()` are `throws never`. For fallible ordering, use `sort_by()`, whose callback still propagates its declared errors but now returns `Ordering` rather than int. `sort_by_key()` keys must implement `Compare`.
+- C25 — BREAKING_CHANGE: Use is_nan instead of non-reflexive equality. Equality is reflexive, including NaN. NaN equals NaN and sorts above every number. Positive and negative zero compare equal. Replace `x != x` NaN checks with `x.is_nan()`, and review logic that relied on IEEE unordered comparisons.
+
+## [#4727](https://github.com/BoundaryML/baml/pull/4727)
+
+- C06 — FEATURE: Read the new developer guide. The [developer documentation portal](https://developer.boundaryml.com) brings the language guide, tutorials, TypeScript bridge guidance, search, and light/dark themes together. BAML examples come from a shared source catalog checked with a selected compiler.
+
+## [#4730](https://github.com/BoundaryML/baml/pull/4730)
+
+- C07 — FEATURE: Find references for your exact toolchain. Browse published versions in the [package reference](https://developer.boundaryml.com/baml/packages) and [CLI reference](https://developer.boundaryml.com/cli). Search includes generated declarations and members. Type links stay on the selected version, and members have copyable declarations and links. New reference snapshots become available through release publication.
+
+## [#4732](https://github.com/BoundaryML/baml/pull/4732)
+
+- C06 — FEATURE: Read the new developer guide. The [developer documentation portal](https://developer.boundaryml.com) brings the language guide, tutorials, TypeScript bridge guidance, search, and light/dark themes together. BAML examples come from a shared source catalog checked with a selected compiler.
+
+## [#4733](https://github.com/BoundaryML/baml/pull/4733)
+
+- C06 — FEATURE: Read the new developer guide. The [developer documentation portal](https://developer.boundaryml.com) brings the language guide, tutorials, TypeScript bridge guidance, search, and light/dark themes together. BAML examples come from a shared source catalog checked with a selected compiler.
+
+## [#4743](https://github.com/BoundaryML/baml/pull/4743)
+
+- C08 — FEATURE: Browse releases alongside articles. Release notes now appear in the [blog’s release filter](https://boundaryml.com/blog?tags=release). Both product and developer-documentation changelog links lead to the release history.
+
+## [#4759](https://github.com/BoundaryML/baml/pull/4759)
+
+- C09 — FEATURE: Generate smaller optimized bytecode. The PR’s audit of 246 pre-existing bytecode snapshots counted 99,860 → 93,984 displayed instructions, about 5.9% fewer. At O2, a plain null-coalescing expression shrank from 9 to 4 instructions, and a chained AND from 8 to 6. These are static instruction counts, include test and standard-library scaffolding, and are not a throughput measurement.
+- C26 — BREAKING_CHANGE: Rebuild compiled artifacts and regenerate SDKs. The compiled artifact ABI moves from 2 to 3 and the cache format from 11 to 12. Rebuild packed applications and regenerate SDKs with the new toolchain. Keep each generated SDK and its bridge on matching versions.
+- C33 — BUGFIX: Preserve effects of discarded expressions. Discarding an expression’s value no longer discards its required effects. Conditional mutations on the right of `&&` or `||` still run, and unused division or indexing still raises catchable panics when it fails. The fixes cover O0, O1, and O2.
+
+## [#4762](https://github.com/BoundaryML/baml/pull/4762)
+
+- C07 — FEATURE: Find references for your exact toolchain. Browse published versions in the [package reference](https://developer.boundaryml.com/baml/packages) and [CLI reference](https://developer.boundaryml.com/cli). Search includes generated declarations and members. Type links stay on the selected version, and members have copyable declarations and links. New reference snapshots become available through release publication.
+
+## [#4764](https://github.com/BoundaryML/baml/pull/4764)
+
+- C07 — FEATURE: Find references for your exact toolchain. Browse published versions in the [package reference](https://developer.boundaryml.com/baml/packages) and [CLI reference](https://developer.boundaryml.com/cli). Search includes generated declarations and members. Type links stay on the selected version, and members have copyable declarations and links. New reference snapshots become available through release publication.
+
+## [#4777](https://github.com/BoundaryML/baml/pull/4777)
+
+- C05 — FEATURE: Browse standard-library source in your editor. Go to Definition opens the toolchain’s embedded standard-library source in read-only documents in VS Code and PromptFiddle. Hover, highlighting, symbols, and further navigation work inside those documents. `baml ide install` no longer needs to extract a local source copy.
+
+## [#4751](https://github.com/BoundaryML/baml/pull/4751)
+
+- C02 — FEATURE: More float math and range constants. Floats gain `exp`, `ln`, `log2`, `log10`, `cbrt`, and `signum`. `float.max_finite()`, `float.min_finite()`, and `float.epsilon()` expose the finite range and machine epsilon. `min_finite()` is the most negative finite value. `cbrt()` accepts negative inputs. `signum()` returns ±1.0, including for signed zero; NaN returns 1.0. Transcendental results have no cross-platform accuracy guarantee.
+
+## [#4783](https://github.com/BoundaryML/baml/pull/4783)
+
+- C08 — FEATURE: Browse releases alongside articles. Release notes now appear in the [blog’s release filter](https://boundaryml.com/blog?tags=release). Both product and developer-documentation changelog links lead to the release history.

--- a/docs/changelog-preparation/0.19.0/step2b-pr-user-effects-reaggregated.md
+++ b/docs/changelog-preparation/0.19.0/step2b-pr-user-effects-reaggregated.md
@@ -1,0 +1,292 @@
+# Aggregated user effects
+
+Each effect has exactly one category. No group contains more than three PRs. There are no headline changes. Examples and migration pairs are in the [release draft](../../../typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md).
+
+## C01 — Call and parse bound LLM specifications
+
+Category: `FEATURE`. PRs: [#4623](https://github.com/BoundaryML/baml/pull/4623).
+
+A bound `ai.FunctionSpec<Out>` now exposes `call()` and `parse()`. Use `call(client = ..., on_event = ...)` to run it. Use `parse()` to turn an existing model reply into its output type. The example parses locally without calling a model.
+
+Evidence: baml_language/crates/baml_builtins2/baml_std/ai/spec.baml.
+
+## C02 — More float math and range constants
+
+Category: `FEATURE`. PRs: [#4751](https://github.com/BoundaryML/baml/pull/4751).
+
+Floats gain `exp`, `ln`, `log2`, `log10`, `cbrt`, and `signum`. `float.max_finite()`, `float.min_finite()`, and `float.epsilon()` expose the finite range and machine epsilon. `min_finite()` is the most negative finite value. `cbrt()` accepts negative inputs. `signum()` returns ±1.0, including for signed zero; NaN returns 1.0. Transcendental results have no cross-platform accuracy guarantee.
+
+Evidence: baml_language/crates/baml_builtins2/baml_std/baml/float.baml; PR final accuracy correction.
+
+## C03 — Infer lambda arguments through a union
+
+Category: `FEATURE`. PRs: [#4646](https://github.com/BoundaryML/baml/pull/4646).
+
+A lambda can infer its parameter types from a union with exactly one callable alternative. For example, a parameter accepting either a string or a callback can supply the callback’s input type. Unions with multiple callable alternatives still need disambiguation.
+
+Evidence: PR #4646 contextual lambda and host callback regression tests.
+
+## C04 — Install the matching agent skill offline
+
+Category: `FEATURE`. PRs: [#4625](https://github.com/BoundaryML/baml/pull/4625).
+
+`baml agent install` installs the skill bundled with the selected toolchain. It no longer fetches the skill from a separate GitHub repository. The skill records its exact toolchain version.
+
+Evidence: baml_language/crates/baml_cli/src/agent_command.rs.
+
+## C05 — Browse standard-library source in your editor
+
+Category: `FEATURE`. PRs: [#4777](https://github.com/BoundaryML/baml/pull/4777).
+
+Go to Definition opens the toolchain’s embedded standard-library source in read-only documents in VS Code and PromptFiddle. Hover, highlighting, symbols, and further navigation work inside those documents. `baml ide install` no longer needs to extract a local source copy.
+
+Evidence: baml_language/crates/baml_lsp; typescript2/pkg-editor; typescript2/app-vscode-ext.
+
+## C06 — Read the new developer guide
+
+Category: `FEATURE`. PRs: [#4727](https://github.com/BoundaryML/baml/pull/4727), [#4732](https://github.com/BoundaryML/baml/pull/4732), [#4733](https://github.com/BoundaryML/baml/pull/4733).
+
+The [developer documentation portal](https://developer.boundaryml.com) brings the language guide, tutorials, TypeScript bridge guidance, search, and light/dark themes together. BAML examples come from a shared source catalog checked with a selected compiler.
+
+Evidence: typescript2/app-developer-docs/content; typescript2/app-developer-docs/content/code.
+
+## C07 — Find references for your exact toolchain
+
+Category: `FEATURE`. PRs: [#4730](https://github.com/BoundaryML/baml/pull/4730), [#4762](https://github.com/BoundaryML/baml/pull/4762), [#4764](https://github.com/BoundaryML/baml/pull/4764).
+
+Browse published versions in the [package reference](https://developer.boundaryml.com/baml/packages) and [CLI reference](https://developer.boundaryml.com/cli). Search includes generated declarations and members. Type links stay on the selected version, and members have copyable declarations and links. New reference snapshots become available through release publication.
+
+Evidence: typescript2/app-developer-docs/lib/generated-content.
+
+## C08 — Browse releases alongside articles
+
+Category: `FEATURE`. PRs: [#4743](https://github.com/BoundaryML/baml/pull/4743), [#4783](https://github.com/BoundaryML/baml/pull/4783).
+
+Release notes now appear in the [blog’s release filter](https://boundaryml.com/blog?tags=release). Both product and developer-documentation changelog links lead to the release history.
+
+Evidence: typescript2/app-website/app/blog; typescript2/app-developer-docs/next.config.ts.
+
+## C09 — Generate smaller optimized bytecode
+
+Category: `FEATURE`. PRs: [#4759](https://github.com/BoundaryML/baml/pull/4759).
+
+The PR’s audit of 246 pre-existing bytecode snapshots counted 99,860 → 93,984 displayed instructions, about 5.9% fewer. At O2, a plain null-coalescing expression shrank from 9 to 4 instructions, and a chained AND from 8 to 6. These are static instruction counts, include test and standard-library scaffolding, and are not a throughput measurement.
+
+Evidence: PR #4759: Snapshot Regression Audit and Before/After Bytecode.
+
+## C10 — Use @ projections in BAML source
+
+Category: `BREAKING_CHANGE`. PRs: [#4623](https://github.com/BoundaryML/baml/pull/4623).
+
+Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Stream directly from the function rather than calling `stream()` on a bound spec.
+
+Evidence: baml_language/crates/baml_tests/baml_src/ns_llm_stream_contract/stream_contract.baml.
+
+## C11 — Rename the request client override
+
+Category: `BREAKING_CHANGE`. PRs: [#4623](https://github.com/BoundaryML/baml/pull/4623).
+
+The named argument on `FunctionSpec.build_request()` is now `client`, replacing `override_client`.
+
+Evidence: baml_language/crates/baml_builtins2/baml_std/ai/spec.baml.
+
+## C13 — Make shared union members explicit
+
+Category: `BREAKING_CHANGE`. PRs: [#4611](https://github.com/BoundaryML/baml/pull/4611).
+
+Same-named fields or methods on unrelated union arms no longer create a shared API, even when their types match. Narrow the union before access, or declare the shared member on one interface implemented by every arm.
+
+Evidence: PR #4611; B-1646.
+
+## C15 — Refresh the skill before agent authoring commands
+
+Category: `BREAKING_CHANGE`. PRs: [#4723](https://github.com/BoundaryML/baml/pull/4723).
+
+Detected coding agents must have a BAML skill matching the selected toolchain before authoring commands run. Install the skill again after changing toolchains. Human sessions warn by default. `--agent-skill-check` and `BAML_AGENT_SKILL_CHECK` accept `auto`, `require`, `warn`, and `off`; installation and management commands remain available.
+
+Evidence: baml_language/crates/baml_cli/src/agent_command.rs.
+
+## C16 — Use shorter standard-library type names
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+Update type annotations, constructors, catches, and generated-SDK references to the names below. Regenerate SDKs with the new toolchain.
+
+| 0.18.0 | 0.19.0 |
+| --- | --- |
+| `anthropic.AnthropicClient` | `anthropic.Client` |
+| `google.GoogleClient` | `google.GeminiClient` |
+| `ai.ClientSelector`, `ai.clients.ClientSelector` | `ai.Selector`, `ai.clients.Selector` |
+| `ai.stream.StreamEvent` | `ai.stream.Event` |
+| `ai.mcp.McpConnection` | `ai.mcp.Connection` |
+| `baml.csv.CsvError`, `CsvErrorKind`, `CsvPosition`, `CsvValue` | `baml.csv.Error`, `ErrorKind`, `Position`, `Value` |
+| `baml.csv.CsvReader`, `CsvRecord`, `CsvRows<T>`, `CsvWriter` | `baml.csv.Reader`, `Record`, `Rows<T>`, `Writer` |
+| `baml.errors.ErrorContext` | `baml.errors.Context` |
+| `baml.future.FutureState` | `baml.future.State` |
+| `baml.host.HostValue` | `baml.host.Value` |
+| `baml.spawn.SpawnParams<T, E>` | `baml.spawn.Params<T, E>` |
+| `baml.json.JsonParseError`, `JsonDecodeError`, `JsonSerializationError`, `JsonPathError` | `baml.json.ParseError`, `DecodeError`, `SerializationError`, `PathError` |
+| `baml.toml.TomlParseError` | `baml.toml.ParseError` |
+| `baml.yaml.YamlParseError` | `baml.yaml.ParseError` |
+
+Evidence: baml_language/crates/baml_builtins2/baml_std; declaration rename audit.
+
+## C17 — Use public parsing and testing APIs
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+Parser caches and polling sentinels are now internal: `baml.sap.ParseCache`, `NoYield`, `baml.csv.CsvNeedData`, `CsvSkip`, and `CsvHeaders` gained underscore-prefixed names. Testing registry execution/selection helpers and pool types also became internal. Use `baml.sap.parse<T>()` or `parse_type()` for parsing, CSV readers for records, and authored `test`/`testset` blocks or the public testing runners. Provider implementation helpers under `*.internal` also dropped provider-name prefixes; those helpers are not stable public APIs.
+
+Evidence: PR #4725 baml_std/{baml/ns_sap,testing,anthropic/ns_internal,google/ns_internal,openai/ns_internal}.
+
+## C18 — Keep panics out of throws clauses
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+Explicitly throwing a `baml.panics.*` value raises a panic. It no longer contributes to inferred `throws`, and wildcard `catch` or `catch_all` arms skip it. Name a panic type explicitly if you intend to intercept it. Assertions now raise `baml.panics.AssertionFailed` instead of a generic user panic.
+
+Evidence: baml_language/crates/baml_tests/baml_src/ns_panic_channel/panic_channel.baml; baml_std/assert/assert.baml.
+
+## C19 — Handle the updated I/O error contracts
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+`baml.http.send()` and `fetch_sse()` include `baml.errors.InvalidArgument`. `baml.io.input()` can throw `baml.errors.Io`. Invalid glob patterns throw `ParseError`, while `Glob.matches()` is `throws never`. `File.close()` is idempotent and only declares `Io`; remove `InvalidArgument` from wrappers that declared it solely for close. CSV reader and writer close operations now propagate file-close failures.
+
+Evidence: baml_std/baml/ns_{http,io,glob,fs,csv}.
+
+## C20 — Remove obsolete catchable runtime error types
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+`baml.errors.NotImplemented` and `baml.errors.DevOther` were removed. Unsupported runtime capabilities use a panic channel, and runtime invariant failures use internal errors. If your own code threw either removed class, define an application error. Handle only the documented errors from standard-library calls.
+
+Evidence: baml_std/baml/ns_errors/errors.baml; sys_ops/src/lib.rs.
+
+## C21 — Check float division results explicitly
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+Float division by zero produces infinity or NaN. It no longer raises `DivisionByZero`; integer division still does. Validate the denominator when your application needs to reject zero.
+
+Evidence: baml_language/crates/bex_vm/src/package_baml/ops_math.rs.
+
+## C22 — Update integer overflow handling
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+`int.abs()` is now `throws never` and raises `baml.panics.IntegerOverflow` for `int.min_value()`. It no longer throws `InvalidArgument`. Integer left-shift interface calls now match the `<<` operator’s truncation: high bits are discarded, `1 << 62` is `int.min_value()`, and `1 << 63` is zero. Negative shifts still panic.
+
+Evidence: baml_language/crates/bex_vm/src/package_baml/{int,ops_bitwise}.rs.
+
+## C23 — Omit the time argument to request midnight
+
+Category: `BREAKING_CHANGE`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+`PlainDate.to_plain_datetime()` takes a non-null `PlainTime`. Omit the argument for midnight instead of passing `null`.
+
+Evidence: baml_std/baml/ns_time/plaindate.baml.
+
+## C24 — Use Compare and Ordering for sorting
+
+Category: `BREAKING_CHANGE`. PRs: [#4739](https://github.com/BoundaryML/baml/pull/4739).
+
+`baml.ops.Compare.cmp()` returns `baml.ops.Ordering.Less`, `Equal`, or `Greater`. It replaces `baml.Comparable.compare()`. Implement `Equals` and `Compare` for custom naturally sorted types. `Compare` supplies `min`, `max`, and `clamp`. `Comparable.CompareError` and `Sortable.SortError` are gone; natural comparison and `sort()` are `throws never`. For fallible ordering, use `sort_by()`, whose callback still propagates its declared errors but now returns `Ordering` rather than int. `sort_by_key()` keys must implement `Compare`.
+
+Evidence: baml_std/baml/ns_ops/comparison.baml; baml_std/baml/sortable.baml.
+
+## C25 — Use is_nan instead of non-reflexive equality
+
+Category: `BREAKING_CHANGE`. PRs: [#4739](https://github.com/BoundaryML/baml/pull/4739).
+
+Equality is reflexive, including NaN. NaN equals NaN and sorts above every number. Positive and negative zero compare equal. Replace `x != x` NaN checks with `x.is_nan()`, and review logic that relied on IEEE unordered comparisons.
+
+Evidence: baml_std/baml/ns_ops/comparison.baml; baml_language/crates/bex_vm/src/package_baml/ops_comparison.rs.
+
+## C26 — Rebuild compiled artifacts and regenerate SDKs
+
+Category: `BREAKING_CHANGE`. PRs: [#4759](https://github.com/BoundaryML/baml/pull/4759).
+
+The compiled artifact ABI moves from 2 to 3 and the cache format from 11 to 12. Rebuild packed applications and regenerate SDKs with the new toolchain. Keep each generated SDK and its bridge on matching versions.
+
+Evidence: PR #4759; baml_language/crates/baml_artifact; baml_language/crates/bex_cache.
+
+## C27 — Correct interface method dispatch
+
+Category: `BUGFIX`. PRs: [#4630](https://github.com/BoundaryML/baml/pull/4630).
+
+Fixed calls to interface default methods and out-of-body implementations, including methods involving associated types. Calls now use the correct implementation and type arguments.
+
+Evidence: PR #4630 dispatch and type-frame regression tests.
+
+## C28 — Diagnose invalid types without crashing the LSP
+
+Category: `BUGFIX`. PRs: [#4686](https://github.com/BoundaryML/baml/pull/4686).
+
+Unresolved types in required interface method signatures and invalid bounds now produce diagnostics instead of crashing the language server or reaching a later compiler panic. PromptFiddle also shows a clearer message if its language server panics.
+
+Evidence: PR #4686.
+
+## C29 — Initialize generated web SDKs in Cloudflare Workers
+
+Category: `BUGFIX`. PRs: [#4692](https://github.com/BoundaryML/baml/pull/4692).
+
+Generated TypeScript/web SDKs can initialize under workerd without trapping on module-scope random-number access.
+
+Evidence: PR #4692; B-1656; bridge_typescript workerd export.
+
+## C30 — Call mounted methods from runtime-compiled packages
+
+Category: `BUGFIX`. PRs: [#4714](https://github.com/BoundaryML/baml/pull/4714).
+
+`reflect.Package.compile()` preserves mounted class methods and required/default interface methods. Runtime-compiled code can implement a mounted interface and call mounted methods without namespace-shadowing errors. Calling `to_string()` on reflected types in that code no longer triggers a compiler panic.
+
+Evidence: baml_language/crates/baml_tests/tests/runtime_package_compile.rs.
+
+## C31 — Respect inherited associated-type constraints
+
+Category: `BUGFIX`. PRs: [#4720](https://github.com/BoundaryML/baml/pull/4720).
+
+The type checker respects associated-type pins inherited through an interface’s `requires` constraints and consistently diagnoses invalid implementation targets.
+
+Evidence: PR #4720.
+
+## C32 — Check closure returns against the closure
+
+Category: `BUGFIX`. PRs: [#4721](https://github.com/BoundaryML/baml/pull/4721).
+
+An early `return` inside a closure is checked against that closure’s return type, rather than the enclosing function’s type. Closure return inference also accounts for explicit and tail returns.
+
+Evidence: PR #4721; B-1682.
+
+## C33 — Preserve effects of discarded expressions
+
+Category: `BUGFIX`. PRs: [#4759](https://github.com/BoundaryML/baml/pull/4759).
+
+Discarding an expression’s value no longer discards its required effects. Conditional mutations on the right of `&&` or `||` still run, and unused division or indexing still raises catchable panics when it fails. The fixes cover O0, O1, and O2.
+
+Evidence: PR #4759 discarded-expression regressions.
+
+## C34 — Bootstrap on older glibc and musl Linux systems
+
+Category: `BUGFIX`. PRs: [#4632](https://github.com/BoundaryML/baml/pull/4632).
+
+The Linux installer selects a compatible GNU wrapper and falls back to musl. Wrapper GNU builds target glibc 2.17 on x86_64 and 2.28 on ARM64; Debian Bookworm and Alpine were covered in the PR. This is an installer/wrapper update delivered alongside the language toolchain, with its own version.
+
+Evidence: PR #4632; GitHub issue #4624.
+
+## C35 — Keep built-in frames out of user tracebacks
+
+Category: `BUGFIX`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+User-facing tracebacks omit standard-library frames, including built-ins implemented in BAML.
+
+Evidence: baml_language/crates/bex_vm_types/src/errors.rs; SDK error renderers.
+
+## C36 — Return empty buffers for non-positive reads
+
+Category: `BUGFIX`. PRs: [#4725](https://github.com/BoundaryML/baml/pull/4725).
+
+Native and web read operations return empty buffers for non-positive byte counts.
+
+Evidence: baml_language/crates/sys_native/src/io_impls.rs; bridge_wasm/src/wasm_io.rs.

--- a/docs/changelog-preparation/0.19.0/step2b-pr-user-effects-reaggregated.md
+++ b/docs/changelog-preparation/0.19.0/step2b-pr-user-effects-reaggregated.md
@@ -78,7 +78,7 @@ Evidence: PR #4759: Snapshot Regression Audit and Before/After Bytecode.
 
 Category: `BREAKING_CHANGE`. PRs: [#4623](https://github.com/BoundaryML/baml/pull/4623).
 
-Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Stream directly from the function rather than calling `stream()` on a bound spec.
+Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Generated spec and stream companions are also omitted from reflection and function listings.
 
 Evidence: baml_language/crates/baml_tests/baml_src/ns_llm_stream_contract/stream_contract.baml.
 

--- a/docs/changelog-preparation/0.19.0/step3-followup-actions.md
+++ b/docs/changelog-preparation/0.19.0/step3-followup-actions.md
@@ -1,0 +1,54 @@
+# Followup drafts for BAML 0.19.0
+
+These are drafts to post after 0.19.0 and its changelog are published. No messages have been sent. Review the final release SHA before posting. The installer response additionally depends on the compatible wrapper and installer being publicly available, since the wrapper is released independently.
+
+## GitHub PR: [#4751 — float math](https://github.com/BoundaryML/baml/pull/4751)
+
+External contributor: [@ritunjaym](https://github.com/ritunjaym).
+
+> Adds nine methods to `float`.
+
+```text
+Thanks @ritunjaym! Your float math methods and finite-range constants are included in BAML 0.19.0: exp, ln, log2, log10, cbrt, signum, max_finite, min_finite, and epsilon. The release notes preserve the accuracy qualifications from your review. The separate signed-zero literal issue #4750 is still outstanding. Release notes: https://boundaryml.com/changelog.
+```
+
+## GitHub PR: [#4752 — contributor setup documentation](https://github.com/BoundaryML/baml/pull/4752)
+
+External contributor: [@ritunjaym](https://github.com/ritunjaym). Included in the complete v1 range even though contributor setup is omitted from the public feature list.
+
+> `README-DEV.md` describes Rust as a mise-managed tool pinned to 1.88.0.
+
+```text
+Thanks @ritunjaym! Your contributor setup documentation cleanup is included in the source revision for BAML 0.19.0. README-DEV now describes mise, direnv, and rustup without stale Rust version pins or a duplicate tools list. Release notes: https://boundaryml.com/changelog.
+```
+
+## GitHub issue: [#4624 — Linux installer bootstrap](https://github.com/BoundaryML/baml/issues/4624)
+
+External reporter: [@BenSpex](https://github.com/BenSpex). Fix: [#4632](https://github.com/BoundaryML/baml/pull/4632).
+
+> The official installer should work on a currently supported stable Debian base.
+
+```text
+Thanks @BenSpex! The installer update accompanying BAML 0.19.0 addresses the wrapper bootstrap failure you reported. It selects a compatible GNU wrapper and falls back to musl; the fix was tested on Debian Bookworm and Alpine on x86_64 and ARM64. The wrapper is versioned separately from the language toolchain, so rerun the current installer to pick up the wrapper fix. Release notes: https://boundaryml.com/changelog.
+```
+
+## Reviewed reports that should not receive a new fixed notification
+
+| Report | Decision |
+| --- | --- |
+| [#4750](https://github.com/BoundaryML/baml/issues/4750) / BAMLGH-73 | Still reproducible at the cut: the two zero literals print `"0.0,0.0"`. #4751 adds signum but does not fix literal aliasing. |
+| [#4587](https://github.com/BoundaryML/baml/issues/4587) / BAMLGH-61 | The reporter confirmed the unresolved-throws crash fixed before 0.18.0. #4686 covers additional diagnostic/LSP paths. Do not present the older report as newly fixed. |
+| [#4468](https://github.com/BoundaryML/baml/issues/4468) | The array/map/loop reproducer already executes correctly with 0.18.0. |
+| [#4370](https://github.com/BoundaryML/baml/issues/4370) / BAMLGH-44 | Historical Rust generator report linked as context, not a fix attributed to this range. |
+| [#2736](https://github.com/BoundaryML/baml/issues/2736) | Historical v0 Python extension GLIBC issue, not the v1 wrapper bootstrap issue. |
+| [#1259](https://github.com/BoundaryML/baml/issues/1259) / BAMLGH-4 | Historical Cloudflare feature request opened by a current member; not an external-user notification. B-1656 is the concrete v1 startup fix. |
+| B-1680 | Future `unreflect` redesign, not shipped by this cut. |
+| B-1655 | Integration-test lifecycle design question, not addressed by the workerd startup fix. |
+
+## Source-thread gaps and deduplication
+
+The body of #4751 says the float proposal was discussed on Discord but supplies no thread URL. Its PR comments, reviews, inline review comments, linked issue #4750, and BAMLGH-73 contain no Discord link. No verified destination or external-thread quote is available; do not invent a Discord reply target. The PR reply above reaches the identified contributor. Locate the original thread before adding a separate Discord draft.
+
+The two direct Linear source threads in Slack were read in full and contain internal discussion. Two historical source threads attached to B-1123 were also read. One forwards older external reports without identifying an external reply destination; those reports are not evidence of additional fixes in this range. No Slack messages are proposed.
+
+External status is based on GitHub association: MEMBER, OWNER, and COLLABORATOR are treated as internal; bot accounts are excluded. All other human PR authors, commenters, reviewers, and inline reviewers were checked. The only external PR participant found in this range is @ritunjaym, on #4751 and #4752. Linear mirror issues are deduplicated to their GitHub source. These three drafts cover two distinct external users.

--- a/docs/changelog-preparation/0.19.0/validation.md
+++ b/docs/changelog-preparation/0.19.0/validation.md
@@ -1,0 +1,82 @@
+# Validation
+
+## Compiler identity
+
+Built the CLI from the unchanged pinned canary source `5b398f2b60cfa78258ac9534e8322d056564e85f` on macOS ARM64 using the repository-pinned Rust 1.98.0:
+
+```sh
+cd baml_language
+cargo build --locked -p baml_cli --bin baml-cli
+```
+
+The debug build succeeded. The macOS linker emitted a compact-unwind size warning; no source change was needed. Binary SHA-256: `522ae68d51348962af44060fb80a79211c31ce126cba7ee10100070d7c23d1f1`. Its version string is still `baml-cli 0.18.0`, because the source release metadata has not been bumped. This is a source-identity validation of the proposed 0.19.0 cut, not a test of a published 0.19.0 binary.
+
+The comparison binary is the published 0.18.0 macOS ARM64 release used in the backtest. This separates source changes from PR descriptions that accidentally describe behavior already present in the previous release.
+
+## Examples and migrations
+
+All 16 positive BAML code blocks in the final blog pass `check` against the candidate. All 13 BAML “before” blocks pass `check` with the published 0.18.0 CLI. Each snippet was isolated in a temporary project with a minimal `baml.toml` and one `baml_src/main.baml`. Checks set `BAML_AGENT_SKILL_CHECK=off` so the separate skill policy does not mask language diagnostics.
+
+| Effect | Positive candidate check | Before on 0.18.0 | Before on candidate |
+| --- | --- | --- | --- |
+| C01: Call and parse bound LLM specifications | Pass | — | — |
+| C02: More float math and range constants | Pass | — | — |
+| C03: Infer lambda arguments through a union | Pass | — | — |
+| C10: Use @ projections in BAML source | Pass | Pass | Rejected |
+| C11: Rename the request client override | Pass | Pass | Rejected |
+| C13: Make shared union members explicit | Pass | Pass | Rejected |
+| C16: Use shorter standard-library type names | Pass | Pass | Rejected |
+| C17: Use public parsing and testing APIs | Pass | Pass | Rejected |
+| C18: Keep panics out of throws clauses | Pass | Pass | Still compiles; behavioral migration |
+| C19: Handle the updated I/O error contracts | Pass | Pass | Rejected |
+| C20: Remove obsolete catchable runtime error types | Pass | Pass | Rejected |
+| C21: Check float division results explicitly | Pass | Pass | Still compiles; behavioral migration |
+| C22: Update integer overflow handling | Pass | Pass | Still compiles; behavioral migration |
+| C23: Omit the time argument to request midnight | Pass | Pass | Rejected |
+| C24: Use Compare and Ordering for sorting | Pass | Pass | Rejected |
+| C25: Use is_nan instead of non-reflexive equality | Pass | Pass | Still compiles; behavioral migration |
+
+Runtime checks use the candidate CLI, without paid provider requests. The request-preview example only builds an HTTP request; it does not send it. The streaming example is compile-checked, not executed against an LLM.
+
+| Runtime probe | Published 0.18.0 | Candidate |
+| --- | --- | --- |
+| Early closure return | E0001 against enclosing return type | `"early"` |
+| Discarded conditional mutation and unused division | `false` | `true` |
+| Float division by zero | `"panic"` | `"Infinity"` |
+| Failed assertion panic class | `"UserPanic"` | `"AssertionFailed"` |
+| NaN reflexivity and ordering above infinity | `false` | `true` |
+| Issue #4468 array/map/loop | `5` | `5` — already fixed |
+| Issue #4750 mixed signed-zero literals | `"0.0,0.0"` | `"0.0,0.0"` — still broken |
+| Bound spec parsing (C01) | — | `Answer { value: 42 }` |
+| Float methods/constants (C02) | — | `true` |
+| Contextual callable-union lambda (C03) | — | `"HELLO"` |
+| Named request client override (C11) | — | Correct POST request shape, no network call |
+| Explicit panic catch (C18) | — | `0` |
+| Ordering-based sort callback (C24) | — | `[1, 2, 3]` |
+| is_nan migration (C25) | — | `true` |
+
+The compiler probe for the discarded-expression regression used the CLI’s default optimization configuration. The PR’s own regression suite additionally covers O0/O1/O2; that full suite was not rerun for this documentation change.
+
+## Agent skill policy
+
+A temporary project without an installed skill failed `check` under `BAML_AGENT_SKILL_CHECK=require` with exit 4. `agent install` succeeded under the same policy. `check` then passed. The installed skill is stamped with the candidate binary’s current canonical version; publication will supply 0.19.0 metadata. The installation only modified the temporary test project.
+
+## Claims corrected by differential checking
+
+- Removed the proposed migration for inline `unreflect` escaping through a stored spec: 0.18.0 already rejects it with E0168.
+- Removed the proposed migration for inference holes in required interface signatures: 0.18.0 already rejects it with E0147.
+- Used `baml.panics.AssertionFailed`, the name in the final source, despite #4725’s prose saying `AssertionFailure`.
+- Preserved #4751’s final accuracy qualifications. Its earlier “within one ulp” and correctly-rounded claims were withdrawn.
+- Kept #4759’s performance evidence to static instruction counts; no runtime speedup claim.
+- Did not notify #4750 as fixed, or reannounce #4468/#4587 as new fixes.
+- Did not claim that #4742 removed access to release notes: #4743 and #4783 establish the final blog and redirects.
+
+## Document and link checks
+
+The inventory contains 74 PRs, 65 non-v0 followup candidates, 25 retained changelog PRs, and 34 effects: 9 features, 15 breaking changes, and 10 bug fixes. There are no headlines. All effect groups contain at most three PRs. Every syntax/library feature has a code block, every breaking entry has before/after blocks, and the performance-only feature has its source measurements.
+
+The draft frontmatter sets `isPublished: false`. The website’s `get-posts.ts` explicitly excludes such files, including direct post lookup. No tag, package version, release configuration, production publication, or user notification was changed.
+
+The developer portal, package catalog, and CLI catalog returned HTTP 200. Both product and developer `/changelog` URLs returned 308 to the product blog’s release filter, which returned 200. Relative artifact links, PR coverage, Markdown fences, and frontmatter were checked locally.
+
+The final source-linked Markdown was checked with `git diff --check` and the applicable `prek` hooks. Browser/VS Code source-navigation smoke tests, live workerd execution, Linux installer containers, SDK runtime matrices, and a final published-0.19.0 smoke test were not rerun; the draft attributes those changes to their merged PRs rather than claiming local end-to-end coverage.

--- a/docs/changelog-preparation/0.19.0/validation.md
+++ b/docs/changelog-preparation/0.19.0/validation.md
@@ -75,7 +75,7 @@ A temporary project without an installed skill failed `check` under `BAML_AGENT_
 
 The inventory contains 74 PRs, 65 non-v0 followup candidates, 25 retained changelog PRs, and 34 effects: 9 features, 15 breaking changes, and 10 bug fixes. There are no headlines. All effect groups contain at most three PRs. Every syntax/library feature has a code block, every breaking entry has before/after blocks, and the performance-only feature has its source measurements.
 
-The draft frontmatter sets `isPublished: false`. The website’s `get-posts.ts` explicitly excludes such files, including direct post lookup. No tag, package version, release configuration, production publication, or user notification was changed.
+The post frontmatter now sets `isPublished: true` for review in the PR’s website preview. Website Git deployments are enabled for all branches in `typescript2/app-website/vercel.json`. Merging the post into `canary` also makes it eligible for production publication. No tag, package version, or user notification was changed.
 
 The developer portal, package catalog, and CLI catalog returned HTTP 200. Both product and developer `/changelog` URLs returned 308 to the product blog’s release filter, which returned 200. Relative artifact links, PR coverage, Markdown fences, and frontmatter were checked locally.
 

--- a/typescript2/app-website/blog-releases/2026-08-27-baml-0.18.0-backtest.md
+++ b/typescript2/app-website/blog-releases/2026-08-27-baml-0.18.0-backtest.md
@@ -1,0 +1,578 @@
+---
+title: BAML 0.18.0 — backtest draft
+description: Local execution queries, expanded reflection, Python streams, and migration guidance for BAML 0.18.0.
+slug: baml-0.18.0-backtest
+date: 2026-08-27
+tags: ['Release']
+isPublished: false
+---
+
+Thanks to everyone who contributed!
+
+# Query local execution traces
+
+Use `baml query` to explore locally recorded executions with SQL. The playground’s Telemetry tab shows executions, call paths, retained spans, errors, and captured values. Profiling data lives in `.baml/profiles-v1`.
+
+```sh
+BAML_PROFILE=1 baml run main
+baml query --schema
+baml query "SELECT * FROM threads WHERE parent_thread_id IS NULL LIMIT 10"
+```
+
+[#4548](https://github.com/BoundaryML/baml/pull/4548), [#4563](https://github.com/BoundaryML/baml/pull/4563), [#4578](https://github.com/BoundaryML/baml/pull/4578)
+
+# Features
+
+## Compile runtime packages faster
+
+Runtime package compilation reuses a precompiled standard library. The PR’s five-sample cold-path median fell from approximately 4–5 seconds to 20.6 milliseconds for a small package. These measurements describe that workload and host.
+
+[#4453](https://github.com/BoundaryML/baml/pull/4453)
+
+## Reduce compiler inference work
+
+PR #4458 reports an empty-project median of 530.2 → 489.1 ms and a full-test-project median of 2.333 → 2.120 s. PR #4463 reports 497.5 → 485.6 ms and 2.180 → 2.133 s against its own immediate baseline. These are separate A/B measurements; their percentages must not be added.
+
+[#4458](https://github.com/BoundaryML/baml/pull/4458), [#4463](https://github.com/BoundaryML/baml/pull/4463)
+
+## Observe LLM calls with on_event
+
+Direct calls, explicit agents, and streams accept the same optional event listener. Events expose usage and request/response information. Errors thrown by a listener do not fail the LLM run. Streams report usage when they settle.
+
+```baml
+function Extract(text: string) -> string {
+    client: "openai/gpt-4o-mini"
+    prompt: `Summarize ${text}. ${ctx.output_format()}`
+}
+function main() -> string {
+    Extract("hello", on_event = (event: ai.events.Event) -> void {
+        log.info(event.to_string());
+    })
+}
+```
+
+[#4570](https://github.com/BoundaryML/baml/pull/4570)
+
+## Iterate over Python streams
+
+Python streams support `async for`. Each iteration yields a non-null partial result. Read the completed value with `final_async()`.
+
+```python
+from baml_sdk import Extract_stream_async
+
+async def summarize(text: str):
+    stream = await Extract_stream_async(text)
+    async for partial in stream:
+        print(partial)
+    return await stream.final_async()
+```
+
+[#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+## Parse streamed backlogs in batches
+
+The PR’s debug-profile benchmark measured 27.2 seconds of per-delta parsing for approximately 99 KB across 2,550 deltas. Parsing 32-delta backlogs took 0.9 seconds; 128-delta backlogs took 0.23 seconds. At approximately 33 KB, the corresponding measurements were 2.9 seconds, 393 ms, and 40 ms. This is parser work under backlogs, not end-to-end provider latency.
+
+[#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+## Preview requests without credentials
+
+Build a provider request for inspection without making an LLM call or requiring API credentials. Preview authentication uses placeholders. A preview that would require file reads or URL fetches reports `PreviewUnsupported`.
+
+```baml
+function Extract(text: string) -> string {
+    client: "openai/gpt-4o-mini"
+    prompt: `Summarize ${text}. ${ctx.output_format()}`
+}
+function main() -> unknown {
+    Extract@spec(text = "hello").build_request()
+}
+```
+
+[#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+## Configure native request deadlines and schema attempts
+
+OpenAI, Anthropic, and Vertex clients support total-request and time-to-first-token deadlines on the native runtime. Configure schema repair attempts on `ai.Agent`. Browser SSE deadlines are not enforced by this change.
+
+```baml
+client Timed = openai.ResponsesClient.new(
+    model = "gpt-4o-mini",
+    request_timeout_ms = 30000,
+    time_to_first_token_timeout_ms = 5000,
+)
+function main() -> ai.Agent {
+    ai.Agent.new(client = Timed, schema_attempts = 3)
+}
+```
+
+[#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+## Default nullable Python model fields to None
+
+Generated Python models default nullable class fields to None and ignore unknown fields. Nullable function parameters still require an argument unless the BAML function declares a default.
+
+```python
+# Given a generated Record class with a nullable label field:
+from baml_sdk import Record
+
+record = Record()
+assert record.label is None
+```
+
+[#4459](https://github.com/BoundaryML/baml/pull/4459)
+
+## Inspect class values through reflection
+
+Narrow an opaque class value to `reflect.AnyClass`. Read fields and inspect their metadata without knowing the class at compile time. The API is read-only. Bound field handles expose `value<T>()`.
+
+```baml
+class Record { label: string }
+function main() -> string? {
+    let opaque: unknown = Record { label: "hello" };
+    let record: reflect.AnyClass = opaque else { return null; };
+    record.get_field("label")?.value<string>()
+}
+```
+
+[#4491](https://github.com/BoundaryML/baml/pull/4491), [#4493](https://github.com/BoundaryML/baml/pull/4493)
+
+## Use unreflect in nested type expressions
+
+`unreflect(expr)` can appear inside local type expressions. Item signatures still reject it because they have no body scope to own the runtime type. Name the runtime type first when it would escape through a result or thrown value.
+
+```baml
+function describe<T>() -> string { reflect.Type.of<T>().to_string() }
+function main() -> string {
+    let t = reflect.Type.of<string>();
+    describe<unreflect(t)[]>()
+}
+```
+
+[#4574](https://github.com/BoundaryML/baml/pull/4574)
+
+## Use truthiness in conditions
+
+Conditions and logical operators accept truthy and falsy values. Null, false, numeric zero, empty strings, empty containers, and empty bytes are falsy. Logical operators still return bool. A truthy nullable-string condition narrows the value to string. Strings also gain `is_empty()`.
+
+```baml
+function greet(name: string?) -> string {
+    if (name) { `Hello ${name}` } else { "Hello" }
+}
+function main() -> bool {
+    greet("") == "Hello" && "".is_empty() && !0
+}
+```
+
+[#4498](https://github.com/BoundaryML/baml/pull/4498)
+
+## Call interface members explicitly
+
+Use `(Type as Interface).member` to select an implementation. `Interface.instance_method(instance)` infers the implementing type.
+
+```baml
+interface Label {
+    function label(self) -> string throws never
+}
+class Item {
+    implements Label {
+        function label(self) -> string { "item" }
+    }
+}
+function main() -> string {
+    Label.label(Item {})
+}
+```
+
+[#4500](https://github.com/BoundaryML/baml/pull/4500)
+
+## Infer stored lambda parameters from later calls
+
+A stored lambda can infer an omitted parameter type from its uses.
+
+```baml
+function main() -> int {
+    let twice = (x) -> { x + x };
+    twice(3)
+}
+```
+
+[#4599](https://github.com/BoundaryML/baml/pull/4599)
+
+## Wrap unknown errors while retaining their cause
+
+`UnknownError.from<T>()` preserves known errors and avoids wrapping an error twice. `with_message<T>()` adds context while retaining the original cause and stack trace.
+
+```baml
+function risky() -> int { throw "failed"; }
+function main() -> int throws baml.errors.UnknownError {
+    risky() catch_all (e) {
+        _ => throw baml.errors.UnknownError.from<never>(e),
+    }
+}
+```
+
+[#4441](https://github.com/BoundaryML/baml/pull/4441)
+
+## Limit and skip iterator elements
+
+Iterators gain `take`, `skip`, `take_while`, and `skip_while`. These adapters are lazy. `take` can bound an infinite iterator before collection.
+
+```baml
+function main() -> int[] {
+    [1, 2, 3, 4].iter().skip(1).take(2).collect()
+}
+```
+
+[#4510](https://github.com/BoundaryML/baml/pull/4510)
+
+## Choose the random generator for primitive values
+
+`int.random()`, `float.random()`, and `bigint.random()` accept an optional `rng`. `bool.random()` is new and accepts the same option.
+
+```baml
+function main() -> bool {
+    let rng = baml.random.Xoshiro256PlusPlus.new();
+    bool.random(rng = rng)
+}
+```
+
+[#4135](https://github.com/BoundaryML/baml/pull/4135)
+
+## Share I/O code across readers and writers
+
+Files, TCP streams, and process pipes implement `baml.io.Read` and `baml.io.Write`. Readers share `bytes()` and `text()`. Writers share `write()`, which retries partial writes until all bytes are accepted. Byte buffers gain `index_of()` for locating a byte.
+
+```baml
+function copy(reader: baml.io.Read, writer: baml.io.Write) -> int {
+    let written = writer.write(reader.bytes());
+    writer.flush();
+    written
+}
+function newline_offset(buffer: uint8array) -> int? { buffer.index_of(10) }
+```
+
+[#4606](https://github.com/BoundaryML/baml/pull/4606)
+
+## Use throwing expressions in prompts
+
+Prompt interpolation can call functions that throw. Rendering failures surface as `ai.errors.PromptRenderError`.
+
+```baml
+function encode(value: unknown) -> string { baml.json.to_string(value) }
+function Extract(value: unknown) -> string {
+    client: "openai/gpt-4o-mini"
+    prompt: `Summarize ${encode(value)}. ${ctx.output_format()}`
+}
+```
+
+[#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+# Breaking changes
+
+## Remove output types from Agent and Runner
+
+`ai.Agent` is no longer generic. `ai.Runner` now puts `Out` on its `run` method and returns `ai.RunResult<Out>`. Custom runner implementations must move their output type parameter to the method and declare their associated `Error`.
+
+Before:
+
+```baml
+ai.Agent<string>.new()
+// Old custom implementations targeted ai.Runner<Out>.
+```
+
+After:
+
+```baml
+// Construct the default agent without an output type argument.
+function agent() -> ai.Agent { ai.Agent.new() }
+// New custom-runner method contract:
+interface CustomRunner {
+    type Error = never
+    function run<Out>(self, spec: ai.FunctionSpec<Out>) -> ai.RunResult<Out> throws Self.Error
+}
+```
+
+[#4570](https://github.com/BoundaryML/baml/pull/4570), [#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+## Handle batches from TurnStream.next()
+
+Low-level `ai.stream.TurnStream.next()` returns `string[] | ai.stream.Done`. Iterate the returned array to process individual deltas. High-level streams continue to return parsed partial values.
+
+Before:
+
+```baml
+while let delta: string = stream.next() { log.info(delta); }
+```
+
+After:
+
+```baml
+function consume(stream: ai.stream.TurnStream) -> void {
+    while let batch: string[] = stream.next() {
+        for (let delta in batch) { log.info(delta); }
+    }
+}
+```
+
+[#4604](https://github.com/BoundaryML/baml/pull/4604)
+
+## Use the reflect root package
+
+Replace `baml.reflect.*` with `reflect.*`. Replace the bare runtime `type` value type with `reflect.Type`. `AnyClass` and `AnyFunction` also move from `baml` into `reflect`.
+
+Before:
+
+```baml
+function runtime_type<T>() -> type { type.of<T>() }
+function package() -> baml.reflect.Package { baml.reflect.Package.current() }
+```
+
+After:
+
+```baml
+function runtime_type<T>() -> reflect.Type { reflect.Type.of<T>() }
+function package() -> reflect.Package { reflect.Package.current() }
+```
+
+[#4543](https://github.com/BoundaryML/baml/pull/4543), [#4580](https://github.com/BoundaryML/baml/pull/4580)
+
+## Convert reflection views explicitly
+
+Reflection kind views are wrappers. They are no longer subtypes of `reflect.Type`. Use `as_type()` when an API needs the underlying type.
+
+Before:
+
+```baml
+let view = reflect.Type.of<Point>().as_class() ?? throw "not a class";
+let t: reflect.Type = view;
+```
+
+After:
+
+```baml
+class Point { x: int }
+function main() -> reflect.Type {
+    let view = reflect.Type.of<Point>().as_class() ?? throw "not a class";
+    view.as_type()
+}
+```
+
+[#4580](https://github.com/BoundaryML/baml/pull/4580)
+
+## Remove generic arguments from JSON serialization
+
+`to_string` and `to_json` now inspect the runtime value, including values typed as `unknown`. Remove explicit type arguments. Replace `encode` with `to_string`. `from_string<T>` remains generic.
+
+Before:
+
+```baml
+baml.json.to_string<unknown>(value)
+baml.json.to_json<unknown>(value)
+baml.json.encode(value)
+```
+
+After:
+
+```baml
+function main() -> string {
+    let value: unknown = { "count": 1 };
+    baml.json.to_string(value)
+}
+```
+
+[#4601](https://github.com/BoundaryML/baml/pull/4601)
+
+## Replace hash string literals
+
+Hash-delimited strings are rejected throughout BAML. Use quoted strings for plain text or backticks for interpolation. Rewrite Jinja expressions as BAML expressions.
+
+Before:
+
+```baml
+function greeting(name: string) -> string { #"Hello {{ name }}"# }
+```
+
+After:
+
+```baml
+function greeting(name: string) -> string { `Hello ${name}` }
+```
+
+[#4565](https://github.com/BoundaryML/baml/pull/4565)
+
+## Replace legacy declarative test blocks
+
+Write tests as expression bodies. Call the function and assert on its result inside the test.
+
+Before:
+
+```baml
+test IdentityCase {
+    functions [Identity]
+    args { value 1 }
+}
+```
+
+After:
+
+```baml
+function Identity(value: int) -> int { value }
+test "identity" { assert.equal(Identity(1), 1); }
+```
+
+[#4602](https://github.com/BoundaryML/baml/pull/4602)
+
+## Call ctx.output_format()
+
+Use `ctx.output_format()` in prompts. It also accepts output-format options such as prefixes, class hoisting, enum formatting, map style, and the null spelling.
+
+Before:
+
+```baml
+prompt: `${text}
+${ctx.output_format}`
+```
+
+After:
+
+```baml
+function Extract(text: string) -> string {
+    client: "openai/gpt-4o-mini"
+    prompt: `${text}
+${ctx.output_format(prefix = null, render_null_as = "nil")}`
+}
+```
+
+[#4567](https://github.com/BoundaryML/baml/pull/4567)
+
+## Update generated SDK paths
+
+With no `output_dir`, generators write `baml_sdk` next to `baml.toml`. C# now uses the same `baml_sdk` directory name. Update build includes and scripts. An explicit manifest `output_dir` still names the parent directory.
+
+Before:
+
+```toml
+# Former default: ../baml_sdk
+# Former C# directory name: baml_client
+```
+
+After:
+
+```toml
+# Restore the former parent-directory location when needed.
+[generator.python]
+output_type = "python/pydantic"
+naming_convention = "preserve-case"
+output_dir = ".."
+# Result: ../baml_sdk relative to baml.toml.
+# C# project references must likewise point to baml_sdk instead of baml_client.
+```
+
+[#4522](https://github.com/BoundaryML/baml/pull/4522), [#4535](https://github.com/BoundaryML/baml/pull/4535)
+
+## Set the test timeout explicitly for long tests
+
+Tests now time out after 300,000 ms by default. Raise `BAML_TEST_TIMEOUT_MS` for tests that intentionally take longer.
+
+Before:
+
+```sh
+baml test  # Previously no per-test deadline.
+```
+
+After:
+
+```sh
+BAML_TEST_TIMEOUT_MS=900000 baml test
+```
+
+[#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+## Migrate file, socket, and process-pipe I/O
+
+Reads now take a byte limit and return null at EOF. Replace file.read_bytes with file.read and file.write_bytes with file.write. Process stdin is a WritePipe: replace write_stdin and close_stdin with stdin.write and stdin.close. TCP read/write no longer accept per-call timeout parameters; use baml.future.with_timeout.
+
+Before:
+
+```baml
+process.write_stdin(text)
+process.close_stdin()
+let chunk = socket.read(timeout = baml.time.Duration.from_milliseconds(5000))
+```
+
+After:
+
+```baml
+function send(process: baml.sys.Process, text: string) -> void {
+    process.stdin.write(text);
+    process.stdin.close();
+}
+function receive(socket: baml.net.TcpStream) -> uint8array? {
+    baml.future.with_timeout(
+        baml.time.Duration.from_milliseconds(5000),
+        () -> uint8array? { socket.read(65536) },
+    )
+}
+```
+
+[#4606](https://github.com/BoundaryML/baml/pull/4606)
+
+## Configure shutdown waits for background work
+
+CLI shutdown now allows 15 seconds for remaining background futures before cancelling and abandoning them. Set BAML_SHUTDOWN_GRACE_MS=0 to restore an unlimited wait. Explicitly await or clean up background work when it must complete.
+
+Before:
+
+```sh
+baml run main  # Previously waited indefinitely for remaining futures.
+```
+
+After:
+
+```sh
+BAML_SHUTDOWN_GRACE_MS=0 baml run main
+```
+
+[#4541](https://github.com/BoundaryML/baml/pull/4541)
+
+# Bug fixes
+
+- **Load the Node bridge on Alpine Linux.** The x86_64 and aarch64 musl Node addons now link against musl and load on Alpine. The PR verified both architectures with fixed and unfixed builds. This user-visible fix is implemented entirely in a GitHub workflow. ([#4502](https://github.com/BoundaryML/baml/pull/4502))
+- **Show BAML logs during CLI execution.** `baml run` surfaces `log.*` events and respects `--log` and `BAML_LOG`. The test command accepts the unified log option. This does not establish that packed-binary logging or `--log-file` is fixed. ([#4409](https://github.com/BoundaryML/baml/pull/4409))
+- **Explain waits during shutdown.** CLI shutdown reports active futures and supports cancellation. Leaked-future cleanup no longer leaves completed tests waiting indefinitely. ([#4408](https://github.com/BoundaryML/baml/pull/4408), [#4541](https://github.com/BoundaryML/baml/pull/4541))
+- **Reject invalid runtime compilation boundaries.** Indirect calls that need unsupported runtime type checks now produce E0010. Runtime-created types no longer leak hidden synthetic names into source diagnostics. ([#4460](https://github.com/BoundaryML/baml/pull/4460))
+- **Diagnose unknown member access.** Calling a nonexistent member on an `unknown` receiver produces E0007 before execution. ([#4466](https://github.com/BoundaryML/baml/pull/4466))
+- **Match numeric literal patterns by membership.** Literal patterns distinguish `1`, `1.0`, and `1n`. Dense integer matches no longer crash on a float. Literal aliases match their value instead of every value of the base type. ([#4478](https://github.com/BoundaryML/baml/pull/4478))
+- **Remove redundant formatter parentheses.** `baml fmt` removes unnecessary parentheses in binary chains, call arguments, postfix receivers, and unary operands. It keeps parentheses needed for meaning or comments. ([#4489](https://github.com/BoundaryML/baml/pull/4489), [#4541](https://github.com/BoundaryML/baml/pull/4541))
+- **Preserve map mutations across loop calls.** A map created before a loop retains changes made by callees in successive iterations. ([#4467](https://github.com/BoundaryML/baml/pull/4467))
+- **Report unsupported LLM output schemas.** Non-data output schemas produce structured errors rather than crashes or silently incomplete schemas. Realized generic output planning is finite and preserves supported schemas. ([#4470](https://github.com/BoundaryML/baml/pull/4470), [#4459](https://github.com/BoundaryML/baml/pull/4459))
+- **Diagnose invalid reflected generic extraction.** Extracting an unspecialized generic function reports a diagnostic instead of returning null silently. Generic specialization is not available in the final release. ([#4473](https://github.com/BoundaryML/baml/pull/4473))
+- **Reject falling-through let-else branches.** A `let ... else` branch must diverge. Invalid branches produce E0113, including loops that can break back into the surrounding function. Invalid primitive companion types also receive source diagnostics. ([#4491](https://github.com/BoundaryML/baml/pull/4491), [#4493](https://github.com/BoundaryML/baml/pull/4493))
+- **Compile loops over inferred iterator results.** Loops over joined map results and `Iterable`-bounded generics no longer abort compilation. ([#4490](https://github.com/BoundaryML/baml/pull/4490))
+- **Retain generic arguments in optional calls.** `x?.method<T>()` carries its type arguments to the method and no longer fails inside the VM. ([#4495](https://github.com/BoundaryML/baml/pull/4495))
+- **Preserve runtime definitions and reflected metadata.** Runtime class and enum definitions survive interface dispatch and nested reflection views. Reflected declarations preserve field metadata, docstrings, and declaration order. ([#4501](https://github.com/BoundaryML/baml/pull/4501), [#4583](https://github.com/BoundaryML/baml/pull/4583))
+- **Preserve runtime type identity through dispatch.** Runtime-created and runtime-compiled types keep their identity inside interface implementations. Equality checks and maps keyed by these types remain consistent. ([#4516](https://github.com/BoundaryML/baml/pull/4516), [#4536](https://github.com/BoundaryML/baml/pull/4536))
+- **Prevent runtime types from escaping unnamed.** Inline runtime type arguments that escape through constructed result types, thrown types, or optional chains produce E0168 with guidance to name the type first. ([#4518](https://github.com/BoundaryML/baml/pull/4518), [#4530](https://github.com/BoundaryML/baml/pull/4530))
+- **Call methods on top-level bindings.** Methods on top-level `let` and `client` bindings receive the correct receiver. Session-bound calls keep their structured errors instead of replacing them with VM failures. ([#4529](https://github.com/BoundaryML/baml/pull/4529))
+- **Type-check Session assignments.** Assigning to a Session binding must match its declared type. Invalid assignments fail during compilation. Redeclaring a binding can establish a new type. ([#4531](https://github.com/BoundaryML/baml/pull/4531))
+- **Validate generator naming conventions.** Unsupported generator naming conventions produce E0019 at `baml.toml`. Go and C# require `language`; other targets require `preserve-case`. ([#4526](https://github.com/BoundaryML/baml/pull/4526))
+- **Preserve reassigned values across branches and loops.** Short-circuit expressions and branch-assigned locals retain their values without leaking operands or hanging later loop iterations. ([#4508](https://github.com/BoundaryML/baml/pull/4508), [#4544](https://github.com/BoundaryML/baml/pull/4544))
+- **Honor array annotations in match coverage.** Match arms annotated with `int[]` or `string[]` correctly refine a union of arrays. ([#4547](https://github.com/BoundaryML/baml/pull/4547))
+- **Avoid compiler failures in local runtime-type calls.** Generic calls involving local runtime type bindings lower without the previous internal compiler failure. Context-typed lambda signatures also infer correctly. Malformed diagnostic fragments fall back to plain text. ([#4541](https://github.com/BoundaryML/baml/pull/4541))
+- **Locate unresolved-type diagnostics correctly.** Undefined types produce diagnostics anchored to the owning signature or body. Diagnostic rendering no longer panics or points at an unrelated expression. ([#4566](https://github.com/BoundaryML/baml/pull/4566))
+- **Truncate overflowing integer left shifts.** Integer left shifts truncate at the 63-bit integer width instead of panicking on overflow. ([#4135](https://github.com/BoundaryML/baml/pull/4135))
+- **Diagnose untyped empty containers.** Empty arrays and maps with no inferable element type produce E0155. Add a type annotation or supply contextual typing. ([#4573](https://github.com/BoundaryML/baml/pull/4573))
+- **Keep editor results tied to the current document.** The language server rejects stale background results and uses unsaved editor buffers during project discovery. File and workspace changes update project ownership and diagnostics. ([#4581](https://github.com/BoundaryML/baml/pull/4581))
+- **Reject incompatible compiler artifacts early.** Versioned bytecode and package artifacts validate their format, compiler fingerprint, and checksum before decoding. Canary or development builds with mismatched fingerprints report an actionable error. Regenerate the SDK and use a matching bridge. ([#4568](https://github.com/BoundaryML/baml/pull/4568))
+- **Avoid Session helper-name collisions.** Generated Session evaluation helpers no longer collide with user-defined binding names. ([#4571](https://github.com/BoundaryML/baml/pull/4571))
+- **Keep reflected container and schema identities intact.** Empty runtime containers preserve their original type identity. Standalone rendered schemas include required static dependencies. Conflicting same-name declarations produce an error; equivalent ones fold together. ([#4577](https://github.com/BoundaryML/baml/pull/4577))
+- **Retain runtime evaluation errors.** Session evaluation and runtime compilation preserve original diagnostics and structured causes. ([#4583](https://github.com/BoundaryML/baml/pull/4583))
+- **Validate reflect.call_any results.** `reflect.call_any` checks the returned value against the requested result type. A mismatch raises `reflect.InvalidArgumentError` at the call boundary. ([#4600](https://github.com/BoundaryML/baml/pull/4600))
+- **Preserve host media and prompt rendering.** Optional media arrays cross the host boundary correctly. Host-provided media appears in rendered requests. Output-format layout and role-edge whitespace match the migration parity fixtures. ([#4604](https://github.com/BoundaryML/baml/pull/4604))
+- **Preserve valid optional class responses.** Omitting an optional nested class field no longer causes a valid containing optional object to become null. Regression coverage exercises both OpenAI Chat and Responses ingestion. ([#4612](https://github.com/BoundaryML/baml/pull/4612))
+- **Require values for required class fields.** Class constructors report E0001 for omitted required fields. Supply every required value or make the field nullable. An `unknown` field still requires an explicit value. ([#4619](https://github.com/BoundaryML/baml/pull/4619))
+- **Specialize generic function values before storing them.** A stored function value needs a concrete signature. Use `identity<string>` or annotate the binding with a concrete function type. Direct generic calls can still infer arguments independently. ([#4621](https://github.com/BoundaryML/baml/pull/4621))
+- **Reject imprecise throws unknown declarations.** Functions that do not throw, or only throw a narrower type, report E0097 for `throws unknown`. Remove the clause or give a precise bound. Real unknown error boundaries remain supported. ([#4593](https://github.com/BoundaryML/baml/pull/4593))
+- **Preserve Python values, cancellation, and typed provider errors.** Generated Python models preserve concrete union values and stream cancellation. Provider errors retain typed failure information, including `FinishReasonError`. Streaming retry, fallback, and round-robin clients can recover before the first text delta. ([#4459](https://github.com/BoundaryML/baml/pull/4459))
+- **Restore HTTP in CLI and playground execution.** HTTP operations work again in baml run and the playground because their runtime includes the HTTP implementation. ([#4609](https://github.com/BoundaryML/baml/pull/4609))

--- a/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
+++ b/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
@@ -214,7 +214,9 @@ Update type annotations, constructors, catches, and generated-SDK references to 
 | `baml.spawn.SpawnParams<T, E>` | `baml.spawn.Params<T, E>` |
 | `baml.json.JsonParseError`, `JsonDecodeError`, `JsonSerializationError`, `JsonPathError` | `baml.json.ParseError`, `DecodeError`, `SerializationError`, `PathError` |
 | `baml.toml.TomlParseError` | `baml.toml.ParseError` |
-| `baml.yaml.YamlParseError` | `baml.yaml.ParseError` | ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+| `baml.yaml.YamlParseError` | `baml.yaml.ParseError` |
+
+Source: [#4725](https://github.com/BoundaryML/baml/pull/4725).
 
 Before:
 

--- a/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
+++ b/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
@@ -4,7 +4,7 @@ description: Bound LLM spec calls, more float math, editor source navigation, an
 slug: baml-0.19.0
 date: 2026-09-08
 tags: ['Release']
-isPublished: false
+isPublished: true
 ---
 
 Thanks to everyone who contributed! Special thanks to [@ritunjaym](https://github.com/ritunjaym) for the float methods and contributor documentation.

--- a/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
+++ b/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
@@ -95,7 +95,7 @@ The PR’s audit of 246 pre-existing bytecode snapshots counted 99,860 → 93,98
 
 ## Use @ projections in BAML source
 
-Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Stream directly from the function rather than calling `stream()` on a bound spec. ([#4623](https://github.com/BoundaryML/baml/pull/4623))
+Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Generated spec and stream companions are also omitted from reflection and function listings. ([#4623](https://github.com/BoundaryML/baml/pull/4623))
 
 Before:
 

--- a/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
+++ b/typescript2/app-website/blog-releases/2026-09-08-baml-0.19.0.md
@@ -1,0 +1,454 @@
+---
+title: BAML 0.19.0
+description: Bound LLM spec calls, more float math, editor source navigation, and migrations for standard-library names and total ordering.
+slug: baml-0.19.0
+date: 2026-09-08
+tags: ['Release']
+isPublished: false
+---
+
+Thanks to everyone who contributed! Special thanks to [@ritunjaym](https://github.com/ritunjaym) for the float methods and contributor documentation.
+
+# Features
+
+## Call and parse bound LLM specifications
+
+A bound `ai.FunctionSpec<Out>` now exposes `call()` and `parse()`. Use `call(client = ..., on_event = ...)` to run it. Use `parse()` to turn an existing model reply into its output type. The example parses locally without calling a model. ([#4623](https://github.com/BoundaryML/baml/pull/4623))
+
+```baml
+class Answer { value: int }
+function Extract(text: string) -> Answer {
+    client: "openai/gpt-4o-mini"
+    prompt: `Extract from ${text}. ${ctx.output_format()}`
+}
+function main() -> Answer {
+    let spec = Extract@spec("value is 42");
+    spec.parse(`{"value": 42}`)
+}
+```
+
+## More float math and range constants
+
+Floats gain `exp`, `ln`, `log2`, `log10`, `cbrt`, and `signum`. `float.max_finite()`, `float.min_finite()`, and `float.epsilon()` expose the finite range and machine epsilon. `min_finite()` is the most negative finite value. `cbrt()` accepts negative inputs. `signum()` returns ±1.0, including for signed zero; NaN returns 1.0. Transcendental results have no cross-platform accuracy guarantee. ([#4751](https://github.com/BoundaryML/baml/pull/4751))
+
+```baml
+function main() -> bool {
+    let scale = (2.0).exp().ln();
+    let cube_root = (-8.0).cbrt();
+    let negative_sign = (-0.0).signum();
+    assert.approx_equal(scale, 2.0, 0.000001);
+    assert.approx_equal(cube_root, -2.0, 0.000001);
+    assert.approx_equal((8.0).log2(), 3.0, 0.000001);
+    assert.approx_equal((1000.0).log10(), 3.0, 0.000001);
+    negative_sign == -1.0 && float.epsilon() > 0.0
+        && float.min_finite() < 0.0 && float.max_finite() > 0.0
+}
+```
+
+## Infer lambda arguments through a union
+
+A lambda can infer its parameter types from a union with exactly one callable alternative. For example, a parameter accepting either a string or a callback can supply the callback’s input type. Unions with multiple callable alternatives still need disambiguation. ([#4646](https://github.com/BoundaryML/baml/pull/4646))
+
+```baml
+class Box { text: string }
+function accept(value: string | ((Box) -> string throws never)) -> string {
+    match (value) {
+        string => value,
+        _ => value(Box { text: "hello" }),
+    }
+}
+function main() -> string {
+    accept((box) -> { box.text.to_upper_case() })
+}
+```
+
+## Install the matching agent skill offline
+
+`baml agent install` installs the skill bundled with the selected toolchain. It no longer fetches the skill from a separate GitHub repository. The skill records its exact toolchain version. ([#4625](https://github.com/BoundaryML/baml/pull/4625))
+
+```sh
+baml agent install
+```
+
+## Browse standard-library source in your editor
+
+Go to Definition opens the toolchain’s embedded standard-library source in read-only documents in VS Code and PromptFiddle. Hover, highlighting, symbols, and further navigation work inside those documents. `baml ide install` no longer needs to extract a local source copy. ([#4777](https://github.com/BoundaryML/baml/pull/4777))
+
+## Read the new developer guide
+
+The [developer documentation portal](https://developer.boundaryml.com) brings the language guide, tutorials, TypeScript bridge guidance, search, and light/dark themes together. BAML examples come from a shared source catalog checked with a selected compiler. ([#4727](https://github.com/BoundaryML/baml/pull/4727), [#4732](https://github.com/BoundaryML/baml/pull/4732), [#4733](https://github.com/BoundaryML/baml/pull/4733))
+
+## Find references for your exact toolchain
+
+Browse published versions in the [package reference](https://developer.boundaryml.com/baml/packages) and [CLI reference](https://developer.boundaryml.com/cli). Search includes generated declarations and members. Type links stay on the selected version, and members have copyable declarations and links. New reference snapshots become available through release publication. ([#4730](https://github.com/BoundaryML/baml/pull/4730), [#4762](https://github.com/BoundaryML/baml/pull/4762), [#4764](https://github.com/BoundaryML/baml/pull/4764))
+
+## Browse releases alongside articles
+
+Release notes now appear in the [blog’s release filter](https://boundaryml.com/blog?tags=release). Both product and developer-documentation changelog links lead to the release history. ([#4743](https://github.com/BoundaryML/baml/pull/4743), [#4783](https://github.com/BoundaryML/baml/pull/4783))
+
+## Generate smaller optimized bytecode
+
+The PR’s audit of 246 pre-existing bytecode snapshots counted 99,860 → 93,984 displayed instructions, about 5.9% fewer. At O2, a plain null-coalescing expression shrank from 9 to 4 instructions, and a chained AND from 8 to 6. These are static instruction counts, include test and standard-library scaffolding, and are not a throughput measurement. ([#4759](https://github.com/BoundaryML/baml/pull/4759))
+
+
+# Breaking changes
+
+## Use @ projections in BAML source
+
+Use `Fn@spec(...)` and `Fn@stream(...)` in BAML source. Compiler-generated `$spec` and `$stream` callables are no longer exposed there. The generated TypeScript SDK still uses `Fn$stream`; Python keeps its `Fn_stream` exports. Stream directly from the function rather than calling `stream()` on a bound spec. ([#4623](https://github.com/BoundaryML/baml/pull/4623))
+
+Before:
+
+```baml
+class Answer { text: string }
+function Extract(text: string) -> Answer {
+    client: "openai/gpt-4o-mini"
+    prompt: `Summarize ${text}. ${ctx.output_format()}`
+}
+function make_stream() -> ai.stream.Stream<Answer$stream?, Answer> {
+    Extract$stream("hello")
+}
+```
+
+After:
+
+```baml
+class Answer { text: string }
+function Extract(text: string) -> Answer {
+    client: "openai/gpt-4o-mini"
+    prompt: `Summarize ${text}. ${ctx.output_format()}`
+}
+function make_stream() -> ai.stream.Stream<Answer$stream?, Answer> {
+    Extract@stream("hello")
+}
+```
+
+## Rename the request client override
+
+The named argument on `FunctionSpec.build_request()` is now `client`, replacing `override_client`. ([#4623](https://github.com/BoundaryML/baml/pull/4623))
+
+Before:
+
+```baml
+client Alternate = openai.ResponsesClient.new(model = "gpt-4o-mini")
+function Extract() -> string {
+    client: "openai/gpt-4o-mini"
+    prompt: `Say hello. ${ctx.output_format()}`
+}
+function main() -> baml.http.Request {
+    Extract@spec().build_request(override_client = Alternate)
+}
+```
+
+After:
+
+```baml
+client Alternate = openai.ResponsesClient.new(model = "gpt-4o-mini")
+function Extract() -> string {
+    client: "openai/gpt-4o-mini"
+    prompt: `Say hello. ${ctx.output_format()}`
+}
+function main() -> baml.http.Request {
+    Extract@spec().build_request(client = Alternate)
+}
+```
+
+## Make shared union members explicit
+
+Same-named fields or methods on unrelated union arms no longer create a shared API, even when their types match. Narrow the union before access, or declare the shared member on one interface implemented by every arm. ([#4611](https://github.com/BoundaryML/baml/pull/4611))
+
+Before:
+
+```baml
+class Cat { name: string }
+class Dog { name: string }
+function name(pet: Cat | Dog) -> string { pet.name }
+```
+
+After:
+
+```baml
+class Cat { name: string }
+class Dog { name: string }
+function name(pet: Cat | Dog) -> string {
+    match (pet) {
+        Cat => pet.name,
+        Dog => pet.name,
+    }
+}
+```
+
+## Refresh the skill before agent authoring commands
+
+Detected coding agents must have a BAML skill matching the selected toolchain before authoring commands run. Install the skill again after changing toolchains. Human sessions warn by default. `--agent-skill-check` and `BAML_AGENT_SKILL_CHECK` accept `auto`, `require`, `warn`, and `off`; installation and management commands remain available. ([#4723](https://github.com/BoundaryML/baml/pull/4723))
+
+Before:
+
+```sh
+baml check
+```
+
+After:
+
+```sh
+baml agent install
+baml check
+```
+
+## Use shorter standard-library type names
+
+Update type annotations, constructors, catches, and generated-SDK references to the names below. Regenerate SDKs with the new toolchain.
+
+| 0.18.0 | 0.19.0 |
+| --- | --- |
+| `anthropic.AnthropicClient` | `anthropic.Client` |
+| `google.GoogleClient` | `google.GeminiClient` |
+| `ai.ClientSelector`, `ai.clients.ClientSelector` | `ai.Selector`, `ai.clients.Selector` |
+| `ai.stream.StreamEvent` | `ai.stream.Event` |
+| `ai.mcp.McpConnection` | `ai.mcp.Connection` |
+| `baml.csv.CsvError`, `CsvErrorKind`, `CsvPosition`, `CsvValue` | `baml.csv.Error`, `ErrorKind`, `Position`, `Value` |
+| `baml.csv.CsvReader`, `CsvRecord`, `CsvRows<T>`, `CsvWriter` | `baml.csv.Reader`, `Record`, `Rows<T>`, `Writer` |
+| `baml.errors.ErrorContext` | `baml.errors.Context` |
+| `baml.future.FutureState` | `baml.future.State` |
+| `baml.host.HostValue` | `baml.host.Value` |
+| `baml.spawn.SpawnParams<T, E>` | `baml.spawn.Params<T, E>` |
+| `baml.json.JsonParseError`, `JsonDecodeError`, `JsonSerializationError`, `JsonPathError` | `baml.json.ParseError`, `DecodeError`, `SerializationError`, `PathError` |
+| `baml.toml.TomlParseError` | `baml.toml.ParseError` |
+| `baml.yaml.YamlParseError` | `baml.yaml.ParseError` | ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function decode(text: string) -> int throws baml.json.JsonParseError | baml.json.JsonDecodeError {
+    baml.json.from_string<int>(text)
+}
+```
+
+After:
+
+```baml
+function decode(text: string) -> int throws baml.json.ParseError | baml.json.DecodeError {
+    baml.json.from_string<int>(text)
+}
+```
+
+## Use public parsing and testing APIs
+
+Parser caches and polling sentinels are now internal: `baml.sap.ParseCache`, `NoYield`, `baml.csv.CsvNeedData`, `CsvSkip`, and `CsvHeaders` gained underscore-prefixed names. Testing registry execution/selection helpers and pool types also became internal. Use `baml.sap.parse<T>()` or `parse_type()` for parsing, CSV readers for records, and authored `test`/`testset` blocks or the public testing runners. Provider implementation helpers under `*.internal` also dropped provider-name prefixes; those helpers are not stable public APIs. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function main() -> int {
+    let cache = baml.sap.__new_parse_cache<int, int>();
+    baml.sap.__parse_final<int, int>("42", cache)
+}
+```
+
+After:
+
+```baml
+function main() -> int {
+    baml.sap.parse<int>("42")
+}
+```
+
+## Keep panics out of throws clauses
+
+Explicitly throwing a `baml.panics.*` value raises a panic. It no longer contributes to inferred `throws`, and wildcard `catch` or `catch_all` arms skip it. Name a panic type explicitly if you intend to intercept it. Assertions now raise `baml.panics.AssertionFailed` instead of a generic user panic. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function fail() -> int throws baml.panics.AssertionFailed {
+    throw baml.panics.AssertionFailed { message: "failed" };
+}
+function main() -> int {
+    fail() catch (e) { _ => 0 }
+}
+```
+
+After:
+
+```baml
+function fail() -> int throws never {
+    throw baml.panics.AssertionFailed { message: "failed" };
+}
+function main() -> int {
+    fail() catch (e) { baml.panics.AssertionFailed => 0 }
+}
+```
+
+## Handle the updated I/O error contracts
+
+`baml.http.send()` and `fetch_sse()` include `baml.errors.InvalidArgument`. `baml.io.input()` can throw `baml.errors.Io`. Invalid glob patterns throw `ParseError`, while `Glob.matches()` is `throws never`. `File.close()` is idempotent and only declares `Io`; remove `InvalidArgument` from wrappers that declared it solely for close. CSV reader and writer close operations now propagate file-close failures. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function read_pattern(pattern: string) -> baml.glob.Glob throws baml.errors.Io {
+    baml.glob.new(pattern)
+}
+```
+
+After:
+
+```baml
+function read_pattern(pattern: string) -> baml.glob.Glob throws baml.errors.ParseError {
+    baml.glob.new(pattern)
+}
+```
+
+## Remove obsolete catchable runtime error types
+
+`baml.errors.NotImplemented` and `baml.errors.DevOther` were removed. Unsupported runtime capabilities use a panic channel, and runtime invariant failures use internal errors. If your own code threw either removed class, define an application error. Handle only the documented errors from standard-library calls. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function fail() -> never throws baml.errors.NotImplemented {
+    throw baml.errors.NotImplemented { message: "application operation unavailable" };
+}
+```
+
+After:
+
+```baml
+class Unsupported { message: string }
+function fail() -> never throws Unsupported {
+    throw Unsupported { message: "application operation unavailable" };
+}
+```
+
+## Check float division results explicitly
+
+Float division by zero produces infinity or NaN. It no longer raises `DivisionByZero`; integer division still does. Validate the denominator when your application needs to reject zero. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function ratio(value: float, divisor: float) -> float? {
+    (value / divisor) catch (e) { baml.panics.DivisionByZero => null }
+}
+```
+
+After:
+
+```baml
+function ratio(value: float, divisor: float) -> float? {
+    if (divisor == 0.0) { return null; }
+    value / divisor
+}
+```
+
+## Update integer overflow handling
+
+`int.abs()` is now `throws never` and raises `baml.panics.IntegerOverflow` for `int.min_value()`. It no longer throws `InvalidArgument`. Integer left-shift interface calls now match the `<<` operator’s truncation: high bits are discarded, `1 << 62` is `int.min_value()`, and `1 << 63` is zero. Negative shifts still panic. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function magnitude(value: int) -> int? {
+    value.abs() catch (e) { baml.errors.InvalidArgument => null }
+}
+```
+
+After:
+
+```baml
+function magnitude(value: int) -> int? {
+    value.abs() catch (e) { baml.panics.IntegerOverflow => null }
+}
+```
+
+## Omit the time argument to request midnight
+
+`PlainDate.to_plain_datetime()` takes a non-null `PlainTime`. Omit the argument for midnight instead of passing `null`. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+
+Before:
+
+```baml
+function midnight(date: baml.time.PlainDate) -> baml.time.PlainDateTime {
+    date.to_plain_datetime(time = null)
+}
+```
+
+After:
+
+```baml
+function midnight(date: baml.time.PlainDate) -> baml.time.PlainDateTime {
+    date.to_plain_datetime()
+}
+```
+
+## Use Compare and Ordering for sorting
+
+`baml.ops.Compare.cmp()` returns `baml.ops.Ordering.Less`, `Equal`, or `Greater`. It replaces `baml.Comparable.compare()`. Implement `Equals` and `Compare` for custom naturally sorted types. `Compare` supplies `min`, `max`, and `clamp`. `Comparable.CompareError` and `Sortable.SortError` are gone; natural comparison and `sort()` are `throws never`. For fallible ordering, use `sort_by()`, whose callback still propagates its declared errors but now returns `Ordering` rather than int. `sort_by_key()` keys must implement `Compare`. ([#4739](https://github.com/BoundaryML/baml/pull/4739))
+
+Before:
+
+```baml
+function main() -> int[] {
+    let values = [3, 1, 2];
+    values.sort_by((a: int, b: int) -> int { a.compare(b) })
+}
+```
+
+After:
+
+```baml
+function main() -> int[] {
+    let values = [3, 1, 2];
+    values.sort_by((a: int, b: int) -> baml.ops.Ordering { a.cmp(b) })
+}
+```
+
+## Use is_nan instead of non-reflexive equality
+
+Equality is reflexive, including NaN. NaN equals NaN and sorts above every number. Positive and negative zero compare equal. Replace `x != x` NaN checks with `x.is_nan()`, and review logic that relied on IEEE unordered comparisons. ([#4739](https://github.com/BoundaryML/baml/pull/4739))
+
+Before:
+
+```baml
+function missing(value: float) -> bool { value != value }
+```
+
+After:
+
+```baml
+function missing(value: float) -> bool { value.is_nan() }
+function main() -> bool {
+    missing(float.nan()) && float.nan() == float.nan()
+}
+```
+
+## Rebuild compiled artifacts and regenerate SDKs
+
+The compiled artifact ABI moves from 2 to 3 and the cache format from 11 to 12. Rebuild packed applications and regenerate SDKs with the new toolchain. Keep each generated SDK and its bridge on matching versions. ([#4759](https://github.com/BoundaryML/baml/pull/4759))
+
+Before:
+
+```sh
+# Previously generated SDKs and packed artifacts used the 0.18.0 toolchain.
+```
+
+After:
+
+```sh
+baml generate
+# Re-run your project’s baml pack command to rebuild packaged applications.
+```
+
+
+# Bug fixes
+
+- Fixed calls to interface default methods and out-of-body implementations, including methods involving associated types. Calls now use the correct implementation and type arguments. ([#4630](https://github.com/BoundaryML/baml/pull/4630))
+- Unresolved types in required interface method signatures and invalid bounds now produce diagnostics instead of crashing the language server or reaching a later compiler panic. PromptFiddle also shows a clearer message if its language server panics. ([#4686](https://github.com/BoundaryML/baml/pull/4686))
+- Generated TypeScript/web SDKs can initialize under workerd without trapping on module-scope random-number access. ([#4692](https://github.com/BoundaryML/baml/pull/4692))
+- `reflect.Package.compile()` preserves mounted class methods and required/default interface methods. Runtime-compiled code can implement a mounted interface and call mounted methods without namespace-shadowing errors. Calling `to_string()` on reflected types in that code no longer triggers a compiler panic. ([#4714](https://github.com/BoundaryML/baml/pull/4714))
+- The type checker respects associated-type pins inherited through an interface’s `requires` constraints and consistently diagnoses invalid implementation targets. ([#4720](https://github.com/BoundaryML/baml/pull/4720))
+- An early `return` inside a closure is checked against that closure’s return type, rather than the enclosing function’s type. Closure return inference also accounts for explicit and tail returns. ([#4721](https://github.com/BoundaryML/baml/pull/4721))
+- Discarding an expression’s value no longer discards its required effects. Conditional mutations on the right of `&&` or `||` still run, and unused division or indexing still raises catchable panics when it fails. The fixes cover O0, O1, and O2. ([#4759](https://github.com/BoundaryML/baml/pull/4759))
+- The Linux installer selects a compatible GNU wrapper and falls back to musl. Wrapper GNU builds target glibc 2.17 on x86_64 and 2.28 on ARM64; Debian Bookworm and Alpine were covered in the PR. This is an installer/wrapper update delivered alongside the language toolchain, with its own version. ([#4632](https://github.com/BoundaryML/baml/pull/4632))
+- User-facing tracebacks omit standard-library frames, including built-ins implemented in BAML. ([#4725](https://github.com/BoundaryML/baml/pull/4725))
+- Native and web read operations return empty buffers for non-positive byte counts. ([#4725](https://github.com/BoundaryML/baml/pull/4725))

--- a/typescript2/app-website/vercel.json
+++ b/typescript2/app-website/vercel.json
@@ -2,10 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "bash scripts/vercel-build.sh",
   "git": {
-    "deploymentEnabled": {
-      "**": false,
-      "canary": true
-    }
+    "deploymentEnabled": true
   },
   "installCommand": "bash scripts/vercel-install.sh"
 }


### PR DESCRIPTION
Backtests changelog preparation against `baml-language-0.17.0..baml-language-0.18.0` and prepares a BAML 0.19.0 post enabled for website preview for the September 8 Pacific canary cut at `5b398f2b60cfa78258ac9534e8322d056564e85f`.

Stacked on the website highlighting and styling fix in #4788, which should merge first.

The preparation guide is maintained separately in #4784. This PR contains the release posts and their supporting audit artifacts.

## Changes

- 0.18.0 backtest: review 114 PRs, retain 64 PRs in 69 user-facing entries, and prepare 17 notification drafts. Document the omitted Alpine Node bridge fix, a reflection feature removed before release, and migration gaps.
- 0.19.0 preparation: review 74 PRs, retain 25 PRs in 34 entries, and prepare three notification drafts. Include 15 breaking-change entries with migrations.
- Enable website Git deployments for all branches and set the 0.19.0 post to `isPublished: true` for PR preview. Merging into `canary` also makes the post eligible for production publication. Keep the 0.18.0 backtest unpublished with a unique slug and preserve the historical 0.18.0 post. No package releases or notifications are published.

Start with `docs/changelog-backtests/0.18.0/README.md` and `docs/changelog-preparation/0.19.0/README.md`.

## Testing

- Backtest: 22 positive BAML snippets compile on released 0.18.0; nine pure examples execute. Python syntax/models, execution queries, and selected issue reproductions were checked.
- 0.19.0: built the CLI from the pinned source with Rust 1.98.0; all 16 positive BAML examples and 13 old-version migration examples pass; 14 candidate execution probes pass.
- Verified the candidate’s required-skill failure/install/success flow in a temporary project.
- Checked artifact links, fences, publication flags, applicable prek hooks, and `git diff --check`. Validated the updated Vercel JSON and the 0.19.0 publication flag. The moved backtest content is unchanged except its link to the separate guide PR.

Each release directory contains a detailed validation record and limits. SDK/platform matrices and a published 0.19.0 smoke test remain release-time checks. The float PR’s unlinked Discord discussion remains an explicit followup gap.


## Review context carried with the backtest

Two original automated backtest findings now belong to this PR: [the ModelTurn calls-field migration](https://github.com/BoundaryML/baml/pull/4784#discussion_r3963814949) and [the concrete ai.Runner implementation example](https://github.com/BoundaryML/baml/pull/4784#discussion_r3963814956). Their old threads are out of scope for the guide-only #4784.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - BAML 0.19.0 adds float math methods, range constants, improved lambda inference, offline agent installation, editor navigation, a new documentation portal, release filtering, and smaller optimized bytecode.
  - Adds bound function `call()` and `parse()` methods.

- **Breaking Changes**
  - Updates projection syntax, request-building APIs, standard-library names, error behavior, numeric operations, sorting, artifacts, and generated SDK formats.

- **Bug Fixes**
  - Improves diagnostics, SDK initialization, type checking, closures, Linux installer compatibility, tracebacks, runtime compilation, and empty-buffer reads.

- **Documentation**
  - Adds release preparation and backtest documentation, validation records, source coverage, and follow-up materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->