### PR TITLE
chore: when building docs, use the shared rust build cache

### DIFF
--- a/.github/workflows/developer-docs.yml
+++ b/.github/workflows/developer-docs.yml
@@ -11,6 +11,10 @@ on:
       - "typescript2/pnpm-lock.yaml"
       - "typescript2/pnpm-workspace.yaml"
       - "baml_language/**"
+      - ".envrc"
+      - "mise.toml"
+      - "tools/baml-sccache"
+      - ".github/actions/setup-mise/**"
       - ".github/actions/setup-node2/**"
       - ".github/workflows/developer-docs.yml"
       - ".github/workflows/release-baml-language.yml"
@@ -68,6 +72,10 @@ jobs:
               typescript2/pnpm-lock.yaml | \
               typescript2/pnpm-workspace.yaml | \
               baml_language/* | \
+              .envrc | \
+              mise.toml | \
+              tools/baml-sccache | \
+              .github/actions/setup-mise/* | \
               .github/actions/setup-node2/* | \
               .github/workflows/developer-docs.yml | \
               .github/workflows/release-baml-language.yml)
@@ -130,6 +138,14 @@ jobs:
     if: needs.determine-changes.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    env:
+      # .envrc supplies the R2 configuration, with a local cache for secretless PRs.
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CARGO_TERM_COLOR: always
+      RUSTUP_MAX_RETRIES: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -138,11 +154,26 @@ jobs:
       - name: Install Rust toolchain
         working-directory: baml_language
         run: rustup show
-      - name: Cache compiler build
+      - name: Install sccache and direnv
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "sccache direnv"
+      - name: Verify sccache
+        run: sccache --version
+      # Cache Cargo downloads only; .envrc routes compilation through R2 sccache.
+      - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: developer-docs-snippets-${{ hashFiles('typescript2/app-developer-docs/lib/snippets/**/*.ts', 'typescript2/app-developer-docs/scripts/validate-snippets.ts', 'typescript2/app-developer-docs/content/code/**') }}
           workspaces: "baml_language -> target"
+          cache-all-crates: true
+          cache-targets: false
+          save-if: ${{ github.ref == 'refs/heads/canary' }}
+          shared-key: "linux-cargo"
+      - name: Load .envrc with direnv
+        run: |
+          set -euo pipefail
+          direnv allow .envrc
+          direnv export gha >> "$GITHUB_ENV"
       - name: Build the selected BAML CLI
         run: cargo build -p baml_cli --bin baml-cli
         working-directory: baml_language
@@ -153,6 +184,9 @@ jobs:
           BAML_BINARY: ${{ github.workspace }}/baml_language/target/debug/baml-cli
         run: pnpm --filter app-developer-docs docs:snippets:validate
         working-directory: typescript2
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats
 
   database-integration:
     name: Immutable document-store integration


### PR DESCRIPTION
swatinem/rust-cache does not cache enough; our own sccache setup is much more aggressive and effective. Since building docs requires the CLI, use our own sccache instead.