### PR TITLE
chore: migrate Infisical project ID

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,5 @@
 {
-  "workspaceId": "63f942680b94e4248e89eb42",
+  "workspaceId": "bdd280e2-259c-4750-9b16-a8597a67214c",
   "defaultEnvironment": "test",
   "gitBranchToEnvironmentMapping": null
 }

--- a/tools/atb2/run_tests.sh
+++ b/tools/atb2/run_tests.sh
@@ -49,7 +49,7 @@ die() { echo "run_tests: $*" >&2; exit 1; }
 command -v infisical >/dev/null || die "infisical CLI not found — brew install infisical"
 env="${FEEDBACK_INFISICAL_ENV:-dev}"
 # boundary-tools: where FEEDBACK_SUPABASE_*, ATB_SLACK_* and (prod) ATB_POSTHOG_* live.
-# The repo's own .infisical.json points at another workspace.
+# This matches the repo's .infisical.json workspace.
 project_id="${FEEDBACK_INFISICAL_PROJECT_ID:-bdd280e2-259c-4750-9b16-a8597a67214c}"
 project="$project_id"
 # (no arrays: macOS ships bash 3.2, where an empty array trips `set -u`)

--- a/typescript2/app-website/.infisical.json
+++ b/typescript2/app-website/.infisical.json
@@ -1,5 +1,5 @@
 {
   "defaultEnvironment": "test",
   "gitBranchToEnvironmentMapping": null,
-  "workspaceId": "63f942680b94e4248e89eb42"
+  "workspaceId": "bdd280e2-259c-4750-9b16-a8597a67214c"
 }


### PR DESCRIPTION
## Changes

Migrate the root and website Infisical configurations from `63f942680b94e4248e89eb42` to the boundary-tools project, `bdd280e2-259c-4750-9b16-a8597a67214c`. Correct the ATB2 test runner comment to reflect that its explicit default now matches the repository configuration. Default environments and branch mappings remain unchanged.

## Testing

- Parsed both JSON configurations and verified that only `workspaceId` changed.
- Scanned all tracked files and confirmed that no references to the legacy project ID remain.
- Passed `bash -n tools/atb2/run_tests.sh` and `git diff --check`.
- Reviewed the three-line diff. Live secret access was not exercised.
