### PR TITLE
ci: run developer docs through the existing language CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -625,6 +625,16 @@ jobs:
     secrets: inherit
     permissions: write-all
 
+  developer-docs:
+    name: "Developer Docs"
+    uses: ./.github/workflows/developer-docs.reusable.yaml
+    permissions:
+      contents: read
+    secrets:
+      GENERATED_CONTENT_DATABASE_URL: ${{ secrets.GENERATED_CONTENT_DATABASE_URL }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+
   webview-tests:
     name: "Webview Tests"
     needs: determine_changes
@@ -1248,6 +1258,7 @@ jobs:
       - cargo-tests
       - wasm-pack-tests
       - docs
+      - developer-docs
       - webview-tests
       - grammar-tests
       - linguist-compile-gate
@@ -1277,6 +1288,7 @@ jobs:
           echo "| cargo-tests | ${{ needs.cargo-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| wasm-pack-tests | ${{ needs.wasm-pack-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| docs | ${{ needs.docs.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| developer-docs | ${{ needs.developer-docs.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| webview-tests | ${{ needs.webview-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| grammar-tests | ${{ needs.grammar-tests.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| linguist-compile-gate | ${{ needs.linguist-compile-gate.result }} |" >> $GITHUB_STEP_SUMMARY
@@ -1316,6 +1328,7 @@ jobs:
       - cargo-tests
       - wasm-pack-tests
       - docs
+      - developer-docs
       - webview-tests
       - grammar-tests
       - linguist-compile-gate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -670,8 +670,8 @@ jobs:
   developer-docs:
     name: "Developer Docs"
     needs: determine_changes
-    # Push validation has its own entry point in developer-docs.yaml.
-    if: github.event_name != 'push' && needs.determine_changes.outputs.developer_docs == 'true'
+    # Push and manual runs use the entry point in developer-docs.yaml.
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.determine_changes.outputs.developer_docs == 'true'
     uses: ./.github/workflows/developer-docs.reusable.yaml
     with:
       can-use-secrets: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
       codegen: ${{ steps.check_codegen.outputs.changed }}
       # Flag for docs/frontend changes
       docs: ${{ steps.check_docs.outputs.changed }}
+      # Flag for developer documentation and its runtime/build inputs
+      developer_docs: ${{ steps.check_developer_docs.outputs.changed }}
       # Flag for typescript2/webview changes
       webview: ${{ steps.check_webview.outputs.changed }}
       # Flag for typescript2 grammar changes
@@ -206,6 +208,46 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Check if developer docs changed
+        id: check_developer_docs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Capture first so a failed diff fails the job instead of passing silently.
+          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          changed=false
+          while IFS= read -r file; do
+            case "$file" in
+              typescript2/app-developer-docs/* | \
+              typescript2/pkg-grammar/* | \
+              typescript2/package.json | \
+              typescript2/pnpm-lock.yaml | \
+              typescript2/pnpm-workspace.yaml | \
+              baml_language/* | \
+              .envrc | \
+              mise.toml | \
+              tools/baml-sccache | \
+              .github/actions/setup-mise/* | \
+              .github/actions/setup-node2/* | \
+              .github/workflows/developer-docs.reusable.yaml | \
+              .github/workflows/developer-docs.yaml | \
+              .github/workflows/ci.yaml | \
+              .github/workflows/release-baml-language.yml)
+                changed=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Check if webview changed
         id: check_webview
@@ -627,7 +669,12 @@ jobs:
 
   developer-docs:
     name: "Developer Docs"
+    needs: determine_changes
+    # Push validation has its own entry point in developer-docs.yaml.
+    if: github.event_name != 'push' && needs.determine_changes.outputs.developer_docs == 'true'
     uses: ./.github/workflows/developer-docs.reusable.yaml
+    with:
+      can-use-secrets: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -674,13 +674,14 @@ jobs:
     if: github.event_name != 'push' && needs.determine_changes.outputs.developer_docs == 'true'
     uses: ./.github/workflows/developer-docs.reusable.yaml
     with:
-      can-use-secrets: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
+      can-use-secrets: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
     permissions:
       contents: read
+    # Merge groups can include fork code; validate them without credentials.
     secrets:
-      GENERATED_CONTENT_DATABASE_URL: ${{ secrets.GENERATED_CONTENT_DATABASE_URL }}
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+      GENERATED_CONTENT_DATABASE_URL: ${{ github.event_name != 'merge_group' && secrets.GENERATED_CONTENT_DATABASE_URL || '' }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ github.event_name != 'merge_group' && secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID || '' }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ github.event_name != 'merge_group' && secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY || '' }}
 
   webview-tests:
     name: "Webview Tests"

--- a/.github/workflows/developer-docs.reusable.yaml
+++ b/.github/workflows/developer-docs.reusable.yaml
@@ -1,29 +1,17 @@
-name: Developer Docs
+name: Developer Docs (Reusable)
 
 on:
-  pull_request:
-  push:
-    branches: [main, canary]
-    paths:
-      - "typescript2/app-developer-docs/**"
-      - "typescript2/pkg-grammar/**"
-      - "typescript2/package.json"
-      - "typescript2/pnpm-lock.yaml"
-      - "typescript2/pnpm-workspace.yaml"
-      - "baml_language/**"
-      - ".envrc"
-      - "mise.toml"
-      - "tools/baml-sccache"
-      - ".github/actions/setup-mise/**"
-      - ".github/actions/setup-node2/**"
-      - ".github/workflows/developer-docs.yml"
-      - ".github/workflows/release-baml-language.yml"
-  workflow_dispatch:
+  workflow_call:
+    secrets:
+      GENERATED_CONTENT_DATABASE_URL:
+        description: Read-only runtime credential for the published documentation store
+        required: false
+      BAML_SCCACHE_R2_ACCESS_KEY_ID:
+        required: false
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY:
+        required: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
+# The caller owns concurrency so this workflow cannot cancel its parent run.
 permissions:
   contents: read
 
@@ -44,10 +32,10 @@ jobs:
         id: changes
         env:
           ACTOR: ${{ github.actor }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -58,11 +46,13 @@ jobs:
           fi
           echo "can-use-secrets=$can_use_secrets" >> "$GITHUB_OUTPUT"
 
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
             echo "should-run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # Capture first so a failed diff fails the job instead of passing silently.
+          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           should_run=false
           while IFS= read -r file; do
             case "$file" in
@@ -77,13 +67,14 @@ jobs:
               tools/baml-sccache | \
               .github/actions/setup-mise/* | \
               .github/actions/setup-node2/* | \
-              .github/workflows/developer-docs.yml | \
+              .github/workflows/developer-docs.reusable.yaml | \
+              .github/workflows/ci.yaml | \
               .github/workflows/release-baml-language.yml)
                 should_run=true
                 break
                 ;;
             esac
-          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          done <<< "$changed_files"
           echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
 
   quality:
@@ -293,8 +284,8 @@ jobs:
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:4173/cli/$VERSION/commands/not-a-command")" = "404"
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:4173/cli/v0.0.0-missing)" = "404"
 
-  pre-merge-gate:
-    name: Developer Docs Pre-merge Gate
+  checks:
+    name: Developer Docs Checks
     needs:
       - determine-changes
       - quality
@@ -302,7 +293,7 @@ jobs:
       - snippets
       - database-integration
       - production-path
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     runs-on: ubuntu-24.04
     steps:
       - name: Require affected documentation checks

--- a/.github/workflows/developer-docs.reusable.yaml
+++ b/.github/workflows/developer-docs.reusable.yaml
@@ -2,6 +2,11 @@ name: Developer Docs (Reusable)
 
 on:
   workflow_call:
+    inputs:
+      can-use-secrets:
+        description: Whether the caller is trusted to run checks against the published documentation store
+        type: boolean
+        default: true
     secrets:
       GENERATED_CONTENT_DATABASE_URL:
         description: Read-only runtime credential for the published documentation store
@@ -16,71 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  determine-changes:
-    name: Determine documentation changes
-    runs-on: ubuntu-24.04
-    outputs:
-      can-use-secrets: ${{ steps.changes.outputs.can-use-secrets }}
-      should-run: ${{ steps.changes.outputs.should-run }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check documentation and runtime inputs
-        id: changes
-        env:
-          ACTOR: ${{ github.actor }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          can_use_secrets=true
-          if [[ "$EVENT_NAME" == "pull_request" ]] && \
-             { [[ "$HEAD_REPOSITORY" != "$REPOSITORY" ]] || [[ "$ACTOR" == "dependabot[bot]" ]]; }; then
-            can_use_secrets=false
-          fi
-          echo "can-use-secrets=$can_use_secrets" >> "$GITHUB_OUTPUT"
-
-          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Capture first so a failed diff fails the job instead of passing silently.
-          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-          should_run=false
-          while IFS= read -r file; do
-            case "$file" in
-              typescript2/app-developer-docs/* | \
-              typescript2/pkg-grammar/* | \
-              typescript2/package.json | \
-              typescript2/pnpm-lock.yaml | \
-              typescript2/pnpm-workspace.yaml | \
-              baml_language/* | \
-              .envrc | \
-              mise.toml | \
-              tools/baml-sccache | \
-              .github/actions/setup-mise/* | \
-              .github/actions/setup-node2/* | \
-              .github/workflows/developer-docs.reusable.yaml | \
-              .github/workflows/ci.yaml | \
-              .github/workflows/release-baml-language.yml)
-                should_run=true
-                break
-                ;;
-            esac
-          done <<< "$changed_files"
-          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
-
   quality:
     name: Lint, tests, type-check, and build
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -105,8 +47,6 @@ jobs:
 
   authored-content:
     name: Authored content and routes
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -125,8 +65,6 @@ jobs:
 
   snippets:
     name: BAML snippets
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -181,8 +119,6 @@ jobs:
 
   database-integration:
     name: Immutable document-store integration
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should-run == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     services:
@@ -214,10 +150,7 @@ jobs:
 
   production-path:
     name: DB-backed SSR and HTTP contracts
-    needs: determine-changes
-    if: >-
-      needs.determine-changes.outputs.should-run == 'true' &&
-      needs.determine-changes.outputs.can-use-secrets == 'true'
+    if: inputs.can-use-secrets
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
@@ -287,7 +220,6 @@ jobs:
   checks:
     name: Developer Docs Checks
     needs:
-      - determine-changes
       - quality
       - authored-content
       - snippets
@@ -296,35 +228,16 @@ jobs:
     if: always()
     runs-on: ubuntu-24.04
     steps:
-      - name: Require affected documentation checks
+      - name: Require documentation checks
         env:
           AUTHORED_CONTENT_RESULT: ${{ needs.authored-content.result }}
           DATABASE_INTEGRATION_RESULT: ${{ needs.database-integration.result }}
-          DETERMINE_CHANGES_RESULT: ${{ needs.determine-changes.result }}
-          CAN_USE_SECRETS: ${{ needs.determine-changes.outputs.can-use-secrets }}
+          CAN_USE_SECRETS: ${{ inputs.can-use-secrets }}
           PRODUCTION_PATH_RESULT: ${{ needs.production-path.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
-          SHOULD_RUN: ${{ needs.determine-changes.outputs.should-run }}
           SNIPPETS_RESULT: ${{ needs.snippets.result }}
         run: |
           set -euo pipefail
-          if [[ "$DETERMINE_CHANGES_RESULT" != "success" ]]; then
-            echo "::error::Could not determine whether documentation checks are required"
-            exit 1
-          fi
-          if [[ "$SHOULD_RUN" == "false" ]]; then
-            echo "No documentation or BAML language runtime inputs changed"
-            exit 0
-          fi
-          if [[ "$SHOULD_RUN" != "true" ]]; then
-            echo "::error::Documentation change detection returned an invalid result"
-            exit 1
-          fi
-          if [[ "$CAN_USE_SECRETS" != "true" && "$CAN_USE_SECRETS" != "false" ]]; then
-            echo "::error::Pull-request trust detection returned an invalid result"
-            exit 1
-          fi
-
           failed=false
           for result in \
             "$QUALITY_RESULT" \

--- a/.github/workflows/developer-docs.reusable.yaml
+++ b/.github/workflows/developer-docs.reusable.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       can-use-secrets:
-        description: Whether the caller is trusted to run checks against the published documentation store
+        description: Whether the caller is trusted to use the shared cache and published documentation store
         type: boolean
         default: true
     secrets:
@@ -69,8 +69,8 @@ jobs:
     timeout-minutes: 45
     env:
       # .envrc supplies the R2 configuration, with a local cache for secretless PRs.
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ inputs.can-use-secrets && secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID || '' }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ inputs.can-use-secrets && secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY || '' }}
       CARGO_INCREMENTAL: 0
       CARGO_NET_RETRY: 10
       CARGO_TERM_COLOR: always

--- a/.github/workflows/developer-docs.yaml
+++ b/.github/workflows/developer-docs.yaml
@@ -1,0 +1,38 @@
+name: Developer Docs
+
+on:
+  push:
+    branches: [main, canary]
+    paths:
+      - "typescript2/app-developer-docs/**"
+      - "typescript2/pkg-grammar/**"
+      - "typescript2/package.json"
+      - "typescript2/pnpm-lock.yaml"
+      - "typescript2/pnpm-workspace.yaml"
+      - "baml_language/**"
+      - ".envrc"
+      - "mise.toml"
+      - "tools/baml-sccache"
+      - ".github/actions/setup-mise/**"
+      - ".github/actions/setup-node2/**"
+      - ".github/workflows/developer-docs.yaml"
+      - ".github/workflows/developer-docs.reusable.yaml"
+      - ".github/workflows/ci.yaml"
+      - ".github/workflows/release-baml-language.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  developer-docs:
+    name: Developer Docs
+    uses: ./.github/workflows/developer-docs.reusable.yaml
+    secrets:
+      GENERATED_CONTENT_DATABASE_URL: ${{ secrets.GENERATED_CONTENT_DATABASE_URL }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}

--- a/typescript2/app-developer-docs/tests/navigation.test.ts
+++ b/typescript2/app-developer-docs/tests/navigation.test.ts
@@ -164,7 +164,10 @@ test('generated references are live SSR without exhaustive static export', async
       'utf8',
     ),
     readFile(
-      resolve(process.cwd(), '../../.github/workflows/developer-docs.yml'),
+      resolve(
+        process.cwd(),
+        '../../.github/workflows/developer-docs.reusable.yaml',
+      ),
       'utf8',
     ),
     readFile(


### PR DESCRIPTION
## Changes

The standalone required Developer Docs check did not run on merge-group commits, leaving the merge queue waiting for a result that could never arrive. Run docs validation through the existing `CI-v2 Failure Alert` using a reusable workflow.

- `ci.yaml` owns developer-docs path filtering in `determine_changes` and conditionally calls the reusable workflow for PRs and merge groups only. Its required failure gate includes the docs result.
- `developer-docs.reusable.yaml` runs the validation jobs directly, without change detection or `should-run` logic. Callers pass the existing database/cache secrets and indicate whether the database-backed checks can use secrets, preserving fork/Dependabot handling. Merge-group runs receive no database or cache credentials and skip the database-backed production check; snippet compilation uses the existing local-cache fallback.
- `developer-docs.yaml` retains the path-filtered push trigger and manual entry point. It exclusively owns push and manual validation, so docs jobs do not run twice after each merge.
- Each caller owns its concurrency. The existing route test follows the renamed reusable workflow.

## Testing

- Passed 29 local scenarios executing the caller's change-detection Bash and the reusable workflow's result gate, including PR/merge-group/push diffs, manual/new-branch runs, invalid diffs, and success/failure/cancellation/skip results.
- Passed all 13 tests from `pnpm --dir typescript2 --filter app-developer-docs docs:routes:validate`.
- Passed Biome for the updated test and `git diff --check`.
- Both developer-docs workflows pass `actionlint`. The caller has the same three pre-existing findings as the base commit (disabled Miri condition/reference and unregistered CodSpeed runner label), with no new findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added automated Developer Docs checks for relevant documentation, grammar, tooling, and configuration changes.
  - Added support for running Developer Docs validation on updates to the main and canary branches, pull requests, merge queues, and manual runs.

- **Chores**
  - Improved workflow coordination and cancellation of superseded runs.
  - Restricted credentials during queued and forked pull request runs to prevent unauthorized secret usage.

- **Tests**
  - Updated navigation validation to use the current Developer Docs workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->