### PR TITLE
ci: trigger developer docs on merge groups

### DIFF
--- a/.github/workflows/developer-docs.yml
+++ b/.github/workflows/developer-docs.yml
@@ -2,6 +2,8 @@ name: Developer Docs
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main, canary]
     paths:


### PR DESCRIPTION
Add the `merge_group` trigger with `types: [checks_requested]` to the existing developer-docs workflow so it starts for merge queue checks.

Validation: `actionlint .github/workflows/developer-docs.yml` and `git diff --check` pass. The diff contains only the two trigger lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Developer documentation checks now also run when checks are requested for merge queue groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->