### PR TITLE
compiler: one registry for builtin type aliases and their carrier classes

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "baml_compiler_lexer",
  "baml_compiler_parser",
  "baml_compiler_syntax",
+ "baml_type",
  "borsh",
  "la-arena",
  "num-bigint",

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
@@ -44,27 +44,15 @@ class Media {
 
     /// Wrap a media value a client just built from a provider payload.
     /// `baml.media.Image.from_base64` and its siblings return the `image` /
-    /// `audio` / `video` / `pdf` primitives, which are distinct static types
-    /// from the `baml.media.*` wrapper classes `MediaPart` is a union of, so
-    /// the value bridges through its BEP-038 `{kind, source, value, mime}`
-    /// envelope. The decode discriminates on the envelope's `kind`, so the
-    /// union lands on the wrapper for the value's own media kind.
+    /// `audio` / `video` / `pdf` primitives, and `baml.media.Image` is the
+    /// declaration that carries `image`'s members rather than a second
+    /// nominal type, so the value already is a `MediaPart` member.
     function new(
         value: image | audio | video | pdf,
         provider_id: string? = null,
         revised_prompt: string? = null,
     ) -> Media {
-        let envelope = baml.json.to_json(value) catch_all (e) {
-            _ => {
-                throw baml.errors.InvalidArgument { message: `media output could not be encoded: ${e.to_string()}` }
-            },
-        };
-        let part: root.MediaPart = baml.json.from_json<root.MediaPart>(envelope) catch_all (e) {
-            _ => {
-                throw baml.errors.InvalidArgument { message: `media output could not be decoded: ${e.to_string()}` }
-            },
-        };
-        Media { media: part, provider_id: provider_id, revised_prompt: revised_prompt }
+        Media { media: value, provider_id: provider_id, revised_prompt: revised_prompt }
     }
 }
 

--- a/baml_language/crates/baml_compiler2_ast/Cargo.toml
+++ b/baml_language/crates/baml_compiler2_ast/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 baml_base = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_compiler_syntax = { workspace = true }
+baml_type = { workspace = true }
 borsh = { workspace = true }
 la-arena = { workspace = true }
 num-bigint = { workspace = true }

--- a/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_type_expr.rs
@@ -314,17 +314,6 @@ fn lower_base_type(type_expr: &CstTypeExpr, diags: &mut Vec<LoweringDiagnostic>)
             .iter()
             .filter_map(|b| lower_associated_type_binding(b, diags))
             .collect();
-        if name == "map" && args.len() == 2 {
-            let key = lower_type_expr_inner(&args[0], false, diags);
-            let value = lower_type_expr_inner(&args[1], false, diags);
-            return TypeExprKind::Map {
-                key: Box::new(key),
-                value: Box::new(value),
-                attrs: vec![],
-            }
-            .at(span);
-        }
-
         // Named type (primitive or user-defined), preserving generic args
         let generic_args: Vec<TypeExpr> = args
             .iter()
@@ -335,6 +324,7 @@ fn lower_base_type(type_expr: &CstTypeExpr, diags: &mut Vec<LoweringDiagnostic>)
             generic_args,
             associated_type_bindings,
             span,
+            diags,
         );
     }
 
@@ -456,19 +446,6 @@ fn lower_union_member_base(
             })
             .unwrap_or_default();
 
-        if name == "map" {
-            if type_arg_exprs.len() == 2 {
-                let key = lower_type_expr_inner(&type_arg_exprs[0], false, diags);
-                let value = lower_type_expr_inner(&type_arg_exprs[1], false, diags);
-                return TypeExprKind::Map {
-                    key: Box::new(key),
-                    value: Box::new(value),
-                    attrs: vec![],
-                }
-                .at(span);
-            }
-        }
-
         let generic_args: Vec<TypeExpr> = type_arg_exprs
             .iter()
             .map(|arg| lower_type_expr_inner(arg, false, diags))
@@ -490,6 +467,7 @@ fn lower_union_member_base(
                 generic_args,
                 associated_type_bindings,
                 span,
+                diags,
             ),
         };
     }
@@ -499,8 +477,8 @@ fn lower_union_member_base(
 
 /// Create a `TypeExpr` from a type name string with optional generic arguments.
 ///
-/// Generic args are preserved on `Path` types (e.g., `Stream<T>`). For primitive
-/// types, generic args are silently dropped (primitives can't be generic).
+/// User-defined paths preserve their arguments. Compiler aliases check their
+/// declared arity before lowering, so invalid arguments cannot disappear.
 pub(crate) fn lower_associated_type_binding(
     binding: &baml_compiler_syntax::ast::AssociatedTypeDecl,
     diags: &mut Vec<LoweringDiagnostic>,
@@ -518,63 +496,84 @@ pub(crate) fn lower_associated_type_binding(
 
 fn lower_from_type_name_with_generic_args(
     name: &str,
-    generic_args: Vec<TypeExpr>,
+    mut generic_args: Vec<TypeExpr>,
     associated_type_bindings: Vec<AssociatedTypeBinding>,
     span: TextRange,
+    diags: &mut Vec<LoweringDiagnostic>,
 ) -> TypeExpr {
-    let kind = match name {
-        "int" => TypeExprKind::Int { attrs: vec![] },
-        "bigint" => TypeExprKind::Bigint { attrs: vec![] },
-        "float" => TypeExprKind::Float { attrs: vec![] },
-        "string" => TypeExprKind::String { attrs: vec![] },
-        "bool" => TypeExprKind::Bool { attrs: vec![] },
-        "null" => TypeExprKind::Null { attrs: vec![] },
-        "never" => TypeExprKind::Never { attrs: vec![] },
-        "void" => TypeExprKind::Void { attrs: vec![] },
-        "unknown" => TypeExprKind::Unknown { attrs: vec![] },
-        // The wildcard `_` is an inference hole, not a named type. Any stray
-        // generic args on it (`_<...>`, nonsensical) are dropped.
-        "_" => TypeExprKind::Infer { attrs: vec![] },
-        // `reflect.Type` is the source spelling of the runtime metatype. Keep
-        // the dedicated AST node so the VM representation remains a compiler
-        // primitive rather than an ordinary class instance.
-        "reflect.Type" => TypeExprKind::Type { attrs: vec![] },
-        "$rust_type" => TypeExprKind::Rust { attrs: vec![] },
-        "image" => TypeExprKind::Media {
-            kind: baml_base::MediaKind::Image,
-            attrs: vec![],
-        },
-        "audio" => TypeExprKind::Media {
-            kind: baml_base::MediaKind::Audio,
-            attrs: vec![],
-        },
-        "video" => TypeExprKind::Media {
-            kind: baml_base::MediaKind::Video,
-            attrs: vec![],
-        },
-        "pdf" => TypeExprKind::Media {
-            kind: baml_base::MediaKind::Pdf,
-            attrs: vec![],
-        },
-        "uint8array" => TypeExprKind::Uint8Array { attrs: vec![] },
-        "json" => TypeExprKind::Path {
-            segments: vec![Name::new("baml"), Name::new("json"), Name::new("json")],
-            generic_args: vec![],
-            associated_type_bindings: vec![],
-            attrs: vec![],
-        },
-        _ => {
-            let segments: Vec<Name> = if name.contains('.') {
-                name.split('.').map(Name::new).collect()
-            } else {
-                vec![Name::new(name)]
-            };
-            TypeExprKind::Path {
-                segments,
-                generic_args,
-                associated_type_bindings,
-                attrs: vec![],
+    use baml_type::{
+        PrimitiveType as P,
+        compiler_aliases::{self, AliasTarget},
+    };
+    let path = |generic_args, associated_type_bindings| TypeExprKind::Path {
+        segments: name.split('.').map(Name::new).collect(),
+        generic_args,
+        associated_type_bindings,
+        attrs: vec![],
+    };
+    let kind = if let Some(alias) = compiler_aliases::by_spelling(name) {
+        if generic_args.len() != alias.arity || !associated_type_bindings.is_empty() {
+            diags.push(LoweringDiagnostic::InvalidBuiltinTypeArguments {
+                name: name.to_owned(),
+                expected: alias.arity,
+                got: generic_args.len(),
+                associated_bindings: associated_type_bindings.len(),
+                span,
+            });
+            // The syntax parsed successfully. Recover without a second,
+            // misleading "could not parse type expression" diagnostic.
+            return TypeExprKind::Unknown { attrs: vec![] }.at(span);
+        }
+        match alias.target {
+            AliasTarget::Primitive(primitive) => match primitive {
+                P::Int => TypeExprKind::Int { attrs: vec![] },
+                P::Bigint => TypeExprKind::Bigint { attrs: vec![] },
+                P::Float => TypeExprKind::Float { attrs: vec![] },
+                P::String => TypeExprKind::String { attrs: vec![] },
+                P::Bool => TypeExprKind::Bool { attrs: vec![] },
+                P::Null => TypeExprKind::Null { attrs: vec![] },
+                P::Uint8Array => TypeExprKind::Uint8Array { attrs: vec![] },
+                P::Image | P::Audio | P::Video | P::Pdf => TypeExprKind::Media {
+                    kind: match primitive {
+                        P::Image => baml_base::MediaKind::Image,
+                        P::Audio => baml_base::MediaKind::Audio,
+                        P::Video => baml_base::MediaKind::Video,
+                        P::Pdf => baml_base::MediaKind::Pdf,
+                        _ => unreachable!("media primitive"),
+                    },
+                    attrs: vec![],
+                },
+            },
+            AliasTarget::Never => TypeExprKind::Never { attrs: vec![] },
+            AliasTarget::Void => TypeExprKind::Void { attrs: vec![] },
+            AliasTarget::Unknown => TypeExprKind::Unknown { attrs: vec![] },
+            AliasTarget::Type => TypeExprKind::Type { attrs: vec![] },
+            AliasTarget::Map => {
+                let value = generic_args.pop().expect("checked map arity");
+                let key = generic_args.pop().expect("checked map arity");
+                TypeExprKind::Map {
+                    key: Box::new(key),
+                    value: Box::new(value),
+                    attrs: vec![],
+                }
             }
+            AliasTarget::Json => {
+                let definition = alias.definition.expect("json has an alias declaration");
+                TypeExprKind::Path {
+                    segments: definition.source_segments().map(Name::new).collect(),
+                    generic_args,
+                    associated_type_bindings,
+                    attrs: vec![],
+                }
+            }
+            AliasTarget::Future => path(generic_args, associated_type_bindings),
+            AliasTarget::List => unreachable!("arrays use postfix syntax"),
+        }
+    } else {
+        match name {
+            "_" => TypeExprKind::Infer { attrs: vec![] },
+            "$rust_type" => TypeExprKind::Rust { attrs: vec![] },
+            _ => path(generic_args, associated_type_bindings),
         }
     };
     kind.at(span)

--- a/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
@@ -13,6 +13,16 @@ use text_size::TextRange;
 /// rather than semantic ones ("duplicate definition", "type mismatch").
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LoweringDiagnostic {
+    /// Builtin aliases have a fixed arity and no associated bindings. Report
+    /// these before AST lowering erases their written type arguments.
+    InvalidBuiltinTypeArguments {
+        name: String,
+        expected: usize,
+        got: usize,
+        associated_bindings: usize,
+        span: TextRange,
+    },
+
     /// A top-level item (class, function, enum, etc.) has no name token.
     MissingItemName {
         item_kind: &'static str,
@@ -292,6 +302,23 @@ impl LoweringDiagnostic {
     /// construct `Span` values from the stored `TextRange`s.
     pub fn to_diagnostic(&self, file_id: FileId) -> Diagnostic {
         let (id, severity, message, range, label) = match self {
+            LoweringDiagnostic::InvalidBuiltinTypeArguments {
+                name,
+                expected,
+                got,
+                associated_bindings,
+                span,
+            } => (
+                DiagnosticId::InvalidBuiltinTypeArguments,
+                Severity::Error,
+                if *associated_bindings == 0 {
+                    format!("type `{name}` expects {expected} type argument(s), got {got}")
+                } else {
+                    format!("builtin type `{name}` does not accept associated-type bindings")
+                },
+                *span,
+                "invalid builtin type arguments",
+            ),
             LoweringDiagnostic::MissingItemName { item_kind, span } => (
                 DiagnosticId::MissingName,
                 Severity::Error,

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -8196,50 +8196,16 @@ impl<'db> InferenceContext<'db> {
     /// use. rust-analyzer expands aliases at lowering so every consumer sees
     /// the target; our lazy-alias design expands at the demand point.
     fn static_qualifier_ty(&self, prefix: &[baml_type::Name]) -> Option<Ty> {
-        let ty = match prefix {
-            [single] => match single.as_str() {
-                "int" => Ty::intern(InferTy::Int {
-                    attr: baml_type::TyAttr::default(),
-                }),
-                "bigint" => Ty::intern(InferTy::Bigint {
-                    attr: baml_type::TyAttr::default(),
-                }),
-                "float" => Ty::intern(InferTy::Float {
-                    attr: baml_type::TyAttr::default(),
-                }),
-                "string" => Ty::intern(InferTy::String {
-                    attr: baml_type::TyAttr::default(),
-                }),
-                "bool" => Ty::intern(InferTy::Bool {
-                    attr: baml_type::TyAttr::default(),
-                }),
-                "uint8array" => Ty::intern(InferTy::Uint8Array {
-                    attr: baml_type::TyAttr::default(),
-                }),
-                "image" => Ty::intern(InferTy::Media(
-                    baml_type::MediaKind::Image,
-                    baml_type::TyAttr::default(),
-                )),
-                "audio" => Ty::intern(InferTy::Media(
-                    baml_type::MediaKind::Audio,
-                    baml_type::TyAttr::default(),
-                )),
-                "video" => Ty::intern(InferTy::Media(
-                    baml_type::MediaKind::Video,
-                    baml_type::TyAttr::default(),
-                )),
-                "pdf" => Ty::intern(InferTy::Media(
-                    baml_type::MediaKind::Pdf,
-                    baml_type::TyAttr::default(),
-                )),
-                _ => crate::impls::interned_ty(&crate::lower::reject_holes(
-                    &self.lower_scoped_type_path(prefix),
-                )),
-            },
-            _ => crate::impls::interned_ty(&crate::lower::reject_holes(
-                &self.lower_scoped_type_path(prefix),
-            )),
+        let builtin = match prefix {
+            [single] => baml_type::compiler_aliases::by_spelling(single.as_str())
+                .and_then(|alias| alias.lower_class(&[])),
+            _ => None,
         };
+        let ty = builtin.unwrap_or_else(|| {
+            crate::impls::interned_ty(&crate::lower::reject_holes(
+                &self.lower_scoped_type_path(prefix),
+            ))
+        });
         if ty.has_error() {
             return None;
         }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
@@ -23,6 +23,7 @@
 //! bodies as inference roots), map-key validation and other diagnostics
 //! (S17).
 
+use baml_base::LangRoots;
 use baml_compiler2_hir::{
     contributions::Definition,
     loc::{ClassLoc, FunctionLoc, InterfaceLoc, TypeAliasLoc},
@@ -33,6 +34,7 @@ use baml_compiler2_ppir::item_data::MethodOwner;
 use baml_type::{
     DeclName, Freshness, LoweringFunctionParamTy, LoweringInterface, LoweringTy, Name, ParamTy,
     TyAttr,
+    compiler_aliases::{self, AliasTarget},
     interned::{InferTy, Ty},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1663,109 +1665,44 @@ pub fn function_generic_frame<'db>(
     frame
 }
 
-/// The builtin class spellings that ARE structural types, so a class
-/// reference at them denotes the structural kind rather than a nominal
-/// `Class`: `baml.future.Future<V, E>` is the dedicated Future kind, and
-/// (B-1080) the builtin `baml.Array<T>` / `baml.Map<K, V>` class spellings
-/// lower to `List`/`Map`, making every algebra arm relate them for free
-/// instead of TIR's one-directional argument-path patch. Keyed on the builtin
-/// package specifically: a user-defined `class Array<T>` stays nominal.
+/// (B-1080) the builtin class spellings denote their structural types:
+/// `baml.Array<T>` / `baml.Map<K, V>` lower to `List`/`Map`, so every
+/// algebra arm relates them for free instead of TIR's one-directional
+/// argument-path patch, and the scalar and media carriers (`class baml.Int`,
+/// `class baml.media.Image`) denote `int` / `image` — a value of the carrier
+/// class IS the primitive at runtime (S11's receiver-class correspondence,
+/// applied in reverse), so the class spelling, `class_self_ty` inside the
+/// class's own methods and implements blocks included, must be the structural
+/// type or an in-class impl's for-target would be a nominal type no value
+/// ever inhabits.
 ///
-/// The ONE bridge decision, shared by the two vocabulary-specific
-/// constructors below ([`class_lowering_ty`], [`class_ty`]) so the name/arity
-/// predicate cannot drift between the lowering chain and the interned
-/// inference world.
-enum BuiltinStructural {
-    Future,
-    List,
-    Map,
-    /// A dedicated-variant scalar carrier (`class baml.Int` and friends),
-    /// which denotes its structural primitive rather than a nominal class.
-    Scalar(BuiltinScalar),
-}
-
-#[derive(Clone, Copy)]
-enum BuiltinScalar {
-    Int,
-    Bigint,
-    Float,
-    Bool,
-    String,
-    Uint8Array,
-    Null,
-}
-
-fn builtin_structural(
-    lang: baml_base::LangRoots,
-    qtn: &DeclName,
-    arity: usize,
-) -> Option<BuiltinStructural> {
-    if !lang.is(baml_base::LangPackage::Baml, qtn.root()) {
-        return None;
-    }
-    if qtn.namespace().len() == 1
-        && qtn.namespace()[0].as_str() == "future"
-        && qtn.name().as_str() == "Future"
-        && arity == 2
-    {
-        return Some(BuiltinStructural::Future);
-    }
-    if qtn.namespace().is_empty() {
-        if qtn.name().as_str() == "Array" && arity == 1 {
-            return Some(BuiltinStructural::List);
-        }
-        if qtn.name().as_str() == "Map" && arity == 2 {
-            return Some(BuiltinStructural::Map);
-        }
-        // The dedicated-variant scalar builtins bridge the same way: a value
-        // of `class baml.Int` IS an `int` at runtime (S11's receiver-class
-        // correspondence, applied in reverse), so the class spelling —
-        // `class_self_ty` inside the class's own methods and implements
-        // blocks included — denotes the structural type. Without this, an
-        // in-class impl's for-target would be a nominal type no runtime value
-        // ever inhabits. The carrier family is total: `class baml.Null`
-        // exists (empty — a doc anchor), and leaving it unbridged would let
-        // `baml.Null` denote a nominal class no value inhabits.
-        if arity == 0 {
-            let scalar = match qtn.name().as_str() {
-                "Int" => Some(BuiltinScalar::Int),
-                "Bigint" => Some(BuiltinScalar::Bigint),
-                "Float" => Some(BuiltinScalar::Float),
-                "Bool" => Some(BuiltinScalar::Bool),
-                "String" => Some(BuiltinScalar::String),
-                "Uint8Array" => Some(BuiltinScalar::Uint8Array),
-                "Null" => Some(BuiltinScalar::Null),
-                _ => None,
-            };
-            if let Some(scalar) = scalar {
-                return Some(BuiltinStructural::Scalar(scalar));
-            }
-        }
-    }
-    None
+/// The ONE bridge decision is the compiler alias registry
+/// ([`baml_type::compiler_aliases`]), keyed on the installed language root
+/// and the full definition path so a user-defined `class Array<T>` stays
+/// nominal. Shared by the two vocabulary-specific constructors below
+/// ([`class_lowering_ty`], [`class_ty`]) so the name/arity predicate cannot
+/// drift between the lowering chain and the interned inference world.
+fn builtin_structural(lang: LangRoots, qtn: &DeclName, arity: usize) -> Option<AliasTarget> {
+    compiler_aliases::by_definition(lang, qtn)?.class_carrier(arity)
 }
 
 /// The type a class reference denotes in the lowering vocabulary, builtin
 /// bridges (`builtin_structural`) applied. The single constructor for class
 /// types in the lowering chain, shared by annotation lowering and
 /// `class_self_ty`.
-pub fn class_lowering_ty(
-    lang: baml_base::LangRoots,
-    qtn: DeclName,
-    mut args: Vec<LoweringTy>,
-) -> LoweringTy {
+pub fn class_lowering_ty(lang: LangRoots, qtn: DeclName, mut args: Vec<LoweringTy>) -> LoweringTy {
     let attr = TyAttr::default;
     match builtin_structural(lang, &qtn, args.len()) {
-        Some(BuiltinStructural::Future) => {
+        Some(AliasTarget::Future) => {
             let error_ty = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
             let value_ty = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
             LoweringTy::Future(Box::new(value_ty), Box::new(error_ty), attr())
         }
-        Some(BuiltinStructural::List) => {
+        Some(AliasTarget::List) => {
             let element = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
             LoweringTy::List(Box::new(element), attr())
         }
-        Some(BuiltinStructural::Map) => {
+        Some(AliasTarget::Map) => {
             let value = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
             let key = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
             LoweringTy::Map {
@@ -1774,54 +1711,26 @@ pub fn class_lowering_ty(
                 attr: attr(),
             }
         }
-        Some(BuiltinStructural::Scalar(scalar)) => match scalar {
-            BuiltinScalar::Int => LoweringTy::Int { attr: attr() },
-            BuiltinScalar::Bigint => LoweringTy::Bigint { attr: attr() },
-            BuiltinScalar::Float => LoweringTy::Float { attr: attr() },
-            BuiltinScalar::Bool => LoweringTy::Bool { attr: attr() },
-            BuiltinScalar::String => LoweringTy::String { attr: attr() },
-            BuiltinScalar::Uint8Array => LoweringTy::Uint8Array { attr: attr() },
-            BuiltinScalar::Null => LoweringTy::Null { attr: attr() },
-        },
-        None => LoweringTy::Class(qtn, args.into(), attr()),
+        Some(AliasTarget::Primitive(primitive)) => {
+            LoweringTy::from(&baml_type::Ty::from_primitive(primitive, attr()))
+        }
+        Some(AliasTarget::Type) => LoweringTy::Type { attr: attr() },
+        // Json expands through the alias resolver; intrinsics have no class.
+        Some(AliasTarget::Json | AliasTarget::Void | AliasTarget::Never | AliasTarget::Unknown)
+        | None => LoweringTy::Class(qtn, args.into(), attr()),
     }
 }
 
 /// [`class_lowering_ty`]'s interned-vocabulary twin, for types minted inside
 /// inference (instantiated class heads, pattern heads): same bridge decision,
 /// handle children.
-pub fn class_ty(lang: baml_base::LangRoots, qtn: DeclName, mut args: Vec<Ty>) -> Ty {
-    let attr = TyAttr::default;
-    match builtin_structural(lang, &qtn, args.len()) {
-        Some(BuiltinStructural::Future) => {
-            let error_ty = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
-            let value_ty = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
-            Ty::intern(InferTy::Future(value_ty, error_ty, attr()))
-        }
-        Some(BuiltinStructural::List) => {
-            let element = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
-            Ty::intern(InferTy::List(element, attr()))
-        }
-        Some(BuiltinStructural::Map) => {
-            let value = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
-            let key = args.pop().unwrap_or_else(|| unreachable!("checked arity"));
-            Ty::intern(InferTy::Map {
-                key,
-                value,
-                attr: attr(),
-            })
-        }
-        Some(BuiltinStructural::Scalar(scalar)) => Ty::intern(match scalar {
-            BuiltinScalar::Int => InferTy::Int { attr: attr() },
-            BuiltinScalar::Bigint => InferTy::Bigint { attr: attr() },
-            BuiltinScalar::Float => InferTy::Float { attr: attr() },
-            BuiltinScalar::Bool => InferTy::Bool { attr: attr() },
-            BuiltinScalar::String => InferTy::String { attr: attr() },
-            BuiltinScalar::Uint8Array => InferTy::Uint8Array { attr: attr() },
-            BuiltinScalar::Null => InferTy::Null { attr: attr() },
-        }),
-        None => Ty::intern(InferTy::Class(qtn, args.into(), attr())),
+pub fn class_ty(lang: LangRoots, qtn: DeclName, args: Vec<Ty>) -> Ty {
+    if let Some(ty) =
+        compiler_aliases::by_definition(lang, &qtn).and_then(|alias| alias.lower_class(&args))
+    {
+        return ty;
     }
+    Ty::intern(InferTy::Class(qtn, args.into(), TyAttr::default()))
 }
 
 /// The qualified name a class definition contributes, from its file's
@@ -3407,4 +3316,68 @@ pub fn throws_clause_parts(ty: &LoweringTy) -> (baml_type::Ty, bool) {
         _ => baml_type::Ty::Union(named.into(), TyAttr::default()),
     };
     (named, open)
+}
+
+#[cfg(test)]
+mod compiler_alias_tests {
+    use super::*;
+    use crate::test_heads;
+
+    #[test]
+    fn compiler_aliases_do_not_create_nominal_media_classes() {
+        let lang = test_heads::lang();
+        for primitive in baml_type::PrimitiveType::ALL {
+            let alias = compiler_aliases::by_target(AliasTarget::Primitive(primitive));
+            let name = alias.definition.unwrap().decl_name(lang).unwrap();
+            let expected = baml_type::Ty::from_primitive(primitive, TyAttr::default());
+            assert_eq!(
+                class_ty(lang, name.clone(), vec![]),
+                Ty::from_plain(&expected)
+            );
+            assert_eq!(
+                class_lowering_ty(lang, name, vec![]),
+                LoweringTy::from(&expected)
+            );
+        }
+    }
+
+    #[test]
+    fn compiler_aliases_preserve_user_defined_names() {
+        let lang = test_heads::lang();
+        for path in [
+            "user.String",
+            "user.Image",
+            "user.Array",
+            "baml.other.Image",
+        ] {
+            let wire = baml_type::TypeName::from_dotted_path(path);
+            let name = test_heads::new(
+                wire.package().clone(),
+                wire.namespace().clone(),
+                wire.name().clone(),
+            );
+            assert!(
+                matches!(class_ty(lang, name.clone(), vec![]).kind(), InferTy::Class(actual, _, _) if actual == &name)
+            );
+            assert!(
+                matches!(class_lowering_ty(lang, name.clone(), vec![]), LoweringTy::Class(actual, _, _) if actual == name)
+            );
+        }
+    }
+
+    #[test]
+    fn compiler_aliases_stay_nominal_without_the_language_root() {
+        // A carrier spelled in a package that is not the installed `baml`
+        // root is an ordinary class: identity is the root, not the name.
+        let name =
+            compiler_aliases::by_target(AliasTarget::Primitive(baml_type::PrimitiveType::Image))
+                .definition
+                .unwrap()
+                .decl_name(test_heads::lang())
+                .unwrap();
+        assert!(matches!(
+            class_ty(LangRoots::default(), name.clone(), vec![]).kind(),
+            InferTy::Class(actual, _, _) if actual == &name
+        ));
+    }
 }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/method_resolution.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/method_resolution.rs
@@ -19,7 +19,7 @@ use baml_compiler2_hir::{
     loc::{ClassLoc, EnumLoc, FunctionLoc, ImplLoc, InterfaceLoc},
 };
 use baml_type::{
-    DeclName, Literal, MediaKind, Name, ParamTy, TyAttr,
+    DeclName, Name, ParamTy, TyAttr,
     interned::{InferInterface, InferTy, Ty},
     normalize::TypeContext as _,
 };
@@ -92,155 +92,50 @@ pub fn lookup_method<'db>(
     })
 }
 
-/// Source-less counterpart of [`receiver_class`]. It maps structural builtin
-/// types to the same canonical class names, but leaves the declaration lookup
-/// to the precompiled `PackageInterface` row.
+/// The member owner of `receiver`: its class declaration's name and the
+/// generic arguments the receiver pins. Nominal classes own themselves; the
+/// structural builtins (`int`, `T[]`, `image`, …) map through the compiler
+/// alias registry to their carrier declaration, literals deferring to their
+/// base primitive's class. Aliases are transparent: expand through the
+/// oracle (fuel-bounded like every alias walk) and resolve on the expansion.
+///
+/// Source-backed and precompiled packages resolve the same owner; only the
+/// declaration lookup differs ([`receiver_class`] vs the `PackageInterface`
+/// row).
 pub(crate) fn external_class_for_type(
     facts: &Facts<'_>,
     receiver: &Ty,
     fuel: u32,
 ) -> Option<(DeclName, Vec<Ty>)> {
-    let lang = facts.lang();
-    // The language root is looked up per builtin arm, not once up front: only
-    // a BUILTIN receiver needs it to name its class, while a class receiver
-    // already carries its own head. Demanding it eagerly made every class
-    // receiver unresolvable in a database with no standard library installed,
-    // which is a state this database supports.
-    let builtin = |namespace: &[&str], name: &str, args: Vec<Ty>| {
-        Some((
-            DeclName::in_root(
-                lang.get(baml_base::LangPackage::Baml)?,
-                namespace.iter().map(Name::new).collect(),
-                Name::new(name),
-            ),
-            args,
-        ))
-    };
     match receiver.kind() {
         InferTy::Class(qtn, args, _) => Some((qtn.clone(), args.to_vec())),
-        InferTy::List(element, _) => builtin(&[], "Array", vec![element.clone()]),
-        InferTy::Map { key, value, .. } => builtin(&[], "Map", vec![key.clone(), value.clone()]),
-        InferTy::Future(value, error, _) => {
-            builtin(&["future"], "Future", vec![value.clone(), error.clone()])
-        }
-        InferTy::String { .. } | InferTy::Literal(Literal::String(_), _, _) => {
-            builtin(&[], "String", Vec::new())
-        }
-        InferTy::Int { .. } | InferTy::Literal(Literal::Int(_), _, _) => {
-            builtin(&[], "Int", Vec::new())
-        }
-        InferTy::Bigint { .. } | InferTy::Literal(Literal::Bigint(_), _, _) => {
-            builtin(&[], "Bigint", Vec::new())
-        }
-        InferTy::Float { .. } | InferTy::Literal(Literal::Float(_), _, _) => {
-            builtin(&[], "Float", Vec::new())
-        }
-        InferTy::Bool { .. } | InferTy::Literal(Literal::Bool(_), _, _) => {
-            builtin(&[], "Bool", Vec::new())
-        }
-        InferTy::Uint8Array { .. } => builtin(&[], "Uint8Array", Vec::new()),
-        InferTy::Type { .. } => Some((
-            DeclName::in_root(
-                lang.get(baml_base::LangPackage::Reflect)?,
-                Vec::new(),
-                Name::new("Type"),
-            ),
-            Vec::new(),
-        )),
-        InferTy::Media(kind, _) => {
-            let class = match kind {
-                MediaKind::Image => "Image",
-                MediaKind::Audio => "Audio",
-                MediaKind::Video => "Video",
-                MediaKind::Pdf => "Pdf",
-                MediaKind::Generic => return None,
-            };
-            builtin(&["media"], class, Vec::new())
-        }
         InferTy::TypeAlias(qtn, _) => {
             let expanded = facts.alias_def(qtn)?;
             external_class_for_type(facts, &Ty::from_plain(&expanded), fuel.checked_sub(1)?)
         }
-        _ => None,
+        // The language root is looked up here, for a BUILTIN receiver, and
+        // not once up front: only a builtin needs it to name its carrier,
+        // while a class receiver already carries its own head. Demanding it
+        // eagerly made every class receiver unresolvable in a database with
+        // no standard library installed, which is a state this database
+        // supports.
+        _ => {
+            let (definition, args) = baml_type::compiler_aliases::member_owner(receiver)?;
+            Some((definition.decl_name(facts.lang())?, args))
+        }
     }
 }
 
 /// The class whose declaration owns `receiver`'s methods, with the generic
-/// arguments the receiver pins. This table IS the language's builtin-class
-/// correspondence (TIR: `resolve_builtin_member` call sites), one row per
-/// structural kind; literals defer to their base primitive's class.
+/// arguments the receiver pins (TIR: `resolve_builtin_member` call sites).
 pub(crate) fn receiver_class<'db>(
     facts: &Facts<'db>,
     receiver: &Ty,
     fuel: u32,
 ) -> Option<(ClassLoc<'db>, Vec<Ty>)> {
-    let lang = facts.lang();
-    let builtin = |namespace: &[&str], name: &str, args: Vec<Ty>| {
-        let qtn = DeclName::in_root(
-            lang.get(baml_base::LangPackage::Baml)?,
-            namespace.iter().map(Name::new).collect(),
-            Name::new(name),
-        );
-        match facts.definition_of(&qtn) {
-            Some(Definition::Class(class)) => Some((class, args)),
-            _ => None,
-        }
-    };
-    match receiver.kind() {
-        InferTy::Class(qtn, args, _) => match facts.definition_of(qtn) {
-            Some(Definition::Class(class)) => Some((class, args.to_vec())),
-            _ => None,
-        },
-        InferTy::List(element, _) => builtin(&[], "Array", vec![element.clone()]),
-        InferTy::Map { key, value, .. } => builtin(&[], "Map", vec![key.clone(), value.clone()]),
-        InferTy::Future(value, error, _) => {
-            builtin(&["future"], "Future", vec![value.clone(), error.clone()])
-        }
-        InferTy::String { .. } | InferTy::Literal(Literal::String(_), _, _) => {
-            builtin(&[], "String", Vec::new())
-        }
-        InferTy::Int { .. } | InferTy::Literal(Literal::Int(_), _, _) => {
-            builtin(&[], "Int", Vec::new())
-        }
-        InferTy::Bigint { .. } | InferTy::Literal(Literal::Bigint(_), _, _) => {
-            builtin(&[], "Bigint", Vec::new())
-        }
-        InferTy::Float { .. } | InferTy::Literal(Literal::Float(_), _, _) => {
-            builtin(&[], "Float", Vec::new())
-        }
-        InferTy::Bool { .. } | InferTy::Literal(Literal::Bool(_), _, _) => {
-            builtin(&[], "Bool", Vec::new())
-        }
-        InferTy::Uint8Array { .. } => builtin(&[], "Uint8Array", Vec::new()),
-        InferTy::Type { .. } => {
-            let qtn = DeclName::in_root(
-                lang.get(baml_base::LangPackage::Reflect)?,
-                Vec::new(),
-                Name::new("Type"),
-            );
-            match facts.definition_of(&qtn) {
-                Some(Definition::Class(class)) => Some((class, Vec::new())),
-                _ => None,
-            }
-        }
-        InferTy::Media(kind, _) => {
-            let class = match kind {
-                MediaKind::Image => "Image",
-                MediaKind::Audio => "Audio",
-                MediaKind::Video => "Video",
-                MediaKind::Pdf => "Pdf",
-                // Generic media (`media`, any subtype) has no single class.
-                MediaKind::Generic => return None,
-            };
-            builtin(&["media"], class, Vec::new())
-        }
-        // Aliases are transparent: expand through the oracle (fuel-bounded
-        // like every alias walk) and resolve on the expansion.
-        InferTy::TypeAlias(qtn, _) => {
-            let expanded = facts.alias_def(qtn)?;
-            let fuel = fuel.checked_sub(1)?;
-            receiver_class(facts, &Ty::from_plain(&expanded), fuel)
-        }
+    let (name, args) = external_class_for_type(facts, receiver, fuel)?;
+    match facts.definition_of(&name) {
+        Some(Definition::Class(class)) => Some((class, args)),
         _ => None,
     }
 }

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -396,6 +396,11 @@ pub enum DiagnosticId {
     ReflectSpecializationFailed,
     /// An ordinary inference variable remained unresolved at writeback (E0155).
     TypeMustBeKnown,
+    /// A builtin type spelling was written with type arguments or
+    /// associated-type bindings it does not take (`image<string>`,
+    /// `map<string>`), diagnosed at AST lowering before the arguments could
+    /// be silently erased.
+    InvalidBuiltinTypeArguments,
 }
 
 impl DiagnosticId {
@@ -607,6 +612,7 @@ impl DiagnosticId {
             DiagnosticId::ReflectSpecializationFailed => "E0169",
             DiagnosticId::InterfaceMethodMissingThrows => "E0170",
             DiagnosticId::TypeMustBeKnown => "E0155",
+            DiagnosticId::InvalidBuiltinTypeArguments => "E0171",
         }
     }
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_compiler_aliases/compiler_aliases.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_compiler_aliases/compiler_aliases.baml
@@ -1,0 +1,53 @@
+// Canonical spellings must resolve both static and instance builtin members.
+// These exercise the compiler and VM together, beyond the type-IR registry tests.
+
+test "compiler_alias_media_factories_and_methods" {
+    let i = image.from_base64("aGk=", "image/png");
+    let a = audio.from_base64("aGk=", "audio/wav");
+    let v = video.from_url("https://example.test/movie", "video/mp4");
+    let p = pdf.from_base64("aGk=", "application/pdf");
+    assert.equal(i.base64(), "aGk=");
+    assert.equal(i.mime_type(), "image/png");
+    assert.equal(a.mime_type(), "audio/wav");
+    assert.equal(v.url(), "https://example.test/movie");
+    assert.equal(p.mime_type(), "application/pdf")
+}
+
+function iterate_alias(values: string[]) -> string throws never {
+    let iterable: baml.iter.Iterable<Item=string, Error=never> = values;
+    iterable.iter().collect().join(",")
+}
+
+test "compiler_alias_array_interface_dispatch" {
+    assert.equal(iterate_alias(["Ada", "Grace"]), "Ada,Grace");
+    assert.equal(iterate_alias([]), "")
+}
+
+// `baml.media.Image` is the declaration that carries `image`'s members, not a
+// second nominal type: both spellings denote the one media type, in
+// annotations, parameters, unions built from the class spelling, and
+// reflection alike.
+function image_mime(value: baml.media.Image) -> string? {
+    value.mime_type()
+}
+
+test "compiler_alias_media_class_spelling_is_the_primitive" {
+    let img = image.from_base64("aGk=", "image/png");
+    let w: baml.media.Image = img;
+    assert.equal(image_mime(img), "image/png");
+    assert.equal(image_mime(w), "image/png");
+    assert.equal(w.base64(), "aGk=");
+
+    // `ai.PromptPart = string | MediaPart`, `MediaPart` spelled through the
+    // `baml.media.*` classes; a primitive media value is a member directly.
+    let p: ai.PromptPart = img;
+    let kind = match (p) {
+        let i: image => i.mime_type(),
+        _ => "not an image",
+    };
+    assert.equal(kind, "image/png");
+
+    assert.is_true(reflect.Type.of<baml.media.Image>() == reflect.Type.of<image>());
+    assert.equal(reflect.Type.of<baml.media.Image>().to_string(), "image");
+    assert.equal(reflect.Type.of<baml.media.Audio[]>().to_string(), "audio[]")
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/compiler_alias_type_arguments/main.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/compiler_alias_type_arguments/main.baml
@@ -1,0 +1,6 @@
+// Builtin type arguments must be diagnosed rather than erased during lowering.
+type InvalidImage = image<string>
+type InvalidString = string<int>
+type InvalidJson = json<string>
+type InvalidMap = map<string>
+type InvalidAssociatedBinding = image<Output=string>

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
@@ -676,6 +676,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_compiler_aliases/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_compiler_aliases/bytecode.snap
@@ -1,0 +1,50 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+function compiler_aliases.$init_test_ns_compiler_aliases_compiler_aliases(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.compiler_aliases"
+    load_const "compiler_alias_media_factories_and_methods"
+    make_closure .<lambda($init_test_ns_compiler_aliases_compiler_aliases, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.compiler_aliases"
+    load_const "compiler_alias_array_interface_dispatch"
+    make_closure .<lambda($init_test_ns_compiler_aliases_compiler_aliases, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.compiler_aliases"
+    load_const "compiler_alias_media_class_spelling_is_the_primitive"
+    make_closure .<lambda($init_test_ns_compiler_aliases_compiler_aliases, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function compiler_aliases.image_mime(value: image) -> string | null {
+    load_var value
+    call baml.media.Image.mime_type
+    return
+}
+
+function compiler_aliases.iterate_alias(values: string[]) -> string {
+    load_var values
+    load_type baml.iter.Iterable<Error = never, Item = string>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    load_type baml.iter.Iterator<Error = never, Item = string>
+    load_const "collect"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+    load_type string
+    load_var _3
+    load_const ","
+    call baml.Array.join
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_promptast_accessors/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_promptast_accessors/bytecode.snap
@@ -196,14 +196,14 @@ function promptast_accessors.pa_message_parts_preserve_media() -> string {
     load_const 0
     load_array_element
     load_field .parts
-    load_type baml.iter.Iterable<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>
+    load_type baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _22
 
   L0:
     load_var _22
-    load_type baml.iter.Iterator<Error = never, Item = string | baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video>
+    load_type baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _23
@@ -220,17 +220,17 @@ function promptast_accessors.pa_message_parts_preserve_media() -> string {
     load_var part
     store_var _35
     load_var _35
-    narrow_bind baml.media.Image, slot=13
+    narrow_bind image, slot=13
     pop_jump_if_true L12
     load_var part
     store_var _44
     load_var _44
-    narrow_bind baml.media.Audio, slot=16
+    narrow_bind audio, slot=16
     pop_jump_if_true L8
     load_var part
     store_var _53
     load_var _53
-    narrow_bind baml.media.Video, slot=19
+    narrow_bind video, slot=19
     pop_jump_if_true L4
     load_var part
     call baml.media.Pdf.url

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -1560,8 +1560,8 @@ function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
     return
 }
 
-function ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf)[] {
-    load_type baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+function ai.ModelTurn.media(self: ai.ModelTurn) -> (image | audio | video | pdf)[] {
+    load_type image | audio | video | pdf
     alloc_array 0
     store_var out
     load_var self
@@ -1585,7 +1585,7 @@ function ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Image | baml.medi
     load_var _9
     narrow_bind ai.content.Media, slot=5
     pop_jump_if_false L0
-    load_type baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+    load_type image | audio | video | pdf
     load_var2 2 5
     load_field .media
     call baml.Array.push
@@ -3220,17 +3220,17 @@ function ai.content.Media.kind(self: ai.content.Media) -> string {
     load_var _2
     store_var _3
     load_var _3
-    narrow_bind baml.media.Image, slot=3
+    narrow_bind image, slot=3
     pop_jump_if_true L2
     load_var _2
     store_var _4
     load_var _4
-    narrow_bind baml.media.Audio, slot=4
+    narrow_bind audio, slot=4
     pop_jump_if_true L1
     load_var _2
     store_var _5
     load_var _5
-    narrow_bind baml.media.Video, slot=5
+    narrow_bind video, slot=5
     pop_jump_if_true L0
     load_const "pdf"
     jump L3
@@ -3267,50 +3267,7 @@ function ai.content.Media.new(value: image | audio | video | pdf, provider_id: s
     store_var revised_prompt
 
   L1:
-    load_var value
-    call baml.json.to_json
-    store_var envelope
-    jump L2
-    load_var e
-    throw_if_panic
-    load_type baml.json.SerializationError
-    load_var e
-    call baml.String.from
-    store_var _11
-    load_type string
-    load_var _11
-    call baml.String.from
-    store_var _10
-    load_const "media output could not be encoded: "
-    load_var _10
-    bin_op +
-    init_instance baml.errors.InvalidArgument .message
-    throw
-
-  L2:
-    load_type baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
-    load_var envelope
-    call baml.json.from_json
-    store_var part
-    jump L3
-    load_var e
-    throw_if_panic
-    load_type baml.json.DecodeError
-    load_var e
-    call baml.String.from
-    store_var _21
-    load_type string
-    load_var _21
-    call baml.String.from
-    store_var _20
-    load_const "media output could not be decoded: "
-    load_var _20
-    bin_op +
-    init_instance baml.errors.InvalidArgument .message
-    throw
-
-  L3:
-    load_var2 8 2
+    load_var2 1 2
     load_var revised_prompt
     init_instance ai.content.Media .media, .provider_id, .revised_prompt
     return
@@ -7433,21 +7390,21 @@ function ai.wire.resolve_credential(cred: string | baml.env.Ref | null, env_fall
     return
 }
 
-function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
+function ai.wire.resolve_media(media: image | audio | video | pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
     load_var media
     store_var _3
     load_var _3
-    narrow_bind baml.media.Image, slot=3
+    narrow_bind image, slot=3
     pop_jump_if_true L5
     load_var media
     store_var _16
     load_var _16
-    narrow_bind baml.media.Audio, slot=10
+    narrow_bind audio, slot=10
     pop_jump_if_true L3
     load_var media
     store_var _29
     load_var _29
-    narrow_bind baml.media.Video, slot=17
+    narrow_bind video, slot=17
     pop_jump_if_true L1
     load_var media
     call baml.media.Pdf.file
@@ -7585,21 +7542,21 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
     return
 }
 
-function ai.wire.resolve_media_preview(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf) -> ai.wire.ResolvedMedia {
+function ai.wire.resolve_media_preview(media: image | audio | video | pdf) -> ai.wire.ResolvedMedia {
     load_var media
     store_var _2
     load_var _2
-    narrow_bind baml.media.Image, slot=2
+    narrow_bind image, slot=2
     pop_jump_if_true L5
     load_var media
     store_var _15
     load_var _15
-    narrow_bind baml.media.Audio, slot=9
+    narrow_bind audio, slot=9
     pop_jump_if_true L3
     load_var media
     store_var _28
     load_var _28
-    narrow_bind baml.media.Video, slot=16
+    narrow_bind video, slot=16
     pop_jump_if_true L1
     load_var media
     call baml.media.Pdf.file

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
@@ -2649,25 +2649,25 @@ fn ai.content.Media.kind(self: ai.content.Media) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: ai.content.Media // self // param
-    let _2: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _3: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _4: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _5: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _2: image | audio | video | pdf
+    let _3: image | audio | video | pdf
+    let _4: image | audio | video | pdf
+    let _5: image | audio | video | pdf
 
     bb0: {
         _2 = copy _1.0;
         _3 = copy _2;
-        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Image" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb1];
+        _3 = narrow_bind copy _3 as Media(Image, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb6, bb1];
     }
 
     bb1: {
         _4 = copy _2;
-        _4 = narrow_bind copy _4 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb5, bb2];
+        _4 = narrow_bind copy _4 as Media(Audio, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb5, bb2];
     }
 
     bb2: {
         _5 = copy _2;
-        _5 = narrow_bind copy _5 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb4, bb3];
+        _5 = narrow_bind copy _5 as Media(Video, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb4, bb3];
     }
 
     bb3: {
@@ -2703,27 +2703,6 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
     let _3: string | null // revised_prompt // param
     let _4: bool
     let _5: bool
-    let _6: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // envelope
-    let _7: unknown // e
-    let _8: baml.errors.InvalidArgument
-    let _9: string
-    let _10: string
-    let _11: string
-    let _12: reflect.Type
-    let _13: reflect.Type
-    let _14: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // part
-    let _15: unknown // e
-    let _16: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _17: reflect.Type
-    let _18: baml.errors.InvalidArgument
-    let _19: string
-    let _20: string
-    let _21: string
-    let _22: reflect.Type
-    let _23: reflect.Type
-    let _24: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _25: string
-    let _26: string
 
     bb0: {
         _4 = copy _2 == const <omitted>;
@@ -2746,65 +2725,12 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
     }
 
     bb4: {
-        _6 = call const fn baml.json.to_json(copy _1) -> [bb5, unwind: bb8];
+        _0 = ai.content.Media { copy _1, copy _2, copy _3 };
+        goto -> bb5;
     }
 
     bb5: {
-        _16 = copy _6;
-        _17 = load_type(baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf);
-        _14 = call const fn baml.json.from_json<copy _17>(copy _16) -> [bb6, unwind: bb12];
-    }
-
-    bb6: {
-        _24 = copy _14;
-        _0 = ai.content.Media { copy _24, copy _2, copy _3 };
-        goto -> bb7;
-    }
-
-    bb7: {
         return;
-    }
-
-    bb8: {
-        throw_if_panic copy _7 -> bb9;
-    }
-
-    bb9: {
-        _12 = load_type(baml.json.SerializationError);
-        _11 = call const fn baml.String.from<copy _12>(copy _7) -> [bb10];
-    }
-
-    bb10: {
-        _13 = load_type(string);
-        _25 = const "media output could not be encoded: ";
-        _10 = call const fn baml.String.from<copy _13>(copy _11) -> [bb11];
-    }
-
-    bb11: {
-        _9 = copy _25 + copy _10;
-        _8 = baml.errors.InvalidArgument { copy _9 };
-        throw copy _8;
-    }
-
-    bb12: {
-        throw_if_panic copy _15 -> bb13;
-    }
-
-    bb13: {
-        _22 = load_type(baml.json.DecodeError);
-        _21 = call const fn baml.String.from<copy _22>(copy _15) -> [bb14];
-    }
-
-    bb14: {
-        _23 = load_type(string);
-        _26 = const "media output could not be decoded: ";
-        _20 = call const fn baml.String.from<copy _23>(copy _21) -> [bb15];
-    }
-
-    bb15: {
-        _19 = copy _26 + copy _20;
-        _18 = baml.errors.InvalidArgument { copy _19 };
-        throw copy _18;
     }
 }
 
@@ -4394,7 +4320,7 @@ fn ai.internal._media_envelope(m: ai.content.Media) -> int | float | string | bo
     let _0: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // _0 // return
     let _1: ai.content.Media // m // param
     let _2: unknown // e
-    let _3: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _3: image | audio | video | pdf
     let _4: baml.errors.UnknownError
     let _5: baml.json.SerializationError
     let _6: string[]
@@ -10146,13 +10072,13 @@ fn ai.wire.render_output_format(t: reflect.Type) -> string {
     }
 }
 
-fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video, fetch_url: bool) -> ai.wire.ResolvedMedia {
+fn ai.wire.resolve_media(media: image | audio | video | pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
     // Locals:
     let _0: ai.wire.ResolvedMedia // _0 // return
-    let _1: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // media // param
+    let _1: image | audio | video | pdf // media // param
     let _2: bool // fetch_url // param
-    let _3: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _4: baml.media.Image // image
+    let _3: image | audio | video | pdf
+    let _4: image // image
     let _5: string // source
     let _6: string
     let _7: string | null
@@ -10164,8 +10090,8 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     let _13: string
     let _14: string | null
     let _15: string
-    let _16: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _17: baml.media.Audio // audio
+    let _16: image | audio | video | pdf
+    let _17: audio // audio
     let _18: string // source
     let _19: string
     let _20: string | null
@@ -10177,8 +10103,8 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     let _26: string
     let _27: string | null
     let _28: string
-    let _29: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _30: baml.media.Video // video
+    let _29: image | audio | video | pdf
+    let _30: video // video
     let _31: string // source
     let _32: string
     let _33: string | null
@@ -10190,7 +10116,7 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     let _39: string
     let _40: string | null
     let _41: string
-    let _42: baml.media.Pdf // pdf
+    let _42: pdf // pdf
     let _43: string // source
     let _44: string
     let _45: string | null
@@ -10205,17 +10131,17 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
 
     bb0: {
         _3 = copy _1;
-        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Image" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb1];
+        _3 = narrow_bind copy _3 as Media(Image, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb1];
     }
 
     bb1: {
         _16 = copy _1;
-        _16 = narrow_bind copy _16 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
+        _16 = narrow_bind copy _16 as Media(Audio, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
     }
 
     bb2: {
         _29 = copy _1;
-        _29 = narrow_bind copy _29 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
+        _29 = narrow_bind copy _29 as Media(Video, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
     }
 
     bb3: {
@@ -10419,12 +10345,12 @@ fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media
     }
 }
 
-fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video) -> ai.wire.ResolvedMedia {
+fn ai.wire.resolve_media_preview(media: image | audio | video | pdf) -> ai.wire.ResolvedMedia {
     // Locals:
     let _0: ai.wire.ResolvedMedia // _0 // return
-    let _1: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // media // param
-    let _2: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _3: baml.media.Image // image
+    let _1: image | audio | video | pdf // media // param
+    let _2: image | audio | video | pdf
+    let _3: image // image
     let _4: string // source
     let _5: string
     let _6: string | null
@@ -10436,8 +10362,8 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
     let _12: string
     let _13: string | null
     let _14: string
-    let _15: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _16: baml.media.Audio // audio
+    let _15: image | audio | video | pdf
+    let _16: audio // audio
     let _17: string // source
     let _18: string
     let _19: string | null
@@ -10449,8 +10375,8 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
     let _25: string
     let _26: string | null
     let _27: string
-    let _28: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
-    let _29: baml.media.Video // video
+    let _28: image | audio | video | pdf
+    let _29: video // video
     let _30: string // source
     let _31: string
     let _32: string | null
@@ -10462,7 +10388,7 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
     let _38: string
     let _39: string | null
     let _40: string
-    let _41: baml.media.Pdf // pdf
+    let _41: pdf // pdf
     let _42: string // source
     let _43: string
     let _44: string | null
@@ -10477,17 +10403,17 @@ fn ai.wire.resolve_media_preview(media: baml.media.Audio | baml.media.Image | ba
 
     bb0: {
         _2 = copy _1;
-        _2 = narrow_bind copy _2 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Image" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb1];
+        _2 = narrow_bind copy _2 as Media(Image, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb1];
     }
 
     bb1: {
         _15 = copy _1;
-        _15 = narrow_bind copy _15 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
+        _15 = narrow_bind copy _15 as Media(Audio, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
     }
 
     bb2: {
         _28 = copy _1;
-        _28 = narrow_bind copy _28 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
+        _28 = narrow_bind copy _28 as Media(Video, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
     }
 
     bb3: {
@@ -13382,11 +13308,11 @@ fn ai.ModelTurn.terminal_text(self: ai.ModelTurn) -> string | null {
     }
 }
 
-fn ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[] {
+fn ai.ModelTurn.media(self: ai.ModelTurn) -> (image | audio | video | pdf)[] {
     // Locals:
-    let _0: (baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[] // _0 // return
+    let _0: (image | audio | video | pdf)[] // _0 // return
     let _1: ai.ModelTurn // self // param
-    let _2: (baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video)[] // out
+    let _2: (image | audio | video | pdf)[] // out
     let _3: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
     let _4: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>
     let _5: unknown
@@ -13396,11 +13322,11 @@ fn ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Audio | baml.media.Imag
     let _9: ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse
     let _10: ai.content.Media // m
     let _11: int
-    let _12: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _12: image | audio | video | pdf
     let _13: reflect.Type
 
     bb0: {
-        _2 = []: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf[];
+        _2 = []: image | audio | video | pdf[];
         _3 = copy _1.0;
         _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _3) -> [bb1];
     }
@@ -13425,7 +13351,7 @@ fn ai.ModelTurn.media(self: ai.ModelTurn) -> (baml.media.Audio | baml.media.Imag
     bb4: {
         _10 = copy _9;
         _12 = copy _10.0;
-        _13 = load_type(baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf);
+        _13 = load_type(image | audio | video | pdf);
         _11 = call const fn baml.Array.push<copy _13>(copy _2, copy _12) -> [bb1];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
@@ -250,7 +250,7 @@ function ai.content.kind(self: ?) -> string  [expr] {
   {  } match (self.media) { image: baml.media.Image => "image", audio: baml.media.Audio => "audio", video: baml.media.Video => "video", pdf: baml.media.Pdf => "pdf" }
 }
 function ai.content.new(value: image | audio | video | pdf, provider_id: string? = null, revised_prompt: string? = null) -> ai.content.Media  [expr] {
-  { let envelope = baml.json.to_json(value) catch_all (e) { _ => { throw baml.errors.InvalidArgument { message: `...` } } }; let part: root.MediaPart = baml.json.from_json(envelope) catch_all (e) { _ => { throw baml.errors.InvalidArgument { message: `...` } } } } ai.content.Media { media: part, provider_id: provider_id, revised_prompt: revised_prompt }
+  {  } ai.content.Media { media: value, provider_id: provider_id, revised_prompt: revised_prompt }
 }
 
 --- <builtin>/ai/ns_errors/errors.baml ---

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -4759,10 +4759,10 @@ function baml.json.to_string(value: unknown) -> string {
     return
 }
 
-function baml.media.Audio.base64(self: baml.media.Audio) -> string {
+function baml.media.Audio.base64(self: audio) -> string {
 }
 
-function baml.media.Audio.file(self: baml.media.Audio) -> string | null {
+function baml.media.Audio.file(self: audio) -> string | null {
 }
 
 function baml.media.Audio.from_base64(base64: string, mime_type: string | null) -> audio {
@@ -4774,16 +4774,16 @@ function baml.media.Audio.from_file(file: string, mime_type: string | null) -> a
 function baml.media.Audio.from_url(url: string, mime_type: string | null) -> audio {
 }
 
-function baml.media.Audio.mime_type(self: baml.media.Audio) -> string | null {
+function baml.media.Audio.mime_type(self: audio) -> string | null {
 }
 
-function baml.media.Audio.url(self: baml.media.Audio) -> string | null {
+function baml.media.Audio.url(self: audio) -> string | null {
 }
 
-function baml.media.Image.base64(self: baml.media.Image) -> string {
+function baml.media.Image.base64(self: image) -> string {
 }
 
-function baml.media.Image.file(self: baml.media.Image) -> string | null {
+function baml.media.Image.file(self: image) -> string | null {
 }
 
 function baml.media.Image.from_base64(base64: string, mime_type: string | null) -> image {
@@ -4795,16 +4795,16 @@ function baml.media.Image.from_file(file: string, mime_type: string | null) -> i
 function baml.media.Image.from_url(url: string, mime_type: string | null) -> image {
 }
 
-function baml.media.Image.mime_type(self: baml.media.Image) -> string | null {
+function baml.media.Image.mime_type(self: image) -> string | null {
 }
 
-function baml.media.Image.url(self: baml.media.Image) -> string | null {
+function baml.media.Image.url(self: image) -> string | null {
 }
 
-function baml.media.Pdf.base64(self: baml.media.Pdf) -> string {
+function baml.media.Pdf.base64(self: pdf) -> string {
 }
 
-function baml.media.Pdf.file(self: baml.media.Pdf) -> string | null {
+function baml.media.Pdf.file(self: pdf) -> string | null {
 }
 
 function baml.media.Pdf.from_base64(base64: string, mime_type: string | null) -> pdf {
@@ -4816,16 +4816,16 @@ function baml.media.Pdf.from_file(file: string, mime_type: string | null) -> pdf
 function baml.media.Pdf.from_url(url: string, mime_type: string | null) -> pdf {
 }
 
-function baml.media.Pdf.mime_type(self: baml.media.Pdf) -> string | null {
+function baml.media.Pdf.mime_type(self: pdf) -> string | null {
 }
 
-function baml.media.Pdf.url(self: baml.media.Pdf) -> string | null {
+function baml.media.Pdf.url(self: pdf) -> string | null {
 }
 
-function baml.media.Video.base64(self: baml.media.Video) -> string {
+function baml.media.Video.base64(self: video) -> string {
 }
 
-function baml.media.Video.file(self: baml.media.Video) -> string | null {
+function baml.media.Video.file(self: video) -> string | null {
 }
 
 function baml.media.Video.from_base64(base64: string, mime_type: string | null) -> video {
@@ -4837,10 +4837,10 @@ function baml.media.Video.from_file(file: string, mime_type: string | null) -> v
 function baml.media.Video.from_url(url: string, mime_type: string | null) -> video {
 }
 
-function baml.media.Video.mime_type(self: baml.media.Video) -> string | null {
+function baml.media.Video.mime_type(self: video) -> string | null {
 }
 
-function baml.media.Video.url(self: baml.media.Video) -> string | null {
+function baml.media.Video.url(self: video) -> string | null {
 }
 
 function baml.net.<(baml.net.TcpStream as baml.io.Read)>.read(self: baml.net.TcpStream, limit: int) -> uint8array | null {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/compiler_alias_type_arguments/baml_tests__diagnostic_errors__compiler_alias_type_arguments__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/compiler_alias_type_arguments/baml_tests__diagnostic_errors__compiler_alias_type_arguments__03_ppir.snap
@@ -1,0 +1,14 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+type user.InvalidAssociatedBinding = unknown
+type user.InvalidAssociatedBinding$stream = unknown
+type user.InvalidImage = unknown
+type user.InvalidImage$stream = unknown
+type user.InvalidJson = unknown
+type user.InvalidJson$stream = unknown
+type user.InvalidMap = unknown
+type user.InvalidMap$stream = unknown
+type user.InvalidString = unknown
+type user.InvalidString$stream = unknown

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/compiler_alias_type_arguments/baml_tests__diagnostic_errors__compiler_alias_type_arguments__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/compiler_alias_type_arguments/baml_tests__diagnostic_errors__compiler_alias_type_arguments__05_diagnostics.snap
@@ -1,0 +1,48 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+  [hir] E0171
+
+  × type `image` expects 0 type argument(s), got 1
+   ╭─[main.baml:2:21]
+ 2 │ type InvalidImage = image<string>
+   ·                     ──────┬──────
+   ·                           ╰── invalid builtin type arguments
+   ╰────
+
+  [hir] E0171
+
+  × type `string` expects 0 type argument(s), got 1
+   ╭─[main.baml:3:22]
+ 3 │ type InvalidString = string<int>
+   ·                      ─────┬─────
+   ·                           ╰── invalid builtin type arguments
+   ╰────
+
+  [hir] E0171
+
+  × type `json` expects 0 type argument(s), got 1
+   ╭─[main.baml:4:20]
+ 4 │ type InvalidJson = json<string>
+   ·                    ──────┬─────
+   ·                          ╰── invalid builtin type arguments
+   ╰────
+
+  [hir] E0171
+
+  × type `map` expects 2 type argument(s), got 1
+   ╭─[main.baml:5:19]
+ 5 │ type InvalidMap = map<string>
+   ·                   ─────┬─────
+   ·                        ╰── invalid builtin type arguments
+   ╰────
+
+  [hir] E0171
+
+  × builtin type `image` does not accept associated-type bindings
+   ╭─[main.baml:6:33]
+ 6 │ type InvalidAssociatedBinding = image<Output=string>
+   ·                                 ──────────┬─────────
+   ·                                           ╰── invalid builtin type arguments
+   ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/compiler_alias_type_arguments/baml_tests__diagnostic_errors__compiler_alias_type_arguments__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/compiler_alias_type_arguments/baml_tests__diagnostic_errors__compiler_alias_type_arguments__10_formatter__main.snap
@@ -1,0 +1,13 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+// Builtin type arguments must be diagnosed rather than erased during lowering.
+type InvalidImage = image<string>;
+
+type InvalidString = string<int>;
+
+type InvalidJson = json<string>;
+
+type InvalidMap = map<string>;
+
+type InvalidAssociatedBinding = image<Output = string>;

--- a/baml_language/crates/baml_type/src/compiler_aliases.rs
+++ b/baml_language/crates/baml_type/src/compiler_aliases.rs
@@ -1,0 +1,553 @@
+//! Canonical compiler spellings and the declarations that carry builtin members.
+//!
+//! A carrier is a declaration anchor, never a second nominal runtime type. Keep
+//! lookup, lowering, documentation and construction policy together so adding a
+//! builtin does not require independent name tables in each consumer.
+//!
+//! Carriers live in the language packages the compiler knows by identity
+//! ([`LangPackage`]); which root each one is installed at is the caller's
+//! [`LangRoots`], so a compile-time head ([`DeclName`]) is matched by root and
+//! a wire name ([`TypeName`]) by the package's manifest spelling. Neither
+//! lookup compares a package name string of its own.
+
+use baml_base::{LangPackage, LangRoots, Name};
+
+use crate::{DeclName, PrimitiveType, QualifiedTypeName, TypeName};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AliasTarget {
+    Primitive(PrimitiveType),
+    List,
+    Map,
+    Future,
+    Type,
+    Json,
+    Void,
+    Never,
+    Unknown,
+}
+
+/// Arrays are syntax, not a bare `array` type name. Named constructors such as
+/// `map` carry their arity separately from their unparameterized spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Spelling {
+    Named(&'static str),
+    PostfixArray,
+}
+
+/// The declaration that carries a builtin's members: a language package and
+/// the `[...namespace, name]` path inside it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Definition {
+    pub package: LangPackage,
+    pub path: &'static [&'static str],
+}
+
+impl Definition {
+    /// The declaration's compile-time head, or `None` when `lang` has no
+    /// installation of its package (a database without the standard library).
+    pub fn decl_name(self, lang: LangRoots) -> Option<DeclName> {
+        let (name, namespace) = self.split_path();
+        Some(DeclName::in_root(
+            lang.get(self.package)?,
+            namespace.iter().map(Name::new).collect(),
+            Name::new(name),
+        ))
+    }
+
+    /// The declaration's wire name (`baml.media.Image`, `reflect.Type`): a
+    /// dependency edge names a language package by its manifest spelling.
+    pub fn type_name(self) -> TypeName {
+        let (name, namespace) = self.split_path();
+        TypeName::new(
+            Name::new(self.package.manifest_name()),
+            namespace.iter().map(Name::new).collect(),
+            Name::new(name),
+        )
+    }
+
+    /// The declaration as source spells it, `[package, ...path]` — what a
+    /// desugaring (`json` → `baml.json.json`) writes into the AST for the
+    /// ordinary path resolver to look up through the package's edges.
+    pub fn source_segments(self) -> impl Iterator<Item = &'static str> {
+        std::iter::once(self.package.manifest_name()).chain(self.path.iter().copied())
+    }
+
+    /// Whether `name` is this declaration under `lang`'s installation.
+    pub fn matches(self, lang: LangRoots, name: &DeclName) -> bool {
+        lang.is(self.package, name.root()) && self.matches_path(name)
+    }
+
+    /// [`matches`](Self::matches) for a wire name.
+    pub fn matches_type_name(self, name: &TypeName) -> bool {
+        !name.is_local()
+            && name.package().as_str() == self.package.manifest_name()
+            && self.matches_path(name)
+    }
+
+    fn matches_path<P>(self, name: &QualifiedTypeName<P>) -> bool {
+        name.namespace()
+            .iter()
+            .chain(std::iter::once(name.name()))
+            .map(Name::as_str)
+            .eq(self.path.iter().copied())
+    }
+
+    fn split_path(self) -> (&'static str, &'static [&'static str]) {
+        let (name, namespace) = self
+            .path
+            .split_last()
+            .expect("builtin definition paths are nonempty");
+        (name, namespace)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Construction {
+    /// A builtin value cannot be made by constructing the carrier's fields.
+    Builtin {
+        origin: &'static str,
+        carries_methods: bool,
+    },
+    /// An alias expands through the ordinary alias resolver, not a constructor.
+    Alias,
+    /// A compiler type with no value constructor or addressable declaration.
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompilerAlias {
+    pub target: AliasTarget,
+    pub spelling: Spelling,
+    pub arity: usize,
+    pub definition: Option<Definition>,
+    pub construction: Construction,
+}
+
+impl CompilerAlias {
+    /// Diagnostic spelling; arrays have no standalone keyword.
+    pub fn display_name(&self) -> &'static str {
+        match self.spelling {
+            Spelling::Named(name) => name,
+            Spelling::PostfixArray => "array",
+        }
+    }
+
+    /// The structural type this entry's class declaration denotes when it is
+    /// applied to `arity` arguments: `class baml.media.Image` IS `image`,
+    /// `class baml.Array<T>` IS `T[]`. Json stays on the alias resolver path,
+    /// and intrinsics without declarations are not class carriers. Callers
+    /// diagnose bad generic arity before constructing a class type, so a
+    /// mismatched arity simply keeps the nominal class.
+    pub fn class_carrier(&self, arity: usize) -> Option<AliasTarget> {
+        match self.construction {
+            Construction::Builtin { .. } if arity == self.arity => Some(self.target),
+            _ => None,
+        }
+    }
+
+    /// [`class_carrier`](Self::class_carrier) in the interned vocabulary: the
+    /// type the carrier's class spelling denotes, or `None` to stay nominal.
+    pub fn lower_class(&self, args: &[crate::interned::Ty]) -> Option<crate::interned::Ty> {
+        use crate::interned::{InferTy, Ty};
+        let attr = crate::TyAttr::default();
+        let kind = match self.class_carrier(args.len())? {
+            AliasTarget::Primitive(primitive) => {
+                return Some(Ty::from_plain(&crate::Ty::from_primitive(primitive, attr)));
+            }
+            AliasTarget::List => InferTy::List(args[0].clone(), attr),
+            AliasTarget::Map => InferTy::Map {
+                key: args[0].clone(),
+                value: args[1].clone(),
+                attr,
+            },
+            AliasTarget::Future => InferTy::Future(args[0].clone(), args[1].clone(), attr),
+            AliasTarget::Type => InferTy::Type { attr },
+            AliasTarget::Json | AliasTarget::Void | AliasTarget::Never | AliasTarget::Unknown => {
+                return None;
+            }
+        };
+        Some(Ty::intern(kind))
+    }
+}
+
+const fn primitive(
+    primitive: PrimitiveType,
+    spelling: &'static str,
+    path: &'static [&'static str],
+    origin: &'static str,
+    carries_methods: bool,
+) -> CompilerAlias {
+    CompilerAlias {
+        target: AliasTarget::Primitive(primitive),
+        spelling: Spelling::Named(spelling),
+        arity: 0,
+        definition: Some(Definition {
+            package: LangPackage::Baml,
+            path,
+        }),
+        construction: Construction::Builtin {
+            origin,
+            carries_methods,
+        },
+    }
+}
+
+const fn intrinsic(target: AliasTarget, spelling: &'static str) -> CompilerAlias {
+    CompilerAlias {
+        target,
+        spelling: Spelling::Named(spelling),
+        arity: 0,
+        definition: None,
+        construction: Construction::None,
+    }
+}
+
+pub const ALL: &[CompilerAlias] = &[
+    primitive(PrimitiveType::Int, "int", &["Int"], "literals", true),
+    primitive(
+        PrimitiveType::Bigint,
+        "bigint",
+        &["Bigint"],
+        "literals",
+        true,
+    ),
+    primitive(PrimitiveType::Float, "float", &["Float"], "literals", true),
+    primitive(
+        PrimitiveType::String,
+        "string",
+        &["String"],
+        "literals",
+        true,
+    ),
+    primitive(PrimitiveType::Bool, "bool", &["Bool"], "literals", false),
+    primitive(
+        PrimitiveType::Null,
+        "null",
+        &["Null"],
+        "the `null` literal",
+        false,
+    ),
+    primitive(
+        PrimitiveType::Uint8Array,
+        "uint8array",
+        &["Uint8Array"],
+        "byte-string literals",
+        true,
+    ),
+    primitive(
+        PrimitiveType::Image,
+        "image",
+        &["media", "Image"],
+        "image factory methods",
+        true,
+    ),
+    primitive(
+        PrimitiveType::Audio,
+        "audio",
+        &["media", "Audio"],
+        "audio factory methods",
+        true,
+    ),
+    primitive(
+        PrimitiveType::Video,
+        "video",
+        &["media", "Video"],
+        "video factory methods",
+        true,
+    ),
+    primitive(
+        PrimitiveType::Pdf,
+        "pdf",
+        &["media", "Pdf"],
+        "pdf factory methods",
+        true,
+    ),
+    CompilerAlias {
+        target: AliasTarget::List,
+        spelling: Spelling::PostfixArray,
+        arity: 1,
+        definition: Some(Definition {
+            package: LangPackage::Baml,
+            path: &["Array"],
+        }),
+        construction: Construction::Builtin {
+            origin: "array literals",
+            carries_methods: true,
+        },
+    },
+    CompilerAlias {
+        target: AliasTarget::Map,
+        spelling: Spelling::Named("map"),
+        arity: 2,
+        definition: Some(Definition {
+            package: LangPackage::Baml,
+            path: &["Map"],
+        }),
+        construction: Construction::Builtin {
+            origin: "map literals",
+            carries_methods: true,
+        },
+    },
+    CompilerAlias {
+        target: AliasTarget::Future,
+        spelling: Spelling::Named("baml.future.Future"),
+        arity: 2,
+        definition: Some(Definition {
+            package: LangPackage::Baml,
+            path: &["future", "Future"],
+        }),
+        construction: Construction::Builtin {
+            origin: "spawn expressions",
+            carries_methods: true,
+        },
+    },
+    CompilerAlias {
+        target: AliasTarget::Type,
+        spelling: Spelling::Named("reflect.Type"),
+        arity: 0,
+        definition: Some(Definition {
+            package: LangPackage::Reflect,
+            path: &["Type"],
+        }),
+        construction: Construction::Builtin {
+            origin: "`reflect.Type.of<T>()` and reflection",
+            carries_methods: true,
+        },
+    },
+    CompilerAlias {
+        target: AliasTarget::Json,
+        spelling: Spelling::Named("json"),
+        arity: 0,
+        definition: Some(Definition {
+            package: LangPackage::Baml,
+            path: &["json", "json"],
+        }),
+        construction: Construction::Alias,
+    },
+    intrinsic(AliasTarget::Void, "void"),
+    intrinsic(AliasTarget::Never, "never"),
+    intrinsic(AliasTarget::Unknown, "unknown"),
+];
+
+/// The member declaration and its type arguments for a structural receiver.
+/// Aliases must be expanded by the caller's type-definition oracle first.
+pub fn member_owner(
+    receiver: &crate::interned::Ty,
+) -> Option<(Definition, Vec<crate::interned::Ty>)> {
+    use crate::{MediaKind, interned::InferTy};
+    let scalar = |primitive| (AliasTarget::Primitive(primitive), Vec::new());
+    let (target, args) = match receiver.kind() {
+        InferTy::Int { .. } => scalar(PrimitiveType::Int),
+        InferTy::Bigint { .. } => scalar(PrimitiveType::Bigint),
+        InferTy::Float { .. } => scalar(PrimitiveType::Float),
+        InferTy::String { .. } => scalar(PrimitiveType::String),
+        InferTy::Bool { .. } => scalar(PrimitiveType::Bool),
+        InferTy::Null { .. } => scalar(PrimitiveType::Null),
+        InferTy::Uint8Array { .. } => scalar(PrimitiveType::Uint8Array),
+        InferTy::Literal(literal, _, _) => scalar(PrimitiveType::from_literal(literal)),
+        InferTy::Media(kind, _) => scalar(match kind {
+            MediaKind::Image => PrimitiveType::Image,
+            MediaKind::Audio => PrimitiveType::Audio,
+            MediaKind::Video => PrimitiveType::Video,
+            MediaKind::Pdf => PrimitiveType::Pdf,
+            MediaKind::Generic => return None,
+        }),
+        InferTy::List(element, _) => (AliasTarget::List, vec![element.clone()]),
+        InferTy::Map { key, value, .. } => (AliasTarget::Map, vec![key.clone(), value.clone()]),
+        InferTy::Future(value, error, _) => {
+            (AliasTarget::Future, vec![value.clone(), error.clone()])
+        }
+        InferTy::Type { .. } => (AliasTarget::Type, Vec::new()),
+        _ => return None,
+    };
+    Some((by_target(target).definition?, args))
+}
+
+pub fn by_target(target: AliasTarget) -> &'static CompilerAlias {
+    ALL.iter()
+        .find(|entry| entry.target == target)
+        .expect("every builtin target has a compiler alias")
+}
+
+pub fn by_spelling(spelling: &str) -> Option<&'static CompilerAlias> {
+    ALL.iter()
+        .find(|entry| matches!(entry.spelling, Spelling::Named(name) if name == spelling))
+}
+
+/// The entry whose carrier declaration is `name` under `lang`'s installed
+/// language packages. Keyed on the full definition path, so a user's own
+/// `class Int` and `reflect.class.Type` stay nominal.
+pub fn by_definition(lang: LangRoots, name: &DeclName) -> Option<&'static CompilerAlias> {
+    ALL.iter().find(|entry| {
+        entry
+            .definition
+            .is_some_and(|definition| definition.matches(lang, name))
+    })
+}
+
+/// [`by_definition`] for a wire name.
+pub fn by_type_name(name: &TypeName) -> Option<&'static CompilerAlias> {
+    ALL.iter().find(|entry| {
+        entry
+            .definition
+            .is_some_and(|definition| definition.matches_type_name(name))
+    })
+}
+
+/// [`by_definition`] for a path inside a language package.
+pub fn by_definition_path(package: LangPackage, path: &[&str]) -> Option<&'static CompilerAlias> {
+    ALL.iter().find(|entry| {
+        entry
+            .definition
+            .is_some_and(|definition| definition.package == package && definition.path == path)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        MediaKind, TyAttr,
+        interned::{InferTy, Ty},
+        test_roots,
+    };
+
+    /// `path` as a compile-time head over the test roots (`user.X` is the
+    /// nameless workspace root), the shape [`TypeName::from_dotted_path`]
+    /// gives on the wire.
+    fn decl(path: &str) -> DeclName {
+        let wire = TypeName::from_dotted_path(path);
+        test_roots::new(
+            wire.package().clone(),
+            wire.namespace().clone(),
+            wire.name().clone(),
+        )
+    }
+
+    #[test]
+    fn registry_is_unambiguous_and_covers_every_primitive() {
+        for (index, entry) in ALL.iter().enumerate() {
+            for other in &ALL[..index] {
+                assert_ne!(entry.target, other.target);
+                assert_ne!(entry.spelling, other.spelling);
+                if let Some(definition) = entry.definition {
+                    assert_ne!(Some(definition), other.definition);
+                }
+            }
+        }
+        for primitive in PrimitiveType::ALL {
+            assert_eq!(by_target(AliasTarget::Primitive(primitive)).arity, 0);
+        }
+        // Syntax is not a second, accidentally accepted name for T[].
+        assert!(by_spelling("array").is_none());
+        assert!(by_spelling("Array").is_none());
+    }
+
+    #[test]
+    fn lowering_and_member_owners_agree_for_every_carrier() {
+        let lang = test_roots::lang();
+        let element = Ty::intern(InferTy::String {
+            attr: TyAttr::default(),
+        });
+        for alias in ALL {
+            if !matches!(alias.construction, Construction::Builtin { .. }) {
+                continue;
+            }
+            let args = vec![element.clone(); alias.arity];
+            let ty = alias.lower_class(&args).expect("class carrier lowers");
+            let (definition, recovered_args) = member_owner(&ty).expect("carrier has members");
+            assert_eq!(Some(definition), alias.definition);
+            assert_eq!(recovered_args, args);
+            let head = definition
+                .decl_name(lang)
+                .expect("language package installed");
+            assert_eq!(by_definition(lang, &head), Some(alias));
+            assert_eq!(by_type_name(&definition.type_name()), Some(alias));
+            assert_eq!(
+                by_definition_path(definition.package, definition.path),
+                Some(alias)
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_checks_package_and_entire_namespace() {
+        let lang = test_roots::lang();
+        for path in [
+            "user.Image",
+            "user.String",
+            "baml.Image",
+            "baml.other.String",
+            "reflect.class.Type",
+        ] {
+            assert!(by_definition(lang, &decl(path)).is_none(), "{path}");
+            assert!(
+                by_type_name(&TypeName::from_dotted_path(path)).is_none(),
+                "{path}"
+            );
+        }
+        let image = AliasTarget::Primitive(PrimitiveType::Image);
+        assert_eq!(
+            by_definition(lang, &decl("baml.media.Image"))
+                .unwrap()
+                .target,
+            image
+        );
+        assert_eq!(
+            by_type_name(&TypeName::from_dotted_path("baml.media.Image"))
+                .unwrap()
+                .target,
+            image
+        );
+    }
+
+    #[test]
+    fn carriers_are_keyed_by_root_not_spelling() {
+        // A package that merely spells itself `baml` is not the language's
+        // `baml`: only the root `lang` installed as `LangPackage::Baml` is.
+        let head = decl("baml.media.Image");
+        assert!(by_definition(test_roots::lang(), &head).is_some());
+        assert!(by_definition(LangRoots::default(), &head).is_none());
+        let other = LangRoots::default().with(LangPackage::Baml, test_roots::root("other"));
+        assert!(by_definition(other, &head).is_none());
+        // And with no standard library installed, a carrier has no head at all.
+        let image = by_target(AliasTarget::Primitive(PrimitiveType::Image));
+        assert!(
+            image
+                .definition
+                .unwrap()
+                .decl_name(LangRoots::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn carrier_lowering_preserves_media_and_container_identity() {
+        let image = by_target(AliasTarget::Primitive(PrimitiveType::Image))
+            .lower_class(&[])
+            .unwrap();
+        assert!(matches!(image.kind(), InferTy::Media(MediaKind::Image, _)));
+        let list = by_target(AliasTarget::List)
+            .lower_class(std::slice::from_ref(&image))
+            .unwrap();
+        assert!(matches!(list.kind(), InferTy::List(element, _) if element == &image));
+        assert!(by_target(AliasTarget::List).lower_class(&[]).is_none());
+        assert!(
+            by_target(AliasTarget::Primitive(PrimitiveType::Image))
+                .lower_class(&[image])
+                .is_none()
+        );
+        // JSON's recursive expansion belongs to ordinary alias lowering.
+        assert!(by_target(AliasTarget::Json).lower_class(&[]).is_none());
+        let error = Ty::intern(InferTy::Never {
+            attr: TyAttr::default(),
+        });
+        let result = Ty::intern(InferTy::String {
+            attr: TyAttr::default(),
+        });
+        assert!(
+            matches!(by_target(AliasTarget::Future).lower_class(&[result.clone(), error.clone()]).unwrap().kind(), InferTy::Future(value, thrown, _) if value == &result && thrown == &error)
+        );
+    }
+}

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -33,6 +33,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 mod attr;
 mod codegen_ty;
+pub mod compiler_aliases;
 pub mod decl_cycles;
 mod declaration_name;
 mod defs;

--- a/baml_language/crates/baml_type/src/primitive.rs
+++ b/baml_language/crates/baml_type/src/primitive.rs
@@ -42,19 +42,10 @@ impl PrimitiveType {
     /// classes in `baml_builtins2/baml_std/baml/ns_media/media.baml`, and
     /// `uint8array` has its class in `baml_builtins2/baml_std/baml/uint8array.baml`.
     pub fn builtin_class_path(&self) -> &'static [&'static str] {
-        match self {
-            Self::Int => &["Int"],
-            Self::Bigint => &["Bigint"],
-            Self::Float => &["Float"],
-            Self::Bool => &["Bool"],
-            Self::Null => &["Null"],
-            Self::String => &["String"],
-            Self::Uint8Array => &["Uint8Array"],
-            Self::Image => &["media", "Image"],
-            Self::Audio => &["media", "Audio"],
-            Self::Video => &["media", "Video"],
-            Self::Pdf => &["media", "Pdf"],
-        }
+        crate::compiler_aliases::by_target(crate::compiler_aliases::AliasTarget::Primitive(*self))
+            .definition
+            .expect("primitives have member declarations")
+            .path
     }
 
     pub fn from_literal(lit: &baml_base::Literal) -> Self {
@@ -71,35 +62,28 @@ impl PrimitiveType {
     /// `image`, …). Single source of truth — the [`fmt::Display`] impl delegates
     /// here.
     pub fn alias(&self) -> &'static str {
-        match self {
-            Self::Int => "int",
-            Self::Bigint => "bigint",
-            Self::Float => "float",
-            Self::String => "string",
-            Self::Bool => "bool",
-            Self::Null => "null",
-            Self::Uint8Array => "uint8array",
-            Self::Image => "image",
-            Self::Audio => "audio",
-            Self::Video => "video",
-            Self::Pdf => "pdf",
-        }
+        crate::compiler_aliases::by_target(crate::compiler_aliases::AliasTarget::Primitive(*self))
+            .display_name()
     }
 
     /// Resolve a lowercase source spelling to its semantic primitive.
     pub fn from_alias(alias: &str) -> Option<Self> {
-        Self::ALL
-            .into_iter()
-            .find(|primitive| primitive.alias() == alias)
+        match crate::compiler_aliases::by_spelling(alias)?.target {
+            crate::compiler_aliases::AliasTarget::Primitive(primitive) => Some(primitive),
+            _ => None,
+        }
     }
 
     /// Inverse of [`builtin_class_path`](Self::builtin_class_path): map a class
     /// path (relative to the `baml` package, e.g. `["media", "Image"]`) back to
     /// the primitive it is the companion class for.
     pub fn from_builtin_class_path(path: &[&str]) -> Option<Self> {
-        Self::ALL
-            .into_iter()
-            .find(|primitive| primitive.builtin_class_path() == path)
+        match crate::compiler_aliases::by_definition_path(baml_base::LangPackage::Baml, path)?
+            .target
+        {
+            crate::compiler_aliases::AliasTarget::Primitive(primitive) => Some(primitive),
+            _ => None,
+        }
     }
 }
 
@@ -137,26 +121,11 @@ impl BuiltinTypeName {
     }
 
     pub fn from_alias(alias: &str) -> Option<Self> {
-        if let Some(primitive) = PrimitiveType::from_alias(alias) {
-            return Some(Self::Primitive(primitive));
-        }
-        Some(match alias {
-            "json" => Self::Json,
-            "void" => Self::Void,
-            "never" => Self::Never,
-            "unknown" => Self::Unknown,
-            _ => return None,
-        })
+        Self::from_target(crate::compiler_aliases::by_spelling(alias)?.target)
     }
 
     pub fn alias(self) -> &'static str {
-        match self {
-            Self::Primitive(primitive) => primitive.alias(),
-            Self::Json => "json",
-            Self::Void => "void",
-            Self::Never => "never",
-            Self::Unknown => "unknown",
-        }
+        crate::compiler_aliases::by_target(self.target()).display_name()
     }
 
     /// The path of this type's definition relative to the `baml` package.
@@ -164,18 +133,38 @@ impl BuiltinTypeName {
     /// Compiler intrinsics deliberately return `None`: their documentation is
     /// supplied by the language-topic registry instead.
     pub fn builtin_definition_path(self) -> Option<&'static [&'static str]> {
+        crate::compiler_aliases::by_target(self.target())
+            .definition
+            .map(|definition| definition.path)
+    }
+
+    fn target(self) -> crate::compiler_aliases::AliasTarget {
+        use crate::compiler_aliases::AliasTarget;
         match self {
-            Self::Primitive(primitive) => Some(primitive.builtin_class_path()),
-            Self::Json => Some(&["json", "json"]),
-            Self::Void | Self::Never | Self::Unknown => None,
+            Self::Primitive(primitive) => AliasTarget::Primitive(primitive),
+            Self::Json => AliasTarget::Json,
+            Self::Void => AliasTarget::Void,
+            Self::Never => AliasTarget::Never,
+            Self::Unknown => AliasTarget::Unknown,
         }
     }
 
+    fn from_target(target: crate::compiler_aliases::AliasTarget) -> Option<Self> {
+        use crate::compiler_aliases::AliasTarget;
+        Some(match target {
+            AliasTarget::Primitive(primitive) => Self::Primitive(primitive),
+            AliasTarget::Json => Self::Json,
+            AliasTarget::Void => Self::Void,
+            AliasTarget::Never => Self::Never,
+            AliasTarget::Unknown => Self::Unknown,
+            _ => return None,
+        })
+    }
+
     pub fn from_builtin_definition_path(path: &[&str]) -> Option<Self> {
-        if path == ["json", "json"] {
-            return Some(Self::Json);
-        }
-        PrimitiveType::from_builtin_class_path(path).map(Self::Primitive)
+        Self::from_target(
+            crate::compiler_aliases::by_definition_path(baml_base::LangPackage::Baml, path)?.target,
+        )
     }
 }
 

--- a/baml_language/crates/baml_type/src/type_kind.rs
+++ b/baml_language/crates/baml_type/src/type_kind.rs
@@ -2,7 +2,10 @@
 
 use baml_base::{LangPackage, LangRoots, SourceRoot};
 
-use crate::{DeclName, Name, QualifiedTypeName, RealizedTy};
+use crate::{
+    DeclName, Name, QualifiedTypeName, RealizedTy, TypeName,
+    compiler_aliases::{self, CompilerAlias, Construction},
+};
 
 /// The nine sealed runtime views of a reflected `type` value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -126,68 +129,47 @@ pub struct BuiltinCompanion {
 /// instance (and, for the generic carriers, an error-recovery type that
 /// reaches MIR lowering), so the two class-literal sites reject them.
 ///
-/// Same discipline as [`QualifiedTypeName::is_builtin_root_type`]: the
-/// `baml` package plus an EMPTY namespace, so a user's own `Int` class and
-/// the field-carrying `reflect.class.Field` are both untouched.
-pub fn builtin_companion_of(name: &QualifiedTypeName) -> Option<BuiltinCompanion> {
-    let package = match name.package().as_str() {
-        "reflect" => LangPackage::Reflect,
-        "baml" => LangPackage::Baml,
-        _ => return None,
-    };
-    builtin_companion_in(package, name.namespace(), name.name())
-}
-
-/// [`builtin_companion_of`] for a compile-time head: the class must live in
-/// the installed `reflect` or `baml` package.
+/// The set is the compiler alias registry's, keyed by the installed language
+/// package and the full definition path, so a user's own `Int` class and
+/// `reflect.class.Field` stay nominal.
 pub fn builtin_companion_of_decl(lang: LangRoots, name: &DeclName) -> Option<BuiltinCompanion> {
-    let package = [LangPackage::Reflect, LangPackage::Baml]
-        .into_iter()
-        .find(|package| lang.is(*package, name.root()))?;
-    builtin_companion_in(package, name.namespace(), name.name())
+    companion(compiler_aliases::by_definition(lang, name)?)
 }
 
-fn builtin_companion_in(
-    package: LangPackage,
-    namespace: &[Name],
-    name: &Name,
-) -> Option<BuiltinCompanion> {
-    if !namespace.is_empty() {
-        return None;
+/// [`builtin_companion_of_decl`] for a wire name (`baml.Int` spelled by the
+/// artifact's dependency edges).
+pub fn builtin_companion_of(name: &TypeName) -> Option<BuiltinCompanion> {
+    companion(compiler_aliases::by_type_name(name)?)
+}
+
+fn companion(alias: &CompilerAlias) -> Option<BuiltinCompanion> {
+    match alias.construction {
+        Construction::Builtin {
+            origin,
+            carries_methods,
+        } => Some(BuiltinCompanion {
+            builtin: alias.display_name(),
+            origin,
+            carries_methods,
+        }),
+        Construction::Alias | Construction::None => None,
     }
-    match package {
-        LangPackage::Reflect => {
-            return (name.as_str() == "Type").then_some(BuiltinCompanion {
-                builtin: "reflect.Type",
-                origin: "`reflect.Type.of<T>()` and reflection",
-                carries_methods: true,
-            });
-        }
-        LangPackage::Baml => {}
-        LangPackage::Ai | LangPackage::Boundary => return None,
-    }
-    let (builtin, origin, carries_methods) = match name.as_str() {
-        "Int" => ("int", "literals", true),
-        "Bigint" => ("bigint", "literals", true),
-        "Float" => ("float", "literals", true),
-        "String" => ("string", "literals", true),
-        "Bool" => ("bool", "literals", false),
-        "Null" => ("null", "the `null` literal", false),
-        "Uint8Array" => ("uint8array", "byte-string literals", true),
-        "Array" => ("array", "array literals", true),
-        "Map" => ("map", "map literals", true),
-        _ => return None,
-    };
-    Some(BuiltinCompanion {
-        builtin,
-        origin,
-        carries_methods,
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_roots;
+
+    /// `path` as a compile-time head over the test roots.
+    fn decl(path: &str) -> DeclName {
+        let wire = TypeName::from_dotted_path(path);
+        test_roots::new(
+            wire.package().clone(),
+            wire.namespace().clone(),
+            wire.name().clone(),
+        )
+    }
 
     #[test]
     fn kind_names_are_closed_and_recognized() {
@@ -200,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn companion_carriers_need_the_baml_package_and_an_empty_namespace() {
+    fn companion_carriers_require_the_exact_builtin_definition() {
         for (path, builtin) in [
             ("baml.Int", "int"),
             ("baml.Bigint", "bigint"),
@@ -212,9 +194,17 @@ mod tests {
             ("baml.Array", "array"),
             ("baml.Map", "map"),
             ("reflect.Type", "reflect.Type"),
+            ("baml.media.Image", "image"),
+            ("baml.future.Future", "baml.future.Future"),
         ] {
             assert_eq!(
-                builtin_companion_of(&QualifiedTypeName::from_dotted_path(path))
+                builtin_companion_of(&TypeName::from_dotted_path(path))
+                    .map(|companion| companion.builtin),
+                Some(builtin),
+                "{path} should be a companion carrier"
+            );
+            assert_eq!(
+                builtin_companion_of_decl(test_roots::lang(), &decl(path))
                     .map(|companion| companion.builtin),
                 Some(builtin),
                 "{path} should be a companion carrier"
@@ -228,13 +218,17 @@ mod tests {
             // field-carrying reflect classes the stdlib itself constructs.
             "reflect.class.Field",
             "reflect.class.Type",
-            "baml.media.Image",
             "baml.iter.Done",
             // A root-namespace `baml` class that really does hold fields.
             "baml.TaggedString",
         ] {
             assert_eq!(
-                builtin_companion_of(&QualifiedTypeName::from_dotted_path(path)),
+                builtin_companion_of(&TypeName::from_dotted_path(path)),
+                None,
+                "{path} should not be a companion carrier"
+            );
+            assert_eq!(
+                builtin_companion_of_decl(test_roots::lang(), &decl(path)),
                 None,
                 "{path} should not be a companion carrier"
             );


### PR DESCRIPTION
## Summary

One registry, `baml_type::compiler_aliases`, now records every builtin type's source spelling, arity, carrier declaration (`class baml.media.Image` for `image`, `class baml.Array<T>` for `T[]`, …) and construction policy. Seven hand-written copies of that knowledge are deleted: `PrimitiveType`/`BuiltinTypeName` lookups, `builtin_companion_of`, the AST spelling match and its two `map` special cases, `class_ty`'s bridging arms, the duplicated `external_class_for_type`/`receiver_class` tables, and `static_qualifier_ty`.

## Bugs fixed

- **Type arguments on builtins were silently erased.** `image<string>`, `string<int>`, `image<Output=string>` compiled as plain `image`/`string`. Now rejected with a new diagnostic, E0171 `InvalidBuiltinTypeArguments`.
- **`map<string>` was reported as an unresolved user type named `map`.** Now E0171 with the expected arity.
- **`baml.media.Image` (Audio/Video/Pdf) was a nominal class distinct from `image`.** `let w: baml.media.Image = image.from_base64(..)` was a type mismatch and `ai.MediaPart` did not accept media values. The carriers now bridge exactly like `baml.Int` → `int`; stdlib signatures render as `self: image`. `ai.content.Media.new` loses its JSON round-trip and two `catch_all` blocks that existed only to work around this.

## Tests

- `baml_type` registry unit tests (unambiguous spellings, lowering/member-owner agreement) and `hir_ty` bridge tests.
- Native BAML: `baml_src/ns_compiler_aliases/` (media factories and methods, array interface dispatch, and the `baml.media.Image == image` regression: annotation, parameter, `ai.PromptPart`, `reflect.Type.of` equality).
- `diagnostic_errors/compiler_alias_type_arguments` fixture for the five E0171 shapes.
- Stdlib snapshots regenerated (`baml.media.X` → `image` renames only).

## Stack

Part of the split of #4797. Bottom of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standardized built-in type aliases across annotations, unions, pattern matching, reflection, and method calls.
  - Added consistent support for media types and canonical spellings such as image, audio, video, and PDF.
  - Media construction now accepts media values directly.

- **Bug Fixes**
  - Invalid type arguments and associated bindings for built-in types now produce clear compiler diagnostics instead of being silently ignored.
  - Improved resolution of built-in container, future, reflection, JSON, and primitive types across supported language features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type lowering, receiver/method dispatch, and media typing across the compiler and AI stdlib; behavior changes are intentional but broad enough to affect any code using builtin or media spellings.
> 
> **Overview**
> Introduces **`baml_type::compiler_aliases`** as the single registry for builtin spellings (`int`, `image`, `map`, …), generic arity, and which stdlib **carrier class** owns methods (`baml.media.Image` ↔ `image`). AST lowering, HIR class bridging, static qualifiers, method/receiver resolution, primitive lookups, and builtin-companion policy all delegate to this module instead of parallel name tables.
> 
> **Type behavior fixes:** invalid arguments on builtins (`image<string>`, `map<string>`, associated bindings) now emit **E0171** at lowering instead of being stripped; **`baml.media.Image`** (and siblings) denote the same structural media types as **`image`**, so primitives assign into class-typed unions and **`ai.content.Media.new`** stores the value directly (JSON encode/decode workaround removed).
> 
> Adds registry/HIR tests, **`ns_compiler_aliases`** integration tests, and a diagnostic fixture; stdlib snapshots reflect primitive media types in signatures and narrowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd98386b41cb37527c45b90e5eb30e4208832e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->