### PR TITLE
ai.events: one content-block vocabulary for user turns and tool results

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
@@ -1,6 +1,7 @@
-// Canonical assistant content: what a model turn produced, normalized away
-// from any one provider's envelope. Clients build these; the journal records
-// them inside root.events.AssistantMessage.
+// Canonical content: the blocks a turn carries, normalized away from any one
+// provider's envelope. `ContentBlock` is what ANY turn may carry (a user turn,
+// a tool result, a model turn); `Block` adds what only a model turn produces.
+// Clients build these; the journal records them inside root.events.*.
 //
 // Mirrors _planv2/pages/04_reference/01_api.md (the `ai.content` namespace).
 
@@ -20,9 +21,13 @@ class ToolUse {
     args: map<string, unknown>,
 }
 
-/// A media payload the turn produced: a generated image, a file a provider-side
-/// tool wrote. The value is a real BAML media value, so `-> image` returns
-/// something callers can save or pass straight back into another prompt.
+/// A media payload: a screenshot a runner attaches to a user turn, a file a
+/// tool returned, a generated image a model produced. The value is a real BAML
+/// media value, so `-> image` returns something callers can save or pass
+/// straight back into another prompt.
+///
+/// `provider_id` and `revised_prompt` are provenance of GENERATED output and
+/// are null on input.
 class Media {
     media: root.MediaPart,
     // The provider's own handle for this output, when it names one
@@ -56,7 +61,55 @@ class Media {
     }
 }
 
-type Block = Text | Reasoning | ToolUse | Media;
+/// What any turn may carry.
+type ContentBlock = Text | Media;
+
+/// What a model turn may additionally produce.
+type Block = ContentBlock | Reasoning | ToolUse;
+
+/// Content blocks from ordinary values: a bare `string` becomes `Text`, a bare
+/// `image` / `audio` / `video` / `pdf` becomes `Media` with null provenance, and
+/// a block already built passes through. The one constructor behind
+/// `root.events.UserMessage.of` and `root.events.ToolCompleted.of`.
+function blocks(items: (string | image | audio | video | pdf | Text | Media)[]) -> ContentBlock[] {
+    let out: ContentBlock[] = [];
+    for (let item in items) {
+        match (item) {
+            let text: string => {
+                out.push(Text { text: text });
+                null
+            },
+            let block: ContentBlock => {
+                out.push(block);
+                null
+            },
+            let media: image | audio | video | pdf => {
+                out.push(Media.new(media));
+                null
+            },
+        };
+    }
+    out
+}
+
+/// The readable projection of a block list: `Text` blocks as written, each
+/// `Media` block as a `[image]`-style placeholder, joined in order.
+function text(content: ContentBlock[]) -> string {
+    let out = "";
+    for (let block in content) {
+        match (block) {
+            let t: Text => {
+                out = `${out}${t.text}`;
+                null
+            },
+            let m: Media => {
+                out = `${out}[${m.kind()}]`;
+                null
+            },
+        };
+    }
+    out
+}
 
 /// Why the model stopped. `ToolUse` means the turn ended with tool calls the
 /// runner must execute before the next turn.

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_content/content.baml
@@ -1,6 +1,6 @@
 // Canonical content: the blocks a turn carries, normalized away from any one
-// provider's envelope. `ContentBlock` is what ANY turn may carry (a user turn,
-// a tool result, a model turn); `Block` adds what only a model turn produces.
+// provider's envelope. `Block` is what ANY turn may carry (a user turn, a tool
+// result, a model turn); `root.content.ModelBlock` adds what only a model turn produces.
 // Clients build these; the journal records them inside root.events.*.
 //
 // Mirrors _planv2/pages/04_reference/01_api.md (the `ai.content` namespace).
@@ -62,24 +62,25 @@ class Media {
 }
 
 /// What any turn may carry.
-type ContentBlock = Text | Media;
+type Block = Text | Media;
 
-/// What a model turn may additionally produce.
-type Block = ContentBlock | Reasoning | ToolUse;
+/// What a model turn produces: any `Block` plus the model-only reasoning and
+/// tool-use blocks. Every other turn carries `Block[]`.
+type ModelBlock = Block | Reasoning | ToolUse;
 
 /// Content blocks from ordinary values: a bare `string` becomes `Text`, a bare
 /// `image` / `audio` / `video` / `pdf` becomes `Media` with null provenance, and
 /// a block already built passes through. The one constructor behind
 /// `root.events.UserMessage.of` and `root.events.ToolCompleted.of`.
-function blocks(items: (string | image | audio | video | pdf | Text | Media)[]) -> ContentBlock[] {
-    let out: ContentBlock[] = [];
+function blocks(items: (string | image | audio | video | pdf | Text | Media)[]) -> Block[] {
+    let out: Block[] = [];
     for (let item in items) {
         match (item) {
             let text: string => {
                 out.push(Text { text: text });
                 null
             },
-            let block: ContentBlock => {
+            let block: Block => {
                 out.push(block);
                 null
             },
@@ -94,7 +95,7 @@ function blocks(items: (string | image | audio | video | pdf | Text | Media)[]) 
 
 /// The readable projection of a block list: `Text` blocks as written, each
 /// `Media` block as a `[image]`-style placeholder, joined in order.
-function text(content: ContentBlock[]) -> string {
+function text(content: Block[]) -> string {
     let out = "";
     for (let block in content) {
         match (block) {

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_events/events.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_events/events.baml
@@ -11,7 +11,7 @@ class RunStarted {
 /// screenshot after a tool ran, a document the host attaches), and every
 /// client lowers the turn at its position in the journal.
 class UserMessage {
-    content: root.content.ContentBlock[],
+    content: root.content.Block[],
     /// Per-message provider directives, carried verbatim like
     /// `root.PromptMessage.metadata` (Anthropic `cache_control`, for example).
     metadata: map<string, baml.json.json>,
@@ -37,7 +37,7 @@ class UserMessage {
 }
 
 class AssistantMessage {
-    content: root.content.Block[],
+    content: root.content.ModelBlock[],
     client_id: string,
 }
 
@@ -51,7 +51,7 @@ class ToolRequested {
 /// screenshot from a computer-use tool, a rendered chart).
 class ToolCompleted {
     id: string,
-    content: root.content.ContentBlock[],
+    content: root.content.Block[],
 
     /// `output` is the tool's result serialized as JSON text.
     function new(id: string, output: string) -> ToolCompleted {

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_events/events.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_events/events.baml
@@ -1,15 +1,39 @@
 // The event catalog: the typed things that can appear in a root.Journal.
 // Only the runner produces events — clients and tools never append.
-//
-// Mirrors _planv2/pages/04_reference/02_events.md.
 
 class RunStarted {
     spec_name: string,
     arguments: map<string, unknown>,
 }
 
+/// A user turn: text and media, in order. The runner records the opening
+/// turn; a runner that observes its environment appends more mid-run (a
+/// screenshot after a tool ran, a document the host attaches), and every
+/// client lowers the turn at its position in the journal.
 class UserMessage {
-    content: string,
+    content: root.content.ContentBlock[],
+    /// Per-message provider directives, carried verbatim like
+    /// `root.PromptMessage.metadata` (Anthropic `cache_control`, for example).
+    metadata: map<string, baml.json.json>,
+
+    function new(text: string) -> UserMessage {
+        UserMessage { content: [root.content.Text { text: text }], metadata: {} }
+    }
+
+    /// A turn from ordinary values: text, the `image` / `audio` / `video` /
+    /// `pdf` primitives, or blocks already built (see `root.content.blocks`).
+    function of(
+        items: (string | image | audio | video | pdf | root.content.Text | root.content.Media)[],
+        metadata: map<string, baml.json.json> = {},
+    ) -> UserMessage {
+        UserMessage { content: root.content.blocks(items), metadata: metadata }
+    }
+
+    /// The `Text` blocks joined; a media block contributes a `[image]`-style
+    /// placeholder.
+    function text(self) -> string {
+        root.content.text(self.content)
+    }
 }
 
 class AssistantMessage {
@@ -23,9 +47,31 @@ class ToolRequested {
     args: map<string, unknown>,
 }
 
+/// A tool's result: its output text, plus any media the tool produced (a
+/// screenshot from a computer-use tool, a rendered chart).
 class ToolCompleted {
     id: string,
-    output: string, // the tool's result, serialized as JSON text
+    content: root.content.ContentBlock[],
+
+    /// `output` is the tool's result serialized as JSON text.
+    function new(id: string, output: string) -> ToolCompleted {
+        ToolCompleted { id: id, content: [root.content.Text { text: output }] }
+    }
+
+    /// A result from ordinary values: text, the `image` / `audio` / `video` /
+    /// `pdf` primitives, or blocks already built (see `root.content.blocks`).
+    function of(
+        id: string,
+        items: (string | image | audio | video | pdf | root.content.Text | root.content.Media)[],
+    ) -> ToolCompleted {
+        ToolCompleted { id: id, content: root.content.blocks(items) }
+    }
+
+    /// The `Text` blocks joined — the tool's text output; a media block
+    /// contributes a `[image]`-style placeholder.
+    function text(self) -> string {
+        root.content.text(self.content)
+    }
 }
 
 class ToolFailed {

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_internal/wire.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_internal/wire.baml
@@ -87,8 +87,11 @@ function _merge_json(base: baml.json.json, patch: baml.json.json) -> baml.json.j
 /// Reasoning survives only for the client that produced it; empty and
 /// whitespace-only text blocks are dropped (Anthropic rejects them outright,
 /// and no provider needs them).
-function _wire_blocks(content: root.content.Block[], keep_reasoning: bool) -> root.content.Block[] {
-    let out: root.content.Block[] = [];
+function _wire_blocks(
+    content: root.content.ModelBlock[],
+    keep_reasoning: bool,
+) -> root.content.ModelBlock[] {
+    let out: root.content.ModelBlock[] = [];
     for (let block in content) {
         match (block) {
             let text: root.content.Text => {

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
@@ -417,9 +417,10 @@ function merge_request_body(base: baml.json.json, overrides: baml.json.json?) ->
 // kind and declares, beside it, what it does with each kind at each position:
 //
 //   Accept   lower natively at that position;
-//   Degrade  keep the text in place and move the media into a trailing `user`
-//            turn (`tool_result_blocks` below) — lowering stays pure, the
-//            journal keeps the original event;
+//   Degrade  keep the text in place and move the media into one `user` turn
+//            after the run of tool results it came from (`degrade_tool_media`
+//            below) — lowering stays pure, the journal keeps the original
+//            event;
 //   Reject   a typed client error before any request is sent.
 
 /// A rendered prompt message's parts as content blocks: a `string` part is
@@ -459,49 +460,72 @@ function tool_name(j: root.Journal, id: string) -> string? {
     null
 }
 
-/// One tool result, split for a client that carries only some media kinds
-/// inside a tool result. `inline` is what stays in the result: every `Text`
-/// block plus the media whose `kind()` is in `carries`. `trailing` is the
-/// Degrade: a one-line note naming the tool, then the media the result could
-/// not carry, in order — or empty when nothing was moved. The client lowers
-/// `trailing` as a `user` turn right after the result.
-class ToolResultBlocks {
-    inline: root.content.ContentBlock[],
-    trailing: root.content.ContentBlock[],
-}
-
-function tool_result_blocks(
-    j: root.Journal,
-    completed: root.events.ToolCompleted,
-    carries: string[],
-) -> ToolResultBlocks {
-    let inline: root.content.ContentBlock[] = [];
-    let moved: root.content.ContentBlock[] = [];
-    for (let block in completed.content) {
-        match (block) {
-            let text: root.content.Text => {
-                inline.push(text);
+/// Degrade, as a journal rewrite. A client that carries only some media
+/// kinds inside a tool result (`carries`, by `kind()`) lowers the copy of `j`
+/// this returns: every other media block has left its result and, behind a
+/// one-line note naming the tool, forms ONE `user` turn after the LAST result
+/// of the same assistant turn. The results of one turn stay contiguous (Chat
+/// Completions, Converse and Responses all reject a `user` message between
+/// two of them), `Text` stays where it was, and a result left with no text
+/// keeps the `[audio]`-style placeholder so no client sends an empty result.
+/// Lowering stays pure: the caller's journal is untouched and the trace still
+/// shows the original events.
+function degrade_tool_media(j: root.Journal, carries: string[]) -> root.Journal {
+    let out: root.events.Event[] = [];
+    // moved out of the current run of tool results, each behind its note
+    let attached: root.content.ContentBlock[] = [];
+    for (let event in j.entries()) {
+        match (event) {
+            let completed: root.events.ToolCompleted => {
+                let inline: root.content.ContentBlock[] = [];
+                let moved: root.content.ContentBlock[] = [];
+                for (let block in completed.content) {
+                    match (block) {
+                        let text: root.content.Text => {
+                            inline.push(text);
+                            null
+                        },
+                        let media: root.content.Media => {
+                            if (carries.includes(media.kind())) {
+                                inline.push(media);
+                            } else {
+                                moved.push(media);
+                            }
+                            null
+                        },
+                    };
+                }
+                if (moved.length() > 0) {
+                    if (inline.length() == 0) {
+                        inline.push(root.content.Text { text: root.content.text(moved) });
+                    }
+                    let tool = tool_name(j, completed.id) ?? completed.id;
+                    attached.push(root.content.Text { text: "attached from the result of tool `" + tool + "`" });
+                    for (let block in moved) {
+                        attached.push(block);
+                    }
+                }
+                out.push(root.events.ToolCompleted { id: completed.id, content: inline });
                 null
             },
-            let media: root.content.Media => {
-                if (carries.includes(media.kind())) {
-                    inline.push(media);
-                } else {
-                    moved.push(media);
+            let failed: root.events.ToolFailed => {
+                out.push(failed);
+                null
+            },
+            _ => {
+                if (attached.length() > 0) {
+                    out.push(root.events.UserMessage { content: attached, metadata: {} });
+                    attached = [];
                 }
+                out.push(event);
                 null
             },
         };
     }
-    let trailing: root.content.ContentBlock[] = [];
-    if (moved.length() > 0) {
-        let tool = tool_name(j, completed.id) ?? completed.id;
-        trailing.push(root.content.Text { text: "attached from the result of tool `" + tool + "`" });
-        for (let block in moved) {
-            trailing.push(block);
-        }
+    if (attached.length() > 0) {
+        out.push(root.events.UserMessage { content: attached, metadata: {} });
     }
-    ToolResultBlocks { inline: inline, trailing: trailing }
+    root.Journal { log: out }
 }
 
 /// Make one run's journal safe to replay to `client_id`, and return the

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
@@ -410,6 +410,100 @@ function merge_request_body(base: baml.json.json, overrides: baml.json.json?) ->
 // model switch inside one provider counts as a different client, exactly like
 // pi's provider+api+model comparison.
 
+// ---------------------------------------------------------------------------
+// Content blocks on the wire. Every turn a client lowers — a rendered prompt
+// message, a journal user turn, a tool result, a model turn — is a list of
+// `root.content.ContentBlock`, so each client has ONE lowering path per block
+// kind and declares, beside it, what it does with each kind at each position:
+//
+//   Accept   lower natively at that position;
+//   Degrade  keep the text in place and move the media into a trailing `user`
+//            turn (`tool_result_blocks` below) — lowering stays pure, the
+//            journal keeps the original event;
+//   Reject   a typed client error before any request is sent.
+
+/// A rendered prompt message's parts as content blocks: a `string` part is
+/// `Text`, a media part is `Media` with null provenance. The rendered prompt
+/// then lowers through the same path as the journal's turns.
+function prompt_blocks(message: root.PromptMessage) -> root.content.ContentBlock[] {
+    let out: root.content.ContentBlock[] = [];
+    for (let part in message.parts) {
+        match (part) {
+            let text: string => {
+                out.push(root.content.Text { text: text });
+                null
+            },
+            let media: root.MediaPart => {
+                out.push(root.content.Media { media: media, provider_id: null, revised_prompt: null });
+                null
+            },
+        };
+    }
+    out
+}
+
+/// The name of the tool a journal call id belongs to: the `ToolUse` block in
+/// the assistant turn that issued it. Null for an id no assistant turn issued.
+function tool_name(j: root.Journal, id: string) -> string? {
+    for (let event in j.entries()) {
+        if let assistant: root.events.AssistantMessage = event {
+            for (let block in assistant.content) {
+                if let use: root.content.ToolUse = block {
+                    if (use.id == id) {
+                        return use.name;
+                    }
+                }
+            }
+        }
+    }
+    null
+}
+
+/// One tool result, split for a client that carries only some media kinds
+/// inside a tool result. `inline` is what stays in the result: every `Text`
+/// block plus the media whose `kind()` is in `carries`. `trailing` is the
+/// Degrade: a one-line note naming the tool, then the media the result could
+/// not carry, in order — or empty when nothing was moved. The client lowers
+/// `trailing` as a `user` turn right after the result.
+class ToolResultBlocks {
+    inline: root.content.ContentBlock[],
+    trailing: root.content.ContentBlock[],
+}
+
+function tool_result_blocks(
+    j: root.Journal,
+    completed: root.events.ToolCompleted,
+    carries: string[],
+) -> ToolResultBlocks {
+    let inline: root.content.ContentBlock[] = [];
+    let moved: root.content.ContentBlock[] = [];
+    for (let block in completed.content) {
+        match (block) {
+            let text: root.content.Text => {
+                inline.push(text);
+                null
+            },
+            let media: root.content.Media => {
+                if (carries.includes(media.kind())) {
+                    inline.push(media);
+                } else {
+                    moved.push(media);
+                }
+                null
+            },
+        };
+    }
+    let trailing: root.content.ContentBlock[] = [];
+    if (moved.length() > 0) {
+        let tool = tool_name(j, completed.id) ?? completed.id;
+        trailing.push(root.content.Text { text: "attached from the result of tool `" + tool + "`" });
+        for (let block in moved) {
+            trailing.push(block);
+        }
+    }
+    ToolResultBlocks { inline: inline, trailing: trailing }
+}
+
 /// Make one run's journal safe to replay to `client_id`, and return the
 /// sanitized copy. Every client should lower
 /// `ai.wire.sanitize_for_client(input.journal, self.id())` instead of

--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
@@ -413,7 +413,7 @@ function merge_request_body(base: baml.json.json, overrides: baml.json.json?) ->
 // ---------------------------------------------------------------------------
 // Content blocks on the wire. Every turn a client lowers — a rendered prompt
 // message, a journal user turn, a tool result, a model turn — is a list of
-// `root.content.ContentBlock`, so each client has ONE lowering path per block
+// `root.content.Block`, so each client has ONE lowering path per block
 // kind and declares, beside it, what it does with each kind at each position:
 //
 //   Accept   lower natively at that position;
@@ -426,8 +426,8 @@ function merge_request_body(base: baml.json.json, overrides: baml.json.json?) ->
 /// A rendered prompt message's parts as content blocks: a `string` part is
 /// `Text`, a media part is `Media` with null provenance. The rendered prompt
 /// then lowers through the same path as the journal's turns.
-function prompt_blocks(message: root.PromptMessage) -> root.content.ContentBlock[] {
-    let out: root.content.ContentBlock[] = [];
+function prompt_blocks(message: root.PromptMessage) -> root.content.Block[] {
+    let out: root.content.Block[] = [];
     for (let part in message.parts) {
         match (part) {
             let text: string => {
@@ -435,7 +435,9 @@ function prompt_blocks(message: root.PromptMessage) -> root.content.ContentBlock
                 null
             },
             let media: root.MediaPart => {
-                out.push(root.content.Media { media: media, provider_id: null, revised_prompt: null });
+                out.push(
+                    root.content.Media { media: media, provider_id: null, revised_prompt: null },
+                );
                 null
             },
         };
@@ -473,12 +475,12 @@ function tool_name(j: root.Journal, id: string) -> string? {
 function degrade_tool_media(j: root.Journal, carries: string[]) -> root.Journal {
     let out: root.events.Event[] = [];
     // moved out of the current run of tool results, each behind its note
-    let attached: root.content.ContentBlock[] = [];
+    let attached: root.content.Block[] = [];
     for (let event in j.entries()) {
         match (event) {
             let completed: root.events.ToolCompleted => {
-                let inline: root.content.ContentBlock[] = [];
-                let moved: root.content.ContentBlock[] = [];
+                let inline: root.content.Block[] = [];
+                let moved: root.content.Block[] = [];
                 for (let block in completed.content) {
                     match (block) {
                         let text: root.content.Text => {
@@ -500,7 +502,11 @@ function degrade_tool_media(j: root.Journal, carries: string[]) -> root.Journal 
                         inline.push(root.content.Text { text: root.content.text(moved) });
                     }
                     let tool = tool_name(j, completed.id) ?? completed.id;
-                    attached.push(root.content.Text { text: "attached from the result of tool `" + tool + "`" });
+                    attached.push(
+                        root.content.Text {
+                            text: "attached from the result of tool `" + tool + "`",
+                        },
+                    );
                     for (let block in moved) {
                         attached.push(block);
                     }

--- a/baml_language/crates/baml_builtins2/baml_std/ai/runner.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/runner.baml
@@ -98,7 +98,7 @@ class Agent {
                     },
                 };
                 if let output: string = outcome {
-                    j.append_all([root.events.ToolCompleted { id: call.id, output: output }]);
+                    j.append_all([root.events.ToolCompleted.new(call.id, output)]);
                 }
                 null
             },
@@ -286,9 +286,9 @@ class Agent {
             turn
         } else if (attempts_left > 1) {
             batch.push(
-                root.events.UserMessage {
-                    content: "The reply did not match the required schema. Answer again with only the corrected value.",
-                },
+                root.events.UserMessage.new(
+                    "The reply did not match the required schema. Answer again with only the corrected value.",
+                ),
             );
             j.append_all(batch);
             self._attempt_turn<Out>(c, spec, j, total, attempts_left - 1)

--- a/baml_language/crates/baml_builtins2/baml_std/ai/turn.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/turn.baml
@@ -13,7 +13,7 @@ class ModelTurnInput {
 }
 
 class ModelTurn {
-    content: root.content.Block[],
+    content: root.content.ModelBlock[],
     stop_reason: root.content.StopReason,
     usage: root.events.Usage?,
     // Every HTTP exchange behind this turn, oldest first: failed legs from

--- a/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
@@ -74,10 +74,12 @@ class AnthToolUseBlock {
     cache_control: baml.json.json?,
 }
 
+/// `content` is the plain string for a text-only result and a block list
+/// (text, image, document) when the result carries media.
 class AnthToolResultBlock {
     type: string,
     tool_use_id: string,
-    content: string,
+    content: string | AnthBlock[],
     is_error: bool,
     cache_control: baml.json.json?,
 }
@@ -334,57 +336,69 @@ function _media_block(
     AnthMediaBlock { type: block_type, source: source, cache_control: null }
 }
 
-function _prompt_blocks(
-    message: ai.PromptMessage,
-    role: string,
+/// One content block at `position` -> its wire block, or null when it lowers
+/// to nothing. The Messages API's input modalities, per position:
+///
+///   position    | text   | image  | pdf    | audio  | video
+///   system      | Accept | Reject | Reject | Reject | Reject
+///   user        | Accept | Accept | Accept | Reject | Reject
+///   assistant   | Accept | Reject | Reject | Reject | Reject
+///   tool_result | Accept | Accept | Accept | Reject | Reject
+///
+/// Image and document blocks are user input: they belong in a user message
+/// or inside a `tool_result` (whose content is a list of the same blocks).
+/// There is no audio or video input block at all, so those are rejected
+/// everywhere — an invented `{"type":"input_audio"}` used to guarantee a 400.
+function _lower_block(
+    block: ai.content.ContentBlock,
+    position: string,
+    preview: bool = false,
+) -> AnthBlock? {
+    match (block) {
+        let text: ai.content.Text => {
+            // The API rejects empty and whitespace-only text blocks, and a
+            // rendered prompt routinely produces them around media parts.
+            if (text.text.trim() == "") {
+                null
+            } else {
+                AnthTextBlock { type: "text", text: text.text, cache_control: null }
+            }
+        },
+        let media: ai.content.Media => {
+            let block_type = match (media.media) {
+                let image: baml.media.Image => "image",
+                let pdf: baml.media.Pdf => "document",
+                let audio: baml.media.Audio => {
+                    throw _reject(
+                        "Anthropic does not support audio prompt input: the Messages API has no audio content block",
+                    )
+                },
+                let video: baml.media.Video => {
+                    throw _reject("Anthropic does not support video prompt input")
+                },
+            };
+            if (position != "user" && position != "tool_result") {
+                throw _reject(
+                    `Anthropic only supports ${media.kind()} input in user messages, found ${position}`,
+                )
+            }
+            _media_block(media.media, block_type, preview = preview)
+        },
+    }
+}
+
+function _lower_blocks(
+    blocks: ai.content.ContentBlock[],
+    position: string,
     preview: bool = false,
 ) -> AnthBlock[] {
-    let blocks: AnthBlock[] = [];
-    for (let part in message.parts) {
-        match (part) {
-            let text: string => {
-                // The API rejects empty and whitespace-only text blocks, and a
-                // rendered prompt routinely produces them around media parts.
-                if (text.trim() != "") {
-                    blocks.push(AnthTextBlock { type: "text", text: text, cache_control: null });
-                }
-                null
-            },
-            let image: baml.media.Image => {
-                if (role != "user") {
-                    throw _reject(
-                        `Anthropic only supports image input in user messages, found ${role}`,
-                    )
-                }
-                blocks.push(_media_block(image, "image", preview = preview));
-                null
-            },
-            // The Messages API has NO audio input content block — audio is not
-            // an input modality for it at all (the 17 documented input blocks
-            // contain nothing of the kind). This used to emit an invented
-            // `{"type":"input_audio"}` block, so every audio-bearing request was
-            // a guaranteed provider 400; it is a client-side error now, exactly
-            // like video below.
-            let audio: baml.media.Audio => {
-                throw _reject(
-                    "Anthropic does not support audio prompt input: the Messages API has no audio content block",
-                )
-            },
-            let pdf: baml.media.Pdf => {
-                if (role != "user") {
-                    throw _reject(
-                        `Anthropic only supports PDF input in user messages, found ${role}`,
-                    )
-                }
-                blocks.push(_media_block(pdf, "document", preview = preview));
-                null
-            },
-            let video: baml.media.Video => {
-                throw _reject("Anthropic does not support video prompt input")
-            },
-        };
+    let out: AnthBlock[] = [];
+    for (let block in blocks) {
+        if let lowered: AnthBlock = _lower_block(block, position, preview = preview) {
+            out.push(lowered);
+        }
     }
-    blocks
+    out
 }
 
 function _lower_prompt(prompt: ai.Prompt, preview: bool = false) -> Prompt {
@@ -393,7 +407,7 @@ function _lower_prompt(prompt: ai.Prompt, preview: bool = false) -> Prompt {
     for (let message in prompt.messages()) {
         let cache_control = message.metadata.get("cache_control");
         if (message.role == "system") {
-            let blocks = _prompt_blocks(message, "system", preview = preview);
+            let blocks = _lower_blocks(ai.wire.prompt_blocks(message), "system", preview = preview);
             _anth_apply_cache_control(blocks, cache_control);
             for (let block in blocks) {
                 system.push(block);
@@ -405,7 +419,7 @@ function _lower_prompt(prompt: ai.Prompt, preview: bool = false) -> Prompt {
             } else {
                 "user"
             };
-            let blocks = _prompt_blocks(message, role, preview = preview);
+            let blocks = _lower_blocks(ai.wire.prompt_blocks(message), role, preview = preview);
             _anth_apply_cache_control(blocks, cache_control);
             // A message that lowered to nothing (all-whitespace text) is
             // dropped: `content: []` is a 400.
@@ -423,42 +437,27 @@ function _lower_prompt(prompt: ai.Prompt, preview: bool = false) -> Prompt {
 // tool_result blocks in a user message immediately after the assistant
 // tool_use message, so consecutive tool results group into ONE user message.
 
-function _assistant_blocks(content: ai.content.Block[]) -> AnthBlock[] {
-    let out: AnthBlock[] = [];
-    for (let b in content) {
-        match (b) {
-            let t: ai.content.Text => {
-                if (t.text.trim() != "") {
-                    out.push(AnthTextBlock { type: "text", text: t.text, cache_control: null });
-                }
-                null
-            },
-            // Dropped: replaying thinking without its signature is rejected
-            // by the API, and ai.content.Reasoning has no signature field.
-            // ai.wire.sanitize_for_client already drops foreign-client
-            // reasoning; this drops the rest.
-            let r: ai.content.Reasoning => null,
-            // Dropped: a generated image is an output, not replayable input.
-            let m: ai.content.Media => null,
-            let u: ai.content.ToolUse => {
-                out.push(
-                    AnthToolUseBlock {
-                        type: "tool_use",
-                        id: u.id,
-                        name: u.name,
-                        input: baml.json.to_json(u.args),
-                        cache_control: null,
-                    },
-                );
-                null
-            },
-        };
+/// (internal) A tool result's `content`: the plain string when the result is
+/// text only (one text block, or nothing), the block list otherwise.
+function _tool_result_content(blocks: AnthBlock[]) -> string | AnthBlock[] {
+    if (blocks.length() == 0) {
+        return "";
     }
-    out
+    if (blocks.length() == 1) {
+        if let text: AnthTextBlock = blocks.at(0) {
+            return text.text;
+        }
+    }
+    blocks
 }
 
 /// (internal) Append one tool_result block, extending the trailing group when open.
-function _push_tool_result(msgs: Message[], id: string, content: string, is_error: bool) -> void {
+function _push_tool_result(
+    msgs: Message[],
+    id: string,
+    content: string | AnthBlock[],
+    is_error: bool,
+) -> void {
     let block = AnthToolResultBlock {
         type: "tool_result",
         tool_use_id: id,
@@ -480,22 +479,47 @@ function _push_tool_result(msgs: Message[], id: string, content: string, is_erro
 
 /// (internal) ai.RunStarted/ai.ToolRequested/ai.Usage/ai.FinalProduced are not promptable and skip;
 /// skipped events never close an open tool_result group.
-function _lower_journal(j: ai.Journal) -> Message[] {
+function _lower_journal(j: ai.Journal, preview: bool = false) -> Message[] {
     let msgs: Message[] = [];
     for (let e in j.entries()) {
         match (e) {
             let m: ai.events.UserMessage => {
-                msgs.push(
-                    Message {
-                        role: "user",
-                        tool_results: false,
-                        blocks: [AnthTextBlock { type: "text", text: m.content, cache_control: null }],
-                    },
-                );
+                let blocks = _lower_blocks(m.content, "user", preview = preview);
+                _anth_apply_cache_control(blocks, m.metadata.get("cache_control"));
+                if (blocks.length() > 0) {
+                    msgs.push(Message { role: "user", tool_results: false, blocks: blocks });
+                }
                 null
             },
             let m: ai.events.AssistantMessage => {
-                let blocks = _assistant_blocks(m.content);
+                let blocks: AnthBlock[] = [];
+                for (let b in m.content) {
+                    match (b) {
+                        let content: ai.content.ContentBlock => {
+                            if let lowered: AnthBlock = _lower_block(content, "assistant", preview = preview) {
+                                blocks.push(lowered);
+                            }
+                            null
+                        },
+                        let u: ai.content.ToolUse => {
+                            blocks.push(
+                                AnthToolUseBlock {
+                                    type: "tool_use",
+                                    id: u.id,
+                                    name: u.name,
+                                    input: baml.json.to_json(u.args),
+                                    cache_control: null,
+                                },
+                            );
+                            null
+                        },
+                        // Dropped: replaying thinking without its signature is
+                        // rejected by the API, and ai.content.Reasoning has no
+                        // signature field. ai.wire.sanitize_for_client already
+                        // drops foreign-client reasoning; this drops the rest.
+                        let r: ai.content.Reasoning => null,
+                    };
+                }
                 // An assistant turn that lowers to nothing is dropped rather
                 // than sent as `content: []` (the reasoning-only turn that made
                 // the API 400). ai.wire.sanitize_for_client removes most of
@@ -506,7 +530,12 @@ function _lower_journal(j: ai.Journal) -> Message[] {
                 null
             },
             let c: ai.events.ToolCompleted => {
-                _push_tool_result(msgs, c.id, c.output, false);
+                _push_tool_result(
+                    msgs,
+                    c.id,
+                    _tool_result_content(_lower_blocks(c.content, "tool_result", preview = preview)),
+                    false,
+                );
             },
             let f: ai.events.ToolFailed => {
                 _push_tool_result(msgs, f.id, f.message, true);
@@ -631,7 +660,12 @@ function messages_request(
     let lowered = lowered_prompt.messages;
     // Sanitize BEFORE lowering: foreign-client reasoning, empty turns and
     // orphaned tool calls are repaired once, in ai.wire, for every provider.
-    for (let message in _lower_journal(ai.wire.sanitize_for_client(input.journal, params.client_id))) {
+    for (
+        let message in _lower_journal(
+            ai.wire.sanitize_for_client(input.journal, params.client_id),
+            preview = preview,
+        )
+    ) {
         lowered.push(message);
     }
 

--- a/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
@@ -350,7 +350,7 @@ function _media_block(
 /// There is no audio or video input block at all, so those are rejected
 /// everywhere — an invented `{"type":"input_audio"}` used to guarantee a 400.
 function _lower_block(
-    block: ai.content.ContentBlock,
+    block: ai.content.Block,
     position: string,
     preview: bool = false,
 ) -> AnthBlock? {
@@ -388,7 +388,7 @@ function _lower_block(
 }
 
 function _lower_blocks(
-    blocks: ai.content.ContentBlock[],
+    blocks: ai.content.Block[],
     position: string,
     preview: bool = false,
 ) -> AnthBlock[] {
@@ -495,7 +495,7 @@ function _lower_journal(j: ai.Journal, preview: bool = false) -> Message[] {
                 let blocks: AnthBlock[] = [];
                 for (let b in m.content) {
                     match (b) {
-                        let content: ai.content.ContentBlock => {
+                        let content: ai.content.Block => {
                             if let lowered: AnthBlock = _lower_block(content, "assistant", preview = preview) {
                                 blocks.push(lowered);
                             }
@@ -843,7 +843,7 @@ function _stop_reason(s: string) -> ai.content.StopReason {
 
 /// One decoded response -> canonical content blocks, stop reason and usage.
 function parse(resp: Response) -> ai.ModelTurn {
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     for (let b in resp.content) {
         match (b.type) {
             "text" => {

--- a/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
@@ -130,16 +130,12 @@ class ToolUseBlock {
     input: map<string, unknown>,
 }
 
-/// One piece of a tool's result. Only `text` is modeled: `ai.events` carries
-/// tool output as a string (`ToolCompleted.output` / `ToolFailed.message`), so
-/// the `json`/`image`/`document` members of the wire union have no source.
-class ToolResultContentBlock {
-    text: string,
-}
-
+/// `content` is a `ToolResultContentBlock[]` on the wire — `text`, `image`,
+/// `document` or `video`, the same members spelled the same way as in a
+/// message `ContentBlock`, so the one class serves both.
 class ToolResultBlock {
     toolUseId: string,
-    content: ToolResultContentBlock[],
+    content: ContentBlock[],
     status: string?, // success | error
 }
 
@@ -561,40 +557,48 @@ class BedrockPrompt {
     messages: Message[],
 }
 
-/// (internal) One rendered prompt message -> Converse content blocks.
-function _prompt_content(message: ai.PromptMessage, preview: bool = false) -> ContentBlock[] {
-    let blocks: ContentBlock[] = [];
-    for (let part in message.parts) {
-        match (part) {
-            let text: string => {
-                // Converse rejects empty and whitespace-only text blocks, and a
-                // rendered prompt routinely produces them around media parts —
-                // the same filter the Anthropic client applies in
-                // `_prompt_blocks`.
-                if (text.trim() != "") {
-                    blocks.push(ContentBlock.of_text(text));
-                }
+/// (internal) One content block -> its Converse `ContentBlock`, or null when it lowers to
+/// nothing. Converse takes every media kind in a conversation message; a tool
+/// result carries `text`, `image`, `document` and `video` but has no audio
+/// member, so audio in a result degrades into a trailing user turn
+/// (`_lower_journal`); system content is text only (`_prompt_system`).
+///
+///   position    | text   | image  | pdf    | audio   | video
+///   system      | Accept | Reject | Reject | Reject  | Reject
+///   user        | Accept | Accept | Accept | Accept  | Accept
+///   assistant   | Accept | Accept | Accept | Accept  | Accept
+///   tool_result | Accept | Accept | Accept | Degrade | Accept
+function _lower_block(block: ai.content.ContentBlock, preview: bool = false) -> ContentBlock? {
+    match (block) {
+        let text: ai.content.Text => {
+            // Converse rejects empty and whitespace-only text blocks, and a
+            // rendered prompt routinely produces them around media parts —
+            // the same filter the Anthropic client applies.
+            if (text.text.trim() == "") {
                 null
-            },
-            let image: baml.media.Image => {
-                blocks.push(_image_block(image, preview = preview));
-                null
-            },
-            let audio: baml.media.Audio => {
-                blocks.push(_audio_block(audio, preview = preview));
-                null
-            },
-            let video: baml.media.Video => {
-                blocks.push(_video_block(video, preview = preview));
-                null
-            },
-            let pdf: baml.media.Pdf => {
-                blocks.push(_document_block(pdf, preview = preview));
-                null
-            },
-        };
+            } else {
+                ContentBlock.of_text(text.text)
+            }
+        },
+        let media: ai.content.Media => {
+            match (media.media) {
+                let image: baml.media.Image => _image_block(image, preview = preview),
+                let audio: baml.media.Audio => _audio_block(audio, preview = preview),
+                let video: baml.media.Video => _video_block(video, preview = preview),
+                let pdf: baml.media.Pdf => _document_block(pdf, preview = preview),
+            }
+        },
     }
-    blocks
+}
+
+function _lower_blocks(blocks: ai.content.ContentBlock[], preview: bool = false) -> ContentBlock[] {
+    let out: ContentBlock[] = [];
+    for (let block in blocks) {
+        if let lowered: ContentBlock = _lower_block(block, preview = preview) {
+            out.push(lowered);
+        }
+    }
+    out
 }
 
 /// (internal) System content is text-only; a media part in a system message is rejected
@@ -633,8 +637,8 @@ function _prompt_system(message: ai.PromptMessage) -> SystemContentBlock[] {
 /// metadata, so nothing populates this yet from the prompt DSL. Until that
 /// lands, use the client's `cache_system_prompt` / `cache_tools` options,
 /// which do not depend on per-message metadata.
-function _wants_cache_point(message: ai.PromptMessage) -> bool {
-    match (message.metadata.get("cache_point")) {
+function _wants_cache_point(metadata: map<string, baml.json.json>) -> bool {
+    match (metadata.get("cache_point")) {
         null => false,
         _ => true,
     }
@@ -670,17 +674,17 @@ function _lower_prompt(prompt: ai.Prompt, preview: bool = false) -> BedrockPromp
             for (let block in _prompt_system(message)) {
                 system.push(block);
             }
-            if (_wants_cache_point(message)) {
+            if (_wants_cache_point(message.metadata)) {
                 system.push(SystemContentBlock.of_cache_point());
             }
             null
         } else {
-            let content = _prompt_content(message, preview = preview);
+            let content = _lower_blocks(ai.wire.prompt_blocks(message), preview = preview);
             // A message that lowered to nothing (all-whitespace text) is
             // dropped: `content: []` is a ValidationException, and a lone
             // `cachePoint` with nothing to cache is no better.
             if (content.length() > 0) {
-                if (_wants_cache_point(message)) {
+                if (_wants_cache_point(message.metadata)) {
                     content.push(ContentBlock.of_cache_point());
                 }
                 messages.push(Message { role: _conversation_role(message.role), content: content });
@@ -705,35 +709,6 @@ class PendingMessage {
     tool_results: bool,
 }
 
-function _assistant_content(content: ai.content.Block[]) -> ContentBlock[] {
-    let out: ContentBlock[] = [];
-    for (let block in content) {
-        match (block) {
-            let text: ai.content.Text => {
-                out.push(ContentBlock.of_text(text.text));
-                null
-            },
-            // Dropped: Converse replays reasoning as `reasoningContent` with
-            // the provider's opaque `signature`, which `ai.content.Reasoning`
-            // (a readable summary) cannot reproduce; replaying it unsigned is
-            // rejected.
-            let reasoning: ai.content.Reasoning => null,
-            // Dropped: a generated media payload is an output, not replayable
-            // model input.
-            let media: ai.content.Media => null,
-            let use: ai.content.ToolUse => {
-                out.push(
-                    ContentBlock.of_tool_use(
-                        ToolUseBlock { toolUseId: use.id, name: use.name, input: use.args },
-                    ),
-                );
-                null
-            },
-        };
-    }
-    out
-}
-
 /// (internal) `ToolResultBlock.status` "is only supported by Amazon Nova and Anthropic
 /// Claude 3 and 4 models" (API_runtime_ToolResultBlock). Sending it to any
 /// other family ships a member that model does not accept, so it is gated on a
@@ -753,7 +728,7 @@ function _supports_tool_result_status(model: string) -> bool {
 function _push_tool_result(
     pending: PendingMessage[],
     id: string,
-    output: string,
+    content: ContentBlock[],
     is_error: bool,
     with_status: bool,
 ) -> void {
@@ -765,11 +740,7 @@ function _push_tool_result(
         "success"
     };
     let block = ContentBlock.of_tool_result(
-        ToolResultBlock {
-            toolUseId: id,
-            content: [ToolResultContentBlock { text: output }],
-            status: status,
-        },
+        ToolResultBlock { toolUseId: id, content: content, status: status },
     );
     // `.at` is null on an empty list, which covers the no-messages case.
     if let last: PendingMessage = pending.at(pending.length() - 1) {
@@ -785,28 +756,61 @@ function _push_tool_result(
 
 /// (internal) `ai.RunStarted` / `ai.ToolRequested` / `ai.Usage` / `ai.FinalProduced` are
 /// journal-only and skip; skipping never closes an open tool-result group.
-function _lower_journal(journal: ai.Journal, with_status: bool) -> Message[] {
+function _lower_journal(
+    journal: ai.Journal,
+    with_status: bool,
+    preview: bool = false,
+) -> Message[] {
     let pending: PendingMessage[] = [];
     for (let event in journal.entries()) {
         match (event) {
             let user: ai.events.UserMessage => {
-                pending.push(
-                    PendingMessage {
-                        message: Message { role: "user", content: [ContentBlock.of_text(user.content)] },
-                        tool_results: false,
-                    },
-                );
+                let content = _lower_blocks(user.content, preview = preview);
+                if (content.length() > 0) {
+                    if (_wants_cache_point(user.metadata)) {
+                        content.push(ContentBlock.of_cache_point());
+                    }
+                    pending.push(
+                        PendingMessage {
+                            message: Message { role: "user", content: content },
+                            tool_results: false,
+                        },
+                    );
+                }
                 null
             },
             let assistant: ai.events.AssistantMessage => {
-                let content = _assistant_content(assistant.content);
+                let content: ContentBlock[] = [];
+                for (let block in assistant.content) {
+                    match (block) {
+                        let inner: ai.content.ContentBlock => {
+                            if let lowered: ContentBlock = _lower_block(inner, preview = preview) {
+                                content.push(lowered);
+                            }
+                            null
+                        },
+                        let use: ai.content.ToolUse => {
+                            content.push(
+                                ContentBlock.of_tool_use(
+                                    ToolUseBlock { toolUseId: use.id, name: use.name, input: use.args },
+                                ),
+                            );
+                            null
+                        },
+                        // Dropped: Converse replays reasoning as
+                        // `reasoningContent` with the provider's opaque
+                        // `signature`, which `ai.content.Reasoning` (a readable
+                        // summary) cannot reproduce; replaying it unsigned is
+                        // rejected.
+                        let reasoning: ai.content.Reasoning => null,
+                    };
+                }
                 // An assistant turn that lowers to nothing is dropped rather
                 // than sent as `content: []`, which Converse rejects with a
                 // ValidationException. A reasoning-only turn is exactly that
-                // shape: `_assistant_content` drops Reasoning and Media, and
-                // `ai.wire.sanitize_for_client` KEEPS same-client reasoning,
-                // so nothing upstream removes it. Mirrors the Anthropic
-                // client's guard in `_lower_journal`.
+                // shape, and `ai.wire.sanitize_for_client` KEEPS same-client
+                // reasoning, so nothing upstream removes it. Mirrors the
+                // Anthropic client's guard in `_lower_journal`.
                 if (content.length() > 0) {
                     pending.push(
                         PendingMessage {
@@ -818,10 +822,39 @@ function _lower_journal(journal: ai.Journal, with_status: bool) -> Message[] {
                 null
             },
             let completed: ai.events.ToolCompleted => {
-                _push_tool_result(pending, completed.id, completed.output, false, with_status);
+                // A toolResult carries text, image, document and video inline.
+                let split = ai.wire.tool_result_blocks(journal, completed, ["image", "pdf", "video"]);
+                _push_tool_result(
+                    pending,
+                    completed.id,
+                    _lower_blocks(split.inline, preview = preview),
+                    false,
+                    with_status,
+                );
+                // Degrade: the media the result cannot carry follows it as a
+                // user turn; `_merge_adjacent_roles` folds it into the same
+                // wire message after the toolResult blocks.
+                if (split.trailing.length() > 0) {
+                    pending.push(
+                        PendingMessage {
+                            message: Message {
+                                role: "user",
+                                content: _lower_blocks(split.trailing, preview = preview),
+                            },
+                            tool_results: false,
+                        },
+                    );
+                }
+                null
             },
             let failed: ai.events.ToolFailed => {
-                _push_tool_result(pending, failed.id, failed.message, true, with_status);
+                _push_tool_result(
+                    pending,
+                    failed.id,
+                    [ContentBlock.of_text(failed.message)],
+                    true,
+                    with_status,
+                );
             },
             _ => null,
         };
@@ -983,6 +1016,7 @@ function converse_request(
     let journal_messages = _lower_journal(
         ai.wire.sanitize_for_client(input.journal, client.id()),
         _supports_tool_result_status(client.model),
+        preview = preview,
     );
     for (let message in journal_messages) {
         messages.push(message);

--- a/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
@@ -568,7 +568,7 @@ class BedrockPrompt {
 ///   user        | Accept | Accept | Accept | Accept  | Accept
 ///   assistant   | Accept | Accept | Accept | Accept  | Accept
 ///   tool_result | Accept | Accept | Accept | Degrade | Accept
-function _lower_block(block: ai.content.ContentBlock, preview: bool = false) -> ContentBlock? {
+function _lower_block(block: ai.content.Block, preview: bool = false) -> ContentBlock? {
     match (block) {
         let text: ai.content.Text => {
             // Converse rejects empty and whitespace-only text blocks, and a
@@ -591,7 +591,7 @@ function _lower_block(block: ai.content.ContentBlock, preview: bool = false) -> 
     }
 }
 
-function _lower_blocks(blocks: ai.content.ContentBlock[], preview: bool = false) -> ContentBlock[] {
+function _lower_blocks(blocks: ai.content.Block[], preview: bool = false) -> ContentBlock[] {
     let out: ContentBlock[] = [];
     for (let block in blocks) {
         if let lowered: ContentBlock = _lower_block(block, preview = preview) {
@@ -739,9 +739,7 @@ function _push_tool_result(
     } else {
         "success"
     };
-    let block = ContentBlock.of_tool_result(
-        ToolResultBlock { toolUseId: id, content: content, status: status },
-    );
+    let block = ContentBlock.of_tool_result(ToolResultBlock { toolUseId: id, content: content, status: status });
     // `.at` is null on an empty list, which covers the no-messages case.
     if let last: PendingMessage = pending.at(pending.length() - 1) {
         if (last.tool_results) {
@@ -783,7 +781,7 @@ function _lower_journal(
                 let content: ContentBlock[] = [];
                 for (let block in assistant.content) {
                     match (block) {
-                        let inner: ai.content.ContentBlock => {
+                        let inner: ai.content.Block => {
                             if let lowered: ContentBlock = _lower_block(inner, preview = preview) {
                                 content.push(lowered);
                             }
@@ -792,7 +790,11 @@ function _lower_journal(
                         let use: ai.content.ToolUse => {
                             content.push(
                                 ContentBlock.of_tool_use(
-                                    ToolUseBlock { toolUseId: use.id, name: use.name, input: use.args },
+                                    ToolUseBlock {
+                                        toolUseId: use.id,
+                                        name: use.name,
+                                        input: use.args,
+                                    },
                                 ),
                             );
                             null
@@ -835,13 +837,7 @@ function _lower_journal(
                 null
             },
             let failed: ai.events.ToolFailed => {
-                _push_tool_result(
-                    pending,
-                    failed.id,
-                    [ContentBlock.of_text(failed.message)],
-                    true,
-                    with_status,
-                );
+                _push_tool_result(pending, failed.id, [ContentBlock.of_text(failed.message)], true, with_status);
             },
             _ => null,
         };
@@ -1321,7 +1317,7 @@ function parse_response(response: ConverseResponse) -> ai.ModelTurn {
             raw_output: baml.json.stringify(baml.json.to_json(response)),
         }
     }
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     let blocks: ResponseContentBlock[] = message.content ?? [];
     for (let block in blocks) {
         if let text: string = block.text {

--- a/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/aws/ns_internal/bedrock.baml
@@ -560,7 +560,7 @@ class BedrockPrompt {
 /// (internal) One content block -> its Converse `ContentBlock`, or null when it lowers to
 /// nothing. Converse takes every media kind in a conversation message; a tool
 /// result carries `text`, `image`, `document` and `video` but has no audio
-/// member, so audio in a result degrades into a trailing user turn
+/// member, so audio in a result degrades into a user turn after the run of results
 /// (`_lower_journal`); system content is text only (`_prompt_system`).
 ///
 ///   position    | text   | image  | pdf    | audio   | video
@@ -822,29 +822,16 @@ function _lower_journal(
                 null
             },
             let completed: ai.events.ToolCompleted => {
-                // A toolResult carries text, image, document and video inline.
-                let split = ai.wire.tool_result_blocks(journal, completed, ["image", "pdf", "video"]);
+                // A toolResult carries text, image, document and video inline;
+                // `ai.wire.degrade_tool_media` has already moved audio out of
+                // the result and behind the run of results it belongs to.
                 _push_tool_result(
                     pending,
                     completed.id,
-                    _lower_blocks(split.inline, preview = preview),
+                    _lower_blocks(completed.content, preview = preview),
                     false,
                     with_status,
                 );
-                // Degrade: the media the result cannot carry follows it as a
-                // user turn; `_merge_adjacent_roles` folds it into the same
-                // wire message after the toolResult blocks.
-                if (split.trailing.length() > 0) {
-                    pending.push(
-                        PendingMessage {
-                            message: Message {
-                                role: "user",
-                                content: _lower_blocks(split.trailing, preview = preview),
-                            },
-                            tool_results: false,
-                        },
-                    );
-                }
                 null
             },
             let failed: ai.events.ToolFailed => {
@@ -1014,7 +1001,10 @@ function converse_request(
     }
     let messages = prompt.messages;
     let journal_messages = _lower_journal(
-        ai.wire.sanitize_for_client(input.journal, client.id()),
+        ai.wire.degrade_tool_media(
+            ai.wire.sanitize_for_client(input.journal, client.id()),
+            ["image", "pdf", "video"],
+        ),
         _supports_tool_result_status(client.model),
         preview = preview,
     );

--- a/baml_language/crates/baml_builtins2/baml_std/claude_code/ns_internal/cli.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/claude_code/ns_internal/cli.baml
@@ -7,8 +7,10 @@ function transcript_text(j: ai.Journal) -> string {
     let lines: string[] = [];
     for (let e in j.entries()) {
         match (e) {
+            // The CLI takes text only: `text()` renders a media block as a
+            // readable `[image]`-style placeholder.
             let u: ai.events.UserMessage => {
-                lines.push(`user: ${u.content}`);
+                lines.push(`user: ${u.text()}`);
             },
             let a: ai.events.AssistantMessage => {
                 for (let b in a.content) {
@@ -28,7 +30,7 @@ function transcript_text(j: ai.Journal) -> string {
                 }
             },
             let done: ai.events.ToolCompleted => {
-                lines.push(`tool result id=${done.id} is_error=false: ${done.output}`);
+                lines.push(`tool result id=${done.id} is_error=false: ${done.text()}`);
             },
             let failed: ai.events.ToolFailed => {
                 lines.push(`tool result id=${failed.id} is_error=true: ${failed.message}`);

--- a/baml_language/crates/baml_builtins2/baml_std/claude_code/ns_internal/cli.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/claude_code/ns_internal/cli.baml
@@ -365,7 +365,7 @@ function invoke(c: root.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelT
         reasoning_tokens: null,
     };
 
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     let stop: ai.content.StopReason = ai.content.StopReason.Complete;
     if (has_tools) {
         let outcome = baml.json.path_or<json>(result, ".structured_output.outcome", structured);

--- a/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
@@ -474,11 +474,7 @@ function _gm_media_part(media: ai.MediaPart, fetch_url: bool, preview: bool = fa
 ///
 /// A tool result's text goes in `functionResponse.response`; its media parts
 /// go in `functionResponse.parts` (`lower_journal`).
-function _lower_block(
-    block: ai.content.ContentBlock,
-    fetch_url: bool,
-    preview: bool = false,
-) -> GmPart {
+function _lower_block(block: ai.content.Block, fetch_url: bool, preview: bool = false) -> GmPart {
     match (block) {
         let text: ai.content.Text => GmPart.of_text(text.text),
         let media: ai.content.Media => _gm_media_part(media.media, fetch_url, preview = preview),
@@ -486,7 +482,7 @@ function _lower_block(
 }
 
 function _lower_blocks(
-    blocks: ai.content.ContentBlock[],
+    blocks: ai.content.Block[],
     fetch_url: bool,
     preview: bool = false,
 ) -> GmPart[] {
@@ -611,7 +607,7 @@ function lower_journal(j: ai.Journal, fetch_url: bool, preview: bool = false) ->
                 let parts: GmPart[] = [];
                 for (let b in a.content) {
                     match (b) {
-                        let content: ai.content.ContentBlock => {
+                        let content: ai.content.Block => {
                             parts.push(_lower_block(content, fetch_url, preview = preview));
                             null
                         },
@@ -862,7 +858,7 @@ function parse(resp: GmResponse, seq: int, provider: string = "google") -> ai.Mo
             err.message ?? baml.json.stringify(baml.json.to_json(resp)),
         )
     }
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     let has_call = false;
     let call_index = 0;
     let cand: GmCandidate? = resp.candidates?.at(0);

--- a/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
@@ -38,9 +38,12 @@ class GmFunctionCall {
     args: map<string, unknown>,
 }
 
+/// `parts` carries the media a tool result produced (`inlineData` /
+/// `fileData` parts only — text rides in `response`); omitted when empty.
 class GmFunctionResponse {
     name: string,
     response: map<string, unknown>,
+    parts: GmPart[]?,
 }
 
 /// One `Part` of a content. Exactly one payload field is set; the rest are
@@ -460,35 +463,36 @@ function _gm_media_part(media: ai.MediaPart, fetch_url: bool, preview: bool = fa
     }
 }
 
-function _gm_prompt_parts(
-    message: ai.PromptMessage,
+/// One content block -> one `Part`. Gemini takes every media kind at every
+/// position, so the table is all Accept and no position is passed:
+///
+///   position    | text   | image  | pdf    | audio  | video
+///   system      | Accept | Accept | Accept | Accept | Accept
+///   user        | Accept | Accept | Accept | Accept | Accept
+///   assistant   | Accept | Accept | Accept | Accept | Accept
+///   tool_result | Accept | Accept | Accept | Accept | Accept
+///
+/// A tool result's text goes in `functionResponse.response`; its media parts
+/// go in `functionResponse.parts` (`lower_journal`).
+function _lower_block(
+    block: ai.content.ContentBlock,
+    fetch_url: bool,
+    preview: bool = false,
+) -> GmPart {
+    match (block) {
+        let text: ai.content.Text => GmPart.of_text(text.text),
+        let media: ai.content.Media => _gm_media_part(media.media, fetch_url, preview = preview),
+    }
+}
+
+function _lower_blocks(
+    blocks: ai.content.ContentBlock[],
     fetch_url: bool,
     preview: bool = false,
 ) -> GmPart[] {
     let parts: GmPart[] = [];
-    for (let part in message.parts) {
-        match (part) {
-            let text: string => {
-                parts.push(GmPart.of_text(text));
-                null
-            },
-            let image: baml.media.Image => {
-                parts.push(_gm_media_part(image, fetch_url, preview = preview));
-                null
-            },
-            let audio: baml.media.Audio => {
-                parts.push(_gm_media_part(audio, fetch_url, preview = preview));
-                null
-            },
-            let video: baml.media.Video => {
-                parts.push(_gm_media_part(video, fetch_url, preview = preview));
-                null
-            },
-            let pdf: baml.media.Pdf => {
-                parts.push(_gm_media_part(pdf, fetch_url, preview = preview));
-                null
-            },
-        };
+    for (let block in blocks) {
+        parts.push(_lower_block(block, fetch_url, preview = preview));
     }
     parts
 }
@@ -508,7 +512,7 @@ function lower_prompt(prompt: ai.Prompt, fetch_url: bool = true, preview: bool =
     let system_parts: GmPart[] = [];
     let contents: GmContent[] = [];
     for (let message in prompt.messages()) {
-        let parts = _gm_prompt_parts(message, fetch_url = fetch_url, preview = preview);
+        let parts = _lower_blocks(ai.wire.prompt_blocks(message), fetch_url, preview = preview);
         if (message.role == "system") {
             for (let part in parts) {
                 system_parts.push(part);
@@ -572,39 +576,12 @@ function _gm_call_id_signature(id: string) -> string? {
     }
 }
 
-/// (internal) Gemini correlates tool results by NAME, not id: find the tool name for a
-/// result id by scanning the ai.AssistantMessage ai.ToolUse blocks in the journal.
-function _gm_tool_name_for(j: ai.Journal, id: string) -> string {
-    let name = "";
-    for (let e in j.entries()) {
-        match (e) {
-            let a: ai.events.AssistantMessage => {
-                for (let b in a.content) {
-                    match (b) {
-                        let u: ai.content.ToolUse => {
-                            if (u.id == id) {
-                                name = u.name;
-                                null
-                            } else {
-                                null
-                            }
-                        },
-                        _ => null,
-                    };
-                }
-                null
-            },
-            _ => null,
-        };
-    }
-    name
-}
-
 /// ai.Journal -> generateContent `contents`. Only promptable events lower;
 /// ai.RunStarted, ai.ToolRequested, ai.Usage, and ai.FinalProduced are journal-only.
 /// Consecutive tool results merge into ONE user content of functionResponse
-/// parts, matching how Gemini expects results for a multi-call turn.
-function lower_journal(j: ai.Journal) -> GmContent[] {
+/// parts, matching how Gemini expects results for a multi-call turn. Gemini
+/// correlates results by tool NAME, not id (`ai.wire.tool_name`).
+function lower_journal(j: ai.Journal, fetch_url: bool, preview: bool = false) -> GmContent[] {
     let contents: GmContent[] = [];
     let pending: GmPart[] = []; // functionResponse parts awaiting flush
     for (let e in j.entries()) {
@@ -617,7 +594,10 @@ function lower_journal(j: ai.Journal) -> GmContent[] {
                 } else {
                     null
                 };
-                contents.push(GmContent { role: "user", parts: [GmPart.of_text(u.content)] });
+                let parts = _lower_blocks(u.content, fetch_url, preview = preview);
+                if (parts.length() > 0) {
+                    contents.push(GmContent { role: "user", parts: parts });
+                }
                 null
             },
             let a: ai.events.AssistantMessage => {
@@ -631,8 +611,8 @@ function lower_journal(j: ai.Journal) -> GmContent[] {
                 let parts: GmPart[] = [];
                 for (let b in a.content) {
                     match (b) {
-                        let t: ai.content.Text => {
-                            parts.push(GmPart.of_text(t.text));
+                        let content: ai.content.ContentBlock => {
+                            parts.push(_lower_block(content, fetch_url, preview = preview));
                             null
                         },
                         let use: ai.content.ToolUse => {
@@ -649,9 +629,8 @@ function lower_journal(j: ai.Journal) -> GmContent[] {
                         },
                         // Reasoning replay needs the `thoughtSignature` Gemini
                         // issued with the thought, which ai.content.Reasoning
-                        // does not carry; generated media is an output, not
-                        // replayable input. Both lower to nothing.
-                        _ => null,
+                        // does not carry: it lowers to nothing.
+                        let r: ai.content.Reasoning => null,
                     };
                 }
                 if (parts.length() > 0) {
@@ -663,11 +642,30 @@ function lower_journal(j: ai.Journal) -> GmContent[] {
                 null
             },
             let c: ai.events.ToolCompleted => {
+                // Text is the `result`; media rides beside it in `parts`.
+                let result = "";
+                let media: GmPart[] = [];
+                for (let part in _lower_blocks(c.content, fetch_url, preview = preview)) {
+                    if let text: string = part.text {
+                        result = `${result}${text}`;
+                    } else {
+                        media.push(part);
+                    }
+                }
                 let response: map<string, unknown> = {};
-                let _ = response.set("result", c.output);
+                let _ = response.set("result", result);
+                let parts: GmPart[]? = if (media.length() > 0) {
+                    media
+                } else {
+                    null
+                };
                 pending.push(
                     GmPart.of_function_response(
-                        GmFunctionResponse { name: _gm_tool_name_for(j, c.id), response: response },
+                        GmFunctionResponse {
+                            name: ai.wire.tool_name(j, c.id) ?? "",
+                            response: response,
+                            parts: parts,
+                        },
                     ),
                 );
                 null
@@ -677,7 +675,11 @@ function lower_journal(j: ai.Journal) -> GmContent[] {
                 let _ = response.set("error", f.message);
                 pending.push(
                     GmPart.of_function_response(
-                        GmFunctionResponse { name: _gm_tool_name_for(j, f.id), response: response },
+                        GmFunctionResponse {
+                            name: ai.wire.tool_name(j, f.id) ?? "",
+                            response: response,
+                            parts: null,
+                        },
                     ),
                 );
                 null
@@ -718,7 +720,7 @@ function gemini_build_body(
     let lowered = lower_prompt(prompt, fetch_url = fetch_url, preview = preview);
     let contents = lowered.contents;
     let journal = ai.wire.sanitize_for_client(input.journal, client_id);
-    for (let item in lower_journal(journal)) {
+    for (let item in lower_journal(journal, fetch_url, preview = preview)) {
         contents.push(item);
     }
 

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
@@ -613,35 +613,36 @@ function _chat_media_part(
     }
 }
 
-function _chat_prompt_parts(
-    message: ai.PromptMessage,
+/// (internal) One content block -> one typed content part. Chat completions imposes no
+/// role restriction on media, so every position accepts what the endpoint
+/// has a part for — except a `tool` message, whose content is text only, so
+/// media in a tool result degrades into a trailing user turn
+/// (`chat_lower_journal`). There is no video part at all (`_chat_media_part`).
+///
+///   position    | text   | image   | pdf     | audio   | video
+///   system      | Accept | Accept  | Accept  | Accept  | Reject
+///   user        | Accept | Accept  | Accept  | Accept  | Reject
+///   assistant   | Accept | Accept  | Accept  | Accept  | Reject
+///   tool_result | Accept | Degrade | Degrade | Degrade | Reject
+function _chat_lower_block(
+    block: ai.content.ContentBlock,
+    compat: ChatCompat,
+    preview: bool = false,
+) -> ChatContentPart {
+    match (block) {
+        let text: ai.content.Text => ChatTextPart { type: "text", text: text.text },
+        let media: ai.content.Media => _chat_media_part(media.media, compat, preview = preview),
+    }
+}
+
+function _chat_lower_blocks(
+    blocks: ai.content.ContentBlock[],
     compat: ChatCompat,
     preview: bool = false,
 ) -> ChatContentPart[] {
     let parts: ChatContentPart[] = [];
-    for (let part in message.parts) {
-        match (part) {
-            let text: string => {
-                parts.push(ChatTextPart { type: "text", text: text });
-                null
-            },
-            let image: baml.media.Image => {
-                parts.push(_chat_media_part(image, compat, preview = preview));
-                null
-            },
-            let audio: baml.media.Audio => {
-                parts.push(_chat_media_part(audio, compat, preview = preview));
-                null
-            },
-            let pdf: baml.media.Pdf => {
-                parts.push(_chat_media_part(pdf, compat, preview = preview));
-                null
-            },
-            let video: baml.media.Video => {
-                parts.push(_chat_media_part(video, compat, preview = preview));
-                null
-            },
-        };
+    for (let block in blocks) {
+        parts.push(_chat_lower_block(block, compat, preview = preview));
     }
     parts
 }
@@ -714,7 +715,7 @@ function chat_lower_prompt(
             "tool" => "user",
             _ => message.role,
         };
-        let parts = _chat_prompt_parts(message, compat, preview = preview);
+        let parts = _chat_lower_blocks(ai.wire.prompt_blocks(message), compat, preview = preview);
         // Placement happens BEFORE the adjacent-same-role merge, so a directive
         // stays on the part it was authored after even when this message is
         // folded into the previous one.
@@ -757,15 +758,26 @@ function chat_lower_prompt(
 ///
 /// Callers pass the journal through `ai.wire.sanitize_for_client` first, so
 /// foreign reasoning, empty turns and unanswered tool calls are already handled.
-function chat_lower_journal(j: ai.Journal) -> ChatMessage[] {
+///
+/// A journal turn's text always collapses to a bare string (`_chat_content`
+/// with `collapse = true`): a text-only turn was always sent that way, and a
+/// bare string is the one content shape every compatible server accepts. A
+/// turn carrying media, or a user turn carrying `metadata`, is a part list.
+function chat_lower_journal(
+    j: ai.Journal,
+    compat: ChatCompat,
+    preview: bool = false,
+) -> ChatMessage[] {
     let out: ChatMessage[] = [];
     for (let event in j.entries()) {
         match (event) {
             let user: ai.events.UserMessage => {
+                let parts = _chat_lower_blocks(user.content, compat, preview = preview);
+                _chat_apply_metadata(parts, user.metadata);
                 out.push(
                     ChatMessage {
                         role: "user",
-                        content: user.content,
+                        content: _chat_content(parts, true),
                         tool_calls: null,
                         tool_call_id: null,
                     },
@@ -773,12 +785,12 @@ function chat_lower_journal(j: ai.Journal) -> ChatMessage[] {
                 null
             },
             let assistant: ai.events.AssistantMessage => {
-                let text = "";
+                let parts: ChatContentPart[] = [];
                 let calls: ChatToolCall[] = [];
                 for (let block in assistant.content) {
                     match (block) {
-                        let t: ai.content.Text => {
-                            text = `${text}${t.text}`;
+                        let content: ai.content.ContentBlock => {
+                            parts.push(_chat_lower_block(content, compat, preview = preview));
                             null
                         },
                         let use: ai.content.ToolUse => {
@@ -794,15 +806,14 @@ function chat_lower_journal(j: ai.Journal) -> ChatMessage[] {
                             );
                             null
                         },
-                        // Reasoning has no replayable wire form here, and a
-                        // generated image is an output, not model input.
-                        _ => null,
+                        // Reasoning has no replayable wire form here.
+                        let r: ai.content.Reasoning => null,
                     };
                 }
-                let content: ChatMessageContent? = if (text == "") {
+                let content: ChatMessageContent? = if (parts.length() == 0) {
                     null
                 } else {
-                    text
+                    _chat_content(parts, true)
                 };
                 let tool_calls: ChatToolCall[]? = if (calls.length() == 0) {
                     null
@@ -822,14 +833,26 @@ function chat_lower_journal(j: ai.Journal) -> ChatMessage[] {
                 null
             },
             let completed: ai.events.ToolCompleted => {
+                // A `tool` message is text only: every media kind degrades.
+                let split = ai.wire.tool_result_blocks(j, completed, []);
                 out.push(
                     ChatMessage {
                         role: "tool",
-                        content: completed.output,
+                        content: _chat_content(_chat_lower_blocks(split.inline, compat, preview = preview), true),
                         tool_calls: null,
                         tool_call_id: completed.id,
                     },
                 );
+                if (split.trailing.length() > 0) {
+                    out.push(
+                        ChatMessage {
+                            role: "user",
+                            content: _chat_content(_chat_lower_blocks(split.trailing, compat, preview = preview), true),
+                            tool_calls: null,
+                            tool_call_id: null,
+                        },
+                    );
+                }
                 null
             },
             let failed: ai.events.ToolFailed => {
@@ -1061,7 +1084,7 @@ function chat_build_request(
     let prompt = input.prompt(ai.internal.build_output_format(input.output_type));
     let messages = chat_lower_prompt(prompt, compat, preview = preview);
     let journal = ai.wire.sanitize_for_client(input.journal, chat_client_id(compat, params));
-    for (let message in chat_lower_journal(journal)) {
+    for (let message in chat_lower_journal(journal, compat, preview = preview)) {
         messages.push(message);
     }
 

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
@@ -625,7 +625,7 @@ function _chat_media_part(
 ///   assistant   | Accept | Accept  | Accept  | Accept  | Reject
 ///   tool_result | Accept | Degrade | Degrade | Degrade | Reject
 function _chat_lower_block(
-    block: ai.content.ContentBlock,
+    block: ai.content.Block,
     compat: ChatCompat,
     preview: bool = false,
 ) -> ChatContentPart {
@@ -636,7 +636,7 @@ function _chat_lower_block(
 }
 
 function _chat_lower_blocks(
-    blocks: ai.content.ContentBlock[],
+    blocks: ai.content.Block[],
     compat: ChatCompat,
     preview: bool = false,
 ) -> ChatContentPart[] {
@@ -789,7 +789,7 @@ function chat_lower_journal(
                 let calls: ChatToolCall[] = [];
                 for (let block in assistant.content) {
                     match (block) {
-                        let content: ai.content.ContentBlock => {
+                        let content: ai.content.Block => {
                             parts.push(_chat_lower_block(content, compat, preview = preview));
                             null
                         },
@@ -1226,7 +1226,7 @@ function _chat_tool_args(raw: string, provider: string) -> map<string, unknown> 
 }
 
 function _chat_push_tool_uses(
-    content: ai.content.Block[],
+    content: ai.content.ModelBlock[],
     calls: CcToolCall[],
     provider: string,
 ) -> void {
@@ -1273,7 +1273,7 @@ function chat_parse(
         null => throw ai.errors.ParseFailed { provider: provider, raw_output: raw },
     };
 
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     if let reasoning: string = message.reasoning_content {
         if (reasoning != "") {
             content.push(ai.content.Reasoning { summary: reasoning });

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/chat.baml
@@ -616,7 +616,7 @@ function _chat_media_part(
 /// (internal) One content block -> one typed content part. Chat completions imposes no
 /// role restriction on media, so every position accepts what the endpoint
 /// has a part for — except a `tool` message, whose content is text only, so
-/// media in a tool result degrades into a trailing user turn
+/// media in a tool result degrades into a user turn after the run of results
 /// (`chat_lower_journal`). There is no video part at all (`_chat_media_part`).
 ///
 ///   position    | text   | image   | pdf     | audio   | video
@@ -833,26 +833,16 @@ function chat_lower_journal(
                 null
             },
             let completed: ai.events.ToolCompleted => {
-                // A `tool` message is text only: every media kind degrades.
-                let split = ai.wire.tool_result_blocks(j, completed, []);
+                // A `tool` message is text only: `ai.wire.degrade_tool_media`
+                // has already moved every media block out of the result.
                 out.push(
                     ChatMessage {
                         role: "tool",
-                        content: _chat_content(_chat_lower_blocks(split.inline, compat, preview = preview), true),
+                        content: _chat_content(_chat_lower_blocks(completed.content, compat, preview = preview), true),
                         tool_calls: null,
                         tool_call_id: completed.id,
                     },
                 );
-                if (split.trailing.length() > 0) {
-                    out.push(
-                        ChatMessage {
-                            role: "user",
-                            content: _chat_content(_chat_lower_blocks(split.trailing, compat, preview = preview), true),
-                            tool_calls: null,
-                            tool_call_id: null,
-                        },
-                    );
-                }
                 null
             },
             let failed: ai.events.ToolFailed => {
@@ -1083,7 +1073,10 @@ function chat_build_request(
 ) -> ChatRequest {
     let prompt = input.prompt(ai.internal.build_output_format(input.output_type));
     let messages = chat_lower_prompt(prompt, compat, preview = preview);
-    let journal = ai.wire.sanitize_for_client(input.journal, chat_client_id(compat, params));
+    let journal = ai.wire.degrade_tool_media(
+        ai.wire.sanitize_for_client(input.journal, chat_client_id(compat, params)),
+        [],
+    );
     for (let message in chat_lower_journal(journal, compat, preview = preview)) {
         messages.push(message);
     }

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/images.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/images.baml
@@ -133,44 +133,39 @@ function _oai_images_media_rejected(kind: string) -> ai.errors.InvalidRequest {
     }
 }
 
-/// (internal) The rendered prompt as one text block: every text part trimmed, blanks
-/// dropped, joined with a blank line. Roles carry no meaning for an image
-/// endpoint, so they are discarded (sys_llm's gateway builder does the same).
-/// Journal user messages follow the prompt so a re-ask still reaches the model;
-/// assistant turns and tool traffic have no representation here.
+/// (internal) Collect a turn's text into `parts`: every text block trimmed, blanks
+/// dropped. Any media block is a hard error: /v1/images/generations takes
+/// text only, at every position.
+function _oai_images_collect(blocks: ai.content.ContentBlock[], parts: string[]) -> void {
+    for (let block in blocks) {
+        match (block) {
+            let text: ai.content.Text => {
+                let trimmed = text.text.trim();
+                if (trimmed != "") {
+                    parts.push(trimmed);
+                }
+                null
+            },
+            let media: ai.content.Media => {
+                throw _oai_images_media_rejected(media.kind())
+            },
+        };
+    }
+}
+
+/// (internal) The rendered prompt as one text block, joined with a blank line. Roles
+/// carry no meaning for an image endpoint, so they are discarded (sys_llm's
+/// gateway builder does the same). Journal user turns follow the prompt so a
+/// re-ask still reaches the model; assistant turns and tool traffic have no
+/// representation here.
 function _oai_images_prompt_text(prompt: ai.Prompt, journal: ai.Journal) -> string {
     let parts: string[] = [];
     for (let message in prompt.messages()) {
-        for (let part in message.parts) {
-            match (part) {
-                let text: string => {
-                    let trimmed = text.trim();
-                    if (trimmed != "") {
-                        parts.push(trimmed);
-                    }
-                    null
-                },
-                let image: baml.media.Image => {
-                    throw _oai_images_media_rejected("image")
-                },
-                let audio: baml.media.Audio => {
-                    throw _oai_images_media_rejected("audio")
-                },
-                let video: baml.media.Video => {
-                    throw _oai_images_media_rejected("video")
-                },
-                let pdf: baml.media.Pdf => {
-                    throw _oai_images_media_rejected("pdf")
-                },
-            };
-        }
+        _oai_images_collect(ai.wire.prompt_blocks(message), parts);
     }
     for (let event in journal.entries()) {
         if let user: ai.events.UserMessage = event {
-            let trimmed = user.content.trim();
-            if (trimmed != "") {
-                parts.push(trimmed);
-            }
+            _oai_images_collect(user.content, parts);
         }
     }
     let joined = parts.join("\n\n");

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/images.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/images.baml
@@ -136,7 +136,7 @@ function _oai_images_media_rejected(kind: string) -> ai.errors.InvalidRequest {
 /// (internal) Collect a turn's text into `parts`: every text block trimmed, blanks
 /// dropped. Any media block is a hard error: /v1/images/generations takes
 /// text only, at every position.
-function _oai_images_collect(blocks: ai.content.ContentBlock[], parts: string[]) -> void {
+function _oai_images_collect(blocks: ai.content.Block[], parts: string[]) -> void {
     for (let block in blocks) {
         match (block) {
             let text: ai.content.Text => {
@@ -369,7 +369,7 @@ function _oai_images_block(datum: OaImageDatum, mime: string) -> ai.content.Medi
 function images_parse(c: root.ImageClient, resp: OaImagesResponse) -> ai.ModelTurn {
     let mime = _oai_images_mime(resp.output_format ?? c.output_format);
     let data: OaImageDatum[] = resp.data ?? [];
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     for (let datum in data) {
         if let block: ai.content.Media = _oai_images_block(datum, mime) {
             content.push(block);

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
@@ -75,10 +75,12 @@ class OaFunctionCallItem {
     arguments: string,
 }
 
+/// `output` is the plain string for a text-only result and a list of input
+/// parts (text, image, file) when the result carries media.
 class OaFunctionCallOutputItem {
     type: string,
     call_id: string,
-    output: string,
+    output: string | OaInputPart[],
 }
 
 type OaInputItem = OaMessageItem | OaFunctionCallItem | OaFunctionCallOutputItem;
@@ -344,120 +346,126 @@ function _media_role_error(kind: string, role: string) -> ai.errors.Failure {
     }
 }
 
-/// (internal) A rendered structural prompt message becomes typed Responses content parts.
-function _prompt_content(
-    message: ai.PromptMessage,
-    role: string,
+/// (internal) One content block at `position` -> its typed input part. The Responses
+/// API's input modalities, per position:
+///
+///   position    | text   | image  | pdf    | audio   | video
+///   system      | Accept | Accept | Reject | Reject  | Reject
+///   user        | Accept | Accept | Accept | Accept  | Reject
+///   assistant   | Accept | Reject | Reject | Reject  | Reject
+///   tool_result | Accept | Accept | Accept | Degrade | Reject
+///
+/// An image in a system message is kept for compatibility: the legacy lowering
+/// accepted image parts in the system message a role-less prompt produced.
+/// `function_call_output.output` takes text, image and file parts but no
+/// audio, so audio in a tool result degrades into a trailing user turn
+/// (`lower_journal`). There is no video input part at all.
+function _lower_block(
+    block: ai.content.ContentBlock,
+    position: string,
     preview: bool = false,
-) -> OaInputPart[] {
-    let content: OaInputPart[] = [];
-    for (let part in message.parts) {
-        match (part) {
-            let text: string => {
-                if (role == "assistant") {
-                    content.push(OaOutputText { type: "output_text", text: text });
-                    null
-                } else {
-                    content.push(OaInputText { type: "input_text", text: text });
-                    null
-                };
-                null
-            },
-            let image: baml.media.Image => {
-                // The legacy OpenAI Responses lowering accepted image parts in
-                // the system message produced for a role-less prompt. Keep
-                // that compatibility while still rejecting assistant/tool
-                // authored media, which has no valid Responses input shape.
-                if (role != "user" && role != "system") {
-                    throw _media_role_error("image", role)
-                }
-                let resolved = if (preview) {
-                    ai.wire.resolve_media_preview(image)
-                } else {
-                    ai.wire.resolve_media(image, false)
-                };
-                let image_url = resolved.url ?? `data:${resolved.mime_type};base64,${resolved.base64 ?? ""}`;
-                content.push(
+) -> OaInputPart {
+    match (block) {
+        let text: ai.content.Text => {
+            if (position == "assistant") {
+                OaOutputText { type: "output_text", text: text.text }
+            } else {
+                OaInputText { type: "input_text", text: text.text }
+            }
+        },
+        let media: ai.content.Media => {
+            let user_input = position == "user" || position == "tool_result";
+            match (media.media) {
+                let image: baml.media.Image => {
+                    if (!user_input && position != "system") {
+                        throw _media_role_error("image", position)
+                    }
+                    let resolved = if (preview) {
+                        ai.wire.resolve_media_preview(image)
+                    } else {
+                        ai.wire.resolve_media(image, false)
+                    };
+                    let image_url = resolved.url ?? `data:${resolved.mime_type};base64,${resolved.base64 ?? ""}`;
                     OaInputImage {
                         type: "input_image",
                         image_url: image_url,
                         file_id: null,
                         detail: "auto",
-                    },
-                );
-                null
-            },
-            let audio: baml.media.Audio => {
-                if (role != "user") {
-                    throw _media_role_error("audio", role)
-                }
-                // audio has no URL form on the wire: always inline base64.
-                let resolved = if (preview) {
-                    ai.wire.resolve_media_preview(audio)
-                } else {
-                    ai.wire.resolve_media(audio, true)
-                };
-                if (preview && resolved.url != null) {
-                    throw ai.errors.PreviewUnsupported {
-                        provider: "openai",
-                        detail: "OpenAI Responses audio input requires downloaded bytes during request preview",
                     }
-                }
-                content.push(
+                },
+                let audio: baml.media.Audio => {
+                    if (!user_input) {
+                        throw _media_role_error("audio", position)
+                    }
+                    // audio has no URL form on the wire: always inline base64.
+                    let resolved = if (preview) {
+                        ai.wire.resolve_media_preview(audio)
+                    } else {
+                        ai.wire.resolve_media(audio, true)
+                    };
+                    if (preview && resolved.url != null) {
+                        throw ai.errors.PreviewUnsupported {
+                            provider: "openai",
+                            detail: "OpenAI Responses audio input requires downloaded bytes during request preview",
+                        }
+                    }
                     OaInputAudio {
                         type: "input_audio",
                         input_audio: OaAudioPayload {
                             data: resolved.base64 ?? "",
                             format: _audio_format(resolved.mime_type),
                         },
-                    },
-                );
-                null
-            },
-            let pdf: baml.media.Pdf => {
-                if (role != "user") {
-                    throw _media_role_error("PDF", role)
-                }
-                let resolved = if (preview) {
-                    ai.wire.resolve_media_preview(pdf)
-                } else {
-                    ai.wire.resolve_media(pdf, false)
-                };
-                let name = _file_name(pdf.file() ?? pdf.url());
-                if let url: string = resolved.url {
-                    content.push(
+                    }
+                },
+                let pdf: baml.media.Pdf => {
+                    if (!user_input) {
+                        throw _media_role_error("PDF", position)
+                    }
+                    let resolved = if (preview) {
+                        ai.wire.resolve_media_preview(pdf)
+                    } else {
+                        ai.wire.resolve_media(pdf, false)
+                    };
+                    let name = _file_name(pdf.file() ?? pdf.url());
+                    if let url: string = resolved.url {
                         OaInputFile {
                             type: "input_file",
                             filename: name,
                             file_data: null,
                             file_url: url,
                             file_id: null,
-                        },
-                    );
-                    null
-                } else {
-                    content.push(
+                        }
+                    } else {
                         OaInputFile {
                             type: "input_file",
                             filename: name,
                             file_data: `data:${resolved.mime_type};base64,${resolved.base64 ?? ""}`,
                             file_url: null,
                             file_id: null,
-                        },
-                    );
-                    null
-                };
-                null
-            },
-            let video: baml.media.Video => {
-                throw ai.errors.InvalidRequest {
-                    provider: "openai",
-                    status_code: null,
-                    detail: "OpenAI Responses does not support video prompt input",
-                    raw_body: null,
-                }
-            },
-        };
+                        }
+                    }
+                },
+                let video: baml.media.Video => {
+                    throw ai.errors.InvalidRequest {
+                        provider: "openai",
+                        status_code: null,
+                        detail: "OpenAI Responses does not support video prompt input",
+                        raw_body: null,
+                    }
+                },
+            }
+        },
+    }
+}
+
+function _lower_blocks(
+    blocks: ai.content.ContentBlock[],
+    position: string,
+    preview: bool = false,
+) -> OaInputPart[] {
+    let content: OaInputPart[] = [];
+    for (let block in blocks) {
+        content.push(_lower_block(block, position, preview = preview));
     }
     content
 }
@@ -473,7 +481,10 @@ function lower_prompt(prompt: ai.Prompt, preview: bool = false) -> OaInputItem[]
             _ => message.role,
         };
         items.push(
-            OaMessageItem { role: role, content: _prompt_content(message, role, preview = preview) },
+            OaMessageItem {
+                role: role,
+                content: _lower_blocks(ai.wire.prompt_blocks(message), role, preview = preview),
+            },
         );
     }
     items
@@ -549,32 +560,55 @@ function _apply_message_metadata(
     body
 }
 
+/// (internal) A tool result's `output`: the plain string when the result is text
+/// only (one text part, or nothing), the part list otherwise.
+function _tool_output(parts: OaInputPart[]) -> string | OaInputPart[] {
+    if (parts.length() == 0) {
+        return "";
+    }
+    if (parts.length() == 1) {
+        if let text: OaInputText = parts.at(0) {
+            return text.text;
+        }
+    }
+    parts
+}
+
 /// ai.Journal -> Responses API input items. Only promptable events lower;
 /// ai.RunStarted, ai.ToolRequested, ai.Usage, and ai.FinalProduced are
 /// journal-only. Callers pass the SANITIZED journal (see _request).
-function lower_journal(j: ai.Journal) -> OaInputItem[] {
+///
+/// `metadata` is the per-item directive list `_apply_message_metadata` walks:
+/// one map is appended per item produced here (a user turn's own, an empty
+/// one for everything else) so it stays aligned one-to-one with `input`.
+function lower_journal(
+    j: ai.Journal,
+    metadata: map<string, baml.json.json>[],
+    preview: bool = false,
+) -> OaInputItem[] {
     let items: OaInputItem[] = [];
+    let none: map<string, baml.json.json> = {};
     for (let e in j.entries()) {
         match (e) {
             let u: ai.events.UserMessage => {
-                items.push(
-                    OaMessageItem {
-                        role: "user",
-                        content: [OaInputText { type: "input_text", text: u.content }],
-                    },
-                );
+                let content = _lower_blocks(u.content, "user", preview = preview);
+                if (content.length() > 0) {
+                    items.push(OaMessageItem { role: "user", content: content });
+                    metadata.push(u.metadata);
+                }
                 null
             },
             let a: ai.events.AssistantMessage => {
                 for (let b in a.content) {
                     match (b) {
-                        let t: ai.content.Text => {
+                        let content: ai.content.ContentBlock => {
                             items.push(
                                 OaMessageItem {
                                     role: "assistant",
-                                    content: [OaOutputText { type: "output_text", text: t.text }],
+                                    content: [_lower_block(content, "assistant", preview = preview)],
                                 },
                             );
+                            metadata.push(none);
                             null
                         },
                         let use: ai.content.ToolUse => {
@@ -586,25 +620,38 @@ function lower_journal(j: ai.Journal) -> OaInputItem[] {
                                     arguments: baml.json.stringify(baml.json.to_json(use.args)),
                                 },
                             );
+                            metadata.push(none);
                             null
                         },
-                        // ai.Reasoning does not round-trip yet (the API wants
+                        // ai.Reasoning does not round-trip yet: the API wants
                         // the encrypted item back, which ai.content.Reasoning
-                        // does not carry), and a generated ai.content.Media is
-                        // an output, not replayable input.
-                        _ => null,
+                        // does not carry.
+                        let r: ai.content.Reasoning => null,
                     };
                 }
                 null
             },
             let c: ai.events.ToolCompleted => {
+                // `function_call_output.output` carries text, image and file
+                // parts inline; audio degrades into the user turn below.
+                let split = ai.wire.tool_result_blocks(j, c, ["image", "pdf", "video"]);
                 items.push(
                     OaFunctionCallOutputItem {
                         type: "function_call_output",
                         call_id: c.id,
-                        output: c.output,
+                        output: _tool_output(_lower_blocks(split.inline, "tool_result", preview = preview)),
                     },
                 );
+                metadata.push(none);
+                if (split.trailing.length() > 0) {
+                    items.push(
+                        OaMessageItem {
+                            role: "user",
+                            content: _lower_blocks(split.trailing, "user", preview = preview),
+                        },
+                    );
+                    metadata.push(none);
+                }
                 null
             },
             let f: ai.events.ToolFailed => {
@@ -617,6 +664,7 @@ function lower_journal(j: ai.Journal) -> OaInputItem[] {
                         output: baml.json.stringify(baml.json.to_json(err)),
                     },
                 );
+                metadata.push(none);
                 null
             },
             _ => null,
@@ -745,7 +793,8 @@ function _request(
     // sanitize BEFORE lowering: foreign reasoning, empty turns and orphaned
     // tool calls are everyone's problem, fixed once in ai.wire.
     let journal = ai.wire.sanitize_for_client(input.journal, c.id());
-    for (let item in lower_journal(journal)) {
+    let metadata = prompt_metadata(prompt);
+    for (let item in lower_journal(journal, metadata, preview = preview)) {
         items.push(item);
     }
     let wants_image = _wants_image(input.output_type);
@@ -773,7 +822,7 @@ function _request(
     // ride on a content part) -> user passthrough LAST.
     let pruned = _restore_tool_schemas(_prune_nulls(baml.json.to_json(request)), tools);
     let body = ai.wire.merge_request_body(
-        _apply_message_metadata(pruned, prompt_metadata(prompt)),
+        _apply_message_metadata(pruned, metadata),
         c.request_body,
     );
     baml.http.Request {

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
@@ -361,7 +361,7 @@ function _media_role_error(kind: string, role: string) -> ai.errors.Failure {
 /// audio, so audio in a tool result degrades into a user turn after the run of results
 /// (`lower_journal`). There is no video input part at all.
 function _lower_block(
-    block: ai.content.ContentBlock,
+    block: ai.content.Block,
     position: string,
     preview: bool = false,
 ) -> OaInputPart {
@@ -459,7 +459,7 @@ function _lower_block(
 }
 
 function _lower_blocks(
-    blocks: ai.content.ContentBlock[],
+    blocks: ai.content.Block[],
     position: string,
     preview: bool = false,
 ) -> OaInputPart[] {
@@ -601,7 +601,7 @@ function lower_journal(
             let a: ai.events.AssistantMessage => {
                 for (let b in a.content) {
                     match (b) {
-                        let content: ai.content.ContentBlock => {
+                        let content: ai.content.Block => {
                             items.push(
                                 OaMessageItem {
                                     role: "assistant",
@@ -815,10 +815,7 @@ function _request(
     // open-ended JSON back (tool schemas, then the per-message directives that
     // ride on a content part) -> user passthrough LAST.
     let pruned = _restore_tool_schemas(_prune_nulls(baml.json.to_json(request)), tools);
-    let body = ai.wire.merge_request_body(
-        _apply_message_metadata(pruned, metadata),
-        c.request_body,
-    );
+    let body = ai.wire.merge_request_body(_apply_message_metadata(pruned, metadata), c.request_body);
     baml.http.Request {
         method: "POST",
         url: _url(c),
@@ -912,7 +909,7 @@ function parse(resp: OaResponse) -> ai.ModelTurn {
     if ((resp.status ?? "") == "failed" || resp.error != null) {
         throw _response_failure(resp)
     }
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     let has_call = false;
     let refused = false;
     let output: OaOutputItem[] = resp.output ?? [];

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
@@ -358,7 +358,7 @@ function _media_role_error(kind: string, role: string) -> ai.errors.Failure {
 /// An image in a system message is kept for compatibility: the legacy lowering
 /// accepted image parts in the system message a role-less prompt produced.
 /// `function_call_output.output` takes text, image and file parts but no
-/// audio, so audio in a tool result degrades into a trailing user turn
+/// audio, so audio in a tool result degrades into a user turn after the run of results
 /// (`lower_journal`). There is no video input part at all.
 function _lower_block(
     block: ai.content.ContentBlock,
@@ -633,25 +633,16 @@ function lower_journal(
             },
             let c: ai.events.ToolCompleted => {
                 // `function_call_output.output` carries text, image and file
-                // parts inline; audio degrades into the user turn below.
-                let split = ai.wire.tool_result_blocks(j, c, ["image", "pdf", "video"]);
+                // parts inline; `ai.wire.degrade_tool_media` has already moved
+                // audio out of the result and behind the run of results.
                 items.push(
                     OaFunctionCallOutputItem {
                         type: "function_call_output",
                         call_id: c.id,
-                        output: _tool_output(_lower_blocks(split.inline, "tool_result", preview = preview)),
+                        output: _tool_output(_lower_blocks(c.content, "tool_result", preview = preview)),
                     },
                 );
                 metadata.push(none);
-                if (split.trailing.length() > 0) {
-                    items.push(
-                        OaMessageItem {
-                            role: "user",
-                            content: _lower_blocks(split.trailing, "user", preview = preview),
-                        },
-                    );
-                    metadata.push(none);
-                }
                 null
             },
             let f: ai.events.ToolFailed => {
@@ -792,7 +783,10 @@ function _request(
     let items = lower_prompt(prompt, preview = preview);
     // sanitize BEFORE lowering: foreign reasoning, empty turns and orphaned
     // tool calls are everyone's problem, fixed once in ai.wire.
-    let journal = ai.wire.sanitize_for_client(input.journal, c.id());
+    let journal = ai.wire.degrade_tool_media(
+        ai.wire.sanitize_for_client(input.journal, c.id()),
+        ["image", "pdf", "video"],
+    );
     let metadata = prompt_metadata(prompt);
     for (let item in lower_journal(journal, metadata, preview = preview)) {
         items.push(item);

--- a/baml_language/crates/baml_builtins2/baml_std/vercel/ns_internal/images.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/vercel/ns_internal/images.baml
@@ -157,15 +157,45 @@ function _gw_images_file(media: ai.MediaPart, preview: bool = false) -> GwImages
     }
 }
 
+/// (internal) Collect a turn into the endpoint's two inputs: text blocks trimmed into
+/// `parts` (blanks dropped), image blocks into `files` — how this endpoint
+/// does image editing / variations (image-model protocol v4) — at every
+/// position. The other media kinds have no representation and are rejected.
+function _gw_images_collect(
+    blocks: ai.content.ContentBlock[],
+    parts: string[],
+    files: GwImagesFile[],
+    preview: bool = false,
+) -> void {
+    for (let block in blocks) {
+        match (block) {
+            let text: ai.content.Text => {
+                let trimmed = text.text.trim();
+                if (trimmed != "") {
+                    parts.push(trimmed);
+                }
+                null
+            },
+            let media: ai.content.Media => {
+                match (media.media) {
+                    let image: baml.media.Image => {
+                        files.push(_gw_images_file(image, preview = preview));
+                        null
+                    },
+                    _ => {
+                        throw _gw_images_media_rejected(media.kind())
+                    },
+                }
+            },
+        };
+    }
+}
+
 /// (internal) The rendered prompt lowered to the endpoint's two inputs.
 ///
 /// Text: every text part, trimmed, blanks dropped, joined with a blank line —
-/// sys_llm's `prompt_to_text`, roles discarded. Journal user messages follow so
+/// sys_llm's `prompt_to_text`, roles discarded. Journal user turns follow so
 /// a re-ask still reaches the model.
-///
-/// Files: image parts become `files[]` entries, which is how this endpoint does
-/// image editing / variations (image-model protocol v4). The other media kinds
-/// have no representation and are still rejected.
 function _gw_images_input(
     prompt: ai.Prompt,
     journal: ai.Journal,
@@ -174,37 +204,11 @@ function _gw_images_input(
     let parts: string[] = [];
     let files: GwImagesFile[] = [];
     for (let message in prompt.messages()) {
-        for (let part in message.parts) {
-            match (part) {
-                let text: string => {
-                    let trimmed = text.trim();
-                    if (trimmed != "") {
-                        parts.push(trimmed);
-                    }
-                    null
-                },
-                let image: baml.media.Image => {
-                    files.push(_gw_images_file(image, preview = preview));
-                    null
-                },
-                let audio: baml.media.Audio => {
-                    throw _gw_images_media_rejected("audio")
-                },
-                let video: baml.media.Video => {
-                    throw _gw_images_media_rejected("video")
-                },
-                let pdf: baml.media.Pdf => {
-                    throw _gw_images_media_rejected("pdf")
-                },
-            };
-        }
+        _gw_images_collect(ai.wire.prompt_blocks(message), parts, files, preview = preview);
     }
     for (let event in journal.entries()) {
         if let user: ai.events.UserMessage = event {
-            let trimmed = user.content.trim();
-            if (trimmed != "") {
-                parts.push(trimmed);
-            }
+            _gw_images_collect(user.content, parts, files, preview = preview);
         }
     }
     let joined = parts.join("\n\n");

--- a/baml_language/crates/baml_builtins2/baml_std/vercel/ns_internal/images.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/vercel/ns_internal/images.baml
@@ -162,7 +162,7 @@ function _gw_images_file(media: ai.MediaPart, preview: bool = false) -> GwImages
 /// does image editing / variations (image-model protocol v4) — at every
 /// position. The other media kinds have no representation and are rejected.
 function _gw_images_collect(
-    blocks: ai.content.ContentBlock[],
+    blocks: ai.content.Block[],
     parts: string[],
     files: GwImagesFile[],
     preview: bool = false,
@@ -426,7 +426,7 @@ function gateway_images_parse(
         ?? _gw_images_find_output_format(c.request_body);
     let fallback_mime = _gw_images_mime(requested);
     let images: string[] = resp.images ?? [];
-    let content: ai.content.Block[] = [];
+    let content: ai.content.ModelBlock[] = [];
     for (let encoded in images) {
         if (encoded.trim() != "") {
             content.push(ai.content.Media.new(value = _gw_images_value(encoded, fallback_mime)));

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_namespace_ai_internal.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_namespace_ai_internal.snap
@@ -38,5 +38,5 @@ function         ai.internal._redact_after        <builtin>/ai/ns_internal/wire.
 function         ai.internal._redact_value_end    <builtin>/ai/ns_internal/wire.baml:34
 function         ai.internal._merge_json          <builtin>/ai/ns_internal/wire.baml:48
 function         ai.internal._wire_blocks         <builtin>/ai/ns_internal/wire.baml:90
-function         ai.internal._flush_orphaned_calls <builtin>/ai/ns_internal/wire.baml:123
-function         ai.internal._resolve_pending_call <builtin>/ai/ns_internal/wire.baml:131
+function         ai.internal._flush_orphaned_calls <builtin>/ai/ns_internal/wire.baml:126
+function         ai.internal._resolve_pending_call <builtin>/ai/ns_internal/wire.baml:134

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_anthropic/anthropic_client.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_anthropic/anthropic_client.baml
@@ -402,12 +402,12 @@ function anthropic_reasoning_only_turn_mid_conversation() -> string {
                 content: [ai.content.Text { text: "4" }],
                 client_id: "anthropic/claude-haiku-4-5",
             },
-            ai.events.UserMessage { content: "And 3+3?" },
+            ai.events.UserMessage.new("And 3+3?"),
             ai.events.AssistantMessage {
                 content: [ai.content.Reasoning { summary: "quietly thinking" }],
                 client_id: "anthropic/claude-haiku-4-5",
             },
-            ai.events.UserMessage { content: "And 4+4?" },
+            ai.events.UserMessage.new("And 4+4?"),
         ],
     };
     let body = anth_render_body(cl, AnthMockPlain@spec(), journal);
@@ -446,7 +446,7 @@ function anthropic_orphaned_tool_call_is_closed() -> string {
                 ],
                 client_id: "anthropic/claude-haiku-4-5",
             },
-            ai.events.UserMessage { content: "never mind" },
+            ai.events.UserMessage.new("never mind"),
         ],
     };
     let body = anth_render_body(cl, AnthMockPlain@spec(), journal);
@@ -1052,7 +1052,7 @@ function anthropic_replayed_tool_args_keep_nulls() -> string {
                 content: [ai.content.ToolUse { id: "t1", name: "anth_weather", args: args }],
                 client_id: "anthropic/claude-haiku-4-5",
             },
-            ai.events.ToolCompleted { id: "t1", output: "sunny in SF" },
+            ai.events.ToolCompleted.new("t1", "sunny in SF"),
         ],
     };
     let body = anth_render_body(cl, AnthMockTools@spec("weather?"), journal);
@@ -1159,4 +1159,89 @@ testset "live" with testing.Sequential() {
     } else {
         log.warn("live::anthropic not registered: ANTHROPIC_API_KEY is unset")
     }
+}
+
+// ─── journal content blocks: media in tool results and user turns ─────────────
+//
+// Anthropic column of the lowering table (`_lower_block` in messages.baml):
+// image and pdf are Accepted inside `tool_result.content` and in user turns;
+// audio and video are Rejected everywhere.
+
+function _anth_media_body(media: image | audio | video | pdf) -> json {
+    let cl = anthropic.Client.new(model = "claude-haiku-4-5", api_key = "test-key");
+    anth_render_body(
+        cl,
+        AnthMockTools@spec("weather?"),
+        root.llm_mock.media_journal("anthropic/claude-haiku-4-5", media),
+    )
+}
+
+// The tool-result user turn and the following user turn merge into one
+// message: [tool_result(text), tool_result(blocks), text, image]. The
+// text-only result keeps `content` as a plain string.
+function anthropic_journal_image_accepted() -> string {
+    let body = _anth_media_body(root.llm_mock.media_png());
+    let m = ".messages[2].content";
+    [
+        baml.json.path<string>(body, ".messages[2].role"),
+        baml.json.path<string>(body, `${m}[0].content`),
+        baml.json.path<string>(body, `${m}[1].content[0].text`),
+        baml.json.path<string>(body, `${m}[1].content[1].type`),
+        baml.json.path<string>(body, `${m}[1].content[1].source.data`),
+        baml.json.path<string>(body, `${m}[2].text`),
+        baml.json.path<string>(body, `${m}[3].type`),
+        baml.json.path<string>(body, `${m}[3].source.media_type`),
+        baml.json.path_or<string>(body, ".messages[3].role", "absent"),
+    ].join("|")
+}
+
+test "anthropic_journal_image_accepted" {
+    assert.equal(
+        anthropic_journal_image_accepted(),
+        "user|sunny in SF|captured:|image|SGVsbG8=|Screenshot after the tool ran:|image|image/png|absent",
+    )
+}
+
+// Audio has no input block at any position: the typed error fires before a
+// request exists, for a tool result exactly as for a user turn.
+function anthropic_journal_audio_rejected() -> string {
+    baml.json.stringify(_anth_media_body(root.llm_mock.media_mp3())) catch_all (e) {
+        let invalid: ai.errors.InvalidRequest => invalid.detail,
+        _ => `unexpected error class: ${e.to_string()}`,
+    }
+}
+
+test "anthropic_journal_audio_rejected" {
+    assert.contains(anthropic_journal_audio_rejected(), "Anthropic does not support audio prompt input")
+}
+
+// `ai.wire.sanitize_for_client` closes a tool call still unanswered when a
+// user turn arrives, whatever the turn carries.
+function anthropic_orphaned_tool_call_closed_before_user_turn() -> string {
+    let cl = anthropic.Client.new(model = "claude-haiku-4-5", api_key = "test-key");
+    let args: map<string, unknown> = { "city": "SF" };
+    let journal = ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [ai.content.ToolUse { id: "t1", name: "anth_weather", args: args }],
+                client_id: "anthropic/claude-haiku-4-5",
+            },
+            ai.events.UserMessage.of(["never mind, look at this instead", root.llm_mock.media_png()]),
+        ],
+    };
+    let body = anth_render_body(cl, AnthMockPlain@spec(), journal);
+    [
+        baml.json.path<string>(body, ".messages[2].content[0].type"),
+        baml.json.path<string>(body, ".messages[2].content[0].tool_use_id"),
+        baml.json.path<bool>(body, ".messages[2].content[0].is_error").to_string(),
+        baml.json.path<string>(body, ".messages[2].content[1].text"),
+        baml.json.path<string>(body, ".messages[2].content[2].type"),
+    ].join("|")
+}
+
+test "anthropic_orphaned_tool_call_closed_before_user_turn" {
+    assert.equal(
+        anthropic_orphaned_tool_call_closed_before_user_turn(),
+        "tool_result|t1|true|never mind, look at this instead|image",
+    )
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_bedrock/bedrock.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_bedrock/bedrock.baml
@@ -438,7 +438,7 @@ function bedrock_multi_turn() -> string {
             content: [ai.content.Text { text: "4" }],
             client_id: `bedrock/${_model()}`,
         },
-        ai.events.UserMessage { content: "And 3+3?" },
+        ai.events.UserMessage.new("And 3+3?"),
     ];
     let journal = ai.Journal { log: log };
     let body = _body(_client(null), _turn_input(BedrockEcho@spec("What is 2+2?"), journal, _no_tools()));
@@ -459,7 +459,7 @@ test "bedrock_multi_turn" {
 // An assistant turn that lowers to NOTHING is dropped, not sent as
 // `content: []` — Converse answers that shape with a ValidationException.
 //
-// A reasoning-only turn is exactly it: `_assistant_content` drops `Reasoning`
+// A reasoning-only turn is exactly it: `_lower_journal` drops `Reasoning`
 // (Converse replays reasoning only with the provider's opaque signature, which
 // `ai.content.Reasoning` cannot reproduce) and drops `Media`. Nothing upstream
 // removes the turn either — `ai.wire.sanitize_for_client` KEEPS reasoning whose
@@ -476,7 +476,7 @@ function bedrock_reasoning_only_turn_is_dropped() -> string {
             content: [ai.content.Reasoning { summary: "thinking about it" }],
             client_id: `bedrock/${_model()}`,
         },
-        ai.events.UserMessage { content: "And 3+3?" },
+        ai.events.UserMessage.new("And 3+3?"),
     ];
     let journal = ai.Journal { log: log };
     let body = _body(_client(null), _turn_input(BedrockEcho@spec("What is 2+2?"), journal, _no_tools()));
@@ -507,12 +507,12 @@ function bedrock_reasoning_only_turn_mid_conversation() -> string {
             content: [ai.content.Text { text: "4" }],
             client_id: `bedrock/${_model()}`,
         },
-        ai.events.UserMessage { content: "And 3+3?" },
+        ai.events.UserMessage.new("And 3+3?"),
         ai.events.AssistantMessage {
             content: [ai.content.Reasoning { summary: "thinking about it" }],
             client_id: `bedrock/${_model()}`,
         },
-        ai.events.UserMessage { content: "And 4+4?" },
+        ai.events.UserMessage.new("And 4+4?"),
     ];
     let journal = ai.Journal { log: log };
     let body = _body(_client(null), _turn_input(BedrockEcho@spec("What is 2+2?"), journal, _no_tools()));
@@ -622,7 +622,7 @@ test "bedrock_no_tool_config_without_tools" {
 function bedrock_tool_replay() -> string {
     let args: map<string, unknown> = { "city": "SF" };
     let log: ai.events.Event[] = [
-        ai.events.UserMessage { content: "weather in SF and NY?" },
+        ai.events.UserMessage.new("weather in SF and NY?"),
         ai.events.AssistantMessage {
             content: [
                 ai.content.ToolUse { id: "tu_1", name: "get_weather", args: args },
@@ -630,7 +630,7 @@ function bedrock_tool_replay() -> string {
             ],
             client_id: `bedrock/${_model()}`,
         },
-        ai.events.ToolCompleted { id: "tu_1", output: "sunny" },
+        ai.events.ToolCompleted.new("tu_1", "sunny"),
         ai.events.ToolFailed { id: "tu_2", message: "upstream down" },
     ];
     let journal = ai.Journal { log: log };
@@ -673,7 +673,7 @@ function bedrock_tool_replay_null_arg() -> string {
             content: [ai.content.ToolUse { id: "tu_1", name: "get_weather", args: args }],
             client_id: `bedrock/${_model()}`,
         },
-        ai.events.ToolCompleted { id: "tu_1", output: "sunny" },
+        ai.events.ToolCompleted.new("tu_1", "sunny"),
     ];
     let journal = ai.Journal { log: log };
     let body = _body(_client(null), _turn_input(BedrockUserOnly@spec("go"), journal, _weather_tools()));
@@ -1266,4 +1266,67 @@ testset "live" with testing.Sequential() {
     } else {
         log.warn("live::bedrock not registered: AWS_PROFILE is unset (local SSO session required)")
     }
+}
+
+// ─── journal content blocks: media in tool results and user turns ─────────────
+//
+// Bedrock column of the lowering table (`_lower_block` in bedrock.baml):
+// image, pdf and video are Accepted inside `toolResult.content`; audio has
+// no toolResult member and Degrades into a trailing user turn.
+
+function _bedrock_media_body(media: image | audio | video | pdf) -> json {
+    _body(
+        _client(null),
+        _turn_input(
+            BedrockUserOnly@spec("go"),
+            root.llm_mock.media_journal(`bedrock/${_model()}`, media),
+            _weather_tools(),
+        ),
+    )
+}
+
+// One merged user message: [toolResult(text), toolResult(text, image), text,
+// image]. The text-only result is a single text block.
+function bedrock_journal_image_accepted() -> string {
+    let body = _bedrock_media_body(root.llm_mock.media_png());
+    let m = ".messages[2].content";
+    [
+        baml.json.path<string>(body, `${m}[0].toolResult.content[0].text`),
+        _array_len(body, `${m}[0].toolResult.content`).to_string(),
+        baml.json.path<string>(body, `${m}[1].toolResult.content[0].text`),
+        baml.json.path<string>(body, `${m}[1].toolResult.content[1].image.format`),
+        baml.json.path<string>(body, `${m}[1].toolResult.content[1].image.source.bytes`),
+        baml.json.path<string>(body, `${m}[2].text`),
+        baml.json.path<string>(body, `${m}[3].image.format`),
+        _array_len(body, ".messages").to_string(),
+    ].join("|")
+}
+
+test "bedrock_journal_image_accepted" {
+    assert.equal(
+        bedrock_journal_image_accepted(),
+        "sunny in SF|1|captured:|png|SGVsbG8=|Screenshot after the tool ran:|png|3",
+    )
+}
+
+// Degrade: the result keeps its text; the audio follows the toolResult
+// blocks behind a note naming the tool, then the user turn carries its own.
+function bedrock_journal_audio_degrades() -> string {
+    let body = _bedrock_media_body(root.llm_mock.media_mp3());
+    let m = ".messages[2].content";
+    [
+        baml.json.path<string>(body, `${m}[1].toolResult.content[0].text`),
+        _array_len(body, `${m}[1].toolResult.content`).to_string(),
+        baml.json.path<string>(body, `${m}[2].text`),
+        baml.json.path<string>(body, `${m}[3].audio.format`),
+        baml.json.path<string>(body, `${m}[4].text`),
+        baml.json.path<string>(body, `${m}[5].audio.source.bytes`),
+    ].join("|")
+}
+
+test "bedrock_journal_audio_degrades" {
+    assert.equal(
+        bedrock_journal_audio_degrades(),
+        `captured:|1|${root.llm_mock.degrade_note("capture")}|mp3|Screenshot after the tool ran:|QUJD`,
+    )
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_google/google_client.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_google/google_client.baml
@@ -1127,3 +1127,66 @@ testset "live" with testing.Sequential() {
         )
     }
 }
+
+// ─── journal content blocks: media in tool results and user turns ─────────────
+//
+// Gemini column of the lowering table (`_lower_block` in gemini.baml): every
+// media kind is Accepted at every position. A result's text is the
+// `functionResponse.response.result`; its media rides in
+// `functionResponse.parts`. Both backends lower the same way.
+
+function _google_media_input() -> ai.ModelTurnInput {
+    let spec = GoogleToolEcho@spec("Weather in NYC?");
+    ai.ModelTurnInput {
+        prompt: spec.prompt_template,
+        journal: root.llm_mock.media_journal("google/gemini-2.5-flash", root.llm_mock.media_png()),
+        toolbox: spec.tools(),
+        output_type: spec.output_type(),
+    }
+}
+
+function _google_media_shape(body: json) -> string {
+    let results = ".contents[2].parts";
+    [
+        baml.json.path<string>(body, ".contents[1].parts[1].functionCall.name"),
+        baml.json.path<string>(body, `${results}[0].functionResponse.response.result`),
+        baml.json.path_or<string>(body, `${results}[0].functionResponse.parts[0].inlineData.data`, "absent"),
+        baml.json.path<string>(body, `${results}[1].functionResponse.name`),
+        baml.json.path<string>(body, `${results}[1].functionResponse.response.result`),
+        baml.json.path<string>(body, `${results}[1].functionResponse.parts[0].inlineData.mimeType`),
+        baml.json.path<string>(body, ".contents[3].role"),
+        baml.json.path<string>(body, ".contents[3].parts[0].text"),
+        baml.json.path<string>(body, ".contents[3].parts[1].inlineData.data"),
+        baml.json.path_or<string>(body, ".contents[4].role", "absent"),
+    ].join("|")
+}
+
+function google_journal_image_accepted() -> string {
+    let cl = google.GeminiClient.new(
+        model = "gemini-2.5-flash",
+        api_key = "test-key",
+        base_url = "https://example.test",
+    );
+    _google_media_shape(baml.json.parse(google.internal.render(cl, _google_media_input()).body))
+}
+
+test "google_journal_image_accepted" {
+    assert.equal(
+        google_journal_image_accepted(),
+        "capture|sunny in SF|absent|capture|captured:|image/png|user|Screenshot after the tool ran:|SGVsbG8=|absent",
+    )
+}
+
+function vertex_journal_image_accepted() -> string {
+    let cl = google.VertexClient.new(
+        model = "gemini-2.5-flash",
+        project_id = "my-project",
+        location = "us-central1",
+        api_key = "express-key",
+    );
+    _google_media_shape(baml.json.parse(google.internal.vertex_render(cl, _google_media_input()).body))
+}
+
+test "vertex_journal_image_accepted" {
+    assert.equal(vertex_journal_image_accepted(), google_journal_image_accepted())
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_images/images.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_images/images.baml
@@ -1128,3 +1128,55 @@ testset "live" with testing.Sequential() {
     // no key to gate on. Add one here (same shape as above, gated on
     // AI_GATEWAY_API_KEY) once the account exists.
 }
+
+// ─── journal content blocks ──────────────────────────────────────────────────
+//
+// The Images clients lower a journal user turn through the same collector as
+// the prompt: OpenAI's endpoint takes text only, so an image in a user turn
+// is Rejected; the gateway takes images as `files[]`, so it is Accepted
+// there. Tool traffic has no representation on either.
+
+function _images_media_input(spec: ai.FunctionSpec<image>) -> ai.ModelTurnInput {
+    ai.ModelTurnInput {
+        prompt: spec.prompt_template,
+        journal: ai.Journal {
+            log: [ai.events.UserMessage.of(["make it warmer", root.llm_mock.media_png()])],
+        },
+        toolbox: ai.tools.Toolbox.new([]),
+        output_type: spec.output_type(),
+    }
+}
+
+function openai_images_journal_image_rejected() -> string {
+    let cl = openai.ImageClient.new(model = "gpt-image-1", api_key = "test-key");
+    openai.internal.images_render(cl, _images_media_input(ImagesDraw@spec("a lamp"))).url catch_all (e) {
+        let invalid: ai.errors.InvalidRequest => invalid.detail,
+        _ => `unexpected error class: ${e.to_string()}`,
+    }
+}
+
+test "openai_images_journal_image_rejected" {
+    assert.equal(
+        openai_images_journal_image_rejected(),
+        "Images API only supports text prompts; found image input",
+    )
+}
+
+function gateway_images_journal_image_accepted() -> string {
+    let cl = vercel.AiGatewayImageClient.new(model = "bfl/flux-2-pro", api_key = "test-key");
+    let body = baml.json.parse(
+        vercel.internal.gateway_images_render(cl, _images_media_input(GatewayDraw@spec("a lamp"))).body,
+    );
+    [
+        baml.json.path<string>(body, ".prompt"),
+        baml.json.path<string>(body, ".files[0].type"),
+        baml.json.path<string>(body, ".files[0].data"),
+    ].join("|")
+}
+
+test "gateway_images_journal_image_accepted" {
+    assert.equal(
+        gateway_images_journal_image_accepted(),
+        "A studio photograph of a lamp.\n\nmake it warmer|file|SGVsbG8=",
+    )
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_mock/mock_provider.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_mock/mock_provider.baml
@@ -457,6 +457,27 @@ function media_journal(client_id: string, media: image | audio | video | pdf) ->
     }
 }
 
+/// Two results for one assistant turn where the media-only result comes
+/// FIRST: a Degrade must still keep both results contiguous and attach the
+/// media after the second one, and the media-only result must not lower to an
+/// empty tool result.
+function parallel_media_journal(client_id: string, media: image | audio | video | pdf) -> ai.Journal {
+    let args: map<string, unknown> = {};
+    ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [
+                    ai.content.ToolUse { id: "call_media", name: "capture", args: args },
+                    ai.content.ToolUse { id: "call_text", name: "lookup", args: args },
+                ],
+                client_id: client_id,
+            },
+            ai.events.ToolCompleted.of("call_media", [media]),
+            ai.events.ToolCompleted.new("call_text", "sunny in SF"),
+        ],
+    }
+}
+
 /// The one-line note a Degrade moves media behind.
 function degrade_note(tool: string) -> string {
     "attached from the result of tool `" + tool + "`"

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_mock/mock_provider.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_mock/mock_provider.baml
@@ -430,3 +430,42 @@ function mock_sse_events_roundtrip() -> string {
 test "mock_sse_events_roundtrip" {
     assert.equal(mock_sse_events_roundtrip(), "event: a\ndata: 1 / event: b\ndata: 2")
 }
+
+// ─── shared journal fixture: media in tool results and user turns ────────────
+
+/// The seed for every client's Accept / Degrade / Reject test: one assistant
+/// turn issuing two tool calls, a text-only result for the first (`call_text`,
+/// tool `lookup`), a result carrying text plus `media` for the second
+/// (`call_media`, tool `capture`), then a user turn carrying text plus the
+/// same `media`. Each client test asserts where the media landed on the wire
+/// and that the text-only result kept its plain-string shape.
+function media_journal(client_id: string, media: image | audio | video | pdf) -> ai.Journal {
+    let args: map<string, unknown> = {};
+    ai.Journal {
+        log: [
+            ai.events.AssistantMessage {
+                content: [
+                    ai.content.ToolUse { id: "call_text", name: "lookup", args: args },
+                    ai.content.ToolUse { id: "call_media", name: "capture", args: args },
+                ],
+                client_id: client_id,
+            },
+            ai.events.ToolCompleted.new("call_text", "sunny in SF"),
+            ai.events.ToolCompleted.of("call_media", ["captured:", media]),
+            ai.events.UserMessage.of(["Screenshot after the tool ran:", media]),
+        ],
+    }
+}
+
+/// The one-line note a Degrade moves media behind.
+function degrade_note(tool: string) -> string {
+    "attached from the result of tool `" + tool + "`"
+}
+
+function media_png() -> image {
+    baml.media.Image.from_base64("SGVsbG8=", "image/png")
+}
+
+function media_mp3() -> audio {
+    baml.media.Audio.from_base64("QUJD", "audio/mp3")
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_on_event/llm_on_event.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_on_event/llm_on_event.baml
@@ -111,6 +111,51 @@ test "content_block_projections" {
     assert.equal(content_block_projections(), `look: [image] ok|3|0|hi|{"k":1}|[image]|1`)
 }
 
+// `ai.wire.degrade_tool_media` is the Degrade every text-only-result client
+// lowers through: the media a result cannot carry leaves it and follows the
+// whole run of results as one user turn, the results stay contiguous, and a
+// media-only result keeps a placeholder instead of becoming empty. A kind the
+// client carries stays where it was.
+function degraded_journal_shape(carries: string[]) -> string {
+    let j = root.llm_mock.parallel_media_journal("x", root.llm_mock.media_mp3());
+    let labels: string[] = [];
+    for (let e in ai.wire.degrade_tool_media(j, carries).entries()) {
+        match (e) {
+            let a: ai.events.AssistantMessage => {
+                labels.push("assistant");
+                null
+            },
+            let c: ai.events.ToolCompleted => {
+                labels.push(`tool:${c.id}:${c.text()}:${c.content.length()}`);
+                null
+            },
+            let u: ai.events.UserMessage => {
+                labels.push(`user:${u.text()}:${u.content.length()}`);
+                null
+            },
+            _ => {
+                labels.push("other");
+                null
+            },
+        };
+    }
+    labels.join("|")
+}
+
+test "degrade_tool_media_attaches_after_the_run_of_results" {
+    assert.equal(
+        degraded_journal_shape([]),
+        `assistant|tool:call_media:[audio]:1|tool:call_text:sunny in SF:1|user:${root.llm_mock.degrade_note("capture")}[audio]:2`,
+    )
+}
+
+test "degrade_tool_media_keeps_carried_media_in_place" {
+    assert.equal(
+        degraded_journal_shape(["audio"]),
+        `assistant|tool:call_media:[audio]:1|tool:call_text:sunny in SF:1`,
+    )
+}
+
 // The Claude Code CLI folds the journal into one text prompt: every turn
 // renders through `text()`, media as a readable placeholder, in order.
 function claude_code_transcript_with_media() -> string {

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_on_event/llm_on_event.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_on_event/llm_on_event.baml
@@ -85,3 +85,43 @@ test "explicit Agent accepts and swallows a throwing listener" {
     assert.equal(out.value.message, "hi");
     assert.equal(probe.labels, ["RunStarted", "AssistantMessage", "Usage", "FinalProduced"])
 }
+
+// ─── content blocks: constructors and the text projection ────────────────────
+
+// `new` wraps text in one block, `of` wraps bare values, `text()` joins the
+// text blocks with a `[kind]` placeholder per media block.
+function content_block_projections() -> string {
+    let png = root.llm_mock.media_png();
+    let user = ai.events.UserMessage.of(["look: ", png, " ok"]);
+    let plain = ai.events.UserMessage.new("hi");
+    let done = ai.events.ToolCompleted.new("t1", `{"k":1}`);
+    let shot = ai.events.ToolCompleted.of("t2", [png]);
+    [
+        user.text(),
+        user.content.length().to_string(),
+        user.metadata.keys().length().to_string(),
+        plain.text(),
+        done.text(),
+        shot.text(),
+        shot.content.length().to_string(),
+    ].join("|")
+}
+
+test "content_block_projections" {
+    assert.equal(content_block_projections(), `look: [image] ok|3|0|hi|{"k":1}|[image]|1`)
+}
+
+// The Claude Code CLI folds the journal into one text prompt: every turn
+// renders through `text()`, media as a readable placeholder, in order.
+function claude_code_transcript_with_media() -> string {
+    claude_code.internal.transcript_text(
+        root.llm_mock.media_journal("claude-code/opus", root.llm_mock.media_png()),
+    )
+}
+
+test "claude_code_transcript_with_media" {
+    assert.contains(
+        claude_code_transcript_with_media(),
+        "tool result id=call_text is_error=false: sunny in SF\ntool result id=call_media is_error=false: captured:[image]\nuser: Screenshot after the tool ran:[image]",
+    )
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
@@ -1830,6 +1830,45 @@ test "chat_journal_image_degrades" {
     )
 }
 
+// messages: [system, user, assistant(tool_calls), tool(placeholder), tool,
+// user(note + audio)]: the two `tool` replies stay contiguous and the media
+// the first one could not carry follows the second.
+function chat_journal_parallel_results_stay_contiguous() -> string {
+    root.llm_mock.mock_json_serve(
+        [root.llm_mock.MockResponse.ok(_chat_ok_body())],
+        (mock: root.llm_mock.MockJsonServer) -> {
+            let cl = openai.ChatClient.new(api_key = "k", base_url = mock.base_url());
+            let spec = ChatEcho@spec("and tomorrow?");
+            let input = ai.ModelTurnInput {
+                prompt: spec.prompt_template,
+                journal: root.llm_mock.parallel_media_journal("openai-chat/gpt-4o-mini", root.llm_mock.media_mp3()),
+                toolbox: ai.tools.Toolbox.new([ai.tools.tool(chat_get_weather)]),
+                output_type: spec.output_type(),
+            };
+            let _ = cl.invoke(input);
+            let body = mock.last_request().json();
+            [
+                baml.json.path<string>(body, ".messages[3].role"),
+                baml.json.path<string>(body, ".messages[3].tool_call_id"),
+                baml.json.path<string>(body, ".messages[3].content"),
+                baml.json.path<string>(body, ".messages[4].role"),
+                baml.json.path<string>(body, ".messages[4].tool_call_id"),
+                baml.json.path<string>(body, ".messages[5].role"),
+                baml.json.path<string>(body, ".messages[5].content[0].text"),
+                baml.json.path<string>(body, ".messages[5].content[1].type"),
+                baml.json.path_or<string>(body, ".messages[6].role", "absent"),
+            ].join("|")
+        },
+    )
+}
+
+test "chat_journal_parallel_results_stay_contiguous" {
+    assert.equal(
+        chat_journal_parallel_results_stay_contiguous(),
+        `tool|call_media|[audio]|tool|call_text|user|${root.llm_mock.degrade_note("capture")}|input_audio|absent`,
+    )
+}
+
 function chat_journal_video_rejected() -> string {
     root.llm_mock.mock_json_serve(
         [root.llm_mock.MockResponse.ok(_chat_ok_body())],

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_openai_chat/openai_chat.baml
@@ -64,7 +64,7 @@ function _chat_input_with_history() -> ai.ModelTurnInput {
     let args: map<string, unknown> = { "city": "SF" };
     let journal = ai.Journal {
         log: [
-            ai.events.UserMessage { content: "weather in SF?" },
+            ai.events.UserMessage.new("weather in SF?"),
             ai.events.AssistantMessage {
                 content: [
                     ai.content.Text { text: "checking" },
@@ -72,7 +72,7 @@ function _chat_input_with_history() -> ai.ModelTurnInput {
                 ],
                 client_id: "openai-chat/gpt-4o-mini",
             },
-            ai.events.ToolCompleted { id: "call_1", output: "sunny in SF" },
+            ai.events.ToolCompleted.new("call_1", "sunny in SF"),
         ],
     };
     ai.ModelTurnInput {
@@ -1779,4 +1779,74 @@ testset "live" with testing.Sequential() {
     } else {
         log.warn("live::openrouter not registered: OPENROUTER_API_KEY is unset")
     }
+}
+
+// ─── journal content blocks: media in tool results and user turns ─────────────
+//
+// Chat column of the lowering table (`_chat_lower_block` in chat.baml): a
+// `tool` message is text only, so every media kind in a result Degrades into
+// a trailing user turn; user turns Accept image, audio and pdf; video has no
+// part at all and is Rejected.
+
+function _chat_media_input(media: image | audio | video | pdf) -> ai.ModelTurnInput {
+    let spec = ChatEcho@spec("and tomorrow?");
+    ai.ModelTurnInput {
+        prompt: spec.prompt_template,
+        journal: root.llm_mock.media_journal("openai-chat/gpt-4o-mini", media),
+        toolbox: ai.tools.Toolbox.new([ai.tools.tool(chat_get_weather)]),
+        output_type: spec.output_type(),
+    }
+}
+
+// messages: [system, user, assistant(tool_calls), tool, tool, user(note +
+// image), user(text + image)]. Both tool messages keep plain-string content.
+function chat_journal_image_degrades() -> string {
+    root.llm_mock.mock_json_serve(
+        [root.llm_mock.MockResponse.ok(_chat_ok_body())],
+        (mock: root.llm_mock.MockJsonServer) -> {
+            let cl = openai.ChatClient.new(api_key = "k", base_url = mock.base_url());
+            let _ = cl.invoke(_chat_media_input(root.llm_mock.media_png()));
+            let body = mock.last_request().json();
+            [
+                baml.json.path<string>(body, ".messages[3].content"),
+                baml.json.path<string>(body, ".messages[4].tool_call_id"),
+                baml.json.path<string>(body, ".messages[4].content"),
+                baml.json.path<string>(body, ".messages[5].role"),
+                baml.json.path<string>(body, ".messages[5].content[0].text"),
+                baml.json.path<string>(body, ".messages[5].content[1].image_url.url"),
+                baml.json.path<string>(body, ".messages[6].role"),
+                baml.json.path<string>(body, ".messages[6].content[0].text"),
+                baml.json.path<string>(body, ".messages[6].content[1].type"),
+                baml.json.path_or<string>(body, ".messages[7].role", "absent"),
+            ].join("|")
+        },
+    )
+}
+
+test "chat_journal_image_degrades" {
+    assert.equal(
+        chat_journal_image_degrades(),
+        `sunny in SF|call_media|captured:|user|${root.llm_mock.degrade_note("capture")}|data:image/png;base64,SGVsbG8=|user|Screenshot after the tool ran:|image_url|absent`,
+    )
+}
+
+function chat_journal_video_rejected() -> string {
+    root.llm_mock.mock_json_serve(
+        [root.llm_mock.MockResponse.ok(_chat_ok_body())],
+        (mock: root.llm_mock.MockJsonServer) -> {
+            let cl = openai.ChatClient.new(api_key = "k", base_url = mock.base_url());
+            let clip = baml.media.Video.from_base64("QUJD", "video/mp4");
+            let detail = cl.invoke(_chat_media_input(clip)).stop_reason.to_string() catch_all (e) {
+                let invalid: ai.errors.InvalidRequest => invalid.detail,
+                _ => `unexpected error class: ${e.to_string()}`,
+            };
+            `${detail}|requests=${mock.request_count()}`
+        },
+    )
+}
+
+test "chat_journal_video_rejected" {
+    let got = chat_journal_video_rejected();
+    assert.contains(got, "OpenAI Chat Completions has no video input part");
+    assert.contains(got, "|requests=0")
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_llm_openai_responses/responses.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_llm_openai_responses/responses.baml
@@ -295,7 +295,7 @@ function oai_tools_and_journal() -> string {
     let args: map<string, unknown> = { };
     let journal = ai.Journal {
         log: [
-            ai.events.UserMessage { content: "earlier question" },
+            ai.events.UserMessage.new("earlier question"),
             ai.events.AssistantMessage {
                 content: [
                     ai.content.Text { text: "on it" },
@@ -1112,4 +1112,78 @@ testset "live" with testing.Sequential() {
     } else {
         log.warn("live::openai_responses not registered: OPENAI_API_KEY is unset")
     }
+}
+
+// ─── journal content blocks: media in tool results and user turns ─────────────
+//
+// Responses column of the lowering table (`_lower_block` in responses.baml):
+// image and pdf are Accepted inside `function_call_output.output` as input
+// parts; audio has no part there and Degrades into a trailing user turn;
+// video is Rejected everywhere.
+
+function _oai_media_body(media: image | audio | video | pdf) -> json {
+    let cl = openai.ResponsesClient.new(model = "gpt-4o-mini", api_key = "test-key");
+    let input = _oai_input(
+        OaiEcho@spec("Say pong."),
+        root.llm_mock.media_journal("openai/gpt-4o-mini", media),
+        ai.tools.Toolbox.new([]),
+    );
+    baml.json.parse(openai.internal.render(cl, input).body)
+}
+
+// input: [prompt user, function_call, function_call, function_call_output
+// (string), function_call_output (parts), user(text + image)].
+function oai_journal_image_accepted() -> string {
+    let body = _oai_media_body(root.llm_mock.media_png());
+    [
+        baml.json.path<string>(body, ".input[3].call_id"),
+        baml.json.path<string>(body, ".input[3].output"),
+        baml.json.path<string>(body, ".input[4].output[0].text"),
+        baml.json.path<string>(body, ".input[4].output[1].type"),
+        baml.json.path<string>(body, ".input[4].output[1].image_url"),
+        baml.json.path<string>(body, ".input[5].role"),
+        baml.json.path<string>(body, ".input[5].content[0].text"),
+        baml.json.path<string>(body, ".input[5].content[1].type"),
+        baml.json.path_or<string>(body, ".input[6].role", "absent"),
+    ].join("|")
+}
+
+test "oai_journal_image_accepted" {
+    assert.equal(
+        oai_journal_image_accepted(),
+        "call_text|sunny in SF|captured:|input_image|data:image/png;base64,SGVsbG8=|user|Screenshot after the tool ran:|input_image|absent",
+    )
+}
+
+// Degrade: the result's output stays the plain text; the audio follows as a
+// user message behind a note naming the tool.
+function oai_journal_audio_degrades() -> string {
+    let body = _oai_media_body(root.llm_mock.media_mp3());
+    [
+        baml.json.path<string>(body, ".input[4].output"),
+        baml.json.path<string>(body, ".input[5].role"),
+        baml.json.path<string>(body, ".input[5].content[0].text"),
+        baml.json.path<string>(body, ".input[5].content[1].input_audio.format"),
+        baml.json.path<string>(body, ".input[6].content[0].text"),
+        baml.json.path<string>(body, ".input[6].content[1].type"),
+    ].join("|")
+}
+
+test "oai_journal_audio_degrades" {
+    assert.equal(
+        oai_journal_audio_degrades(),
+        `captured:|user|${root.llm_mock.degrade_note("capture")}|mp3|Screenshot after the tool ran:|input_audio`,
+    )
+}
+
+function oai_journal_video_rejected() -> string {
+    let clip = baml.media.Video.from_base64("QUJD", "video/mp4");
+    baml.json.stringify(_oai_media_body(clip)) catch_all (e) {
+        let invalid: ai.errors.InvalidRequest => invalid.detail,
+        _ => `unexpected error class: ${e.to_string()}`,
+    }
+}
+
+test "oai_journal_video_rejected" {
+    assert.equal(oai_journal_video_rejected(), "OpenAI Responses does not support video prompt input")
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_streaming_composite_clients/bytecode.snap
@@ -115,7 +115,7 @@ function streaming_composite_clients.<(user.streaming_composite_clients.NonStrea
 function streaming_composite_clients.<(user.streaming_composite_clients.NonStreamingClient as ai.Client)>.invoke(self: streaming_composite_clients.NonStreamingClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
     load_const "not streamed"
     init_instance ai.content.Text .text
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     alloc_array 1
     load_const ai.content.StopReason.Complete
     alloc_variant ai.content.StopReason
@@ -159,7 +159,7 @@ function streaming_composite_clients.<(user.streaming_composite_clients.Scripted
     store_var _6
     load_var _6
     init_instance ai.content.Text .text
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     alloc_array 1
     load_const ai.content.StopReason.Complete
     alloc_variant ai.content.StopReason

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -538,10 +538,11 @@ function ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionS
     throw
 
   L15:
-    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
-    load_var batch
     load_const "The reply did not match the required schema. Answer again with only the corrected value."
-    init_instance ai.events.UserMessage .content
+    call ai.events.UserMessage.new
+    store_var _94
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 19 30
     call baml.Array.push
     pop 1
     load_var2 4 19
@@ -1097,7 +1098,7 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     load_field .name
     call baml.String.from
     store_var _43
-    load_var2 4 16
+    load_var2 4 17
     load_const "tool is not in the active toolbox: "
     load_var _43
     bin_op +
@@ -1181,10 +1182,12 @@ function ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.c
     load_var _31
     narrow_bind string, slot=15
     pop_jump_if_false L6
-    load_var2 4 3
+    load_var call
     load_field .id
     load_var _31
-    init_instance ai.events.ToolCompleted .id, .output
+    call ai.events.ToolCompleted.new
+    store_var _35
+    load_var2 4 16
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
     alloc_array 1
     call ai.Journal.append_all
@@ -3273,6 +3276,134 @@ function ai.content.Media.new(value: image | audio | video | pdf, provider_id: s
     return
 }
 
+function ai.content.blocks(items: (string | image | audio | video | pdf | ai.content.Text | ai.content.Media)[]) -> (ai.content.Text | ai.content.Media)[] {
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var out
+    load_var items
+    load_type baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf | ai.content.Media | ai.content.Text>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+
+  L0:
+    load_var _3
+    load_type baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf | ai.content.Media | ai.content.Text>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_true L3
+    load_var _4
+    store_var item
+    load_var item
+    store_var _8
+    load_var _8
+    narrow_bind string, slot=6
+    pop_jump_if_true L2
+    load_var item
+    store_var _14
+    load_var _14
+    narrow_bind ai.content.Text, slot=7
+    pop_jump_if_true L1
+    load_var _14
+    narrow_bind ai.content.Media, slot=7
+    pop_jump_if_true L1
+    load_var item
+    load_const <omitted>
+    load_const <omitted>
+    call ai.content.Media.new
+    store_var _21
+    load_type ai.content.Text | ai.content.Media
+    load_var2 2 8
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L1:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 2 7
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L2:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 2 6
+    init_instance ai.content.Text .text
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L3:
+    load_var out
+    return
+}
+
+function ai.content.text(content: (ai.content.Text | ai.content.Media)[]) -> string {
+    load_const ""
+    store_var out
+    load_var content
+    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+
+  L0:
+    load_var _3
+    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_true L2
+    load_var _4
+    store_var block
+    load_var block
+    store_var _8
+    load_var _8
+    narrow_bind ai.content.Text, slot=6
+    pop_jump_if_true L1
+    load_type string
+    load_var out
+    call baml.String.from
+    load_var block
+    call ai.content.Media.kind
+    store_var _23
+    load_type string
+    load_var _23
+    call baml.String.from
+    store_var _22
+    load_const "["
+    bin_op +
+    load_var _22
+    bin_op +
+    load_const "]"
+    bin_op +
+    store_var out
+    jump L0
+
+  L1:
+    load_var _8
+    store_var t
+    load_type string
+    load_var out
+    call baml.String.from
+    load_type string
+    load_var t
+    load_field .text
+    call baml.String.from
+    bin_op +
+    store_var out
+    jump L0
+
+  L2:
+    load_var out
+    return
+}
+
 function ai.errors.<(ai.errors.FinishReasonError as ai.errors.Failure)>.retry_safety(self: ai.errors.FinishReasonError) -> ai.errors.RetrySafety {
     load_const ai.errors.RetrySafety.Safe
     alloc_variant ai.errors.RetrySafety
@@ -3548,6 +3679,68 @@ function ai.errors.normalize(error: ai.errors.Failure | baml.errors.Timeout | ba
 function ai.errors.normalize_invoke(error: ai.errors.Failure | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError | baml.errors.InvalidArgument | baml.errors.Io | baml.errors.ParseError | baml.json.SerializationError | baml.json.ParseError | baml.json.DecodeError | baml.errors.AccessError | baml.errors.Unsupported) -> ai.errors.Failure | baml.errors.Timeout | baml.errors.UnknownError | reflect.errors.CompilationError {
     load_var error
     call ai.errors.normalize
+    return
+}
+
+function ai.events.ToolCompleted.new(id: string, output: string) -> ai.events.ToolCompleted {
+    load_var2 1 2
+    init_instance ai.content.Text .text
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 1
+    init_instance ai.events.ToolCompleted .id, .content
+    return
+}
+
+function ai.events.ToolCompleted.of(id: string, items: (string | image | audio | video | pdf | ai.content.Text | ai.content.Media)[]) -> ai.events.ToolCompleted {
+    load_var items
+    call ai.content.blocks
+    store_var _3
+    load_var2 1 3
+    init_instance ai.events.ToolCompleted .id, .content
+    return
+}
+
+function ai.events.ToolCompleted.text(self: ai.events.ToolCompleted) -> string {
+    load_var self
+    load_field .content
+    call ai.content.text
+    return
+}
+
+function ai.events.UserMessage.new(text: string) -> ai.events.UserMessage {
+    load_var text
+    init_instance ai.content.Text .text
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 1
+    load_type string
+    load_type baml.json.json
+    alloc_map 0
+    init_instance ai.events.UserMessage .content, .metadata
+    return
+}
+
+function ai.events.UserMessage.of(items: (string | image | audio | video | pdf | ai.content.Text | ai.content.Media)[], metadata: map<string, baml.json.json>) -> ai.events.UserMessage {
+    load_var metadata
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L0
+    load_type string
+    load_type baml.json.json
+    alloc_map 0
+    store_var metadata
+
+  L0:
+    load_var items
+    call ai.content.blocks
+    load_var metadata
+    init_instance ai.events.UserMessage .content, .metadata
+    return
+}
+
+function ai.events.UserMessage.text(self: ai.events.UserMessage) -> string {
+    load_var self
+    load_field .content
+    call ai.content.text
     return
 }
 
@@ -5250,8 +5443,8 @@ function ai.internal._schema_for_signature(handler: reflect.AnyFunction<Returns 
     return
 }
 
-function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media)[], keep_reasoning: bool) -> (ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media)[] {
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse)[], keep_reasoning: bool) -> (ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse)[] {
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     alloc_array 0
     store_var out
     load_var content
@@ -5286,7 +5479,7 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     load_var _22
     narrow_bind ai.content.ToolUse, slot=11
     pop_jump_if_false L0
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     load_var2 3 11
     call baml.Array.push
     pop 1
@@ -5297,7 +5490,7 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     store_var reasoning
     load_var keep_reasoning
     pop_jump_if_false L0
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     load_var2 3 10
     call baml.Array.push
     pop 1
@@ -5311,7 +5504,7 @@ function ai.internal._wire_blocks(content: (ai.content.Text | ai.content.Reasoni
     load_const ""
     cmp_op !=
     pop_jump_if_false L0
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     load_var2 3 8
     call baml.Array.push
     pop 1
@@ -6359,7 +6552,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
     load_var self
     load_field ._text
     init_instance ai.content.Text .text
-    load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
+    load_type ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse
     alloc_array 1
     load_var2 10 3
     load_var self
@@ -7221,6 +7414,55 @@ function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.j
     load_var base
 
   L1:
+    return
+}
+
+function ai.wire.prompt_blocks(message: ai.PromptMessage) -> (ai.content.Text | ai.content.Media)[] {
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var out
+    load_var message
+    load_field .parts
+    load_type baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+
+  L0:
+    load_var _4
+    load_type baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_var _5
+    is_type baml.iter.Done
+    pop_jump_if_true L2
+    load_var _5
+    store_var part
+    load_var part
+    store_var _9
+    load_var _9
+    narrow_bind string, slot=6
+    pop_jump_if_true L1
+    load_type ai.content.Text | ai.content.Media
+    load_var2 2 5
+    load_const null
+    load_const null
+    init_instance ai.content.Media .media, .provider_id, .revised_prompt
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L1:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 2 6
+    init_instance ai.content.Text .text
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L2:
+    load_var out
     return
 }
 
@@ -8127,5 +8369,188 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
     init_instance ai.events.LLMCall .client_name, .provider, .timing, .http_request, .http_response, .usage, .selected, .sse_responses
     load_type #0
     init_instance<1> ai.wire.SentAs .value, .call
+    return
+}
+
+function ai.wire.tool_name(j: ai.Journal, id: string) -> string | null {
+    load_var j
+    call ai.Journal.entries
+    load_type baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+
+  L0:
+    load_var _4
+    load_type baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_var _5
+    is_type baml.iter.Done
+    pop_jump_if_true L2
+    load_var _5
+    store_var _9
+    load_var _9
+    narrow_bind ai.events.AssistantMessage, slot=5
+    pop_jump_if_false L0
+    load_var _9
+    load_field .content
+    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _12
+
+  L1:
+    load_var _12
+    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _13
+    load_var _13
+    is_type baml.iter.Done
+    pop_jump_if_true L0
+    load_var _13
+    store_var _17
+    load_var _17
+    narrow_bind ai.content.ToolUse, slot=8
+    pop_jump_if_false L1
+    load_var _17
+    store_var_load_var use
+    load_field .id
+    load_var id
+    cmp_op ==
+    pop_jump_if_false L1
+    load_var use
+    load_field .name
+    jump L3
+
+  L2:
+    load_const null
+
+  L3:
+    return
+}
+
+function ai.wire.tool_result_blocks(j: ai.Journal, completed: ai.events.ToolCompleted, carries: string[]) -> ai.wire.ToolResultBlocks {
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var inline
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var moved
+    load_var completed
+    load_field .content
+    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _7
+
+  L0:
+    load_var _7
+    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _8
+    load_var _8
+    is_type baml.iter.Done
+    pop_jump_if_true L3
+    load_var _8
+    store_var block
+    load_var block
+    store_var _12
+    load_var _12
+    narrow_bind ai.content.Text, slot=9
+    pop_jump_if_true L2
+    load_var block
+    store_var media
+    load_var media
+    call ai.content.Media.kind
+    store_var _19
+    load_type string
+    load_var2 3 11
+    call baml.Array.includes
+    pop_jump_if_true L1
+    load_type ai.content.Text | ai.content.Media
+    load_var2 5 10
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L1:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 4 10
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L2:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 4 9
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L3:
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var trailing
+    load_var moved
+    container_len
+    store_var _29
+    load_var _29
+    load_const 0
+    cmp_int_op >
+    pop_jump_if_false L8
+    load_var2 1 2
+    load_field .id
+    call ai.wire.tool_name
+    jump_if_not_null_or_pop L4
+    jump L5
+
+  L4:
+    store_var _31
+    jump L6
+
+  L5:
+    load_var completed
+    load_field .id
+    store_var _31
+
+  L6:
+    load_type ai.content.Text | ai.content.Media
+    load_var trailing
+    load_const "attached from the result of tool `"
+    load_var _31
+    bin_op +
+    load_const "`"
+    bin_op +
+    init_instance ai.content.Text .text
+    call baml.Array.push
+    pop 1
+    load_var moved
+    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _41
+
+  L7:
+    load_var _41
+    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _42
+    load_var _42
+    is_type baml.iter.Done
+    pop_jump_if_true L8
+    load_type ai.content.Text | ai.content.Media
+    load_var2 12 16
+    call baml.Array.push
+    pop 1
+    jump L7
+
+  L8:
+    load_var2 4 12
+    init_instance ai.wire.ToolResultBlocks .inline, .trailing
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -7401,6 +7401,240 @@ function ai.wire.credential_sources(cred: string | baml.env.Ref | null, canonica
     return
 }
 
+function ai.wire.degrade_tool_media(j: ai.Journal, carries: string[]) -> ai.Journal {
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    alloc_array 0
+    store_var out
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var attached
+    load_var j
+    call ai.Journal.entries
+    load_type baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _6
+
+  L0:
+    load_var _6
+    load_type baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _7
+    load_var _7
+    is_type baml.iter.Done
+    pop_jump_if_true L14
+    load_var _7
+    store_var event
+    load_var event
+    store_var _11
+    load_var _11
+    narrow_bind ai.events.ToolCompleted, slot=8
+    pop_jump_if_true L3
+    load_var event
+    store_var _69
+    load_var _69
+    narrow_bind ai.events.ToolFailed, slot=24
+    pop_jump_if_true L2
+    load_var attached
+    container_len
+    store_var _75
+    load_var _75
+    load_const 0
+    cmp_int_op >
+    pop_jump_if_false L1
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 4
+    load_type string
+    load_type baml.json.json
+    alloc_map 0
+    init_instance ai.events.UserMessage .content, .metadata
+    call baml.Array.push
+    pop 1
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var attached
+
+  L1:
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 7
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L2:
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 24
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L3:
+    load_var _11
+    store_var completed
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var inline
+    load_type ai.content.Text | ai.content.Media
+    alloc_array 0
+    store_var moved
+    load_var completed
+    load_field .content
+    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _16
+
+  L4:
+    load_var _16
+    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _17
+    load_var _17
+    is_type baml.iter.Done
+    pop_jump_if_true L7
+    load_var _17
+    store_var block
+    load_var block
+    store_var _21
+    load_var _21
+    narrow_bind ai.content.Text, slot=15
+    pop_jump_if_true L6
+    load_var block
+    store_var media
+    load_var media
+    call ai.content.Media.kind
+    store_var _28
+    load_type string
+    load_var2 2 17
+    call baml.Array.includes
+    pop_jump_if_true L5
+    load_type ai.content.Text | ai.content.Media
+    load_var2 11 16
+    call baml.Array.push
+    pop 1
+    jump L4
+
+  L5:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 10 16
+    call baml.Array.push
+    pop 1
+    jump L4
+
+  L6:
+    load_type ai.content.Text | ai.content.Media
+    load_var2 10 15
+    call baml.Array.push
+    pop 1
+    jump L4
+
+  L7:
+    load_var moved
+    container_len
+    store_var _37
+    load_var _37
+    load_const 0
+    cmp_int_op >
+    pop_jump_if_false L13
+    load_var inline
+    container_len
+    store_var _39
+    load_var _39
+    load_const 0
+    cmp_int_op ==
+    pop_jump_if_false L8
+    load_var moved
+    call ai.content.text
+    store_var _42
+    load_type ai.content.Text | ai.content.Media
+    load_var2 10 20
+    init_instance ai.content.Text .text
+    call baml.Array.push
+    pop 1
+
+  L8:
+    load_var2 1 9
+    load_field .id
+    call ai.wire.tool_name
+    jump_if_not_null_or_pop L9
+    jump L10
+
+  L9:
+    store_var _46
+    jump L11
+
+  L10:
+    load_var completed
+    load_field .id
+    store_var _46
+
+  L11:
+    load_type ai.content.Text | ai.content.Media
+    load_var attached
+    load_const "attached from the result of tool `"
+    load_var _46
+    bin_op +
+    load_const "`"
+    bin_op +
+    init_instance ai.content.Text .text
+    call baml.Array.push
+    pop 1
+    load_var moved
+    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _56
+
+  L12:
+    load_var _56
+    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _57
+    load_var _57
+    is_type baml.iter.Done
+    pop_jump_if_true L13
+    load_type ai.content.Text | ai.content.Media
+    load_var2 4 23
+    call baml.Array.push
+    pop 1
+    jump L12
+
+  L13:
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 9
+    load_field .id
+    load_var inline
+    init_instance ai.events.ToolCompleted .id, .content
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L14:
+    load_var attached
+    container_len
+    store_var _85
+    load_var _85
+    load_const 0
+    cmp_int_op >
+    pop_jump_if_false L15
+    load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
+    load_var2 3 4
+    load_type string
+    load_type baml.json.json
+    alloc_map 0
+    init_instance ai.events.UserMessage .content, .metadata
+    call baml.Array.push
+    pop 1
+
+  L15:
+    load_var out
+    init_instance ai.Journal .log
+    return
+}
+
 function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.json | null) -> baml.json.json {
     load_var overrides
     load_const null
@@ -8429,128 +8663,5 @@ function ai.wire.tool_name(j: ai.Journal, id: string) -> string | null {
     load_const null
 
   L3:
-    return
-}
-
-function ai.wire.tool_result_blocks(j: ai.Journal, completed: ai.events.ToolCompleted, carries: string[]) -> ai.wire.ToolResultBlocks {
-    load_type ai.content.Text | ai.content.Media
-    alloc_array 0
-    store_var inline
-    load_type ai.content.Text | ai.content.Media
-    alloc_array 0
-    store_var moved
-    load_var completed
-    load_field .content
-    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
-    load_const "iter"
-    virtual_call nargs=1 ntypeargs=0
-    store_var _7
-
-  L0:
-    load_var _7
-    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
-    load_const "next"
-    virtual_call nargs=1 ntypeargs=0
-    store_var _8
-    load_var _8
-    is_type baml.iter.Done
-    pop_jump_if_true L3
-    load_var _8
-    store_var block
-    load_var block
-    store_var _12
-    load_var _12
-    narrow_bind ai.content.Text, slot=9
-    pop_jump_if_true L2
-    load_var block
-    store_var media
-    load_var media
-    call ai.content.Media.kind
-    store_var _19
-    load_type string
-    load_var2 3 11
-    call baml.Array.includes
-    pop_jump_if_true L1
-    load_type ai.content.Text | ai.content.Media
-    load_var2 5 10
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L1:
-    load_type ai.content.Text | ai.content.Media
-    load_var2 4 10
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L2:
-    load_type ai.content.Text | ai.content.Media
-    load_var2 4 9
-    call baml.Array.push
-    pop 1
-    jump L0
-
-  L3:
-    load_type ai.content.Text | ai.content.Media
-    alloc_array 0
-    store_var trailing
-    load_var moved
-    container_len
-    store_var _29
-    load_var _29
-    load_const 0
-    cmp_int_op >
-    pop_jump_if_false L8
-    load_var2 1 2
-    load_field .id
-    call ai.wire.tool_name
-    jump_if_not_null_or_pop L4
-    jump L5
-
-  L4:
-    store_var _31
-    jump L6
-
-  L5:
-    load_var completed
-    load_field .id
-    store_var _31
-
-  L6:
-    load_type ai.content.Text | ai.content.Media
-    load_var trailing
-    load_const "attached from the result of tool `"
-    load_var _31
-    bin_op +
-    load_const "`"
-    bin_op +
-    init_instance ai.content.Text .text
-    call baml.Array.push
-    pop 1
-    load_var moved
-    load_type baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>
-    load_const "iter"
-    virtual_call nargs=1 ntypeargs=0
-    store_var _41
-
-  L7:
-    load_var _41
-    load_type baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
-    load_const "next"
-    virtual_call nargs=1 ntypeargs=0
-    store_var _42
-    load_var _42
-    is_type baml.iter.Done
-    pop_jump_if_true L8
-    load_type ai.content.Text | ai.content.Media
-    load_var2 12 16
-    call baml.Array.push
-    pop 1
-    jump L7
-
-  L8:
-    load_var2 4 12
-    init_instance ai.wire.ToolResultBlocks .inline, .trailing
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
@@ -2734,6 +2734,201 @@ fn ai.content.Media.new(value: image | audio | video | pdf, provider_id: string 
     }
 }
 
+fn ai.content.blocks(items: (string | image | audio | video | pdf | ai.content.Media | ai.content.Text)[]) -> (ai.content.Media | ai.content.Text)[] {
+    // Locals:
+    let _0: (ai.content.Media | ai.content.Text)[] // _0 // return
+    let _1: (string | image | audio | video | pdf | ai.content.Media | ai.content.Text)[] // items // param
+    let _2: (ai.content.Media | ai.content.Text)[] // out
+    let _3: baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf | ai.content.Media | ai.content.Text>
+    let _4: unknown
+    let _5: bool
+    let _6: string | image | audio | video | pdf | ai.content.Media | ai.content.Text
+    let _7: string | image | audio | video | pdf | ai.content.Media | ai.content.Text // item
+    let _8: string | image | audio | video | pdf | ai.content.Media | ai.content.Text
+    let _9: string // text
+    let _10: int
+    let _11: ai.content.Text
+    let _12: string
+    let _13: reflect.Type
+    let _14: string | image | audio | video | pdf | ai.content.Media | ai.content.Text
+    let _15: ai.content.Text | ai.content.Media // block
+    let _16: int
+    let _17: ai.content.Media | ai.content.Text
+    let _18: reflect.Type
+    let _19: image | audio | video | pdf // media
+    let _20: int
+    let _21: ai.content.Media
+    let _22: image | audio | video | pdf
+    let _23: reflect.Type
+
+    bb0: {
+        _2 = []: ai.content.Text | ai.content.Media[];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf | ai.content.Media | ai.content.Text>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf | ai.content.Media | ai.content.Text>(copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _5 = is_type(copy _4, baml.iter.Done);
+        branch copy _5 -> [bb10, bb3];
+    }
+
+    bb3: {
+        _6 = copy _4;
+        fresh_cell(_7);
+        _7 = copy _6;
+        _8 = copy _7;
+        _8 = narrow_bind copy _8 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb9, bb4];
+    }
+
+    bb4: {
+        _14 = copy _7;
+        _14 = narrow_bind copy _14 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "Text" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb5];
+    }
+
+    bb5: {
+        _14 = narrow_bind copy _14 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "Media" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb6];
+    }
+
+    bb6: {
+        _19 = copy _7;
+        _22 = copy _19;
+        _21 = call const fn ai.content.Media.new(copy _22, const <omitted>, const <omitted>) -> [bb7];
+    }
+
+    bb7: {
+        _23 = load_type(ai.content.Text | ai.content.Media);
+        _20 = call const fn baml.Array.push<copy _23>(copy _2, copy _21) -> [bb1];
+    }
+
+    bb8: {
+        _15 = copy _14;
+        _17 = copy _15;
+        _18 = load_type(ai.content.Text | ai.content.Media);
+        _16 = call const fn baml.Array.push<copy _18>(copy _2, copy _17) -> [bb1];
+    }
+
+    bb9: {
+        _9 = copy _8;
+        _12 = copy _9;
+        _11 = ai.content.Text { copy _12 };
+        _13 = load_type(ai.content.Text | ai.content.Media);
+        _10 = call const fn baml.Array.push<copy _13>(copy _2, copy _11) -> [bb1];
+    }
+
+    bb10: {
+        _0 = copy _2;
+        goto -> bb11;
+    }
+
+    bb11: {
+        return;
+    }
+}
+
+fn ai.content.text(content: (ai.content.Media | ai.content.Text)[]) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: (ai.content.Media | ai.content.Text)[] // content // param
+    let _2: string // out
+    let _3: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    let _4: unknown
+    let _5: bool
+    let _6: ai.content.Media | ai.content.Text
+    let _7: ai.content.Media | ai.content.Text // block
+    let _8: ai.content.Media | ai.content.Text
+    let _9: ai.content.Text // t
+    let _10: string
+    let _11: string
+    let _12: reflect.Type
+    let _13: string
+    let _14: string
+    let _15: reflect.Type
+    let _16: ai.content.Media // m
+    let _17: string
+    let _18: string
+    let _19: string
+    let _20: string
+    let _21: reflect.Type
+    let _22: string
+    let _23: string
+    let _24: reflect.Type
+
+    bb0: {
+        _2 = const "";
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _5 = is_type(copy _4, baml.iter.Done);
+        branch copy _5 -> [bb11, bb3];
+    }
+
+    bb3: {
+        _6 = copy _4;
+        fresh_cell(_7);
+        _7 = copy _6;
+        _8 = copy _7;
+        _8 = narrow_bind copy _8 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "Text" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb8, bb4];
+    }
+
+    bb4: {
+        _16 = copy _7;
+        _20 = copy _2;
+        _21 = load_type(string);
+        _19 = call const fn baml.String.from<copy _21>(copy _20) -> [bb5];
+    }
+
+    bb5: {
+        _18 = copy _19 + const "[";
+        _23 = call const fn ai.content.Media.kind(copy _16) -> [bb6];
+    }
+
+    bb6: {
+        _24 = load_type(string);
+        _22 = call const fn baml.String.from<copy _24>(copy _23) -> [bb7];
+    }
+
+    bb7: {
+        _17 = copy _18 + copy _22;
+        _2 = copy _17 + const "]";
+        goto -> bb1;
+    }
+
+    bb8: {
+        _9 = copy _8;
+        _11 = copy _2;
+        _12 = load_type(string);
+        _10 = call const fn baml.String.from<copy _12>(copy _11) -> [bb9];
+    }
+
+    bb9: {
+        _14 = copy _9.0;
+        _15 = load_type(string);
+        _13 = call const fn baml.String.from<copy _15>(copy _14) -> [bb10];
+    }
+
+    bb10: {
+        _2 = copy _10 + copy _13;
+        goto -> bb1;
+    }
+
+    bb11: {
+        _0 = copy _2;
+        goto -> bb12;
+    }
+
+    bb12: {
+        return;
+    }
+}
+
 fn ai.errors.Failure.retry_safety(_1: void) -> void {
     // Locals:
     let _0: void // return
@@ -3182,6 +3377,132 @@ fn ai.errors.classify_http(provider: string, status_code: int, body: string, hea
     }
 
     bb11: {
+        return;
+    }
+}
+
+fn ai.events.UserMessage.new(text: string) -> ai.events.UserMessage {
+    // Locals:
+    let _0: ai.events.UserMessage // _0 // return
+    let _1: string // text // param
+    let _2: (ai.content.Media | ai.content.Text)[]
+    let _3: ai.content.Text
+    let _4: map<string, baml.json.json>
+
+    bb0: {
+        _3 = ai.content.Text { copy _1 };
+        _2 = [copy _3]: ai.content.Text | ai.content.Media[];
+        _4 = {  }: map<string, baml.json.json>;
+        _0 = ai.events.UserMessage { copy _2, copy _4 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn ai.events.UserMessage.of(items: (string | image | audio | video | pdf | ai.content.Media | ai.content.Text)[], metadata: map<string, baml.json.json>) -> ai.events.UserMessage {
+    // Locals:
+    let _0: ai.events.UserMessage // _0 // return
+    let _1: (string | image | audio | video | pdf | ai.content.Media | ai.content.Text)[] // items // param
+    let _2: map<string, baml.json.json> // metadata // param
+    let _3: bool
+    let _4: (ai.content.Media | ai.content.Text)[]
+
+    bb0: {
+        _3 = copy _2 == const <omitted>;
+        branch copy _3 -> [bb1, bb2];
+    }
+
+    bb1: {
+        _2 = {  }: map<string, baml.json.json>;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = call const fn ai.content.blocks(copy _1) -> [bb3];
+    }
+
+    bb3: {
+        _0 = ai.events.UserMessage { copy _4, copy _2 };
+        goto -> bb4;
+    }
+
+    bb4: {
+        return;
+    }
+}
+
+fn ai.events.UserMessage.text(self: ai.events.UserMessage) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: ai.events.UserMessage // self // param
+    let _2: (ai.content.Media | ai.content.Text)[]
+
+    bb0: {
+        _2 = copy _1.0;
+        _0 = call const fn ai.content.text(copy _2) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn ai.events.ToolCompleted.new(id: string, output: string) -> ai.events.ToolCompleted {
+    // Locals:
+    let _0: ai.events.ToolCompleted // _0 // return
+    let _1: string // id // param
+    let _2: string // output // param
+    let _3: (ai.content.Media | ai.content.Text)[]
+    let _4: ai.content.Text
+
+    bb0: {
+        _4 = ai.content.Text { copy _2 };
+        _3 = [copy _4]: ai.content.Text | ai.content.Media[];
+        _0 = ai.events.ToolCompleted { copy _1, copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn ai.events.ToolCompleted.of(id: string, items: (string | image | audio | video | pdf | ai.content.Media | ai.content.Text)[]) -> ai.events.ToolCompleted {
+    // Locals:
+    let _0: ai.events.ToolCompleted // _0 // return
+    let _1: string // id // param
+    let _2: (string | image | audio | video | pdf | ai.content.Media | ai.content.Text)[] // items // param
+    let _3: (ai.content.Media | ai.content.Text)[]
+
+    bb0: {
+        _3 = call const fn ai.content.blocks(copy _2) -> [bb1];
+    }
+
+    bb1: {
+        _0 = ai.events.ToolCompleted { copy _1, copy _3 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn ai.events.ToolCompleted.text(self: ai.events.ToolCompleted) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: ai.events.ToolCompleted // self // param
+    let _2: (ai.content.Media | ai.content.Text)[]
+
+    bb0: {
+        _2 = copy _1.1;
+        _0 = call const fn ai.content.text(copy _2) -> [bb1];
+    }
+
+    bb1: {
         return;
     }
 }
@@ -6240,7 +6561,7 @@ fn ai.internal._wire_blocks(content: (ai.content.Media | ai.content.Reasoning | 
     let _26: reflect.Type
 
     bb0: {
-        _3 = []: ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media[];
+        _3 = []: ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse[];
         _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _1) -> [bb1];
     }
 
@@ -6274,7 +6595,7 @@ fn ai.internal._wire_blocks(content: (ai.content.Media | ai.content.Reasoning | 
     bb6: {
         _23 = copy _22;
         _25 = copy _23;
-        _26 = load_type(ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media);
+        _26 = load_type(ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse);
         _24 = call const fn baml.Array.push<copy _26>(copy _3, copy _25) -> [bb1];
     }
 
@@ -6285,7 +6606,7 @@ fn ai.internal._wire_blocks(content: (ai.content.Media | ai.content.Reasoning | 
 
     bb8: {
         _20 = copy _18;
-        _21 = load_type(ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media);
+        _21 = load_type(ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse);
         _19 = call const fn baml.Array.push<copy _21>(copy _3, copy _20) -> [bb1];
     }
 
@@ -6302,7 +6623,7 @@ fn ai.internal._wire_blocks(content: (ai.content.Media | ai.content.Reasoning | 
 
     bb11: {
         _15 = copy _10;
-        _16 = load_type(ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media);
+        _16 = load_type(ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse);
         _14 = call const fn baml.Array.push<copy _16>(copy _3, copy _15) -> [bb1];
     }
 
@@ -8250,7 +8571,7 @@ fn ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.ModelTurn {
     bb21: {
         _30 = copy _1.7;
         _29 = ai.content.Text { copy _30 };
-        _28 = [copy _29]: ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media[];
+        _28 = [copy _29]: ai.content.Text | ai.content.Media | ai.content.Reasoning | ai.content.ToolUse[];
         _33 = copy _1.8;
         _32 = short_circuit(??) copy _33 -> [eval: bb22, join: bb23];
     }
@@ -10643,6 +10964,353 @@ fn ai.wire.merge_request_body(base: int | float | string | bool | null | baml.js
     }
 }
 
+fn ai.wire.prompt_blocks(message: ai.PromptMessage) -> (ai.content.Media | ai.content.Text)[] {
+    // Locals:
+    let _0: (ai.content.Media | ai.content.Text)[] // _0 // return
+    let _1: ai.PromptMessage // message // param
+    let _2: (ai.content.Media | ai.content.Text)[] // out
+    let _3: (string | image | audio | video | pdf)[]
+    let _4: baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>
+    let _5: unknown
+    let _6: bool
+    let _7: string | image | audio | video | pdf
+    let _8: string | image | audio | video | pdf // part
+    let _9: string | image | audio | video | pdf
+    let _10: string // text
+    let _11: int
+    let _12: ai.content.Text
+    let _13: string
+    let _14: reflect.Type
+    let _15: image | audio | video | pdf // media
+    let _16: int
+    let _17: ai.content.Media
+    let _18: image | audio | video | pdf
+    let _19: reflect.Type
+
+    bb0: {
+        _2 = []: ai.content.Text | ai.content.Media[];
+        _3 = copy _1.2;
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string | image | audio | video | pdf>(copy _3) -> [bb1];
+    }
+
+    bb1: {
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string | image | audio | video | pdf>(copy _4) -> [bb2];
+    }
+
+    bb2: {
+        _6 = is_type(copy _5, baml.iter.Done);
+        branch copy _6 -> [bb6, bb3];
+    }
+
+    bb3: {
+        _7 = copy _5;
+        fresh_cell(_8);
+        _8 = copy _7;
+        _9 = copy _8;
+        _9 = narrow_bind copy _9 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb5, bb4];
+    }
+
+    bb4: {
+        _15 = copy _8;
+        _18 = copy _15;
+        _17 = ai.content.Media { copy _18, const null, const null };
+        _19 = load_type(ai.content.Text | ai.content.Media);
+        _16 = call const fn baml.Array.push<copy _19>(copy _2, copy _17) -> [bb1];
+    }
+
+    bb5: {
+        _10 = copy _9;
+        _13 = copy _10;
+        _12 = ai.content.Text { copy _13 };
+        _14 = load_type(ai.content.Text | ai.content.Media);
+        _11 = call const fn baml.Array.push<copy _14>(copy _2, copy _12) -> [bb1];
+    }
+
+    bb6: {
+        _0 = copy _2;
+        goto -> bb7;
+    }
+
+    bb7: {
+        return;
+    }
+}
+
+fn ai.wire.tool_name(j: ai.Journal, id: string) -> string | null {
+    // Locals:
+    let _0: string | null // _0 // return
+    let _1: ai.Journal // j // param
+    let _2: string // id // param
+    let _3: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _4: baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    let _5: unknown
+    let _6: bool
+    let _7: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _8: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage // event
+    let _9: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _10: ai.events.AssistantMessage // assistant
+    let _11: (ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
+    let _12: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>
+    let _13: unknown
+    let _14: bool
+    let _15: ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse
+    let _16: ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse // block
+    let _17: ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse
+    let _18: ai.content.ToolUse // use
+    let _19: bool
+    let _20: string
+
+    bb0: {
+        _3 = call const fn ai.Journal.entries(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _4) -> [bb3];
+    }
+
+    bb3: {
+        _6 = is_type(copy _5, baml.iter.Done);
+        branch copy _6 -> [bb11, bb4];
+    }
+
+    bb4: {
+        _7 = copy _5;
+        fresh_cell(_8);
+        _8 = copy _7;
+        _9 = copy _8;
+        _9 = narrow_bind copy _9 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "AssistantMessage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb5, bb2];
+    }
+
+    bb5: {
+        _10 = copy _9;
+        _11 = copy _10.0;
+        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _11) -> [bb6];
+    }
+
+    bb6: {
+        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Reasoning | ai.content.Text | ai.content.ToolUse>(copy _12) -> [bb7];
+    }
+
+    bb7: {
+        _14 = is_type(copy _13, baml.iter.Done);
+        branch copy _14 -> [bb2, bb8];
+    }
+
+    bb8: {
+        _15 = copy _13;
+        fresh_cell(_16);
+        _16 = copy _15;
+        _17 = copy _16;
+        _17 = narrow_bind copy _17 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb6];
+    }
+
+    bb9: {
+        _18 = copy _17;
+        _20 = copy _18.0;
+        _19 = copy _20 == copy _2;
+        branch copy _19 -> [bb10, bb6];
+    }
+
+    bb10: {
+        _0 = copy _18.1;
+        goto -> bb12;
+    }
+
+    bb11: {
+        _0 = const null;
+        goto -> bb12;
+    }
+
+    bb12: {
+        return;
+    }
+}
+
+fn ai.wire.tool_result_blocks(j: ai.Journal, completed: ai.events.ToolCompleted, carries: string[]) -> ai.wire.ToolResultBlocks {
+    // Locals:
+    let _0: ai.wire.ToolResultBlocks // _0 // return
+    let _1: ai.Journal // j // param
+    let _2: ai.events.ToolCompleted // completed // param
+    let _3: string[] // carries // param
+    let _4: (ai.content.Media | ai.content.Text)[] // inline
+    let _5: (ai.content.Media | ai.content.Text)[] // moved
+    let _6: (ai.content.Media | ai.content.Text)[]
+    let _7: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    let _8: unknown
+    let _9: bool
+    let _10: ai.content.Media | ai.content.Text
+    let _11: ai.content.Media | ai.content.Text // block
+    let _12: ai.content.Media | ai.content.Text
+    let _13: ai.content.Text // text
+    let _14: int
+    let _15: ai.content.Text
+    let _16: reflect.Type
+    let _17: ai.content.Media // media
+    let _18: bool
+    let _19: string
+    let _20: reflect.Type
+    let _21: int
+    let _22: ai.content.Media
+    let _23: reflect.Type
+    let _24: int
+    let _25: ai.content.Media
+    let _26: reflect.Type
+    let _27: (ai.content.Media | ai.content.Text)[] // trailing
+    let _28: bool
+    let _29: int
+    let _30: string // tool
+    let _31: string
+    let _32: string | null
+    let _33: string
+    let _34: int
+    let _35: ai.content.Text
+    let _36: string
+    let _37: string
+    let _38: string
+    let _39: reflect.Type
+    let _40: (ai.content.Media | ai.content.Text)[]
+    let _41: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    let _42: unknown
+    let _43: bool
+    let _44: ai.content.Media | ai.content.Text
+    let _45: ai.content.Media | ai.content.Text // block
+    let _46: int
+    let _47: ai.content.Media | ai.content.Text
+    let _48: reflect.Type
+    let _49: (ai.content.Media | ai.content.Text)[]
+    let _50: (ai.content.Media | ai.content.Text)[]
+
+    bb0: {
+        _4 = []: ai.content.Text | ai.content.Media[];
+        _5 = []: ai.content.Text | ai.content.Media[];
+        _6 = copy _2.1;
+        _7 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _6) -> [bb1];
+    }
+
+    bb1: {
+        _8 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _7) -> [bb2];
+    }
+
+    bb2: {
+        _9 = is_type(copy _8, baml.iter.Done);
+        branch copy _9 -> [bb10, bb3];
+    }
+
+    bb3: {
+        _10 = copy _8;
+        fresh_cell(_11);
+        _11 = copy _10;
+        _12 = copy _11;
+        _12 = narrow_bind copy _12 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "Text" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb4];
+    }
+
+    bb4: {
+        _17 = copy _11;
+        _19 = call const fn ai.content.Media.kind(copy _17) -> [bb5];
+    }
+
+    bb5: {
+        _20 = load_type(string);
+        _18 = call const fn baml.Array.includes<copy _20>(copy _3, copy _19) -> [bb6];
+    }
+
+    bb6: {
+        branch copy _18 -> [bb8, bb7];
+    }
+
+    bb7: {
+        _25 = copy _17;
+        _26 = load_type(ai.content.Text | ai.content.Media);
+        _24 = call const fn baml.Array.push<copy _26>(copy _5, copy _25) -> [bb1];
+    }
+
+    bb8: {
+        _22 = copy _17;
+        _23 = load_type(ai.content.Text | ai.content.Media);
+        _21 = call const fn baml.Array.push<copy _23>(copy _4, copy _22) -> [bb1];
+    }
+
+    bb9: {
+        _13 = copy _12;
+        _15 = copy _13;
+        _16 = load_type(ai.content.Text | ai.content.Media);
+        _14 = call const fn baml.Array.push<copy _16>(copy _4, copy _15) -> [bb1];
+    }
+
+    bb10: {
+        _27 = []: ai.content.Text | ai.content.Media[];
+        _29 = len(_5);
+        goto -> bb11;
+    }
+
+    bb11: {
+        _28 = copy _29 > const 0_i64;
+        branch copy _28 -> [bb12, bb20];
+    }
+
+    bb12: {
+        _33 = copy _2.0;
+        _32 = call const fn ai.wire.tool_name(copy _1, copy _33) -> [bb13];
+    }
+
+    bb13: {
+        _31 = short_circuit(??) copy _32 -> [eval: bb14, join: bb15];
+    }
+
+    bb14: {
+        _31 = copy _2.0;
+        goto -> bb15;
+    }
+
+    bb15: {
+        _30 = copy _31;
+        _38 = copy _30;
+        _37 = const "attached from the result of tool `" + copy _38;
+        _36 = copy _37 + const "`";
+        _35 = ai.content.Text { copy _36 };
+        _39 = load_type(ai.content.Text | ai.content.Media);
+        _34 = call const fn baml.Array.push<copy _39>(copy _27, copy _35) -> [bb16];
+    }
+
+    bb16: {
+        _40 = copy _5;
+        _41 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _40) -> [bb17];
+    }
+
+    bb17: {
+        _42 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _41) -> [bb18];
+    }
+
+    bb18: {
+        _43 = is_type(copy _42, baml.iter.Done);
+        branch copy _43 -> [bb20, bb19];
+    }
+
+    bb19: {
+        _44 = copy _42;
+        fresh_cell(_45);
+        _45 = copy _44;
+        _47 = copy _45;
+        _48 = load_type(ai.content.Text | ai.content.Media);
+        _46 = call const fn baml.Array.push<copy _48>(copy _27, copy _47) -> [bb17];
+    }
+
+    bb20: {
+        _49 = copy _4;
+        _50 = copy _27;
+        _0 = ai.wire.ToolResultBlocks { copy _49, copy _50 };
+        goto -> bb21;
+    }
+
+    bb21: {
+        return;
+    }
+}
+
 fn ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Journal {
     // Locals:
     let _0: ai.Journal // _0 // return
@@ -11098,7 +11766,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
 
     bb4: {
         _0 = const null;
-        goto -> bb17;
+        goto -> bb18;
     }
 
     bb5: {
@@ -11139,7 +11807,7 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb12: {
-        branch copy _18 -> [bb18, bb13];
+        branch copy _18 -> [bb19, bb13];
     }
 
     bb13: {
@@ -11149,51 +11817,54 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
 
     bb14: {
         _31 = copy _9;
-        _31 = narrow_bind copy _31 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb16];
+        _31 = narrow_bind copy _31 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb17];
     }
 
     bb15: {
         _32 = copy _31;
         _36 = copy _3.0;
         _37 = copy _32;
-        _35 = ai.events.ToolCompleted { copy _36, copy _37 };
-        _34 = [copy _35]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
-        _33 = call const fn ai.Journal.append_all(copy _4, copy _34) -> [bb16];
+        _35 = call const fn ai.events.ToolCompleted.new(copy _36, copy _37) -> [bb16];
     }
 
     bb16: {
-        _0 = const null;
-        goto -> bb17;
+        _34 = [copy _35]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
+        _33 = call const fn ai.Journal.append_all(copy _4, copy _34) -> [bb17];
     }
 
     bb17: {
-        return;
+        _0 = const null;
+        goto -> bb18;
     }
 
     bb18: {
-        _23 = copy _10;
-        _23 = narrow_bind copy _23 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb19];
+        return;
     }
 
     bb19: {
-        _22 = const null;
-        goto -> bb21;
+        _23 = copy _10;
+        _23 = narrow_bind copy _23 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb21, bb20];
     }
 
     bb20: {
-        _24 = copy _23;
-        _22 = copy _24;
-        goto -> bb21;
+        _22 = const null;
+        goto -> bb22;
     }
 
     bb21: {
-        _26 = copy _3.0;
-        _27 = copy _3.1;
-        _29 = load_type(unknown);
-        _28 = call const fn baml.String.from<copy _29>(copy _10) -> [bb22];
+        _24 = copy _23;
+        _22 = copy _24;
+        goto -> bb22;
     }
 
     bb22: {
+        _26 = copy _3.0;
+        _27 = copy _3.1;
+        _29 = load_type(unknown);
+        _28 = call const fn baml.String.from<copy _29>(copy _10) -> [bb23];
+    }
+
+    bb23: {
         _30 = copy _22;
         _25 = ai.errors.ToolFailedError { copy _26, copy _27, copy _28, copy _30 };
         throw copy _25;
@@ -12179,7 +12850,7 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     bb35: {
         _67 = copy _68;
         _81 = copy _67;
-        branch copy _81 -> [bb43, bb36];
+        branch copy _81 -> [bb44, bb36];
     }
 
     bb36: {
@@ -12203,56 +12874,59 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     }
 
     bb40: {
-        _94 = ai.events.UserMessage { const "The reply did not match the required schema. Answer again with only the corrected value." };
-        _95 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
-        _93 = call const fn baml.Array.push<copy _95>(copy _33, copy _94) -> [bb41];
+        _94 = call const fn ai.events.UserMessage.new(const "The reply did not match the required schema. Answer again with only the corrected value.") -> [bb41];
     }
 
     bb41: {
-        _97 = copy _33;
-        _96 = call const fn ai.Journal.append_all(copy _4, copy _97) -> [bb42];
+        _95 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _93 = call const fn baml.Array.push<copy _95>(copy _33, copy _94) -> [bb42];
     }
 
     bb42: {
-        _98 = copy _6 - const 1_i64;
-        _99 = load_type(#0);
-        _0 = call const fn ai.Agent._attempt_turn<copy _99>(copy _1, copy _2, copy _3, copy _4, copy _5, copy _98) -> [bb46];
+        _97 = copy _33;
+        _96 = call const fn ai.Journal.append_all(copy _4, copy _97) -> [bb43];
     }
 
     bb43: {
-        _83 = copy _33;
-        _82 = call const fn ai.Journal.append_all(copy _4, copy _83) -> [bb44];
+        _98 = copy _6 - const 1_i64;
+        _99 = load_type(#0);
+        _0 = call const fn ai.Agent._attempt_turn<copy _99>(copy _1, copy _2, copy _3, copy _4, copy _5, copy _98) -> [bb47];
     }
 
     bb44: {
-        _84 = copy _7.1;
-        _85 = discriminant(_84);
-        switch copy _85 [StopReason.MaxTokens: bb49, StopReason.Refused: bb47, otherwise: bb45];
+        _83 = copy _33;
+        _82 = call const fn ai.Journal.append_all(copy _4, copy _83) -> [bb45];
     }
 
     bb45: {
-        _0 = copy _7;
-        goto -> bb46;
+        _84 = copy _7.1;
+        _85 = discriminant(_84);
+        switch copy _85 [StopReason.MaxTokens: bb50, StopReason.Refused: bb48, otherwise: bb46];
     }
 
     bb46: {
-        return;
+        _0 = copy _7;
+        goto -> bb47;
     }
 
     bb47: {
-        _91 = virtual_call id as ai.Client(copy _2) -> [bb48];
+        return;
     }
 
     bb48: {
+        _91 = virtual_call id as ai.Client(copy _2) -> [bb49];
+    }
+
+    bb49: {
         _90 = ai.errors.Refused { copy _91, const "the model declined to answer", const null };
         throw copy _90;
     }
 
-    bb49: {
-        _87 = virtual_call id as ai.Client(copy _2) -> [bb50];
+    bb50: {
+        _87 = virtual_call id as ai.Client(copy _2) -> [bb51];
     }
 
-    bb50: {
+    bb51: {
         _88 = copy _7.1;
         _89 = copy _64;
         _86 = ai.errors.FinishReasonError { copy _87, copy _88, copy _89 };

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/mir.snap
@@ -11130,183 +11130,338 @@ fn ai.wire.tool_name(j: ai.Journal, id: string) -> string | null {
     }
 }
 
-fn ai.wire.tool_result_blocks(j: ai.Journal, completed: ai.events.ToolCompleted, carries: string[]) -> ai.wire.ToolResultBlocks {
+fn ai.wire.degrade_tool_media(j: ai.Journal, carries: string[]) -> ai.Journal {
     // Locals:
-    let _0: ai.wire.ToolResultBlocks // _0 // return
+    let _0: ai.Journal // _0 // return
     let _1: ai.Journal // j // param
-    let _2: ai.events.ToolCompleted // completed // param
-    let _3: string[] // carries // param
-    let _4: (ai.content.Media | ai.content.Text)[] // inline
-    let _5: (ai.content.Media | ai.content.Text)[] // moved
-    let _6: (ai.content.Media | ai.content.Text)[]
-    let _7: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
-    let _8: unknown
-    let _9: bool
-    let _10: ai.content.Media | ai.content.Text
-    let _11: ai.content.Media | ai.content.Text // block
-    let _12: ai.content.Media | ai.content.Text
-    let _13: ai.content.Text // text
-    let _14: int
-    let _15: ai.content.Text
-    let _16: reflect.Type
-    let _17: ai.content.Media // media
+    let _2: string[] // carries // param
+    let _3: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // out
+    let _4: (ai.content.Media | ai.content.Text)[] // attached
+    let _5: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _6: baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>
+    let _7: unknown
+    let _8: bool
+    let _9: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _10: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage // event
+    let _11: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _12: ai.events.ToolCompleted // completed
+    let _13: (ai.content.Media | ai.content.Text)[] // inline
+    let _14: (ai.content.Media | ai.content.Text)[] // moved
+    let _15: (ai.content.Media | ai.content.Text)[]
+    let _16: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    let _17: unknown
     let _18: bool
-    let _19: string
-    let _20: reflect.Type
-    let _21: int
-    let _22: ai.content.Media
-    let _23: reflect.Type
-    let _24: int
-    let _25: ai.content.Media
-    let _26: reflect.Type
-    let _27: (ai.content.Media | ai.content.Text)[] // trailing
-    let _28: bool
-    let _29: int
-    let _30: string // tool
-    let _31: string
-    let _32: string | null
-    let _33: string
-    let _34: int
-    let _35: ai.content.Text
-    let _36: string
-    let _37: string
-    let _38: string
-    let _39: reflect.Type
-    let _40: (ai.content.Media | ai.content.Text)[]
-    let _41: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
-    let _42: unknown
-    let _43: bool
-    let _44: ai.content.Media | ai.content.Text
-    let _45: ai.content.Media | ai.content.Text // block
-    let _46: int
-    let _47: ai.content.Media | ai.content.Text
-    let _48: reflect.Type
-    let _49: (ai.content.Media | ai.content.Text)[]
-    let _50: (ai.content.Media | ai.content.Text)[]
+    let _19: ai.content.Media | ai.content.Text
+    let _20: ai.content.Media | ai.content.Text // block
+    let _21: ai.content.Media | ai.content.Text
+    let _22: ai.content.Text // text
+    let _23: int
+    let _24: ai.content.Text
+    let _25: reflect.Type
+    let _26: ai.content.Media // media
+    let _27: bool
+    let _28: string
+    let _29: reflect.Type
+    let _30: int
+    let _31: ai.content.Media
+    let _32: reflect.Type
+    let _33: int
+    let _34: ai.content.Media
+    let _35: reflect.Type
+    let _36: bool
+    let _37: int
+    let _38: bool
+    let _39: int
+    let _40: int
+    let _41: ai.content.Text
+    let _42: string
+    let _43: (ai.content.Media | ai.content.Text)[]
+    let _44: reflect.Type
+    let _45: string // tool
+    let _46: string
+    let _47: string | null
+    let _48: string
+    let _49: int
+    let _50: ai.content.Text
+    let _51: string
+    let _52: string
+    let _53: string
+    let _54: reflect.Type
+    let _55: (ai.content.Media | ai.content.Text)[]
+    let _56: baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>
+    let _57: unknown
+    let _58: bool
+    let _59: ai.content.Media | ai.content.Text
+    let _60: ai.content.Media | ai.content.Text // block
+    let _61: int
+    let _62: ai.content.Media | ai.content.Text
+    let _63: reflect.Type
+    let _64: int
+    let _65: ai.events.ToolCompleted
+    let _66: string
+    let _67: (ai.content.Media | ai.content.Text)[]
+    let _68: reflect.Type
+    let _69: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _70: ai.events.ToolFailed // failed
+    let _71: int
+    let _72: ai.events.ToolFailed
+    let _73: reflect.Type
+    let _74: bool
+    let _75: int
+    let _76: int
+    let _77: ai.events.UserMessage
+    let _78: (ai.content.Media | ai.content.Text)[]
+    let _79: map<string, baml.json.json>
+    let _80: reflect.Type
+    let _81: int
+    let _82: ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _83: reflect.Type
+    let _84: bool
+    let _85: int
+    let _86: int
+    let _87: ai.events.UserMessage
+    let _88: (ai.content.Media | ai.content.Text)[]
+    let _89: map<string, baml.json.json>
+    let _90: reflect.Type
+    let _91: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
 
     bb0: {
+        _3 = []: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced[];
         _4 = []: ai.content.Text | ai.content.Media[];
-        _5 = []: ai.content.Text | ai.content.Media[];
-        _6 = copy _2.1;
-        _7 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _6) -> [bb1];
+        _5 = call const fn ai.Journal.entries(copy _1) -> [bb1];
     }
 
     bb1: {
-        _8 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _7) -> [bb2];
+        _6 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _5) -> [bb2];
     }
 
     bb2: {
-        _9 = is_type(copy _8, baml.iter.Done);
-        branch copy _9 -> [bb10, bb3];
+        _7 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.LLMCall | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage>(copy _6) -> [bb3];
     }
 
     bb3: {
-        _10 = copy _8;
-        fresh_cell(_11);
-        _11 = copy _10;
-        _12 = copy _11;
-        _12 = narrow_bind copy _12 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "Text" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb9, bb4];
+        _8 = is_type(copy _7, baml.iter.Done);
+        branch copy _8 -> [bb37, bb4];
     }
 
     bb4: {
-        _17 = copy _11;
-        _19 = call const fn ai.content.Media.kind(copy _17) -> [bb5];
+        _9 = copy _7;
+        fresh_cell(_10);
+        _10 = copy _9;
+        _11 = copy _10;
+        _11 = narrow_bind copy _11 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolCompleted" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb12, bb5];
     }
 
     bb5: {
-        _20 = load_type(string);
-        _18 = call const fn baml.Array.includes<copy _20>(copy _3, copy _19) -> [bb6];
+        _69 = copy _10;
+        _69 = narrow_bind copy _69 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb11, bb6];
     }
 
     bb6: {
-        branch copy _18 -> [bb8, bb7];
+        _75 = len(_4);
+        goto -> bb7;
     }
 
     bb7: {
-        _25 = copy _17;
-        _26 = load_type(ai.content.Text | ai.content.Media);
-        _24 = call const fn baml.Array.push<copy _26>(copy _5, copy _25) -> [bb1];
+        _74 = copy _75 > const 0_i64;
+        branch copy _74 -> [bb8, bb10];
     }
 
     bb8: {
-        _22 = copy _17;
-        _23 = load_type(ai.content.Text | ai.content.Media);
-        _21 = call const fn baml.Array.push<copy _23>(copy _4, copy _22) -> [bb1];
+        _78 = copy _4;
+        _79 = {  }: map<string, baml.json.json>;
+        _77 = ai.events.UserMessage { copy _78, copy _79 };
+        _80 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _76 = call const fn baml.Array.push<copy _80>(copy _3, copy _77) -> [bb9];
     }
 
     bb9: {
-        _13 = copy _12;
-        _15 = copy _13;
-        _16 = load_type(ai.content.Text | ai.content.Media);
-        _14 = call const fn baml.Array.push<copy _16>(copy _4, copy _15) -> [bb1];
+        _4 = []: ai.content.Text | ai.content.Media[];
+        goto -> bb10;
     }
 
     bb10: {
-        _27 = []: ai.content.Text | ai.content.Media[];
-        _29 = len(_5);
-        goto -> bb11;
+        _82 = copy _10;
+        _83 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _81 = call const fn baml.Array.push<copy _83>(copy _3, copy _82) -> [bb2];
     }
 
     bb11: {
-        _28 = copy _29 > const 0_i64;
-        branch copy _28 -> [bb12, bb20];
+        _70 = copy _69;
+        _72 = copy _70;
+        _73 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _71 = call const fn baml.Array.push<copy _73>(copy _3, copy _72) -> [bb2];
     }
 
     bb12: {
-        _33 = copy _2.0;
-        _32 = call const fn ai.wire.tool_name(copy _1, copy _33) -> [bb13];
+        _12 = copy _11;
+        _13 = []: ai.content.Text | ai.content.Media[];
+        _14 = []: ai.content.Text | ai.content.Media[];
+        _15 = copy _12.1;
+        _16 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _15) -> [bb13];
     }
 
     bb13: {
-        _31 = short_circuit(??) copy _32 -> [eval: bb14, join: bb15];
+        _17 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _16) -> [bb14];
     }
 
     bb14: {
-        _31 = copy _2.0;
-        goto -> bb15;
+        _18 = is_type(copy _17, baml.iter.Done);
+        branch copy _18 -> [bb22, bb15];
     }
 
     bb15: {
-        _30 = copy _31;
-        _38 = copy _30;
-        _37 = const "attached from the result of tool `" + copy _38;
-        _36 = copy _37 + const "`";
-        _35 = ai.content.Text { copy _36 };
-        _39 = load_type(ai.content.Text | ai.content.Media);
-        _34 = call const fn baml.Array.push<copy _39>(copy _27, copy _35) -> [bb16];
+        _19 = copy _17;
+        fresh_cell(_20);
+        _20 = copy _19;
+        _21 = copy _20;
+        _21 = narrow_bind copy _21 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "Text" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb21, bb16];
     }
 
     bb16: {
-        _40 = copy _5;
-        _41 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _40) -> [bb17];
+        _26 = copy _20;
+        _28 = call const fn ai.content.Media.kind(copy _26) -> [bb17];
     }
 
     bb17: {
-        _42 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _41) -> [bb18];
+        _29 = load_type(string);
+        _27 = call const fn baml.Array.includes<copy _29>(copy _2, copy _28) -> [bb18];
     }
 
     bb18: {
-        _43 = is_type(copy _42, baml.iter.Done);
-        branch copy _43 -> [bb20, bb19];
+        branch copy _27 -> [bb20, bb19];
     }
 
     bb19: {
-        _44 = copy _42;
-        fresh_cell(_45);
-        _45 = copy _44;
-        _47 = copy _45;
-        _48 = load_type(ai.content.Text | ai.content.Media);
-        _46 = call const fn baml.Array.push<copy _48>(copy _27, copy _47) -> [bb17];
+        _34 = copy _26;
+        _35 = load_type(ai.content.Text | ai.content.Media);
+        _33 = call const fn baml.Array.push<copy _35>(copy _14, copy _34) -> [bb13];
     }
 
     bb20: {
-        _49 = copy _4;
-        _50 = copy _27;
-        _0 = ai.wire.ToolResultBlocks { copy _49, copy _50 };
-        goto -> bb21;
+        _31 = copy _26;
+        _32 = load_type(ai.content.Text | ai.content.Media);
+        _30 = call const fn baml.Array.push<copy _32>(copy _13, copy _31) -> [bb13];
     }
 
     bb21: {
+        _22 = copy _21;
+        _24 = copy _22;
+        _25 = load_type(ai.content.Text | ai.content.Media);
+        _23 = call const fn baml.Array.push<copy _25>(copy _13, copy _24) -> [bb13];
+    }
+
+    bb22: {
+        _37 = len(_14);
+        goto -> bb23;
+    }
+
+    bb23: {
+        _36 = copy _37 > const 0_i64;
+        branch copy _36 -> [bb24, bb36];
+    }
+
+    bb24: {
+        _39 = len(_13);
+        goto -> bb25;
+    }
+
+    bb25: {
+        _38 = copy _39 == const 0_i64;
+        branch copy _38 -> [bb26, bb28];
+    }
+
+    bb26: {
+        _43 = copy _14;
+        _42 = call const fn ai.content.text(copy _43) -> [bb27];
+    }
+
+    bb27: {
+        _41 = ai.content.Text { copy _42 };
+        _44 = load_type(ai.content.Text | ai.content.Media);
+        _40 = call const fn baml.Array.push<copy _44>(copy _13, copy _41) -> [bb28];
+    }
+
+    bb28: {
+        _48 = copy _12.0;
+        _47 = call const fn ai.wire.tool_name(copy _1, copy _48) -> [bb29];
+    }
+
+    bb29: {
+        _46 = short_circuit(??) copy _47 -> [eval: bb30, join: bb31];
+    }
+
+    bb30: {
+        _46 = copy _12.0;
+        goto -> bb31;
+    }
+
+    bb31: {
+        _45 = copy _46;
+        _53 = copy _45;
+        _52 = const "attached from the result of tool `" + copy _53;
+        _51 = copy _52 + const "`";
+        _50 = ai.content.Text { copy _51 };
+        _54 = load_type(ai.content.Text | ai.content.Media);
+        _49 = call const fn baml.Array.push<copy _54>(copy _4, copy _50) -> [bb32];
+    }
+
+    bb32: {
+        _55 = copy _14;
+        _56 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.Media | ai.content.Text>(copy _55) -> [bb33];
+    }
+
+    bb33: {
+        _57 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.Media | ai.content.Text>(copy _56) -> [bb34];
+    }
+
+    bb34: {
+        _58 = is_type(copy _57, baml.iter.Done);
+        branch copy _58 -> [bb36, bb35];
+    }
+
+    bb35: {
+        _59 = copy _57;
+        fresh_cell(_60);
+        _60 = copy _59;
+        _62 = copy _60;
+        _63 = load_type(ai.content.Text | ai.content.Media);
+        _61 = call const fn baml.Array.push<copy _63>(copy _4, copy _62) -> [bb33];
+    }
+
+    bb36: {
+        _66 = copy _12.0;
+        _67 = copy _13;
+        _65 = ai.events.ToolCompleted { copy _66, copy _67 };
+        _68 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _64 = call const fn baml.Array.push<copy _68>(copy _3, copy _65) -> [bb2];
+    }
+
+    bb37: {
+        _85 = len(_4);
+        goto -> bb38;
+    }
+
+    bb38: {
+        _84 = copy _85 > const 0_i64;
+        branch copy _84 -> [bb39, bb40];
+    }
+
+    bb39: {
+        _88 = copy _4;
+        _89 = {  }: map<string, baml.json.json>;
+        _87 = ai.events.UserMessage { copy _88, copy _89 };
+        _90 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced);
+        _86 = call const fn baml.Array.push<copy _90>(copy _3, copy _87) -> [bb40];
+    }
+
+    bb40: {
+        _91 = copy _3;
+        _0 = ai.Journal { copy _91 };
+        goto -> bb41;
+    }
+
+    bb41: {
         return;
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
@@ -244,13 +244,21 @@ class ai.content.ToolUse$stream {
   args: map<string, unknown>
 }
 enum ai.content.StopReason {Complete, ToolUse, MaxTokens, Refused}
-type ai.content.Block = ai.content.Text | ai.content.Reasoning | ai.content.ToolUse | ai.content.Media
-type ai.content.Block$stream = ai.content.Text$stream | ai.content.Reasoning$stream | ai.content.ToolUse$stream | ai.content.Media$stream
+type ai.content.Block = ai.content.ContentBlock | ai.content.Reasoning | ai.content.ToolUse
+type ai.content.Block$stream = ai.content.ContentBlock$stream | ai.content.Reasoning$stream | ai.content.ToolUse$stream
+type ai.content.ContentBlock = ai.content.Text | ai.content.Media
+type ai.content.ContentBlock$stream = ai.content.Text$stream | ai.content.Media$stream
+function ai.content.blocks(items: string | image | audio | video | pdf | ai.content.Text | ai.content.Media[]) -> ai.content.ContentBlock[]  [expr] {
+  { let out: ai.content.ContentBlock[] = []; for item in items { match (item) { text: string => { out.push(ai.content.Text { text: text }) } null, block: ai.content.ContentBlock => { out.push(block) } null, media: image | audio | video | pdf => { out.push(Media.new(media)) } null } } } out
+}
 function ai.content.kind(self: ?) -> string  [expr] {
   {  } match (self.media) { image: baml.media.Image => "image", audio: baml.media.Audio => "audio", video: baml.media.Video => "video", pdf: baml.media.Pdf => "pdf" }
 }
 function ai.content.new(value: image | audio | video | pdf, provider_id: string? = null, revised_prompt: string? = null) -> ai.content.Media  [expr] {
   {  } ai.content.Media { media: value, provider_id: provider_id, revised_prompt: revised_prompt }
+}
+function ai.content.text(content: ai.content.ContentBlock[]) -> string  [expr] {
+  { let out = ""; for block in content { match (block) { t: ai.content.Text => { out = `...` } null, m: ai.content.Media => { out = `...` } null } } } out
 }
 
 --- <builtin>/ai/ns_errors/errors.baml ---
@@ -482,11 +490,11 @@ class ai.events.Timing$stream {
 }
 class ai.events.ToolCompleted {
   id: string
-  output: string
+  content: root.content.ContentBlock[]
 }
 class ai.events.ToolCompleted$stream {
   id: string | null
-  output: string | null
+  content: root.content.ContentBlock$stream[]
 }
 class ai.events.ToolFailed {
   id: string
@@ -519,15 +527,35 @@ class ai.events.Usage$stream {
   reasoning_tokens: int | null
 }
 class ai.events.UserMessage {
-  content: string
+  content: root.content.ContentBlock[]
+  metadata: map<string, baml.json.json>
 }
 class ai.events.UserMessage$stream {
-  content: string | null
+  content: root.content.ContentBlock$stream[]
+  metadata: map<string, baml.json.json$stream>
 }
 type ai.events.Event = ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
 type ai.events.Event$stream = ai.events.RunStarted$stream | ai.events.UserMessage$stream | ai.events.AssistantMessage$stream | ai.events.ToolRequested$stream | ai.events.ToolCompleted$stream | ai.events.ToolFailed$stream | ai.events.Usage$stream | ai.events.LLMCall$stream | ai.events.FinalProduced$stream
 function ai.events.guard(listener: (ai.events.Event) -> void throws E?) -> (ai.events.Event) -> void throws never?  [expr] {
   {  } if let cb: (ai.events.Event) -> void throws E = listener {  } (e: ai.events.Event) -> void { {  } cb(e) catch_all (err) { _ => {  } } } else {  } null
+}
+function ai.events.new(text: string) -> ai.events.UserMessage  [expr] {
+  {  } ai.events.UserMessage { content: [root.content.Text { text: text }], metadata: map {  } }
+}
+function ai.events.new(id: string, output: string) -> ai.events.ToolCompleted  [expr] {
+  {  } ai.events.ToolCompleted { id: id, content: [root.content.Text { text: output }] }
+}
+function ai.events.of(items: string | image | audio | video | pdf | root.content.Text | root.content.Media[], metadata: map<string, baml.json.json> = ...) -> ai.events.UserMessage  [expr] {
+  {  } ai.events.UserMessage { content: root.content.blocks(items), metadata: metadata }
+}
+function ai.events.of(id: string, items: string | image | audio | video | pdf | root.content.Text | root.content.Media[]) -> ai.events.ToolCompleted  [expr] {
+  {  } ai.events.ToolCompleted { id: id, content: root.content.blocks(items) }
+}
+function ai.events.text(self: ?) -> string  [expr] {
+  {  } root.content.text(self.content)
+}
+function ai.events.text(self: ?) -> string  [expr] {
+  {  } root.content.text(self.content)
 }
 
 --- captures ---
@@ -898,11 +926,22 @@ class ai.wire.SentAs$stream {
   value: T | null
   call: root.events.LLMCall$stream | null
 }
+class ai.wire.ToolResultBlocks {
+  inline: root.content.ContentBlock[]
+  trailing: root.content.ContentBlock[]
+}
+class ai.wire.ToolResultBlocks$stream {
+  inline: root.content.ContentBlock$stream[]
+  trailing: root.content.ContentBlock$stream[]
+}
 function ai.wire.credential_sources(cred: root.Credential?, canonical_env: string?) -> string  [expr] {
   { let names: string[] = []; if let named: baml.env.Ref = cred { names.push(named.name) }; if let canonical: string = canonical_env { names.push(canonical) } } if (names.length() Eq 0) {  } "(no environment v..." else {  } names.join(", ")
 }
 function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.json?) -> baml.json.json  [expr] {
   {  } match (overrides) { null => base, _ => root.internal._merge_json(base, overrides) }
+}
+function ai.wire.prompt_blocks(message: root.PromptMessage) -> root.content.ContentBlock[]  [expr] {
+  { let out: root.content.ContentBlock[] = []; for part in message.parts { match (part) { text: string => { out.push(root.content.Text { text: text }) } null, media: root.MediaPart => { out.push(root.content.Media { media: media, provider_id: null, revised_prompt: null }) } null } } } out
 }
 function ai.wire.redact_request_headers(headers: map<string, string>) -> map<string, string>  [expr] {
   { let out: map<string, string> = map {  }; for name in headers.keys() { let lower = name.to_lower_case(); let sensitive = lower Eq "authorization" Or lower Eq "proxy-authorization" Or lower Eq "x-api-key" Or lower Eq "api-key" Or lower Eq "x-goog-api-key" Or lower Eq "x-amz-security-token" Or lower Eq "cookie" } if (sensitive) { let _ = out.set(name, "REDACTED") } else {  } if let value: string = headers.get(name) { let _ = out.set(name, value) } } out
@@ -931,6 +970,12 @@ function ai.wire.send_as(req: baml.http.Request, provider: string, request_timeo
 function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, client_name: string, capture_wire: bool = true, request_timeout_ms: int? = null) -> ai.wire.SentAs<T>  [expr] {
   { let started = baml.time.Instant.now(); let timeout = match (request_timeout_ms) { milliseconds: int => baml.time.Duration.from_milliseconds(milliseconds), null => null }; let resp = baml.http.send(req, timeout = timeout) catch_all (e) { timeout: baml.errors.Timeout => throw timeout, _ => { throw root.errors.NetworkFailure { status_code: null, provider: provider, detail: `...`, raw_body: null } } }; let text = resp.text() catch_all (e) { timeout: baml.errors.Timeout => throw timeout, _ => { throw root.errors.NetworkFailure { status_code: null, provider: provider, detail: "the response body...", raw_body: null } } }; if (Not resp.ok()) { throw root.errors.classify_http(provider, resp.status_code, text, headers = resp.headers) }; let value = baml.json.from_string(text) catch_all (e) { _ => throw root.errors.ParseFailed { provider: provider, raw_output: text } }; let call = root.events.LLMCall { client_name: client_name, provider: provider, timing: root.events.Timing { start_time_utc_ms: started.to_timestamp_milliseconds(), duration_ms: started.elapsed().to_milliseconds(), ttft_ms: null }, http_request: if (capture_wire) {  } baml.http.Request { method: req.method, url: redact_url_secrets(req.url), headers: redact_request_headers(req.headers), body: req.body } else {  } null, http_response: root.events.HttpResponse { status: resp.status_code, headers: resp.headers, body: if (capture_wire) {  } redact_url_secrets(text) else {  } null }, usage: null, selected: true, sse_responses: null } } ai.wire.SentAs { value: value, call: call }
 }
+function ai.wire.tool_name(j: root.Journal, id: string) -> string?  [expr] {
+  { for event in j.entries() {  } if let assistant: root.events.AssistantMessage = event { for block in assistant.content {  } if let use: root.content.ToolUse = block {  } if (use.id Eq id) { return use.name } } } null
+}
+function ai.wire.tool_result_blocks(j: root.Journal, completed: root.events.ToolCompleted, carries: string[]) -> ai.wire.ToolResultBlocks  [expr] {
+  { let inline: root.content.ContentBlock[] = []; let moved: root.content.ContentBlock[] = []; for block in completed.content { match (block) { text: root.content.Text => { inline.push(text) } null, media: root.content.Media => { if (carries.includes(media.kind())) { inline.push(media) } else { moved.push(media) } } null } }; let trailing: root.content.ContentBlock[] = []; if (moved.length() Gt 0) { let tool = tool_name(j, completed.id) NullCoalesce completed.id; trailing.push(root.content.Text { text: "attached from the..." Add tool Add "`" }); for block in moved { trailing.push(block) } } } ai.wire.ToolResultBlocks { inline: inline, trailing: trailing }
+}
 
 --- <builtin>/ai/runner.baml ---
 class ai.Agent {
@@ -958,7 +1003,7 @@ class ai.RunResult$stream {
   usage: root.events.Usage$stream | null
 }
 function ai._attempt_turn(self: ?, c: Client, spec: FunctionSpec<Out>, j: Journal, total: root.events.Usage, attempts_left: int) -> ModelTurn  [expr] {
-  { let turn = c.invoke(ModelTurnInput { prompt: spec.prompt_template, journal: j, toolbox: spec.tools(), output_type: spec.output_type() }); if let u: root.events.Usage = turn.usage { total.input_tokens Add= u.input_tokens; total.output_tokens Add= u.output_tokens; if let ci: int = u.cached_input_tokens { total.cached_input_tokens = total.cached_input_tokens NullCoalesce 0 Add ci } } if let rt: int = u.reasoning_tokens { total.reasoning_tokens = total.reasoning_tokens NullCoalesce 0 Add rt }; let batch: root.events.Event[] = [root.events.AssistantMessage { content: turn.content, client_id: c.id() }]; for call in turn.calls { batch.push(call) }; for u in turn.tool_uses() { batch.push(root.events.ToolRequested { id: u.id, name: u.name, args: u.args }) }; if let u: root.events.Usage = turn.usage { batch.push(u) }; let candidate = turn.terminal_text() NullCoalesce ""; let accepted = turn.tool_uses().length() Gt 0 Or turn.stop_reason Eq root.content.StopReason.MaxTokens Or turn.stop_reason Eq root.content.StopReason.Refused Or self._parses(turn, candidate) } if (accepted) { j.append_all(batch); match (turn.stop_reason) { root.content.StopReason.MaxTokens => { throw root.errors.FinishReasonError { provider: c.id(), finish_reason: turn.stop_reason, raw_output: candidate } }, root.content.StopReason.Refused => { throw root.errors.Refused { provider: c.id(), reason: "the model decline...", raw_body: null } }, _ => null } } turn else if (attempts_left Gt 1) { batch.push(root.events.UserMessage { content: "The reply did not..." }); j.append_all(batch) } self._attempt_turn(c, spec, j, total, attempts_left Sub 1) else { j.append_all(batch); throw root.errors.ParseFailed { provider: c.id(), raw_output: candidate } }
+  { let turn = c.invoke(ModelTurnInput { prompt: spec.prompt_template, journal: j, toolbox: spec.tools(), output_type: spec.output_type() }); if let u: root.events.Usage = turn.usage { total.input_tokens Add= u.input_tokens; total.output_tokens Add= u.output_tokens; if let ci: int = u.cached_input_tokens { total.cached_input_tokens = total.cached_input_tokens NullCoalesce 0 Add ci } } if let rt: int = u.reasoning_tokens { total.reasoning_tokens = total.reasoning_tokens NullCoalesce 0 Add rt }; let batch: root.events.Event[] = [root.events.AssistantMessage { content: turn.content, client_id: c.id() }]; for call in turn.calls { batch.push(call) }; for u in turn.tool_uses() { batch.push(root.events.ToolRequested { id: u.id, name: u.name, args: u.args }) }; if let u: root.events.Usage = turn.usage { batch.push(u) }; let candidate = turn.terminal_text() NullCoalesce ""; let accepted = turn.tool_uses().length() Gt 0 Or turn.stop_reason Eq root.content.StopReason.MaxTokens Or turn.stop_reason Eq root.content.StopReason.Refused Or self._parses(turn, candidate) } if (accepted) { j.append_all(batch); match (turn.stop_reason) { root.content.StopReason.MaxTokens => { throw root.errors.FinishReasonError { provider: c.id(), finish_reason: turn.stop_reason, raw_output: candidate } }, root.content.StopReason.Refused => { throw root.errors.Refused { provider: c.id(), reason: "the model decline...", raw_body: null } }, _ => null } } turn else if (attempts_left Gt 1) { batch.push(root.events.UserMessage.new("The reply did not...")); j.append_all(batch) } self._attempt_turn(c, spec, j, total, attempts_left Sub 1) else { j.append_all(batch); throw root.errors.ParseFailed { provider: c.id(), raw_output: candidate } }
 }
 function ai._emit_from(self: ?, j: Journal, seen: int) -> int  [expr] {
   { let entries = j.entries(); if let cb: (root.events.Event) -> void throws never = self.on_event { let i = seen; while i Lt entries.length() { if let e: root.events.Event = entries.at(i) { cb(e) }; i = i Add 1 } } } entries.length()
@@ -973,7 +1018,7 @@ function ai._parses(self: ?, turn: ModelTurn, candidate: string) -> bool  [expr]
   { if (self._has_media_output(turn)) { return true }; let _ = baml.sap.parse(candidate) catch_all (e) { _ => { return false } } } true
 }
 function ai._run_one_tool(self: ?, tb: root.tools.Toolbox, call: root.content.ToolUse, j: Journal) -> void  [expr] {
-  {  } match (tb.get(call.name)) { t: root.tools.Tool => { let outcome: string? = t.call(call.args) catch_all (e) { _ => { j.append_all([root.events.ToolFailed { id: call.id, message: e.to_string() }]) } if (t.on_error NullCoalesce self.tool_errors Eq root.tools.ErrorMode.Raise) { let classified = match (e) { f: root.errors.Failure => f, _ => null }; throw root.errors.ToolFailedError { id: call.id, name: call.name, message: e.to_string(), cause: classified } } else {  } null }; if let output: string = outcome { j.append_all([root.events.ToolCompleted { id: call.id, output: output }]) } } null, null => { j.append_all([root.events.ToolFailed { id: call.id, message: `...` }]) } null }
+  {  } match (tb.get(call.name)) { t: root.tools.Tool => { let outcome: string? = t.call(call.args) catch_all (e) { _ => { j.append_all([root.events.ToolFailed { id: call.id, message: e.to_string() }]) } if (t.on_error NullCoalesce self.tool_errors Eq root.tools.ErrorMode.Raise) { let classified = match (e) { f: root.errors.Failure => f, _ => null }; throw root.errors.ToolFailedError { id: call.id, name: call.name, message: e.to_string(), cause: classified } } else {  } null }; if let output: string = outcome { j.append_all([root.events.ToolCompleted.new(call.id, output)]) } } null, null => { j.append_all([root.events.ToolFailed { id: call.id, message: `...` }]) } null }
 }
 function ai._validated_schema_attempts(self: ?) -> int  [expr] {
   { if (self.schema_attempts Lt 1) { throw baml.errors.InvalidArgument { message: "Agent schema_atte..." } } } self.schema_attempts

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/ppir.snap
@@ -244,12 +244,12 @@ class ai.content.ToolUse$stream {
   args: map<string, unknown>
 }
 enum ai.content.StopReason {Complete, ToolUse, MaxTokens, Refused}
-type ai.content.Block = ai.content.ContentBlock | ai.content.Reasoning | ai.content.ToolUse
-type ai.content.Block$stream = ai.content.ContentBlock$stream | ai.content.Reasoning$stream | ai.content.ToolUse$stream
-type ai.content.ContentBlock = ai.content.Text | ai.content.Media
-type ai.content.ContentBlock$stream = ai.content.Text$stream | ai.content.Media$stream
-function ai.content.blocks(items: string | image | audio | video | pdf | ai.content.Text | ai.content.Media[]) -> ai.content.ContentBlock[]  [expr] {
-  { let out: ai.content.ContentBlock[] = []; for item in items { match (item) { text: string => { out.push(ai.content.Text { text: text }) } null, block: ai.content.ContentBlock => { out.push(block) } null, media: image | audio | video | pdf => { out.push(Media.new(media)) } null } } } out
+type ai.content.Block = ai.content.Text | ai.content.Media
+type ai.content.Block$stream = ai.content.Text$stream | ai.content.Media$stream
+type ai.content.ModelBlock = ai.content.Block | ai.content.Reasoning | ai.content.ToolUse
+type ai.content.ModelBlock$stream = ai.content.Block$stream | ai.content.Reasoning$stream | ai.content.ToolUse$stream
+function ai.content.blocks(items: string | image | audio | video | pdf | ai.content.Text | ai.content.Media[]) -> ai.content.Block[]  [expr] {
+  { let out: ai.content.Block[] = []; for item in items { match (item) { text: string => { out.push(ai.content.Text { text: text }) } null, block: ai.content.Block => { out.push(block) } null, media: image | audio | video | pdf => { out.push(Media.new(media)) } null } } } out
 }
 function ai.content.kind(self: ?) -> string  [expr] {
   {  } match (self.media) { image: baml.media.Image => "image", audio: baml.media.Audio => "audio", video: baml.media.Video => "video", pdf: baml.media.Pdf => "pdf" }
@@ -257,7 +257,7 @@ function ai.content.kind(self: ?) -> string  [expr] {
 function ai.content.new(value: image | audio | video | pdf, provider_id: string? = null, revised_prompt: string? = null) -> ai.content.Media  [expr] {
   {  } ai.content.Media { media: value, provider_id: provider_id, revised_prompt: revised_prompt }
 }
-function ai.content.text(content: ai.content.ContentBlock[]) -> string  [expr] {
+function ai.content.text(content: ai.content.Block[]) -> string  [expr] {
   { let out = ""; for block in content { match (block) { t: ai.content.Text => { out = `...` } null, m: ai.content.Media => { out = `...` } null } } } out
 }
 
@@ -417,11 +417,11 @@ function ai.errors.retry_safety(self: ?) -> ai.errors.RetrySafety  [expr] {
 
 --- <builtin>/ai/ns_events/events.baml ---
 class ai.events.AssistantMessage {
-  content: root.content.Block[]
+  content: root.content.ModelBlock[]
   client_id: string
 }
 class ai.events.AssistantMessage$stream {
-  content: root.content.Block$stream[]
+  content: root.content.ModelBlock$stream[]
   client_id: string | null
 }
 class ai.events.FinalProduced {
@@ -490,11 +490,11 @@ class ai.events.Timing$stream {
 }
 class ai.events.ToolCompleted {
   id: string
-  content: root.content.ContentBlock[]
+  content: root.content.Block[]
 }
 class ai.events.ToolCompleted$stream {
   id: string | null
-  content: root.content.ContentBlock$stream[]
+  content: root.content.Block$stream[]
 }
 class ai.events.ToolFailed {
   id: string
@@ -527,11 +527,11 @@ class ai.events.Usage$stream {
   reasoning_tokens: int | null
 }
 class ai.events.UserMessage {
-  content: root.content.ContentBlock[]
+  content: root.content.Block[]
   metadata: map<string, baml.json.json>
 }
 class ai.events.UserMessage$stream {
-  content: root.content.ContentBlock$stream[]
+  content: root.content.Block$stream[]
   metadata: map<string, baml.json.json$stream>
 }
 type ai.events.Event = ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.LLMCall | ai.events.FinalProduced
@@ -677,8 +677,8 @@ function ai.internal._redact_value_end(tail: string) -> int  [expr] {
 function ai.internal._resolve_pending_call(pending: string[], id: string) -> void  [expr] {
   {  } if let index: int = pending.index_of(id) { let _ = pending.remove_at(index) }
 }
-function ai.internal._wire_blocks(content: root.content.Block[], keep_reasoning: bool) -> root.content.Block[]  [expr] {
-  { let out: root.content.Block[] = []; for block in content { match (block) { text: root.content.Text => { if (text.text.trim() Ne "") { out.push(text) } } null, reasoning: root.content.Reasoning => { if (keep_reasoning) { out.push(reasoning) } } null, use: root.content.ToolUse => { out.push(use) } null, media: root.content.Media => null } } } out
+function ai.internal._wire_blocks(content: root.content.ModelBlock[], keep_reasoning: bool) -> root.content.ModelBlock[]  [expr] {
+  { let out: root.content.ModelBlock[] = []; for block in content { match (block) { text: root.content.Text => { if (text.text.trim() Ne "") { out.push(text) } } null, reasoning: root.content.Reasoning => { if (keep_reasoning) { out.push(reasoning) } } null, use: root.content.ToolUse => { out.push(use) } null, media: root.content.Media => null } } } out
 }
 
 --- <builtin>/ai/ns_mcp/mcp.baml ---
@@ -926,22 +926,17 @@ class ai.wire.SentAs$stream {
   value: T | null
   call: root.events.LLMCall$stream | null
 }
-class ai.wire.ToolResultBlocks {
-  inline: root.content.ContentBlock[]
-  trailing: root.content.ContentBlock[]
-}
-class ai.wire.ToolResultBlocks$stream {
-  inline: root.content.ContentBlock$stream[]
-  trailing: root.content.ContentBlock$stream[]
-}
 function ai.wire.credential_sources(cred: root.Credential?, canonical_env: string?) -> string  [expr] {
   { let names: string[] = []; if let named: baml.env.Ref = cred { names.push(named.name) }; if let canonical: string = canonical_env { names.push(canonical) } } if (names.length() Eq 0) {  } "(no environment v..." else {  } names.join(", ")
+}
+function ai.wire.degrade_tool_media(j: root.Journal, carries: string[]) -> root.Journal  [expr] {
+  { let out: root.events.Event[] = []; let attached: root.content.Block[] = []; for event in j.entries() { match (event) { completed: root.events.ToolCompleted => { let inline: root.content.Block[] = []; let moved: root.content.Block[] = []; for block in completed.content { match (block) { text: root.content.Text => { inline.push(text) } null, media: root.content.Media => { if (carries.includes(media.kind())) { inline.push(media) } else { moved.push(media) } } null } }; if (moved.length() Gt 0) { if (inline.length() Eq 0) { inline.push(root.content.Text { text: root.content.text(moved) }) }; let tool = tool_name(j, completed.id) NullCoalesce completed.id; attached.push(root.content.Text { text: "attached from the..." Add tool Add "`" }); for block in moved { attached.push(block) } }; out.push(root.events.ToolCompleted { id: completed.id, content: inline }) } null, failed: root.events.ToolFailed => { out.push(failed) } null, _ => { if (attached.length() Gt 0) { out.push(root.events.UserMessage { content: attached, metadata: map {  } }); attached = [] }; out.push(event) } null } }; if (attached.length() Gt 0) { out.push(root.events.UserMessage { content: attached, metadata: map {  } }) } } root.Journal { log: out }
 }
 function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.json?) -> baml.json.json  [expr] {
   {  } match (overrides) { null => base, _ => root.internal._merge_json(base, overrides) }
 }
-function ai.wire.prompt_blocks(message: root.PromptMessage) -> root.content.ContentBlock[]  [expr] {
-  { let out: root.content.ContentBlock[] = []; for part in message.parts { match (part) { text: string => { out.push(root.content.Text { text: text }) } null, media: root.MediaPart => { out.push(root.content.Media { media: media, provider_id: null, revised_prompt: null }) } null } } } out
+function ai.wire.prompt_blocks(message: root.PromptMessage) -> root.content.Block[]  [expr] {
+  { let out: root.content.Block[] = []; for part in message.parts { match (part) { text: string => { out.push(root.content.Text { text: text }) } null, media: root.MediaPart => { out.push(root.content.Media { media: media, provider_id: null, revised_prompt: null }) } null } } } out
 }
 function ai.wire.redact_request_headers(headers: map<string, string>) -> map<string, string>  [expr] {
   { let out: map<string, string> = map {  }; for name in headers.keys() { let lower = name.to_lower_case(); let sensitive = lower Eq "authorization" Or lower Eq "proxy-authorization" Or lower Eq "x-api-key" Or lower Eq "api-key" Or lower Eq "x-goog-api-key" Or lower Eq "x-amz-security-token" Or lower Eq "cookie" } if (sensitive) { let _ = out.set(name, "REDACTED") } else {  } if let value: string = headers.get(name) { let _ = out.set(name, value) } } out
@@ -972,9 +967,6 @@ function ai.wire.send_as_with_wire(req: baml.http.Request, provider: string, cli
 }
 function ai.wire.tool_name(j: root.Journal, id: string) -> string?  [expr] {
   { for event in j.entries() {  } if let assistant: root.events.AssistantMessage = event { for block in assistant.content {  } if let use: root.content.ToolUse = block {  } if (use.id Eq id) { return use.name } } } null
-}
-function ai.wire.tool_result_blocks(j: root.Journal, completed: root.events.ToolCompleted, carries: string[]) -> ai.wire.ToolResultBlocks  [expr] {
-  { let inline: root.content.ContentBlock[] = []; let moved: root.content.ContentBlock[] = []; for block in completed.content { match (block) { text: root.content.Text => { inline.push(text) } null, media: root.content.Media => { if (carries.includes(media.kind())) { inline.push(media) } else { moved.push(media) } } null } }; let trailing: root.content.ContentBlock[] = []; if (moved.length() Gt 0) { let tool = tool_name(j, completed.id) NullCoalesce completed.id; trailing.push(root.content.Text { text: "attached from the..." Add tool Add "`" }); for block in moved { trailing.push(block) } } } ai.wire.ToolResultBlocks { inline: inline, trailing: trailing }
 }
 
 --- <builtin>/ai/runner.baml ---
@@ -1117,13 +1109,13 @@ lambda (ctx) in prompt: captures [body]
 
 --- <builtin>/ai/turn.baml ---
 class ai.ModelTurn {
-  content: root.content.Block[]
+  content: root.content.ModelBlock[]
   stop_reason: root.content.StopReason
   usage: root.events.Usage?
   calls: root.events.LLMCall[]
 }
 class ai.ModelTurn$stream {
-  content: root.content.Block$stream[]
+  content: root.content.ModelBlock$stream[]
   stop_reason: root.content.StopReason | null
   usage: root.events.Usage$stream | null
   calls: root.events.LLMCall$stream[]


### PR DESCRIPTION
## Summary

Every journal turn now carries one content vocabulary, `ai.content.Block[]` (`Text | Media`), the same blocks a model turn already used; the model-turn superset (reasoning and tool use on top) is `ai.content.ModelBlock`. `UserMessage` and `ToolCompleted` gain `new`/`of`/`text()` constructors and projections, and `UserMessage` gains per-message `metadata` for provider directives. Each client lowers the rendered prompt, user turns, tool results and model turns through one `_lower_block` per block kind, with its Accept / Degrade / Reject table beside it. This lands the final shape from `JOURNAL_MEDIA_DESIGN.md` §4 directly and supersedes #4746's interim `UserContent` event.

## Bugs fixed

- **An agent could not add an image after the first turn.** The journal only carried text, so a screenshot after a tool call had to be re-rendered into the prompt template, defeating prefix caching. `journal.append_all([UserMessage.of(["caption", host.screenshot()])])` now lowers at its position in the journal on every client.
- **Tool results could not carry media.** `ToolCompleted.of(id, [text, image])` lowers natively where the provider allows it and degrades to a trailing user turn ("attached from the result of tool `x`") where it does not.

| client | user image / audio / video / pdf | tool result |
|---|---|---|
| Gemini / Vertex | Accept / Accept / Accept / Accept | Accept (`functionResponse.parts`) |
| Anthropic Messages | Accept / Reject / Reject / Accept | image, pdf Accept; audio, video Reject |
| OpenAI Responses | Accept / Accept / Reject / Accept | image, pdf Accept; audio Degrade; video Reject |
| OpenAI Chat Completions | Accept / Accept / Reject / Accept | Degrade (tool content is text only) |
| Bedrock Converse | Accept / Accept / Accept / Accept | image, pdf, video Accept; audio Degrade |
| Claude Code CLI | `text()` placeholder | placeholder |
| OpenAI Images | Reject | not represented |
| AI Gateway Images | `files[]` / Reject / Reject / Reject | not represented |

Degrade is a pure journal rewrite, `ai.wire.degrade_tool_media`, applied after `sanitize_for_client`: media a client cannot carry moves into one user turn after the whole run of tool results, so the results of one assistant turn stay contiguous and a media-only result keeps a placeholder.

## Breaking changes

| before | after |
|---|---|
| `ai.events.UserMessage { content: "..." }` | `ai.events.UserMessage.new("...")` |
| `user.content` (string) | `user.text()`; `content` is `ai.content.Block[]` |
| `ai.content.Block` (model-turn union) | `ai.content.ModelBlock` |
| `ai.events.ToolCompleted { id, output }` | `ai.events.ToolCompleted.new(id, output)` |
| `completed.output` | `completed.text()`; `content` for structure |
| `ai.events.UserContent` (#4746) | `ai.events.UserMessage.of(items)` |
| `ai.internal.media_part(value)` | the value itself |

Wire bytes are unchanged for text-only journals (pinned by the existing replay tests).

## Tests

Native BAML only, on a shared `ns_llm_mock.media_journal` fixture: per client one Accept test and, where the table has one, one Degrade and one Reject test; `sanitize_for_client` still closes an orphaned tool call before a user turn; `text()` projections; the CLI transcript.

## Stack

Part of the split of #4797; stacked on #4806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking journal event shapes and sweeping changes to every LLM client’s request-lowering path; risk is tempered by extensive per-provider tests and unchanged wire for text-only histories.
> 
> **Overview**
> **Unifies journal turns on structured content blocks** so user messages and tool results can carry text and media in order, not bare strings. `ai.content.Block` is now `Text | Media` for any turn; model output uses `ModelBlock` (adds `Reasoning` and `ToolUse`). `UserMessage` and `ToolCompleted` expose `new` / `of` / `text()`, and user turns gain optional `metadata` for provider directives.
> 
> **Shared lowering on the wire:** `ai.wire.prompt_blocks`, per-block `_lower_block` paths in each client, and `degrade_tool_media` rewrite media that a provider cannot embed in tool results into a trailing user turn while keeping tool-result runs contiguous. Runner and CLI call sites move to the new constructors (`UserMessage.new`, `ToolCompleted.new`).
> 
> **Breaking:** string `UserMessage.content` and `ToolCompleted.output` are replaced by `content: Block[]` plus `text()`; callers must use the new factory methods. Text-only journals should still produce the same provider wire shape per existing replay tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf75532e441d41f878c9406d2779a0b3a4b3eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->