### PR TITLE
Nine standalone fixes: build script, handle table, Python bridge, runtime-mount stubs, callable throws

### DIFF
--- a/baml_language/crates/baml_artifact/build.rs
+++ b/baml_language/crates/baml_artifact/build.rs
@@ -17,7 +17,24 @@ fn track_git_head() {
     if let Some(reference) = git_output(&["symbolic-ref", "-q", "HEAD"])
         && let Some(path) = git_output(&["rev-parse", "--git-path", &reference])
     {
-        println!("cargo:rerun-if-changed={path}");
+        // A packed ref has no loose file. Watching a nonexistent path makes
+        // Cargo rerun this script (and rebuild the compiler) on every command.
+        // Watch an existing ancestor to notice a future loose ref, plus the
+        // packed-ref file for updates to the current packed value.
+        let mut watched = PathBuf::from(path);
+        while !watched.exists() {
+            if !watched.pop() {
+                break;
+            }
+        }
+        if watched.exists() {
+            println!("cargo:rerun-if-changed={}", watched.display());
+        }
+        if let Some(packed) = git_output(&["rev-parse", "--git-path", "packed-refs"])
+            && PathBuf::from(&packed).exists()
+        {
+            println!("cargo:rerun-if-changed={packed}");
+        }
     }
 }
 

--- a/baml_language/crates/baml_compiler2_hir_ty/src/callable.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/callable.rs
@@ -184,7 +184,17 @@ pub fn callable_throws<'db>(
     let data = baml_compiler2_ppir::item_data::elaborated_function_data(db, function);
     if let Some(throws_ref) = data.throws {
         let frame = crate::lower::function_generic_frame(db, function);
-        let ctx = crate::lower::lower_ctx_for_file(db, function.file(db)).with_frame(frame);
+        // A throwing effect has the same owner/bound scope as the rest of
+        // the signature. A frame alone cannot resolve `Self.Error` in an
+        // implements-block or free-impl method (it projects through the
+        // impl target's binding) or `T.Error` on a bounded parameter (it
+        // projects through `T`'s bound).
+        let impl_target = crate::lower::owner_impl_target(db, function, &frame);
+        let ctx = crate::lower::lower_ctx_for_file(db, function.file(db))
+            .with_frame(frame)
+            .with_bounds(crate::lower::function_generic_bounds(db, function))
+            .with_self_ty(crate::lower::owner_self_ty(db, function))
+            .with_impl_target(impl_target);
         let lowered = ctx.lower_type_ref(&data.type_refs, throws_ref);
         // A PARTIAL clause (`throws T | _`, spec Functions rule 3) keeps
         // inferring: fall through to the body run, whose finalize unions

--- a/baml_language/crates/baml_tests/src/compiler2_tir/callable_throws_scope.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/callable_throws_scope.rs
@@ -1,0 +1,108 @@
+//! `callable_throws` lowers a written `throws` clause in the same scope as
+//! the rest of the signature. `Self.Error` in an implements-block or free-impl
+//! method resolves through the impl target's binding, and `T.Error` on a
+//! bounded parameter resolves through `T`'s bound - a bare generic frame
+//! cannot lower either, which used to leave the runtime throws metadata
+//! wrong for exactly the methods that declare their error via an
+//! associated type (e.g. `baml.iter.Iterator.collect`).
+
+use baml_compiler2_ppir::item_data::MethodOwner;
+use baml_db::ProjectDatabase;
+
+use super::support::make_db;
+use crate::engine::TestDbExt;
+
+const SOURCE: &str = r#"
+interface Fallible {
+    type Error
+    function run(self) -> int throws Self.Error
+}
+
+class Worker {
+    implements Fallible {
+        type Error = string
+        function run(self) -> int throws Self.Error { throw "boom" }
+    }
+}
+
+class Other {}
+
+implement Fallible for Other {
+    type Error = int
+    function run(self) -> int throws Self.Error { throw 7 }
+}
+
+function drive<T extends Fallible>(w: T) -> int throws T.Error { w.run() }
+"#;
+
+/// The effective (`callable_throws`) error type of the function named `name`
+/// whose owner's concrete `Self` renders as `owner_self` (`None` for a free
+/// function), asserted equal to the signature road's `throws`, which lowers
+/// in the full owner/bound scope. Types render as the test file's own package
+/// sees them (its classes bare).
+fn callable_throws(
+    db: &ProjectDatabase,
+    file: baml_base::SourceFile,
+    name: &str,
+    owner_self: Option<&str>,
+) -> String {
+    let viewer = baml_compiler2_hir::file_package::file_package(db, file).root;
+    let vp = baml_compiler2_hir_ty::render::Viewpoint::user_facing(db, viewer);
+    let loc = *baml_compiler2_ppir::item_data::file_functions(db, file)
+        .iter()
+        .find(|&&loc| {
+            baml_compiler2_ppir::item_data::function_data(db, loc)
+                .name
+                .as_str()
+                == name
+                && baml_compiler2_ppir::item_data::method_owner(db, loc)
+                    .as_ref()
+                    .is_none_or(|owner| !matches!(owner, MethodOwner::Interface(_)))
+                && baml_compiler2_hir_ty::lower::owner_self_ty(db, loc)
+                    .map(|ty| ty.render_with(&vp))
+                    .as_deref()
+                    == owner_self
+        })
+        .unwrap_or_else(|| panic!("function `{name}` (self: {owner_self:?}) not found"));
+    let effective = baml_compiler2_hir_ty::callable::callable_throws(db, loc)
+        .0
+        .render_with(&vp);
+    let signature = baml_compiler2_hir_ty::lower::function_signature(db, loc)
+        .throws
+        .render_with(&vp);
+    assert_eq!(
+        effective, signature,
+        "`{name}`: callable_throws must lower the clause in the signature's scope"
+    );
+    effective
+}
+
+#[test]
+fn implements_block_method_throws_resolves_self_error_binding() {
+    let mut db = make_db();
+    let file = db.file("test.baml", SOURCE);
+    assert_eq!(
+        callable_throws(&db, file, "run", Some("Worker")),
+        "(Worker as Fallible<Error = string>).Error"
+    );
+}
+
+#[test]
+fn free_impl_method_throws_resolves_self_error_binding() {
+    let mut db = make_db();
+    let file = db.file("test.baml", SOURCE);
+    assert_eq!(
+        callable_throws(&db, file, "run", Some("Other")),
+        "(Other as Fallible<Error = int>).Error"
+    );
+}
+
+#[test]
+fn bounded_parameter_throws_resolves_through_its_bound() {
+    let mut db = make_db();
+    let file = db.file("test.baml", SOURCE);
+    assert_eq!(
+        callable_throws(&db, file, "drive", None),
+        "(T as Fallible).Error"
+    );
+}

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -8,6 +8,8 @@
 #[cfg(test)]
 mod array_rest;
 #[cfg(test)]
+mod callable_throws_scope;
+#[cfg(test)]
 mod explicit_type_args;
 #[cfg(test)]
 mod inference;

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -251,6 +251,82 @@ async fn mounted_method_stubs_do_not_shadow_their_owner() {
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
 
+/// A host interface whose declaration carries a generic parameter bound, a
+/// `requires` clause, and an associated type with a default, implemented by
+/// runtime-compiled source across a mount. The implementor omits the
+/// defaulted associated type, satisfies `requires` through a second
+/// `implements` block, and binds the bounded parameter to a marker class.
+const MOUNTED_INTERFACE_CONTRACT_SOURCE: &str = r####"
+interface Marker {}
+interface Named {
+  function name(self) -> string throws never
+}
+interface Counter<T extends Marker> requires Named {
+  type Value = int
+  function count(self, at: T) -> int throws never
+  function label(self, at: T) -> string throws never {
+    self.name() + "=" + self.count(at).to_string()
+  }
+}
+
+class Tag {
+  weight int
+  implements Marker {}
+}
+
+function compile_counter_plugin() -> reflect.Package {
+  reflect.Package.compile(
+    { "plugin.baml": `
+class Tally {
+  n int
+  implements app.Named {
+    function name(self) -> string throws never { "tally" }
+  }
+  implements app.Counter<app.Tag> {
+    function count(self, at: app.Tag) -> int throws never { self.n + at.weight }
+  }
+}
+
+function label_tally(n: int) -> string throws never {
+  Tally { n: n }.label(app.Tag { weight: 1 })
+}
+` },
+    packages = { "app": reflect.Package.current() },
+  )
+}
+
+function contract_mount_is_clean() -> bool {
+  compile_counter_plugin().diagnostics().length() == 0
+}
+
+function main() -> string {
+  let pkg = compile_counter_plugin()
+  let label = pkg.get_function<(int) -> string>("root.label_tally")
+    ?? throw "missing label_tally"
+  label(40)
+}
+"####;
+
+/// The mount's interface stub carries the declaration's whole contract
+/// (parameter bounds, `requires`, associated-type bounds and defaults), so a
+/// runtime-compiled implementor may rely on an associated-type default and
+/// the inherited `requires` interface, and the host's default method calls
+/// through it. A stub that dropped the default rejected the implementor for
+/// not binding `Value`.
+#[tokio::test]
+async fn mounted_interface_stub_keeps_its_contract() {
+    let output = baml_test!(
+        baml: MOUNTED_INTERFACE_CONTRACT_SOURCE,
+        entry: "contract_mount_is_clean"
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+    let output = baml_test!(baml: MOUNTED_INTERFACE_CONTRACT_SOURCE);
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("tally=41".into()))
+    );
+}
+
 /// `baml.ToString` is implemented for `reflect.Type` out-of-body in the
 /// stdlib. A runtime compile has no stdlib source to devirtualize that call
 /// against, so it must dispatch — it used to reach the emitter as a static

--- a/baml_language/crates/bex_engine/tests/fire_and_forget.rs
+++ b/baml_language/crates/bex_engine/tests/fire_and_forget.rs
@@ -642,3 +642,55 @@ async fn combinator_observation_is_not_preempted_by_unrelated_await() {
     "#;
     assert_eq!(run_main(source).await.unwrap(), BexExternalValue::Int(42));
 }
+
+#[tokio::test]
+async fn reported_host_value_is_reclaimed_by_subsequent_collection() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use bex_resource_types::{HostValueArc, HostValueKind, host_release_dispatch};
+
+    const KEY: u64 = 9_100_001;
+    static RELEASES: AtomicUsize = AtomicUsize::new(0);
+    extern "C" fn released(key: u64) {
+        if key == KEY {
+            RELEASES.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    host_release_dispatch::install(released).unwrap();
+    let engine = make_engine(
+        r#"
+        function main<T>(value: T) -> int {
+            spawn { throw value; };
+            1
+        }
+    "#,
+    );
+    let reports = Arc::new(AtomicUsize::new(0));
+    let reports_for_handler = reports.clone();
+    engine.set_unhandled_spawn_error_handler(Some(Arc::new(move |_error| {
+        reports_for_handler.fetch_add(1, Ordering::SeqCst);
+    })));
+    let host = HostValueArc::new(KEY, HostValueKind::Opaque);
+    let weak = Arc::downgrade(&host);
+    let result = engine
+        .call_function(
+            "main",
+            vec![BexExternalValue::HostValue(host)],
+            FunctionCallContextBuilder::new(sys_types::CallId::next()).build(),
+            true,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result, BexExternalValue::Int(1));
+    wait_for_spawn_completion(&engine).await;
+    engine.collect_garbage(CollectionLevel::Major).await;
+    assert_eq!(reports.load(Ordering::SeqCst), 1);
+    // The reporting collection keeps an object-valued throw rooted while it
+    // materializes the notification. A subsequent collection reclaims that
+    // now-unrooted VM object; releasing the notification alone cannot free it.
+    engine.collect_garbage(CollectionLevel::Major).await;
+    assert!(weak.upgrade().is_none());
+    assert_eq!(RELEASES.load(Ordering::SeqCst), 1);
+    // No later call, explicit release, or runtime shutdown drives cleanup.
+    engine.shutdown().await;
+}

--- a/baml_language/crates/bex_project/src/runtime_compile.rs
+++ b/baml_language/crates/bex_project/src/runtime_compile.rs
@@ -586,6 +586,8 @@ fn enrich_runtime_mount(
                 ExportedType::Interface {
                     qtn,
                     generic_params,
+                    param_bounds,
+                    requires,
                     associated_types,
                     fields,
                     required_methods,
@@ -594,18 +596,66 @@ fn enrich_runtime_mount(
                 } => {
                     let namespace = qtn.namespace().clone();
                     let name = qtn.name().clone();
+                    // The stub is the interface the consumer's type checker
+                    // sees, so it must carry the declaration's whole contract:
+                    // parameter bounds, the `requires` closure, and each
+                    // associated type's bound and default. Dropping them let a
+                    // consumer bind an unbounded argument, skip a required
+                    // interface, and forced it to spell every defaulted
+                    // associated type. A bound this world cannot name is
+                    // dropped rather than widened, as for method generics.
+                    let spell_bound = |bound: &baml_type::Interface<TypeName>| {
+                        (!viewpoint.hides_interface(bound)).then(|| {
+                            baml_type::Ty::Interface(
+                                bound.name.clone(),
+                                bound.generics.clone(),
+                                bound.associated_types.clone(),
+                                baml_type::TyAttr::default(),
+                            )
+                            .to_string()
+                        })
+                    };
                     let generics = generic_params
                         .iter()
-                        .map(ToString::to_string)
+                        .enumerate()
+                        .map(|(index, param)| {
+                            let bounds = param_bounds
+                                .get(index)
+                                .map(|bounds| bounds.iter().filter_map(spell_bound).collect())
+                                .unwrap_or_else(Vec::new);
+                            if bounds.is_empty() {
+                                param.to_string()
+                            } else {
+                                format!("{param} extends {}", bounds.join(" & "))
+                            }
+                        })
                         .collect::<Vec<_>>();
                     let generic_suffix = if generics.is_empty() {
                         String::new()
                     } else {
                         format!("<{}>", generics.join(", "))
                     };
-                    let mut source = format!("interface {name}{generic_suffix} {{\n");
-                    for associated in associated_types {
-                        writeln!(&mut source, "  type {}", associated.name)
+                    let required = requires.iter().filter_map(spell_bound).collect::<Vec<_>>();
+                    let requires_suffix = if required.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" requires {}", required.join(", "))
+                    };
+                    let mut source =
+                        format!("interface {name}{generic_suffix}{requires_suffix} {{\n");
+                    for associated in associated_types.iter() {
+                        let bound = associated
+                            .bound
+                            .as_ref()
+                            .and_then(spell_bound)
+                            .map(|bound| format!(" extends {bound}"))
+                            .unwrap_or_default();
+                        let default = associated
+                            .default
+                            .as_ref()
+                            .map(|default| format!(" = {}", stub_type(default, &viewpoint)))
+                            .unwrap_or_default();
+                        writeln!(&mut source, "  type {}{bound}{default}", associated.name)
                             .expect("writing to String is infallible");
                     }
                     for (field, ty, attrs) in fields {
@@ -2825,6 +2875,101 @@ mod tests {
         assert_eq!(
             free_stub("make"),
             "function make(name: unknown) -> string { $rust_function }\n"
+        );
+    }
+
+    /// An interface stub carries the declaration's whole contract: generic
+    /// parameter bounds, the `requires` closure, and associated-type bounds
+    /// and defaults - not just the names.
+    #[test]
+    fn runtime_mount_interface_stubs_keep_bounds_requires_and_associated_types() {
+        use baml_compiler2_hir_ty::{
+            callable::{ExternalCallTarget, ExternalLinkability},
+            package_interface::{ExportedAssociatedType, ExportedFunction, ExportedType},
+        };
+        use baml_type::{FunctionParamTy, ParamTy, Ty, TyAttr};
+
+        let app = Name::new("app");
+        let qtn = |name: &str| {
+            baml_type::QualifiedTypeName::new(app.clone(), Vec::new(), Name::new(name))
+        };
+        let iface = |name: &str| baml_type::Interface::new(qtn(name), Box::new([]), Box::new([]));
+        let self_param = ParamTy::new(0, Name::new("Self"));
+        let value_param = ParamTy::new(1, Name::new("T"));
+        let counter = qtn("Counter");
+        let count = ExportedFunction {
+            name: Name::new("count"),
+            params: vec![
+                FunctionParamTy::required(
+                    Some(Name::new("self")),
+                    Ty::TypeVar(self_param.clone(), TyAttr::default()),
+                ),
+                FunctionParamTy::required(
+                    Some(Name::new("at")),
+                    Ty::TypeVar(value_param.clone(), TyAttr::default()),
+                ),
+            ],
+            return_type: Ty::int(),
+            callable_throws: Ty::Never {
+                attr: TyAttr::default(),
+            },
+            generic_params: Vec::new(),
+            generic_param_bounds: Vec::new(),
+            builtin_kind: None,
+            target: ExternalCallTarget::Interface {
+                interface: counter.clone(),
+                method: Name::new("count"),
+            },
+            linkability: ExternalLinkability::Linkable,
+        };
+        let mut root = IndexMap::new();
+        root.insert(
+            Name::new("Counter"),
+            ExportedType::Interface {
+                qtn: counter,
+                self_param,
+                generic_params: vec![value_param],
+                param_bounds: vec![vec![iface("Marker")]],
+                requires: vec![iface("Named")],
+                associated_types: vec![ExportedAssociatedType {
+                    name: Name::new("Value"),
+                    bound: Some(iface("Anchor")),
+                    default: Some(Ty::int()),
+                }],
+                fields: Vec::new(),
+                required_methods: vec![count],
+                default_methods: Vec::new(),
+            },
+        );
+        let mut types = IndexMap::new();
+        types.insert(Vec::new(), root);
+        let interface = PackageInterface {
+            types,
+            functions: IndexMap::new(),
+            throw_sets: FunctionThrowSets::default(),
+            namespaces: std::collections::BTreeSet::default(),
+            impls: Vec::new(),
+        };
+        let interface_blob =
+            baml_artifact::encode(baml_artifact::ArtifactKind::PackageInterface, &interface)
+                .expect("package interface encodes");
+        let package = RuntimePackageMount {
+            identity: bex_vm_types::RuntimePackageIdentity::synthetic(1),
+            interface_blob,
+            types: Vec::new(),
+        };
+        let (_, stubs) = enrich_runtime_mount(&[Name::new("app")], &[Name::new("app")], package)
+            .expect("runtime mount enriches");
+        let (namespace, name, source) = stubs
+            .iter()
+            .find(|(_, stub, _)| stub.as_str() == "Counter")
+            .unwrap_or_else(|| panic!("missing stub for Counter: {stubs:?}"));
+        assert!(namespace.is_empty());
+        assert_eq!(name.as_str(), "Counter");
+        assert_eq!(
+            source,
+            "interface Counter<T extends app.Marker> requires app.Named {\n  type Value extends \
+             app.Anchor = int\n  function count(self, at: T) -> int throws never\n}\n"
         );
     }
 

--- a/baml_language/crates/bridge_cffi/src/baml_to_host.rs
+++ b/baml_language/crates/bridge_cffi/src/baml_to_host.rs
@@ -199,6 +199,15 @@ pub fn result_to_outbound(
             infra_error_arm(message_instance(TYPE_MISMATCH_CLASS, message), options)
         }
 
+        // 🟥 Calling a function the program does not define is a *caller*
+        // error, not an SDK panic: route it to `baml.errors.InvalidArgument`
+        // like the pre-call `BridgeError::FunctionNotFound` in
+        // [`error_to_outbound`].
+        Err(RuntimeError::Engine(err @ EngineError::FunctionNotFound { .. })) => infra_error_arm(
+            message_instance(INVALID_ARGUMENT_CLASS, err.to_string()),
+            options,
+        ),
+
         // Every other 🟥 engine/VM-internal failure → one opaque `SdkPanic`,
         // its `Display` (incl. any formatted VM trace) carried as `message`.
         Err(RuntimeError::Engine(engine_err)) => sdk_panic_arm(engine_err.to_string(), options),
@@ -445,6 +454,26 @@ mod tests {
         let envelope = BamlOutboundResult::decode(encoded.as_slice()).unwrap();
         let Some(baml_outbound_result::Result::Error(error)) = envelope.result else {
             panic!("expected an error envelope");
+        };
+        let Some(baml_outbound_value::Value::ClassValue(class)) =
+            error.value.and_then(|value| value.value)
+        else {
+            panic!("expected a structured error class");
+        };
+        assert_eq!(class.name, "baml.errors.InvalidArgument");
+    }
+
+    #[test]
+    fn engine_function_not_found_is_classified_as_invalid_argument() {
+        let err = BridgeError::Runtime(bex_project::RuntimeError::Engine(
+            bex_project::EngineError::FunctionNotFound {
+                name: "missing_function".to_string(),
+            },
+        ));
+        let encoded = error_to_outbound(err);
+        let envelope = BamlOutboundResult::decode(encoded.as_slice()).unwrap();
+        let Some(baml_outbound_result::Result::Error(error)) = envelope.result else {
+            panic!("a missing function is a caller error, not an SdkPanic");
         };
         let Some(baml_outbound_value::Value::ClassValue(class)) =
             error.value.and_then(|value| value.value)

--- a/baml_language/crates/bridge_cffi/src/ffi/handle.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/handle.rs
@@ -122,9 +122,12 @@ pub unsafe extern "C" fn baml_handle_clone(key: u64, out_key: *mut u64) -> BamlC
 /// accept an `InvalidHandle` status.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn baml_handle_release(key: u64) -> BamlCffiStatus {
-    match handle::release_handle(key) {
-        Ok(()) => BamlCffiStatus::Ok,
-        Err(error) => error.into(),
+    // The last release runs the entry's destructor (RustData / ADT resource
+    // cleanup). A panic there must not unwind across the C ABI.
+    match std::panic::catch_unwind(|| handle::release_handle(key)) {
+        Ok(Ok(())) => BamlCffiStatus::Ok,
+        Ok(Err(error)) => error.into(),
+        Err(_) => BamlCffiStatus::InternalError,
     }
 }
 

--- a/baml_language/crates/bridge_cffi/tests/handle_release.rs
+++ b/baml_language/crates/bridge_cffi/tests/handle_release.rs
@@ -1,0 +1,27 @@
+//! `baml_handle_release` is a C ABI entry point: the last release of a key
+//! runs the entry's destructor, and a panic there must be reported as a
+//! status rather than unwinding into the caller.
+use std::sync::Arc;
+
+use bridge_ctypes::{CffiHandleTableEntry, HANDLE_TABLE};
+
+#[test]
+fn resource_cleanup_panic_stays_inside_handle_release_abi() {
+    struct PanicOnDrop;
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            panic!("synthetic resource cleanup failure");
+        }
+    }
+    let key = HANDLE_TABLE.insert(
+        CffiHandleTableEntry::try_from(bex_project::BexExternalValue::RustData(Arc::new(
+            PanicOnDrop,
+        )))
+        .unwrap(),
+    );
+    assert_eq!(
+        unsafe { bridge_cffi::baml_handle_release(key) },
+        bridge_cffi::BamlCffiStatus::InternalError,
+    );
+    assert!(HANDLE_TABLE.resolve(key).is_none());
+}

--- a/baml_language/crates/bridge_ctypes/src/handle_table.rs
+++ b/baml_language/crates/bridge_ctypes/src/handle_table.rs
@@ -255,25 +255,33 @@ impl CffiHandleTable {
     /// The row (and its dedup index entry) is removed when the last
     /// ownership is released.
     pub fn release(&self, key: u64) -> bool {
-        let mut entries = self
-            .entries
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let Some(row) = entries.get_mut(&key) else {
-            return false;
-        };
-        row.refcount -= 1;
-        if row.refcount == 0 {
-            let row = entries
-                .remove(&key)
-                .unwrap_or_else(|| unreachable!("row was just read under the same write lock"));
-            if let CffiHandleTableEntry::BexHeapHandle(handle) = &*row.value {
-                self.heap_keys
-                    .write()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .remove(handle);
+        let removed = {
+            let mut entries = self
+                .entries
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let Some(row) = entries.get_mut(&key) else {
+                return false;
+            };
+            row.refcount -= 1;
+            if row.refcount == 0 {
+                let row = entries
+                    .remove(&key)
+                    .unwrap_or_else(|| unreachable!("row was just read under the same write lock"));
+                if let CffiHandleTableEntry::BexHeapHandle(handle) = &*row.value {
+                    self.heap_keys
+                        .write()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .remove(handle);
+                }
+                Some(row)
+            } else {
+                None
             }
-        }
+        };
+        // RustData/ADT destructors may reenter the bridge. Never run the last
+        // value destructor while holding a handle-table write lock.
+        drop(removed);
         true
     }
 
@@ -400,6 +408,28 @@ mod tests {
         let key = table.insert(make_function_ref());
         assert!(table.release(key));
         assert!(!table.release(key)); // second release returns false
+    }
+
+    #[test]
+    fn last_release_drops_resource_after_unlocking_table() {
+        struct Resource(
+            std::sync::Weak<CffiHandleTable>,
+            Arc<std::sync::atomic::AtomicBool>,
+        );
+        impl Drop for Resource {
+            fn drop(&mut self) {
+                let table = self.0.upgrade().unwrap();
+                assert!(table.entries.try_write().is_ok());
+                assert!(table.heap_keys.try_write().is_ok());
+                self.1.store(true, Ordering::SeqCst);
+            }
+        }
+        let table = Arc::new(CffiHandleTable::new());
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let resource = Arc::new(Resource(Arc::downgrade(&table), dropped.clone()));
+        let key = table.insert(CffiHandleTableEntry::RustData(BexRustData(resource)));
+        assert!(table.release(key));
+        assert!(dropped.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/baml_language/sdk_tests/README.md
+++ b/baml_language/sdk_tests/README.md
@@ -20,7 +20,7 @@ cargo nextest run -p sdk_test_python_pydantic2 function_calls::pytest
 cargo nextest run -p sdk_test_typescript function_calls::vitest_node
 cargo nextest run -p sdk_test_typescript_web function_calls::vitest_web
 cargo nextest run -p sdk_test_typescript_web function_calls::vitest_workers
-cargo nextest run -p sdk_test_rust function_calls::cargo_test
+cargo nextest run -p sdk_test_rust function_calls::nextest
 ```
 
 > SDK tests are designed to be run using `cargo nextest run` and will > fail in
@@ -47,8 +47,9 @@ cargo nextest run -p sdk_test_typescript function_calls::vitest_node
 
 # rust: run tests matching a name filter (set CARGO_TARGET_DIR to reuse the
 # shared build cache the nextest-driven runs populate).
-cargo nextest run -p sdk_test_rust function_calls::cargo_test
-(cd sdk_tests/crates/rust/function_calls/generated && CARGO_TARGET_DIR=../../../../../target/sdk-rust-target cargo test optional_args)
+cargo nextest run -p sdk_test_rust function_calls::nextest
+CARGO_TARGET_DIR="$PWD/target/sdk-rust-target" cargo nextest run \
+  --manifest-path sdk_tests/crates/rust/function_calls/generated/Cargo.toml optional_args
 ```
 
 ### Rust port gating

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_errors.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_errors.py
@@ -32,7 +32,13 @@ import traceback
 import pytest
 
 import baml_sdk  # noqa: F401  — importing initializes the BAML runtime
-from baml_bridge import BamlCallContext, BamlCancelledError, call_function, get_runtime
+from baml_bridge import (
+    BamlCallContext,
+    BamlCancelledError,
+    call_function,
+    call_function_sync,
+    get_runtime,
+)
 from baml_sdk import hello_world
 from baml_sdk.baml import BamlError, BamlPanic
 from baml_sdk.baml.errors import InvalidArgument
@@ -93,6 +99,19 @@ def test_errors_host_invalid_argument_wraps_baml_errors_invalid_argument():
     synthesized host-side rather than thrown from the VM."""
     with pytest.raises(BamlError) as exc_info:
         hello_world(not_a_param=2)  # type: ignore[call-arg]
+    assert isinstance(exc_info.value.value, InvalidArgument)
+
+
+# SDK_PARITY_LINT(skip): calls the Python bridge by name; a generated surface cannot reference an undefined function
+def test_errors_missing_function_is_invalid_argument():
+    """Calling a function the program does not define is a *caller* error:
+    the engine's `FunctionNotFound` is classified as
+    `baml.errors.InvalidArgument` (matching the host-side pre-call arm), not
+    as an `SdkPanic`. With the generated SDK loaded the payload decodes to
+    the generated `InvalidArgument` model."""
+    with pytest.raises(BamlError, match="Function not found") as exc_info:
+        call_function_sync(get_runtime(), "user.missing_function", {})
+    assert exc_info.value.class_name == "baml.errors.InvalidArgument"
     assert isinstance(exc_info.value.value, InvalidArgument)
 
 

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
@@ -20,7 +20,9 @@ from typing import Any, Generator
 import pytest
 
 import baml_sdk  # noqa: F401  — initializes the BAML runtime
+from baml_bridge import flush_events
 from baml_sdk.baml import BamlError
+from baml_sdk.baml.sys import collect_garbage
 from baml_sdk.host_callable_tests import (
     Person,
     ValidationError,
@@ -229,19 +231,20 @@ def test_host_callables_multiple_throws_in_flight_do_not_collide_in_registry():
     assert ei1.value is not ei2.value
 
 
-@pytest.mark.xfail(
-    reason="host-callable release fires only when the engine GCs the "
-    "Object::HostClosure on its heap; one BAML call rarely triggers "
-    "the GC heuristic, so for now the callable leaks until the engine "
-    "collects.",
-    strict=False,
-)
 def test_host_callables_release_fires_on_drop_of_callable():
-    """After BAML finishes invoking the callable and the engine GCs the
+    """After BAML finishes invoking the callable and the engine collects the
     `Object::HostClosure` it allocated, the registered release callback
     removes the Python callable from the bridge's host-value table.
     Dropping the user's last reference then leaves the object
     unreachable for the cycle collector.
+
+    Keeping the default runtime installed must not keep dead callbacks
+    alive. A single BAML call rarely trips the engine's own GC heuristic,
+    so `baml.sys.collect_garbage` makes the ownership handoff
+    deterministic: its collection safepoint drains the queued host release
+    and the bridge drops its registry entry. `flush_events()` first clears
+    the event sink's argument-snapshot clone, which would otherwise keep
+    the closure reachable.
     """
 
     class CallableObj:
@@ -252,9 +255,16 @@ def test_host_callables_release_fires_on_drop_of_callable():
     wr = weakref.ref(cb)
     result = call_with_callback(callback=cb, x=3)
     assert result == "3"
-    del cb
+    del cb, result
+    flush_events()
+    collect_garbage()
+    flush_events()
     gc.collect()
-    assert wr() is None, "host callable should be released after BAML drops it"
+    assert wr() is None, (
+        "host callable should be released after BAML collected its HostClosure"
+    )
+    # The runtime is still usable after the release.
+    assert call_int_callback(callback=lambda x: x + 1, x=1) == 2
 
 
 def test_host_callables_lambda_round_trip():

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_host_callables.py
@@ -12,8 +12,10 @@ encodes the result back to the engine.
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import weakref
+from typing import Any, Generator
 
 import pytest
 
@@ -26,6 +28,7 @@ from baml_sdk.host_callable_tests import (
     call_callback_with_optional_args_all_unset,
     call_callback_with_optional_args_partially_set,
     call_int_callback,
+    call_int_callback_async,
     call_repeatedly,
     call_with_callback,
     call_with_class_callback,
@@ -190,7 +193,7 @@ def test_host_callables_throwing_callable_bamlerror_propagates_back_with_typed_f
 
 
 def test_host_callables_throwing_async_callable_round_trips_original_python_exception():
-    """Async callables go through the same `run_if_coroutine` dispatch
+    """Async callables go through the same `run_if_awaitable` dispatch
     path; native exceptions raised inside the coroutine should round-trip
     by identity just like the sync case."""
     raised = ValueError("async nope")
@@ -263,7 +266,7 @@ def test_host_callables_lambda_round_trip():
 
 
 def test_host_callables_async_callable_runs_to_completion():
-    """Async callables are detected (via `asyncio.iscoroutine` on the
+    """Async callables are detected (via `inspect.isawaitable` on the
     return value) and run to completion on a fresh asyncio loop inside
     the dispatch thread."""
 
@@ -275,6 +278,56 @@ def test_host_callables_async_callable_runs_to_completion():
 
     result = call_with_callback(callback=cb, x=4)
     assert result == "async-4"
+
+
+# SDK_PARITY_LINT(skip): Python-specific dispatch — any `inspect.isawaitable` return is driven, not only coroutines
+def test_host_callables_callable_returning_non_coroutine_awaitable_is_awaited():
+    """Any awaitable return (`inspect.isawaitable`), not only a coroutine,
+    is driven to completion — a callback may hand back a task-like object
+    or a custom `__await__` wrapper rather than a bare coroutine."""
+
+    class Deferred:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def __await__(self) -> Generator[Any, None, str]:
+            yield from asyncio.sleep(0).__await__()
+            return self.value
+
+    def cb(x: int) -> Any:
+        return Deferred(f"deferred-{x}")
+
+    assert call_with_callback(callback=cb, x=5) == "deferred-5"
+
+
+# SDK_PARITY_LINT(skip): pins the Python bridge's blocking-pool callback dispatch (bridge_python host_value.rs)
+def test_host_callables_async_callable_can_await_a_reentrant_baml_call():
+    """An async callback that itself awaits a BAML call must not deadlock.
+
+    The dispatch runs the callback's private asyncio loop on a Tokio
+    *blocking* thread; blocking an async worker instead could strand the
+    reentrant call's freshly spawned work in that worker's local queue
+    while the callback waits for it.
+    """
+
+    async def cb(x: int) -> str:
+        inner = await call_int_callback_async(callback=lambda y: y * 2, x=x)
+        return f"outer-{inner}"
+
+    assert call_with_callback(callback=cb, x=21) == "outer-42"
+
+
+# SDK_PARITY_LINT(skip): pins the Python bridge's blocking-pool callback dispatch (bridge_python host_value.rs)
+def test_host_callables_sync_callable_can_make_a_reentrant_sync_baml_call():
+    """A sync callback may block on a nested BAML call: the dispatch thread
+    is a blocking-pool thread, never an async worker (where `block_on`
+    would panic)."""
+
+    def cb(x: int) -> str:
+        inner = call_int_callback(callback=lambda y: y + 1, x=x)
+        return f"outer-{inner}"
+
+    assert call_with_callback(callback=cb, x=1) == "outer-2"
 
 
 def test_host_callables_multiple_callable_keys_are_distinct():

--- a/baml_language/sdk_tests/crates/rust/setup.ps1
+++ b/baml_language/sdk_tests/crates/rust/setup.ps1
@@ -41,10 +41,10 @@ Get-ChildItem -Directory | ForEach-Object {
             Write-Host "==> skipping $($_.Name)/generated (no Cargo.toml - codegen failed?)"
             return
         }
-        Write-Host "==> cargo test --no-run in $($_.Name)/generated"
-        Push-Location $generated
+        Write-Host "==> nextest pre-warm for $($_.Name)/generated"
+        Push-Location $WorkspaceRoot
         try {
-            cargo test --no-run --manifest-path Cargo.toml
+            cargo nextest list --list-type binaries-only --manifest-path $manifest
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         } finally {
             Pop-Location

--- a/baml_language/sdk_tests/crates/rust/setup.sh
+++ b/baml_language/sdk_tests/crates/rust/setup.sh
@@ -3,17 +3,16 @@
 #
 # Invoked automatically by `cargo nextest run` via the setup-script
 # binding in `baml_language/.config/nextest.toml` — whenever the run
-# selects any sdk_test_rust test. For plain `cargo test` (no nextest)
-# run this manually after `cargo test --no-run` populates each
-# fixture's `generated/` crate.
+# selects any sdk_test_rust test. Run the outer harness through nextest;
+# its build script populates each fixture's generated crate first.
 #
 # Unlike the python/node targets there is no package manager or native
 # addon to install — the only toolchain is cargo itself. What this
 # script buys:
 #
-#   1. A serial `cargo test --no-run` per fixture into the shared
+#   1. A serial `cargo nextest list --list-type binaries-only` per fixture into the shared
 #      CARGO_TARGET_DIR pre-builds the bridge_rust → BEX runtime stack
-#      once, so the test-time `cargo clippy` / `cargo test` invocations
+#      once, so the test-time `cargo clippy` / `cargo nextest run` invocations
 #      (which nextest fans out in parallel, all flock-queueing on the
 #      same target dir) hit a warm cache instead of racing a cold build.
 #
@@ -51,8 +50,9 @@ for fixture_dir in */generated; do
         echo "==> skipping $fixture_dir (no Cargo.toml — codegen failed?)"
         continue
     fi
-    echo "==> cargo test --no-run in $fixture_dir"
-    (cd "$fixture_dir" && cargo test --no-run --manifest-path Cargo.toml)
+    fixture_manifest="$WORKSPACE_ROOT/sdk_tests/crates/rust/$fixture_dir/Cargo.toml"
+    echo "==> nextest pre-warm for $fixture_dir"
+    (cd "$WORKSPACE_ROOT" && cargo nextest list --list-type binaries-only --manifest-path "$fixture_manifest")
 done
 
 # Per-run breadcrumb for the in-test guard. nextest reads $NEXTEST_ENV

--- a/baml_language/sdk_tests/crates/rust/type_shapes/customizable/roundtrip_tests/test_primitives.rs
+++ b/baml_language/sdk_tests/crates/rust/type_shapes/customizable/roundtrip_tests/test_primitives.rs
@@ -63,6 +63,9 @@ fn test_primitives_round_trip_float_accepts_int() {
     // the wire is inexpressible through it. Go through the low-level invoke
     // API instead so the wire-level intent (int out, float back) is
     // preserved.
+    // The generated wrappers initialize the runtime lazily; a raw invoke
+    // does not, and under nextest this test is its own process.
+    baml_sdk::init().unwrap();
     let int_on_the_wire = baml_bridge::wire::InboundValue {
         value_type: None,
         value: Some(baml_bridge::wire::inbound_value::Value::IntValue(7)),

--- a/baml_language/sdk_tests/harness_runner/src/lib.rs
+++ b/baml_language/sdk_tests/harness_runner/src/lib.rs
@@ -255,6 +255,94 @@ fn run_test_cmd_with_env_allowing_exit_codes(
     );
 }
 
+/// Run Cargo for a generated Rust fixture from the BAML workspace root.
+/// Structured arguments preserve paths containing spaces.
+///
+/// Never spawn cargo without the generated manifest in place: cargo
+/// discovers manifests *upward*, so in its absence a fixture-level cargo
+/// invocation would silently become a workspace-wide one — re-entering this
+/// very test suite and forking cargo processes without bound. The explicit
+/// `--manifest-path` pin below is the second layer of the same defense.
+pub fn run_rust_fixture_cargo(fixture: &str, args: &[&str], extra_env: &[(&str, &str)]) {
+    let sdk_manifest = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set; run via nextest"),
+    );
+    let manifest = sdk_manifest.join(fixture).join("generated/Cargo.toml");
+    assert!(
+        manifest.is_file(),
+        "{} is missing — codegen failed for this fixture (see the build_diagnostics \
+         test); refusing to run cargo without it",
+        manifest.display(),
+    );
+    let workspace_root = workspace_root_from_manifest(&sdk_manifest);
+    let mut command = rust_fixture_cargo_command(workspace_root, &manifest, args);
+    command.env(
+        "CARGO_TARGET_DIR",
+        workspace_root.join("target/sdk-rust-target"),
+    );
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    let output = command.output().unwrap_or_else(|error| {
+        panic!("failed to spawn Cargo for Rust fixture {fixture}: {error}")
+    });
+    assert!(
+        output.status.success(),
+        "Rust fixture {fixture} cargo {args:?} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn rust_fixture_cargo_command(workspace_root: &Path, manifest: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new("cargo");
+    // The manifest option belongs before rustc/clippy/test-binary arguments.
+    let split = args
+        .iter()
+        .position(|arg| *arg == "--")
+        .unwrap_or(args.len());
+    command
+        .args(&args[..split])
+        .arg("--manifest-path")
+        .arg(manifest);
+    command.args(&args[split..]).current_dir(workspace_root);
+    // An inner nextest run must never append to an outer setup script's file.
+    command.env_remove("NEXTEST_ENV");
+    command
+}
+
+#[cfg(test)]
+mod rust_fixture_tests {
+    use super::*;
+
+    #[test]
+    fn cargo_uses_workspace_cwd_and_keeps_manifest_before_tool_arguments() {
+        let root = Path::new("/checkout with spaces/baml_language");
+        let manifest = root.join("sdk_tests/crates/rust/function_calls/generated/Cargo.toml");
+        for args in [
+            vec!["nextest", "run"],
+            vec!["clippy", "--", "-D", "warnings"],
+        ] {
+            let command = rust_fixture_cargo_command(root, &manifest, &args);
+            assert_eq!(command.get_current_dir(), Some(root));
+            let actual: Vec<_> = command.get_args().collect();
+            let pin = actual
+                .iter()
+                .position(|arg| *arg == "--manifest-path")
+                .unwrap();
+            assert_eq!(actual[pin + 1], manifest.as_os_str());
+            if let Some(separator) = actual.iter().position(|arg| *arg == "--") {
+                assert!(pin < separator);
+            }
+            assert!(
+                command
+                    .get_envs()
+                    .any(|(key, value)| key == "NEXTEST_ENV" && value.is_none())
+            );
+        }
+    }
+}
+
 fn workspace_root_from_manifest(manifest: &Path) -> &Path {
     manifest
         .ancestors()

--- a/baml_language/sdk_tests/harness_setup/src/rust.rs
+++ b/baml_language/sdk_tests/harness_setup/src/rust.rs
@@ -209,7 +209,7 @@ pub fn run_all() {
         codegen_fixture(&fixtures_root, fixture, &manifest_dir, &mut diagnostics);
     }
 
-    // Toolchain pre-warm (`cargo test --no-run` per fixture) is NOT run
+    // Toolchain pre-warm (`cargo nextest list --list-type binaries-only` per fixture) is NOT run
     // here — it lives in `crates/rust/setup.sh`, fired by `cargo nextest
     // run` (see module docs), so `cargo check` / `cargo doc` of the
     // workspace never build the fixture crates.
@@ -395,8 +395,8 @@ fn render_tests_main(fixture: &str) -> String {
 /// `tests/main.rs` (rustfmt follows the enabled `mod` declarations;
 /// generated `src/` is intentionally not rustfmt-checked — the emitter's
 /// pretty-printer is its canonical format), `clippy` lints the generated
-/// library, and `cargo_test` compiles and runs the enabled ports.
-/// `cargo_test` alone gets `BAML_LIBRARY_PATH`: `baml_bridge` is
+/// library, and `nextest` compiles and runs the enabled ports.
+/// `nextest` alone gets `BAML_LIBRARY_PATH`: `baml_bridge` is
 /// dylib-only, so the fixture's tests load the engine cdylib at run time
 /// (built by the setup script; fmt/clippy never execute the engine).
 fn write_fixtures_tests_rs(out_dir: &Path, fixtures: &[String]) {
@@ -438,53 +438,28 @@ fn write_fixtures_tests_rs(out_dir: &Path, fixtures: &[String]) {
         let fmt_cmd = format!("rustfmt --edition {GENERATED_EDITION} --check tests/main.rs");
         items.extend(quote::quote! {
             mod #mod_ident {
-                fn cmd_env(c: &str, extra_env: &[(&str, &str)]) {
-                    // Never spawn cargo without the generated manifest in
-                    // place: cargo discovers manifests *upward*, so in its
-                    // absence a fixture-level `cargo test` would silently
-                    // become a workspace-wide one — re-entering this very
-                    // test suite and forking cargo processes without bound.
-                    // (The `--manifest-path Cargo.toml` pin on the commands
-                    // below is the second layer of the same defense.)
-                    let manifest = ::std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                        .join(#fixture)
-                        .join("generated")
-                        .join("Cargo.toml");
-                    assert!(
-                        manifest.exists(),
-                        "{} is missing — codegen failed for this fixture \
-                         (see the build_diagnostics test); refusing to run \
-                         cargo without it",
-                        manifest.display(),
-                    );
-                    ::sdk_test_harness_runner::run_test_cmd_with_env(
-                        #fixture,
-                        c,
-                        #CACHE_SUBDIR,
-                        #CACHE_ENV_VAR,
-                        extra_env,
-                    );
-                }
-
-                fn cmd(c: &str) {
-                    cmd_env(c, &[]);
-                }
-
                 #[test]
                 fn fmt() {
-                    cmd(#fmt_cmd);
+                    ::sdk_test_harness_runner::run_test_cmd(
+                        #fixture, #fmt_cmd, #CACHE_SUBDIR, #CACHE_ENV_VAR,
+                    );
                 }
 
                 #[test]
                 fn clippy() {
-                    cmd("cargo clippy --manifest-path Cargo.toml -- -D warnings");
+                    ::sdk_test_harness_runner::run_rust_fixture_cargo(
+                        #fixture, &["clippy", "--", "-D", "warnings"], &[],
+                    );
                 }
 
                 #[test]
-                fn cargo_test() {
+                fn nextest() {
                     let engine = super::engine_library();
-                    cmd_env(
-                        "cargo test --manifest-path Cargo.toml",
+                    // A fixture whose ports are all unsupported generates no
+                    // tests; `cargo test` accepted that and nextest must too.
+                    ::sdk_test_harness_runner::run_rust_fixture_cargo(
+                        #fixture,
+                        &["nextest", "run", "--no-tests=pass"],
                         &[
                             (
                                 "BAML_LIBRARY_PATH",

--- a/baml_language/sdks/python/rust/bridge_python/src/host_value.rs
+++ b/baml_language/sdks/python/rust/bridge_python/src/host_value.rs
@@ -13,11 +13,10 @@
 //! 1. Looks up the Python callable by `host_value_key`.
 //! 2. Decodes the `BamlOutboundValue` args into Python values via
 //!    `baml_bridge.proto._decode_value_holder` (already a list shape).
-//! 3. Invokes the callable. If the return is a coroutine, runs it to
+//! 3. Invokes the callable. If the return is awaitable, runs it to
 //!    completion on a fresh `asyncio` event loop. The dispatch runs on a
-//!    spawned tokio task (see [`host_dispatch_callback`]), so blocking that
-//!    task to drive the coroutine to completion does not stall the engine,
-//!    which concurrently awaits the call's completion.
+//!    Tokio blocking task (see [`host_dispatch_callback`]); the engine's
+//!    async workers remain free to run BAML calls made by the callback.
 //! 4. Encodes the result into `InboundValue` bytes via
 //!    `baml_bridge.proto.encode_call_args`-style serialization, then calls
 //!    `bridge_cffi::complete_host_call(call_id, 0, ptr, len)`.
@@ -238,9 +237,11 @@ pub extern "C" fn host_dispatch_callback(
     };
 
     // We're called on a tokio worker from the engine's sysop dispatch (see
-    // `sys_native::host_dispatch::fire_dispatch`). Spawn a task so the
-    // dispatch callback returns promptly and the engine can continue
-    // making progress on other work while Python runs.
+    // `sys_native::host_dispatch::fire_dispatch`). Python may block, including
+    // while its callback awaits a reentrant BAML call. Use the blocking pool:
+    // blocking an async worker can strand newly spawned work in its local
+    // queue and deadlock the callback waiting for that work, and a nested
+    // `block_on` from an async worker panics outright.
     //
     // The Python encode/decode and the user callable invocation happen
     // inside this task with the GIL held. Async user callables are run
@@ -287,7 +288,7 @@ pub extern "C" fn host_dispatch_callback(
         );
         return;
     };
-    handle.spawn(async move {
+    handle.spawn_blocking(move || {
         // A Rust-level *panic* (not a `PyErr`) inside `dispatch_in_python`
         // would unwind out of this task and silently drop the in-flight
         // `call_id`, leaving the engine awaiting it forever (there is no
@@ -341,9 +342,10 @@ fn dispatch_in_python(callable: Py<PyAny>, call_id: u32, args_bytes: Vec<u8>) {
         // own defaults apply.
         let result_obj = callable.call(py, &positional, Some(&kwargs))?;
 
-        // If the callable returned a coroutine (async function), run it to
-        // completion on a fresh asyncio loop. Sync callables fall through.
-        let final_result = run_if_coroutine(py, result_obj)?;
+        // If the callable returned an awaitable (a coroutine from an async
+        // function, or any `__await__`-bearing object), run it to completion
+        // on a fresh asyncio loop. Sync callables fall through.
+        let final_result = run_if_awaitable(py, result_obj)?;
 
         // Encode the result as an `InboundValue` via `baml_bridge.proto`.
         encode_result_inbound(py, final_result)
@@ -394,17 +396,25 @@ fn decode_args<'py>(
     Ok((positional, kwargs))
 }
 
-/// If `value` is a coroutine, run it to completion on a fresh asyncio loop
+/// If `value` is awaitable, run it to completion on a fresh asyncio loop
 /// and return the resolved result. Otherwise return `value` unchanged.
-fn run_if_coroutine(py: Python<'_>, value: Py<PyAny>) -> PyResult<Py<PyAny>> {
+///
+/// `inspect.isawaitable` rather than `asyncio.iscoroutine`: a callback may
+/// return a task-like object or a custom `__await__` wrapper, which
+/// `iscoroutine` rejects — such a value used to be encoded as a plain
+/// (unencodable) result instead of being awaited.
+fn run_if_awaitable(py: Python<'_>, value: Py<PyAny>) -> PyResult<Py<PyAny>> {
     let bound = value.bind(py);
     let asyncio = PyModule::import(py, "asyncio")?;
-    let is_coro: bool = asyncio.getattr("iscoroutine")?.call1((bound,))?.extract()?;
-    if !is_coro {
+    let is_awaitable: bool = PyModule::import(py, "inspect")?
+        .getattr("isawaitable")?
+        .call1((bound,))?
+        .extract()?;
+    if !is_awaitable {
         return Ok(value);
     }
     // Run the coroutine to completion on a new event loop in the current
-    // thread. The bridge is on a tokio worker — Python sees a fresh loop
+    // thread. The bridge is on the blocking pool — Python sees a fresh loop
     // dedicated to this dispatch only.
     let new_loop = asyncio.getattr("new_event_loop")?.call0()?;
     let set_event_loop = asyncio.getattr("set_event_loop")?;

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
@@ -189,7 +189,10 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 )
             }
         }
-        Ty::Void { .. } | Ty::Never { .. } => "None".to_string(),
+        Ty::Void { .. } => "None".to_string(),
+        // A function that never returns (`-> never`) is `NoReturn`, not
+        // `None`: `None` would let callers believe a value comes back.
+        Ty::Never { .. } => "typing.NoReturn".to_string(),
         // `$rust_type` fields in stdlib stubs (Response._body, SseStream._handle, …).
         // The host-language opaque-handle wrapper is `BamlPyHandle` from the
         // bridge runtime, imported as `_BamlPyHandle` to keep `baml` (the
@@ -562,6 +565,14 @@ mod tests {
                 },
                 ctx: ctx(&["lorem"]),
                 expected: "None",
+            },
+            Case {
+                label: "never",
+                ty: Ty::Never {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                ctx: ctx(&["lorem"]),
+                expected: "typing.NoReturn",
             },
             Case {
                 label: "baml options",

--- a/baml_language/sdks/python/src/baml_bridge/errors.py
+++ b/baml_language/sdks/python/src/baml_bridge/errors.py
@@ -2,7 +2,9 @@
 #
 # A thrown BAML value surfaces in Python as one of these *wrappers* carrying
 # the decoded value via `.value` (a plain pydantic model / enum / alias,
-# codegen'd by the normal rules) — see 31a-spec. The wrappers are raised by
+# codegen'd by the normal rules, or an SDK-owned `BamlFailureValue` for a
+# builtin failure no generated model describes) — see 31a-spec. The wrappers
+# are raised by
 # `decode_call_result` (proto.py) from the `BamlOutboundResult` envelope.
 #
 # They are deliberately plain Python classes: a BAML error type cannot itself
@@ -15,12 +17,36 @@ from __future__ import annotations
 import re
 import sys
 import types
-from typing import Any, List, Optional, TypeVar
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TypeVar
 
 # Wire trace line shape, e.g. `File "resume.baml", line 12, in user.extract`.
 _TRACE_LINE = re.compile(r'File "(?P<file>.*)", line (?P<line>\d+), in (?P<func>.*)')
 
 _E = TypeVar("_E", bound=BaseException)
+
+
+@dataclass
+class BamlFailureValue:
+    """SDK-owned payload for a builtin runtime failure (`baml.errors.*` /
+    `baml.panics.*`) when no generated model describes it.
+
+    Unlike application error models this needs no generated typemap, so an
+    SDK diagnostic (an `SdkPanic` raised before any SDK is imported, a
+    missing-function `InvalidArgument`, ...) is never masked by an
+    "unknown class" lookup failure. Fields keep their decoded values
+    (including owned references such as a `HostCallable._handle`), and
+    ``class_name`` preserves the exact builtin name when the value is passed
+    back to BAML.
+    """
+
+    class_name: str
+    fields: Dict[str, Any]
+
+    @property
+    def message(self) -> Optional[str]:
+        value = self.fields.get("message")
+        return value if isinstance(value, str) else None
 
 
 def _capture_frame(filename: str, lineno: int, func: str) -> Optional[types.FrameType]:
@@ -175,19 +201,15 @@ def make_sdk_panic(message: str) -> BamlPanic:
     Used by the Rust pre-call *handle-returning* sites (`get_runtime` /
     `initialize_runtime`) — SDK-internal *setup* failures, which are
     panic-shaped, not recoverable `baml.errors.*` (32c). When the runtime
-    isn't initialized the typemap may be unavailable, so we fall back to the
-    plain string as `.value` rather than letting construction fail.
+    isn't initialized the application typemap may be unavailable, so the
+    payload always uses the SDK-owned representation.
     """
-    try:
-        from .typemap import get_type_map  # local import: avoid circular load
-
-        value: Any = get_type_map().get_class("baml.panics.SdkPanic")(message=message)
-    except Exception:
-        value = message
+    value = BamlFailureValue("baml.panics.SdkPanic", {"message": message})
     return BamlPanic(value, class_name="baml.panics.SdkPanic")
 
 
 __all__ = [
+    "BamlFailureValue",
     "BamlError",
     "BamlCancelledError",
     "BamlPanic",

--- a/baml_language/sdks/python/src/baml_bridge/proto.py
+++ b/baml_language/sdks/python/src/baml_bridge/proto.py
@@ -35,7 +35,13 @@ from .baml_py import (
 from ._stream import BamlStream
 from ._function_spec import BamlFunctionSpec
 from ._runtime_value import BamlRuntimeValue
-from .errors import BamlCancelledError, BamlError, BamlPanic, attach_baml_traceback
+from .errors import (
+    BamlCancelledError,
+    BamlError,
+    BamlFailureValue,
+    BamlPanic,
+    attach_baml_traceback,
+)
 from .typemap import BamlTypeMap, get_type_map
 
 
@@ -348,6 +354,22 @@ def _set_inbound_value(
         return
     if isinstance(value, (bytes, bytearray)):
         inbound_value.uint8array_value = bytes(value)
+        return
+    if isinstance(value, BamlFailureValue):
+        # Preserve the builtin class identity when a caught failure is passed
+        # back or rethrown; encoding it as a dict would erase that contract.
+        inbound_value.value_type.class_ty.name = value.class_name
+        cv = inbound_value.class_value
+        cv.SetInParent()
+        for key, item in value.fields.items():
+            _set_inbound_map_entry(
+                cv.fields.add(),
+                key,
+                item,
+                kwarg_name=kwarg_name,
+                registered=registered,
+                cloned_handles=cloned_handles,
+            )
         return
     if isinstance(value, (list, tuple)):
         list_val = inbound_value.list_value
@@ -1269,14 +1291,12 @@ def decode_value(holder, type_map: BamlTypeMap) -> Any:
     return None
 
 
-def _try_rehydrate_host_value(decoded: Any) -> Optional[BaseException]:
-    """If `decoded` is a `baml.errors.HostCallable` pydantic instance
-    whose `_handle` points at a still-live entry in this runtime's
-    host-value registry, return the *original* Python exception object.
-    Otherwise return `None` (foreign runtime, released key, or
-    unexpected shape) so the caller falls back to the metadata-bearing
-    `BamlError` wrapper.
-    """
+def _host_callable_handle(decoded: Any) -> Any:
+    """The `_handle` a decoded `baml.errors.HostCallable` carries: a field of
+    the SDK-owned failure payload, a Pydantic private attr, or a generated
+    public field whose wire alias is `_handle`."""
+    if isinstance(decoded, BamlFailureValue):
+        return decoded.fields.get("_handle")
     private = getattr(decoded, "__pydantic_private__", None)
     handle = private.get("_handle") if isinstance(private, dict) else None
     if handle is None and _is_pydantic_model_class(type(decoded)):
@@ -1290,6 +1310,18 @@ def _try_rehydrate_host_value(decoded: Any) -> Optional[BaseException]:
             if "_handle" in aliases:
                 handle = values.get(name)
                 break
+    return handle
+
+
+def _try_rehydrate_host_value(decoded: Any) -> Optional[BaseException]:
+    """If `decoded` is a `baml.errors.HostCallable` pydantic instance
+    whose `_handle` points at a still-live entry in this runtime's
+    host-value registry, return the *original* Python exception object.
+    Otherwise return `None` (foreign runtime, released key, or
+    unexpected shape) so the caller falls back to the metadata-bearing
+    `BamlError` wrapper.
+    """
+    handle = _host_callable_handle(decoded)
     if handle is None:
         return None
     from .baml_py import lookup_host_value
@@ -1321,6 +1353,34 @@ def _outbound_class_fqn(holder) -> Optional[str]:
     return None
 
 
+def _is_builtin_failure_class(fqn: str) -> bool:
+    """`baml.errors.*` / `baml.panics.*`: failures the runtime or the bridge
+    synthesizes, which can surface before any application SDK is imported
+    (an `SdkPanic` from `get_runtime`, a missing-function `InvalidArgument`,
+    a host callback's `HostCallable`)."""
+    return fqn.startswith("baml.errors.") or fqn.startswith("baml.panics.")
+
+
+def _decode_failure_value(holder, type_map: BamlTypeMap) -> Any:
+    """Decode a thrown / panicked value.
+
+    A builtin failure the application typemap has no generated model for
+    decodes to the SDK-owned `BamlFailureValue` instead of failing the whole
+    decode with an "unknown class" error that masks the real diagnostic.
+    Application-defined errors (and builtin failures a generated SDK does
+    model) still use their generated models.
+    """
+    inner = _unwrap_union_variant(holder)
+    if inner.WhichOneof("value") == "class_value":
+        cls = inner.class_value
+        if _is_builtin_failure_class(cls.name) and not type_map.has_class(cls.name):
+            return BamlFailureValue(
+                cls.name,
+                {field.key: decode_value(field.value, type_map) for field in cls.fields},
+            )
+    return decode_value(holder, type_map)
+
+
 def decode_call_result(data: bytes) -> Any:
     """Decode a `BamlOutboundResult` envelope to a Python value, raising
     `BamlError` / `BamlPanic` for the thrown arms (31c / 31f).
@@ -1340,7 +1400,7 @@ def decode_call_result(data: bytes) -> Any:
 
     if which == "error":
         msg = result.error
-        decoded = decode_value(msg.value, type_map)
+        decoded = _decode_failure_value(msg.value, type_map)
         # A value/type mismatch at the call boundary (`baml.errors.TypeMismatch`,
         # synthesized host-side from `EngineError::TypeMismatch`) is a *caller*
         # type error — surface it as Python's native `TypeError` rather than a
@@ -1389,7 +1449,7 @@ def decode_call_result(data: bytes) -> Any:
         )
         raise attach_baml_traceback(
             panic_type(
-                decode_value(msg.value, type_map),
+                _decode_failure_value(msg.value, type_map),
                 baml_trace=list(msg.trace),
                 class_name=_outbound_class_fqn(msg.value),
             )

--- a/baml_language/sdks/python/src/baml_bridge/typemap.py
+++ b/baml_language/sdks/python/src/baml_bridge/typemap.py
@@ -89,6 +89,10 @@ class BamlTypeMap:
 
     # — lookup (lazy fallback) —
 
+    def has_class(self, fqn: str) -> bool:
+        """Whether `fqn` has a generated class entry (without importing it)."""
+        return fqn in self._class_cache or fqn in self._class_lazy
+
     def get_class(self, fqn: str) -> Type:
         cached = self._class_cache.get(fqn)
         if cached is not None:

--- a/baml_language/sdks/python/tests/test_builtin_failures.py
+++ b/baml_language/sdks/python/tests/test_builtin_failures.py
@@ -1,0 +1,125 @@
+"""Builtin runtime failures (`baml.errors.*` / `baml.panics.*`) must decode
+without a generated SDK.
+
+Before this fix every thrown class went through the application typemap, so
+with no SDK loaded an `SdkPanic` (or a host callback's own exception, carried
+as `baml.errors.HostCallable`) surfaced as an "Unknown class FQN" `BamlError`
+that masked the real diagnostic. Now a builtin failure the typemap does not
+model decodes to the SDK-owned `BamlFailureValue`.
+
+Only the *no generated SDK* half lives here: it needs an empty typemap, which
+the generated-SDK fixture crate (`sdk_tests/crates/python_pydantic2`) cannot
+provide. The other half — a generated model still wins, a missing function is
+an `InvalidArgument`, host exceptions rehydrate through the generated
+`HostCallable` model — runs there.
+
+Run with:
+    cd baml_language/sdks/python
+    uv run maturin develop --uv
+    uv run pytest tests/test_builtin_failures.py -v
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import baml_bridge.proto as proto
+from baml_bridge import call_function_sync
+from baml_bridge.baml_py import BamlRuntime, new_function_call
+from baml_bridge.cffi.v1 import baml_outbound_pb2
+from baml_bridge.errors import BamlError, BamlFailureValue, BamlPanic, make_sdk_panic
+from baml_bridge.typemap import BamlTypeMap, get_type_map, set_type_map
+
+
+SOURCE = """
+function failure_message(value: baml.errors.InvalidArgument) -> string throws never {
+    value.message
+}
+function builtin_failure() -> never throws baml.errors.InvalidArgument {
+    throw baml.errors.InvalidArgument { message: "bad input" }
+}
+function call_callback(callback: (int) -> string, x: int) -> string {
+    callback(x)
+}
+"""
+
+
+@pytest.fixture
+def empty_typemap():
+    saved = get_type_map()
+    set_type_map(BamlTypeMap())
+    yield
+    set_type_map(saved)
+
+
+@pytest.fixture
+def runtime(empty_typemap):
+    return BamlRuntime.initialize_runtime(".", {"main.baml": SOURCE})
+
+
+def args(name: str, values: dict[str, Any] | None = None) -> bytes:
+    return proto.encode_call_args(values or {}, new_function_call(), function_name=name)
+
+
+def raw(runtime, name: str, values: dict[str, Any] | None = None) -> bytes:
+    return runtime.call_function_sync(args(name, values))
+
+
+def test_sdk_panic_payload_does_not_depend_on_generated_models(
+    empty_typemap, monkeypatch
+):
+    def broken_lookup(_self, _name):
+        raise AssertionError("panic decoding must not run application model code")
+
+    monkeypatch.setattr(BamlTypeMap, "get_class", broken_lookup)
+    original = make_sdk_panic("setup failed")
+    assert isinstance(original.value, BamlFailureValue)
+    assert original.value.message == "setup failed"
+    envelope = baml_outbound_pb2.BamlOutboundResult()
+    envelope.panic.value.class_value.name = "baml.panics.SdkPanic"
+    field = envelope.panic.value.class_value.fields.add()
+    field.key = "message"
+    field.value.string_value = "delivery failed"
+    with pytest.raises(BamlPanic) as raised:
+        proto.decode_call_result(envelope.SerializeToString())
+    assert raised.value.value.class_name == "baml.panics.SdkPanic"
+    assert raised.value.value.message == "delivery failed"
+    assert "delivery failed" in str(raised.value)
+
+
+def test_builtin_failure_decodes_without_generated_models_and_preserves_passback(
+    runtime, monkeypatch
+):
+    def broken_lookup(_self, _name):
+        raise AssertionError("no generated model exists; lookup must not run")
+
+    monkeypatch.setattr(BamlTypeMap, "get_class", broken_lookup)
+    with pytest.raises(BamlError) as raised:
+        proto.decode_call_result(raw(runtime, "builtin_failure"))
+    value = raised.value.value
+    assert isinstance(value, BamlFailureValue)
+    assert value.class_name == "baml.errors.InvalidArgument"
+    assert value.message == "bad input"
+    assert raised.value.class_name == "baml.errors.InvalidArgument"
+    # Passing the caught failure back keeps its builtin class identity.
+    result = raw(runtime, "failure_message", {"value": value})
+    assert proto.decode_call_result(result) == "bad input"
+
+
+def test_host_callback_exception_keeps_identity_without_generated_models(runtime):
+    """A callback's own exception rides through BAML as
+    `baml.errors.HostCallable`. With no generated model for that class the
+    payload decodes to a `BamlFailureValue` whose `_handle` field still
+    rehydrates the *original* exception object — never a `BamlPanic`, and
+    never an "unknown class" decode failure."""
+    original = ValueError("ordinary user error")
+
+    def cb(_x: int) -> str:
+        raise original
+
+    with pytest.raises(ValueError) as raised:
+        call_function_sync(runtime, "call_callback", {"callback": cb, "x": 1})
+    assert raised.value is original
+    assert not isinstance(raised.value, BamlPanic)

--- a/baml_language/sdks/python/tests/test_host_callable.py
+++ b/baml_language/sdks/python/tests/test_host_callable.py
@@ -13,9 +13,6 @@ Run with:
 
 from __future__ import annotations
 
-import gc
-import weakref
-
 import pytest
 
 import baml_bridge.proto as _proto
@@ -25,7 +22,6 @@ from baml_bridge import (
     BamlRuntime,
     call_function_sync,
     call_function,
-    flush_events,
 )
 from baml_bridge.baml_py import (
     _live_handle_count,
@@ -93,48 +89,6 @@ def test_lambda_round_trip():
         rt, "CallCb", {"callback": lambda x: f"lambda-{x}", "x": 12}
     )
     assert result.result() == "lambda-12"
-
-
-@pytest.mark.xfail(
-    reason="host-callable release fires only when the engine GCs the "
-    "Object::HostClosure on its heap; one BAML call rarely triggers "
-    "the GC heuristic. v1 leaks until the engine collects.",
-    strict=False,
-)
-def test_release_fires_on_drop():
-    """The Rust side drops its `HostValueArc` once the engine GCs the
-    `Object::HostClosure` it allocated for the callable; the release
-    callback then removes the Python callable from the registry, and
-    dropping the user's last reference makes it collectible.
-
-    `flush_events()` clears the event-sink arg-snapshot clone; the
-    remaining clone sits on the engine's heap and only goes away when
-    GC walks it. Driving extra BAML calls *eventually* triggers GC,
-    but a single one usually doesn't — hence xfail-strict-false. The
-    release path itself is exercised directly by the `bex_external_types`
-    unit tests in `host_value::tests::drop_fires_release_once_at_last_clone`.
-    """
-    rt = _make_runtime()
-
-    class CallableObj:
-        def __call__(self, x: int) -> str:
-            return str(x)
-
-    cb = CallableObj()
-    wr = weakref.ref(cb)
-    result = call_function_sync(rt, "CallCb", {"callback": cb, "x": 3})
-    assert result.result() == "3"
-    del cb
-    flush_events()
-    # Drive enough calls to nudge the engine's GC heuristic. Even with
-    # this, a single-callable program may stay below the threshold.
-    for _ in range(64):
-        _ = call_function_sync(rt, "CallCb", {"callback": lambda _x: "", "x": 0})
-    flush_events()
-    gc.collect()
-    assert wr() is None, (
-        "expected the host callable to be released after BAML drops its HostClosure"
-    )
 
 
 def test_multiple_callables_have_distinct_keys():

--- a/baml_language/sdks/python/tests/test_host_callable.py
+++ b/baml_language/sdks/python/tests/test_host_callable.py
@@ -234,7 +234,11 @@ def test_host_result_successful_encode_transfers_capability_clone_to_engine():
     handle = BamlPyHandle(key, handle_type)
     before = _live_handle_count()
 
-    with pytest.raises(Exception, match="TypeMismatch"):
+    # `baml.errors.TypeMismatch` surfaces as a native `TypeError` carrying
+    # the engine's diagnostic. (Before builtin failures decoded without a
+    # generated SDK, this matched "TypeMismatch" only because the decode
+    # failed with "Unknown class FQN 'baml.errors.TypeMismatch'".)
+    with pytest.raises(TypeError, match="cannot be bound"):
         call_function_sync(
             rt,
             "ConsumeUnknownCb",
@@ -315,38 +319,12 @@ def test_encode_error_releases_registered_callables(monkeypatch):
 # must surface on the host as `BamlPanic(SdkPanic)`, NOT a catchable
 # `BamlError(HostCallable)`. The engine side is covered by
 # `host_callable_bridge_failure_surfaces_as_internal_error` in
-# `crates/bex_engine/tests/host_value_callable.rs`; these tests pin the
-# Python-side routing.
+# `crates/bex_engine/tests/host_value_callable.rs`; this test pins the
+# Python-side routing. (A *normal* user exception is the opposite case —
+# it rehydrates as the original object; see
+# `test_builtin_failures.py::test_host_callback_exception_keeps_identity_without_generated_models`
+# and the generated-SDK fixture crate.)
 # ---------------------------------------------------------------------------
-
-
-def test_normal_user_exception_routes_to_BamlError_not_BamlPanic():
-    """Regression guard for the BamlError vs BamlPanic dichotomy. A
-    *normal* user exception raised by the lambda is a user-level error
-    (catchable), not a bridge-layer fault — it must surface as
-    `BamlError`, never `BamlPanic`. If a future change accidentally
-    routed every host throw through `send_dispatch_bridge_failure`, the
-    test fails because `BamlPanic` subclasses `BaseException` (not
-    `Exception`), so the `pytest.raises(Exception)` check below would
-    miss it.
-    """
-    from baml_bridge.errors import BamlError, BamlPanic
-
-    rt = _make_runtime()
-
-    def cb(_x: int) -> str:
-        raise ValueError("ordinary user error")
-
-    with pytest.raises(Exception) as exc_info:
-        call_function_sync(rt, "CallCb", {"callback": cb, "x": 1})
-
-    assert isinstance(exc_info.value, BamlError), (
-        f"expected BamlError, got {type(exc_info.value).__name__}"
-    )
-    assert not isinstance(exc_info.value, BamlPanic), (
-        "user exceptions must NOT route as BamlPanic — that's reserved "
-        "for bridge-layer faults like missing-callable-for-key"
-    )
 
 
 def test_sdk_panic_wire_envelope_decodes_to_BamlPanic():

--- a/baml_language/sdks/rust/bridge_rust/tests/live_engine.rs
+++ b/baml_language/sdks/rust/bridge_rust/tests/live_engine.rs
@@ -134,19 +134,25 @@ fn unset_takes_default_and_null_stays_null() {
 }
 
 #[test]
-fn unknown_function_is_a_panic() {
-    // The engine reports a missing entry point on the panic arm (the same
-    // envelope python surfaces as `BamlPanic`), not as a thrown error.
+fn unknown_function_is_an_invalid_argument() {
+    // A missing entry point is the caller's mistake: the engine reports it
+    // as `baml.errors.InvalidArgument`, the same class the bridge raises
+    // before a call, not on the panic arm.
     ensure_runtime();
     let result = runtime::invoke_sync::<i64, Infallible>("user.does_not_exist", vec![], vec![]);
     match result {
-        Err(Error::Panic { message, .. }) => {
+        Err(Error::Runtime {
+            class_name,
+            message,
+            ..
+        }) => {
+            assert_eq!(class_name.as_deref(), Some("baml.errors.InvalidArgument"));
             assert!(
                 message.contains("user.does_not_exist"),
                 "message: {message}"
             );
         }
-        other => panic!("expected a panic, got {other:?}"),
+        other => panic!("expected an InvalidArgument error, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

Nine small, independent fixes, one commit each so any can be dropped. None depends on the interface feature in #4797.

## Bugs fixed

- **`baml_artifact/build.rs` rebuilt the compiler on every cargo command** on a packed-refs checkout (it watched a loose ref file that did not exist). It now watches the nearest existing ancestor plus `packed-refs`.
- **Handle table ran the last destructor under its write lock**, so a RustData/ADT destructor that re-enters the table deadlocked; `baml_handle_release` could also unwind across the C ABI. The row is dropped after unlocking and the release is `catch_unwind`ed to `InternalError`.
- **Python builtin failures were decoded through the application typemap.** With no generated SDK loaded, an `SdkPanic` became "Unknown class FQN", masking the real diagnostic; same-host exception identity was lost; `FunctionNotFound` was classified as a panic instead of `InvalidArgument`. `BamlFailureValue` carries builtin payloads independently of the typemap; a generated model still wins when present.
- **Python callbacks ran on a Tokio async worker**, so a callback re-entering BAML synchronously panicked and an async one could deadlock; non-coroutine awaitables were returned unawaited. Dispatch moves to `spawn_blocking` and uses `inspect.isawaitable`.
- **Tests only:** host-value reclamation after an unhandled spawn error is pinned (the previously `xfail` Python test is made deterministic via `baml.sys.collect_garbage`).
- **Runtime-mount interface stubs dropped bounds, `requires`, and associated-type bounds/defaults**, so a runtime-compiled implementor relying on a default was rejected. The stub now spells the full contract.
- **`callable_throws` lowered `throws Self.Error` / `T.Error` to `<error>`** (no owner/bound scope), giving wrong effective error types for methods like `Iterator.collect`. It now builds the same context as the signature road.
- **Python codegen rendered `never` as `None`.** It is `typing.NoReturn`.
- **Rust sdk_tests harness spawned a nested `cargo test`** from inside the fixture directory. It now runs `cargo nextest` from the workspace root with an explicit `--manifest-path` (the upward-discovery guard is kept).

## Tests

Python behaviour is tested through the generated SDK in `sdk_tests/crates/python_pydantic2` (runs in CI as `sdk_test_python_pydantic2`); only the empty-typemap cases stay in `sdks/python/tests`. Rust tests for the handle table, the artifact build script, runtime-mount stubs (unit plus a `baml_tests` e2e), `callable_throws` (three TIR cases), the codegen case matrix, and the harness runner.

## Stack

Part of the split of #4797; stacked on #4808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Undefined functions now return structured `InvalidArgument` errors instead of generic SDK failures.
  * Python SDKs preserve and decode built-in runtime errors and panics when generated models are unavailable.
  * Host callbacks support custom awaitables, reentrant calls, and safer resource release.
  * Runtime-mounted interfaces preserve generic bounds, requirements, associated types, and defaults.
  * Functions that never return are typed as `typing.NoReturn` in generated Python code.
  * Compiler error types resolve correctly across implementations and bounded generics.
  * C API resource-release failures are reported safely without unwinding into callers.

* **Chores**
  * Rust SDK test tooling now uses `cargo nextest` for fixture setup and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches FFI/C ABI, handle-table locking, error classification at the bridge boundary, and compiler/runtime metadata for throws and mounted interfaces—wide surface but each change is narrowly scoped with targeted tests.
> 
> **Overview**
> This PR bundles nine independent fixes across the compiler, runtime mount, CFFI handle table, Python bridge, and SDK test harness.
> 
> **Compiler & runtime compile:** `callable_throws` now lowers written `throws` clauses with the same owner/bound scope as the signature (`Self.Error`, `T.Error` on bounded generics), fixing wrong effective error types for impl methods. Runtime-mounted **interface stubs** spell generic bounds, `requires`, and associated-type bounds/defaults so cross-mount implementors can rely on defaults and inherited contracts.
> 
> **Build & FFI:** `baml_artifact`’s build script stops watching a missing loose ref on packed-refs checkouts (which forced rebuilds every cargo invocation). The CFFI handle table drops the last row **after** releasing the write lock so destructors can re-enter safely; `baml_handle_release` catches panics and returns `InternalError`. Engine `FunctionNotFound` is routed as **`baml.errors.InvalidArgument`** (Rust/Python), not `SdkPanic`.
> 
> **Python SDK:** Builtin `baml.errors.*` / `baml.panics.*` decode via **`BamlFailureValue`** when no generated model exists; pass-back encoding preserves class identity. Host callback dispatch moves to **`spawn_blocking`** with **`inspect.isawaitable`** so reentrant BAML calls don’t deadlock and non-coroutine awaitables run. Codegen maps `never` to **`typing.NoReturn`**. SDK tests use **`cargo nextest`** for Rust fixtures with an explicit workspace `--manifest-path` guard.
> 
> Tests cover callable throws scope, mount interface contracts, spawn-error host-value GC, handle release ABI, and parity fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfcbb6a1b1b710adf8db857006f02d141045528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->