### PR TITLE
bridge_ctypes/bridge_cffi: leak-free encode/decode ledgers and pinned call targets

### DIFF
--- a/baml_language/crates/bex_resource_types/src/host_value.rs
+++ b/baml_language/crates/bex_resource_types/src/host_value.rs
@@ -81,8 +81,7 @@ impl HostValueArc {
     /// when the last clone (across the entire process) drops — even when BAML
     /// returns a host callable to the host and it is later passed back in.
     pub fn intern(key: u64, kind: HostValueKind) -> Arc<Self> {
-        let mut map = INTERNER.lock().unwrap_or_else(PoisonError::into_inner);
-        if let Some(existing) = map.get(&key).and_then(Weak::upgrade) {
+        Self::try_intern(key, kind).unwrap_or_else(|existing| {
             debug_assert_eq!(
                 existing.kind, kind,
                 "host-value key {key} re-interned with a different kind \
@@ -93,13 +92,28 @@ impl HostValueArc {
             // Prefer the existing live identity. The same key always carries
             // the same kind in practice; if a buggy caller disagrees we keep
             // the established one rather than mint a conflicting second Arc.
-            return existing;
+            existing
+        })
+    }
+
+    /// [`intern`](Self::intern) for untrusted input: a `kind` that disagrees
+    /// with the live registration for `key` is reported (as that registration)
+    /// instead of asserted, so a forged wire discriminator can neither panic
+    /// the boundary nor alias the established identity.
+    pub fn try_intern(key: u64, kind: HostValueKind) -> Result<Arc<Self>, Arc<Self>> {
+        let mut map = INTERNER.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(existing) = map.get(&key).and_then(Weak::upgrade) {
+            return if existing.kind == kind {
+                Ok(existing)
+            } else {
+                Err(existing)
+            };
         }
         // No live entry (absent, or a dangling `Weak` whose `Arc` already
         // dropped). Create a fresh identity and record a `Weak` to it.
         let arc = Arc::new(Self { key, kind });
         map.insert(key, Arc::downgrade(&arc));
-        arc
+        Ok(arc)
     }
 }
 

--- a/baml_language/crates/bridge_cffi/src/baml_to_host.rs
+++ b/baml_language/crates/bridge_cffi/src/baml_to_host.rs
@@ -3,8 +3,8 @@
 //! `BamlOutboundResult` envelope.
 //!
 //! The whole classify-and-encode lives here, in the bridge — not in bex.
-//! Both the C-ABI entry point (`call_function` in `lib.rs`) and the PyO3 path
-//! (`bridge_python`'s `runtime.rs`) call [`call_and_encode`], so the
+//! Every adapter (the C ABI, Wasm, PyO3, napi, JNI) calls [`prepare_call`] and
+//! then [`invoke_prepared`], so argument decoding, target pinning, the
 //! `catch_unwind` → `SdkPanic` boundary and the error/panic routing are
 //! defined exactly once. Every result — ok value, thrown error, panic, and
 //! pre-call host-boundary failure — leaves the bridge as one envelope; there is
@@ -24,9 +24,10 @@ use bex_project::{
     UnhandledSpawnError,
 };
 use bridge_ctypes::{
-    CffiHandleTableEntry, CffiHandleTableOptions, HANDLE_TABLE,
+    CffiHandleTableEntry, CffiHandleTableOptions, HANDLE_TABLE, InboundTransfer,
     baml_bridge::cffi::{
-        BamlOutboundError, BamlOutboundPanic, BamlOutboundResult, baml_outbound_result,
+        BamlOutboundError, BamlOutboundPanic, BamlOutboundResult, CallFunctionArgs,
+        baml_outbound_result, call_function_args::CallTarget,
     },
     external_to_outbound,
 };
@@ -319,7 +320,82 @@ pub fn panic_to_outbound(panic_info: &(dyn std::any::Any + Send)) -> Vec<u8> {
     .encode_to_vec()
 }
 
-/// Call a BAML function and encode the result as `BamlOutboundResult` bytes.
+/// A decoded `CallFunctionArgs` whose target is already pinned.
+///
+/// Every adapter yields to an executor between decoding a call and running
+/// it. The SDK may release the callable's handle-table key in that gap, so a
+/// handle target is resolved to its heap [`Handle`](bex_project::Handle) here,
+/// while the key is known to be live, and the prepared call keeps that pin
+/// until the engine has run it.
+pub struct PreparedCall {
+    target: PreparedTarget,
+    args: BexArgs,
+    context: FunctionCallContext,
+}
+
+enum PreparedTarget {
+    Named(String),
+    Callable(bex_project::Handle),
+}
+
+/// Decode `CallFunctionArgs` bytes into a [`PreparedCall`].
+///
+/// The argument batch is captured before anything is validated, so a rejected
+/// envelope still consumes every handle lease it named.
+pub fn prepare_call(bytes: &[u8]) -> Result<PreparedCall, BridgeError> {
+    let call = CallFunctionArgs::decode(bytes).map_err(bridge_ctypes::CtypesError::from)?;
+    let inputs = InboundTransfer::capture_kwargs(&call.kwargs, &HANDLE_TABLE);
+    if call.call_id == 0 {
+        return Err(BridgeError::InvalidCallId);
+    }
+    let target = call.call_target.ok_or(BridgeError::MissingCallTarget)?;
+    if matches!(target, CallTarget::FunctionHandle(_)) && !call.type_args.is_empty() {
+        return Err(BridgeError::FunctionHandleTypeArgs);
+    }
+    let type_args = bridge_ctypes::proto_ty_args_to_named(&call.type_args)?;
+    let context = crate::function_call_context_builder(bex_project::CallId(call.call_id))
+        .with_type_args(type_args.type_args)
+        .with_type_defs(type_args.type_defs)
+        .build();
+    let kwargs = inputs.decode_kwargs(call.kwargs)?;
+
+    let (target, args) = match target {
+        CallTarget::FunctionName(name) => (PreparedTarget::Named(name), kwargs.into()),
+        CallTarget::FunctionHandle(key) => {
+            let entry = HANDLE_TABLE.resolve(key).ok_or_else(|| {
+                BridgeError::Internal("callable handle is no longer live".to_string())
+            })?;
+            let CffiHandleTableEntry::Adt(bex_project::BexExternalAdt::TaggedHeapHandle {
+                kind: bex_project::TaggedHeapHandleKind::Callable,
+                ty: bex_project::RuntimeTy::Function { params, .. },
+                heap_handle,
+            }) = &*entry
+            else {
+                return Err(BridgeError::Internal(
+                    "handle does not reference a BAML callable".to_string(),
+                ));
+            };
+            let params = params.iter().enumerate().map(|(index, parameter)| {
+                (
+                    parameter
+                        .name
+                        .as_ref()
+                        .map_or_else(|| format!("arg{index}"), ToString::to_string),
+                    parameter.is_required(),
+                )
+            });
+            let args = partition_callable_args(key, params, kwargs.into_iter().collect())?;
+            (PreparedTarget::Callable(heap_handle.clone()), args)
+        }
+    };
+    Ok(PreparedCall {
+        target,
+        args,
+        context,
+    })
+}
+
+/// Run a [`PreparedCall`] and encode the result as `BamlOutboundResult` bytes.
 ///
 /// The `catch_unwind` boundary wraps the engine call so a Rust panic surfaces
 /// as a `baml.panics.SdkPanic` ⇒ `BamlOutboundPanic` (a catchable `BamlPanic`
@@ -328,18 +404,22 @@ pub fn panic_to_outbound(panic_info: &(dyn std::any::Any + Send)) -> Vec<u8> {
 /// point keeps its own outer `catch_unwind` for that (encoding via
 /// [`panic_to_outbound`]), and the PyO3 glue lets it become pyo3's
 /// `PanicException`.
-pub async fn call_and_encode(
-    runtime: Arc<dyn Bex>,
-    function_name: String,
-    args: BexArgs,
-    call_ctx: FunctionCallContext,
-) -> Vec<u8> {
+pub async fn invoke_prepared(runtime: Arc<dyn Bex>, call: PreparedCall) -> Vec<u8> {
     let options = CffiHandleTableOptions::for_wire();
-    let _route = crate::register_active_call_runtime(call_ctx.host_call_id.0, &runtime);
+    let _route = crate::register_active_call_runtime(call.context.host_call_id.0, &runtime);
 
-    let caught = AssertUnwindSafe(runtime.call_function(&function_name, args, call_ctx))
-        .catch_unwind()
-        .await;
+    let caught = AssertUnwindSafe(async move {
+        match call.target {
+            PreparedTarget::Named(name) => {
+                runtime.call_function(&name, call.args, call.context).await
+            }
+            PreparedTarget::Callable(handle) => {
+                runtime.call_callable(handle, call.args, call.context).await
+            }
+        }
+    })
+    .catch_unwind()
+    .await;
 
     let result = match caught {
         Ok(call_result) => result_to_outbound(call_result, &options),
@@ -376,65 +456,6 @@ fn partition_callable_args(
     }
     optional.extend(supplied);
     Ok(BexArgs { required, optional })
-}
-
-/// Invoke an engine-owned callable referenced by an ordinary handle-table key
-/// and encode the result through the same envelope path as a named call.
-pub async fn call_handle_and_encode(
-    runtime: Arc<dyn Bex>,
-    handle_key: u64,
-    BexArgs { required, optional }: BexArgs,
-    call_ctx: FunctionCallContext,
-) -> Vec<u8> {
-    let mut supplied = required;
-    supplied.extend(optional);
-    let (handle, args) = match HANDLE_TABLE.resolve(handle_key) {
-        Some(entry) => match &*entry {
-            CffiHandleTableEntry::Adt(bex_project::BexExternalAdt::TaggedHeapHandle {
-                kind: bex_project::TaggedHeapHandleKind::Callable,
-                ty: bex_project::RuntimeTy::Function { params, .. },
-                heap_handle,
-            }) => {
-                let params = params.iter().enumerate().map(|(index, parameter)| {
-                    (
-                        parameter
-                            .name
-                            .as_ref()
-                            .map_or_else(|| format!("arg{index}"), ToString::to_string),
-                        parameter.is_required(),
-                    )
-                });
-                let args = match partition_callable_args(handle_key, params, supplied) {
-                    Ok(args) => args,
-                    Err(err) => return error_to_outbound(err),
-                };
-                (heap_handle.clone(), args)
-            }
-            _ => {
-                return error_to_outbound(BridgeError::Internal(
-                    "handle does not reference a BAML callable".to_string(),
-                ));
-            }
-        },
-        None => {
-            return error_to_outbound(BridgeError::Internal(
-                "callable handle is no longer live".to_string(),
-            ));
-        }
-    };
-
-    let options = CffiHandleTableOptions::for_wire();
-    let _route = crate::register_active_call_runtime(call_ctx.host_call_id.0, &runtime);
-    let caught = AssertUnwindSafe(runtime.call_callable(handle, args, call_ctx))
-        .catch_unwind()
-        .await;
-    let result = match caught {
-        Ok(call_result) => result_to_outbound(call_result, &options),
-        Err(panic_info) => BamlOutboundResult {
-            result: Some(sdk_panic_arm(panic_message(panic_info.as_ref()), &options)),
-        },
-    };
-    result.encode_to_vec()
 }
 
 #[cfg(test)]

--- a/baml_language/crates/bridge_cffi/src/ffi/host_value.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/host_value.rs
@@ -17,8 +17,8 @@
 //! the `call_host_value` sysop impl (also in `sys_native`) needs them,
 //! and bridge_cffi → sys_native is the one-way dependency direction.
 
-use bex_project::{BexExternalValue, host_release_dispatch};
-use bridge_ctypes::{HANDLE_TABLE, baml_bridge::cffi::InboundValue, inbound_to_external};
+use bex_project::host_release_dispatch;
+use bridge_ctypes::{HANDLE_TABLE, InboundTransfer, baml_bridge::cffi::InboundValue};
 use prost::Message;
 use sys_native::host_dispatch;
 use sys_types::{OpError, SysOp, VmBamlError, VmInternalError};
@@ -150,6 +150,13 @@ pub extern "C" fn complete_host_call(
         unsafe { std::slice::from_raw_parts(content as *const u8, length) }
     };
 
+    // The parsed payload transfers every reference it names, no matter what
+    // the flag says: capture ownership first so an invalid completion still
+    // consumes (and releases) the host's leases. Decode only after the flag
+    // has been validated.
+    let inbound = InboundValue::decode(bytes)
+        .map(|value| (InboundTransfer::capture_value(&value, &HANDLE_TABLE), value));
+
     // Strict 0/1 contract: any other value is a bridge wire-protocol bug
     // (an `i32` could carry uninitialised memory, a forgotten cast, or
     // someone repurposing the flag) — surface it as `BridgeFailure` so the
@@ -170,104 +177,63 @@ pub extern "C" fn complete_host_call(
         return;
     }
 
-    if is_error == 0 {
-        // Success: decode InboundValue → BexExternalValue.
-        if bytes.is_empty() {
-            // No payload → Null return.
-            host_dispatch::complete_with_value(call_id, BexExternalValue::Null);
-            return;
-        }
-        let inbound = match InboundValue::decode(bytes) {
-            Ok(v) => v,
-            Err(e) => {
-                host_dispatch::complete_with_error(
-                    call_id,
-                    OpError::new(
-                        SysOp::BamlHostCallHostValue,
-                        VmBamlError::ParseError {
-                            message: format!("complete_host_call decode failure: {e}"),
-                        },
-                    ),
-                );
-                return;
-            }
-        };
-        match inbound_to_external(inbound, &HANDLE_TABLE) {
-            Ok(v) => host_dispatch::complete_with_value(call_id, v),
-            Err(e) => host_dispatch::complete_with_error(
-                call_id,
-                OpError::new(
-                    SysOp::BamlHostCallHostValue,
-                    VmBamlError::ParseError {
-                        message: format!("complete_host_call decode failure: {e}"),
-                    },
-                ),
+    // An empty throw payload is a host bridge bug, not a user contract
+    // violation: `is_error == 1` requires a protobuf-encoded `InboundValue`,
+    // and only the bridge itself decides what to send on the wire. A
+    // misbehaving bridge is an infrastructure fault — surface it as
+    // `BridgeFailure` (which codegens to `baml.panics.SdkPanic` on the host
+    // side), not as `HostContractViolation` (which would falsely accuse the
+    // user's callable of returning the wrong shape). An empty success
+    // payload, by contrast, is simply a `Null` return.
+    if is_error == 1 && bytes.is_empty() {
+        host_dispatch::complete_with_error(
+            call_id,
+            OpError::new(
+                SysOp::BamlHostCallHostValue,
+                VmInternalError::BridgeFailure {
+                    message: "host bridge called complete_host_call(is_error=1) \
+                              with no payload; expected a protobuf-encoded \
+                              InboundValue describing the thrown value"
+                        .to_string(),
+                },
             ),
-        }
-    } else {
-        // Throw: decode `InboundValue` → `BexExternalValue` → engine.
-        //
-        // The host bridge SDK wraps native exceptions in a synthetic
-        // `Instance` of class `baml.errors.HostCallable` carrying
-        // `message` / `class_name` / `language` / `traceback` fields
-        // (and a hidden `HostValue(arc, kind=Error)` reference field, on
-        // bridges that support same-host round-trip). Codegenned BAML
-        // values flow through as their own `Instance` / primitive
-        // shape. Either way, the engine's `materialize_host_throw`
-        // runs the declared-throws contract check on this value and
-        // either materialises it as a catchable throw or escalates to
-        // a `HostContractViolation` panic.
-        if bytes.is_empty() {
-            // An empty throw payload is a host bridge bug, not a user
-            // contract violation: `is_error == 1` requires a protobuf-
-            // encoded `InboundValue`, and only the bridge itself decides
-            // what to send on the wire. A misbehaving bridge is an
-            // infrastructure fault — surface it as `BridgeFailure` (which
-            // codegens to `baml.panics.SdkPanic` on the host side), not as
-            // `HostContractViolation` (which would falsely accuse the
-            // user's callable of returning the wrong shape).
+        );
+        return;
+    }
+
+    // Success: the decoded value is the call's return (the engine re-validates
+    // it against the declared return type).
+    //
+    // Throw: the host bridge SDK wraps native exceptions in a synthetic
+    // `Instance` of class `baml.errors.HostCallable` carrying `message` /
+    // `class_name` / `language` / `traceback` fields (and a hidden
+    // `HostValue(arc, kind=Error)` reference field, on bridges that support
+    // same-host round-trip). Codegenned BAML values flow through as their own
+    // `Instance` / primitive shape. Either way, the engine's
+    // `materialize_host_throw` runs the declared-throws contract check on this
+    // value and either materialises it as a catchable throw or escalates to a
+    // `HostContractViolation` panic.
+    let decoded = inbound
+        .map_err(bridge_ctypes::CtypesError::from)
+        .and_then(|(transfer, value)| transfer.decode(value));
+    match decoded {
+        Ok(value) if is_error == 0 => host_dispatch::complete_with_value(call_id, value),
+        Ok(value) => host_dispatch::complete_with_throw(call_id, value),
+        Err(error) => {
+            let context = if is_error == 0 {
+                "complete_host_call"
+            } else {
+                "complete_host_call throw-payload"
+            };
             host_dispatch::complete_with_error(
                 call_id,
                 OpError::new(
                     SysOp::BamlHostCallHostValue,
-                    VmInternalError::BridgeFailure {
-                        message: "host bridge called complete_host_call(is_error=1) \
-                                  with no payload; expected a protobuf-encoded \
-                                  InboundValue describing the thrown value"
-                            .to_string(),
+                    VmBamlError::ParseError {
+                        message: format!("{context} decode failure: {error}"),
                     },
                 ),
             );
-            return;
-        }
-        let inbound = match InboundValue::decode(bytes) {
-            Ok(v) => v,
-            Err(e) => {
-                host_dispatch::complete_with_error(
-                    call_id,
-                    OpError::new(
-                        SysOp::BamlHostCallHostValue,
-                        VmBamlError::ParseError {
-                            message: format!(
-                                "complete_host_call throw-payload decode failure: {e}"
-                            ),
-                        },
-                    ),
-                );
-                return;
-            }
-        };
-        match inbound_to_external(inbound, &HANDLE_TABLE) {
-            Ok(v) => host_dispatch::complete_with_throw(call_id, v),
-            Err(e) => host_dispatch::complete_with_error(
-                call_id,
-                OpError::new(
-                    SysOp::BamlHostCallHostValue,
-                    VmBamlError::ParseError {
-                        message: format!("complete_host_call throw-payload decode failure: {e}"),
-                    },
-                ),
-            ),
         }
     }
 }
@@ -278,6 +244,8 @@ mod tests {
         LazyLock, Mutex, Once,
         atomic::{AtomicU64, Ordering},
     };
+
+    use bex_project::BexExternalValue;
 
     use super::*;
 
@@ -330,6 +298,29 @@ mod tests {
             })),
         }
         .encode_to_vec()
+    }
+
+    /// A completion rejected for its flag still names host keys in its
+    /// payload. Those leases are the host's to hand over and ours to balance:
+    /// the payload is captured before the flag check, so the rejected call
+    /// releases them on return instead of leaking them forever.
+    #[test]
+    fn invalid_completion_flag_releases_the_parsed_payload() {
+        install_release_recorder();
+        let key = NEXT_TEST_HOST_KEY.fetch_add(1, Ordering::Relaxed);
+        let payload = host_callable_throw_payload(key);
+
+        complete_host_call(
+            host_dispatch::next_call_id(),
+            7,
+            payload.as_ptr().cast(),
+            payload.len(),
+        );
+
+        assert!(
+            take_recorded_release(key),
+            "rejected completion did not release host key {key}"
+        );
     }
 
     /// Verify first-call-wins semantics for dispatch registration.

--- a/baml_language/crates/bridge_cffi/src/lib.rs
+++ b/baml_language/crates/bridge_cffi/src/lib.rs
@@ -138,7 +138,7 @@ pub mod handle;
 mod identity;
 
 pub use baml_to_host::{
-    call_and_encode, call_handle_and_encode, error_to_outbound, result_to_outbound,
+    PreparedCall, error_to_outbound, invoke_prepared, prepare_call, result_to_outbound,
     unhandled_spawn_error_to_outbound,
 };
 pub use bridge_ctypes::baml_bridge;

--- a/baml_language/crates/bridge_cffi/src/lib_native.rs
+++ b/baml_language/crates/bridge_cffi/src/lib_native.rs
@@ -7,16 +7,12 @@ use std::{
 };
 
 use bex_project::Bex;
-use bridge_ctypes::{DecodeFromBuffer, HANDLE_TABLE, kwargs_to_bex_values};
 use futures::future::FutureExt;
 use once_cell::sync::OnceCell;
 use sys_native::SysOpsExt;
 use tokio::runtime::Runtime;
 
-use crate::{
-    BridgeError, baml_to_host, call_and_encode, call_handle_and_encode, error_to_outbound,
-    function_call_context_builder,
-};
+use crate::{BridgeError, baml_to_host, error_to_outbound};
 
 #[path = "api.rs"]
 pub mod api;
@@ -143,40 +139,21 @@ pub extern "C" fn call_function(encoded_args: *const u8, length: usize, id: u32)
 }
 
 fn call_function_inner(encoded_args: *const u8, length: usize, id: u32) -> Result<(), BridgeError> {
-    use bridge_ctypes::baml_bridge::cffi::{CallFunctionArgs, call_function_args::CallTarget};
-
     let runtime = get_runtime()?;
-
-    let args = if encoded_args.is_null() || length == 0 {
-        CallFunctionArgs::default()
+    let bytes: &[u8] = if encoded_args.is_null() || length == 0 {
+        &[]
     } else {
-        unsafe { CallFunctionArgs::from_c_buffer(encoded_args, length) }?
+        // SAFETY: the caller promises `encoded_args` is valid for `length` bytes.
+        unsafe { std::slice::from_raw_parts(encoded_args, length) }
     };
-    let call_id = decoded_call_id(args.call_id)?;
-    let target = args.call_target.ok_or(BridgeError::MissingCallTarget)?;
-    if matches!(target, CallTarget::FunctionHandle(_)) && !args.type_args.is_empty() {
-        return Err(BridgeError::FunctionHandleTypeArgs);
-    }
-    let type_args = bridge_ctypes::proto_ty_args_to_named(&args.type_args)?;
-    let kwargs = kwargs_to_bex_values(args.kwargs, &HANDLE_TABLE)?;
-    let call_ctx = function_call_context_builder(call_id)
-        .with_type_args(type_args.type_args)
-        .with_type_defs(type_args.type_defs);
+    // Pin the target before yielding to the executor: the SDK may release the
+    // callable's key as soon as this returns.
+    let prepared = crate::prepare_call(bytes)?;
 
     get_tokio_runtime()?.spawn(async move {
-        let encoded = AssertUnwindSafe(async move {
-            match target {
-                CallTarget::FunctionName(function_name) => {
-                    call_and_encode(runtime, function_name, kwargs.into(), call_ctx.build()).await
-                }
-                CallTarget::FunctionHandle(handle_key) => {
-                    call_handle_and_encode(runtime, handle_key, kwargs.into(), call_ctx.build())
-                        .await
-                }
-            }
-        })
-        .catch_unwind()
-        .await;
+        let encoded = AssertUnwindSafe(crate::invoke_prepared(runtime, prepared))
+            .catch_unwind()
+            .await;
 
         let bytes = match encoded {
             Ok(bytes) => bytes,
@@ -186,11 +163,4 @@ fn call_function_inner(encoded_args: *const u8, length: usize, id: u32) -> Resul
     });
 
     Ok(())
-}
-
-fn decoded_call_id(id: u64) -> Result<sys_types::CallId, BridgeError> {
-    if id == 0 {
-        return Err(BridgeError::InvalidCallId);
-    }
-    Ok(sys_types::CallId(id))
 }

--- a/baml_language/crates/bridge_cffi/src/lib_wasm.rs
+++ b/baml_language/crates/bridge_cffi/src/lib_wasm.rs
@@ -2,14 +2,9 @@
 
 use std::{cell::RefCell, sync::Arc};
 
-use bex_project::{Bex, BexArgs};
-use bridge_ctypes::{HANDLE_TABLE, kwargs_to_bex_values};
-use prost::Message;
+use bex_project::Bex;
 
-use crate::{
-    BridgeError, call_and_encode, call_handle_and_encode, error_to_outbound,
-    function_call_context_builder,
-};
+use crate::{BridgeError, error_to_outbound};
 
 thread_local! {
     static RUNTIME: RefCell<Option<Arc<dyn Bex>>> = RefCell::new(None);
@@ -33,52 +28,11 @@ pub(crate) fn get_runtime() -> Result<Arc<dyn Bex>, BridgeError> {
     RUNTIME.with(|slot| slot.borrow().clone().ok_or(BridgeError::NotInitialized))
 }
 
-struct DecodedCall {
-    runtime: Arc<dyn Bex>,
-    target: bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget,
-    args: BexArgs,
-    context: bex_project::FunctionCallContext,
-}
-
-fn decode_call(encoded_args: &[u8]) -> Result<DecodedCall, BridgeError> {
-    use bridge_ctypes::baml_bridge::cffi::{CallFunctionArgs, call_function_args::CallTarget};
-
-    let call = CallFunctionArgs::decode(encoded_args).map_err(bridge_ctypes::CtypesError::from)?;
-    if call.call_id == 0 {
-        return Err(BridgeError::InvalidCallId);
-    }
-    let target = call.call_target.ok_or(BridgeError::MissingCallTarget)?;
-    if matches!(target, CallTarget::FunctionHandle(_)) && !call.type_args.is_empty() {
-        return Err(BridgeError::FunctionHandleTypeArgs);
-    }
-    let type_args = bridge_ctypes::proto_ty_args_to_named(&call.type_args)?;
-    let kwargs = kwargs_to_bex_values(call.kwargs, &HANDLE_TABLE)?;
-    let context = function_call_context_builder(bex_project::CallId(call.call_id))
-        .with_type_args(type_args.type_args)
-        .with_type_defs(type_args.type_defs)
-        .build();
-    Ok(DecodedCall {
-        runtime: crate::get_runtime()?,
-        target,
-        args: kwargs.into(),
-        context,
-    })
-}
-
 pub async fn call_function_in_wasm(encoded_args: &[u8]) -> Vec<u8> {
-    use bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget;
-
-    let call = match decode_call(encoded_args) {
-        Ok(call) => call,
-        Err(error) => return error_to_outbound(error),
-    };
-    match call.target {
-        CallTarget::FunctionName(function_name) => {
-            call_and_encode(call.runtime, function_name, call.args, call.context).await
-        }
-        CallTarget::FunctionHandle(handle_key) => {
-            call_handle_and_encode(call.runtime, handle_key, call.args, call.context).await
-        }
+    let prepared = crate::prepare_call(encoded_args).and_then(|call| Ok((get_runtime()?, call)));
+    match prepared {
+        Ok((runtime, call)) => crate::invoke_prepared(runtime, call).await,
+        Err(error) => error_to_outbound(error),
     }
 }
 

--- a/baml_language/crates/bridge_cffi/tests/prepared_call.rs
+++ b/baml_language/crates/bridge_cffi/tests/prepared_call.rs
@@ -1,0 +1,82 @@
+//! `prepare_call` pins a handle target while the SDK's key is still live, so
+//! the SDK releasing that key between an adapter returning and its executor
+//! running the call cannot invalidate the call.
+
+use std::collections::HashMap;
+
+use bridge_cffi::baml_bridge::cffi::{
+    BamlOutboundResult, CallFunctionArgs, InboundMapEntry, InboundValue, baml_outbound_result,
+    baml_outbound_value, call_function_args::CallTarget, inbound_map_entry::Key,
+    inbound_value::Value as InboundValueVariant,
+};
+use bridge_ctypes::HANDLE_TABLE;
+use prost::Message;
+
+fn call_args(target: CallTarget, arg: (&str, i64)) -> Vec<u8> {
+    CallFunctionArgs {
+        call_id: bridge_cffi::new_function_call_id(),
+        call_target: Some(target),
+        kwargs: vec![InboundMapEntry {
+            key: Some(Key::StringKey(arg.0.to_string())),
+            value: Some(InboundValue {
+                value_type: None,
+                value: Some(InboundValueVariant::IntValue(arg.1)),
+            }),
+        }],
+        ..Default::default()
+    }
+    .encode_to_vec()
+}
+
+fn ok_value(bytes: &[u8]) -> baml_outbound_value::Value {
+    let envelope = BamlOutboundResult::decode(bytes).unwrap();
+    let Some(baml_outbound_result::Result::Ok(value)) = envelope.result else {
+        panic!("expected an ok envelope, got {envelope:?}");
+    };
+    value.value.expect("ok envelope carries a value")
+}
+
+#[tokio::test]
+async fn prepared_handle_call_survives_release_of_its_key() {
+    bridge_cffi::initialize_runtime(
+        ".",
+        HashMap::from([(
+            "main.baml".to_string(),
+            r#"
+                function make_adder(base: int) -> (int) -> int throws never {
+                    (x: int) -> { base + x }
+                }
+            "#
+            .to_string(),
+        )]),
+    )
+    .unwrap();
+    let runtime = bridge_cffi::get_runtime().unwrap();
+
+    // The callable reaches the host as a handle-table key the SDK now owns.
+    let prepared = bridge_cffi::prepare_call(&call_args(
+        CallTarget::FunctionName("make_adder".to_string()),
+        ("base", 40),
+    ))
+    .unwrap();
+    let bytes = bridge_cffi::invoke_prepared(runtime.clone(), prepared).await;
+    let baml_outbound_value::Value::HandleValue(handle) = ok_value(&bytes) else {
+        panic!("expected the callable as a handle");
+    };
+
+    // Prepare the call through that key, then release it before invoking:
+    // the window between `call_function` returning and its task running.
+    // A closure's parameters are unnamed on the wire, so they go by position.
+    let prepared = bridge_cffi::prepare_call(&call_args(
+        CallTarget::FunctionHandle(handle.key),
+        ("arg0", 2),
+    ))
+    .unwrap();
+    assert!(HANDLE_TABLE.release(handle.key));
+    assert!(HANDLE_TABLE.resolve(handle.key).is_none());
+
+    let bytes = bridge_cffi::invoke_prepared(runtime, prepared).await;
+    assert_eq!(ok_value(&bytes), baml_outbound_value::Value::IntValue(42));
+
+    bridge_cffi::shutdown_runtime().await.unwrap();
+}

--- a/baml_language/crates/bridge_ctypes/src/error.rs
+++ b/baml_language/crates/bridge_ctypes/src/error.rs
@@ -14,6 +14,9 @@ pub enum CtypesError {
     #[error("Invalid handle key: {0}")]
     InvalidHandleKey(u64),
 
+    #[error("Host value key {0} does not match its registered kind")]
+    InvalidHostValueKind(u64),
+
     #[error("Map entry missing key")]
     MapEntryMissingKey,
 

--- a/baml_language/crates/bridge_ctypes/src/lib.rs
+++ b/baml_language/crates/bridge_ctypes/src/lib.rs
@@ -33,6 +33,6 @@ pub use ty_decode::{
 pub use ty_encode::{portable_type_def_to_proto, runtime_ty_to_proto_ty};
 pub use utils::DecodeFromBuffer;
 pub use value_decode::{
-    inbound_to_external, kwargs_to_bex_values, playground_run_args_to_bex_values,
+    InboundTransfer, inbound_to_external, kwargs_to_bex_values, playground_run_args_to_bex_values,
 };
 pub use value_encode::{artifact_safe_outbound_bytes, build_to_host_call, external_to_outbound};

--- a/baml_language/crates/bridge_ctypes/src/value_decode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_decode.rs
@@ -21,7 +21,7 @@ use crate::{
         inbound_value::Value as InboundValueVariant,
     },
     error::CtypesError,
-    handle_table::CffiHandleTable,
+    handle_table::{CffiHandleTable, CffiHandleTableEntry},
 };
 
 /// Decode a protobuf `InboundValue` into a `BexExternalValue` for use by the BEX engine.
@@ -30,6 +30,121 @@ use crate::{
 pub fn inbound_to_external(
     value: InboundValue,
     handle_table: &CffiHandleTable,
+) -> Result<BexExternalValue, CtypesError> {
+    InboundTransfer::capture_value(&value, handle_table).decode(value)
+}
+
+/// Every reference transferred by one parsed inbound message, taken before any
+/// of it is decoded.
+///
+/// The host hands over one handle-table lease per wire occurrence and expects
+/// each to be consumed whether or not the message decodes. Capturing first
+/// makes that unconditional: engine keys are drained and host keys interned in
+/// a single pass over the parsed tree, decoding then only clones from the
+/// batch, and whatever a failed decode never reached is released when the
+/// batch drops.
+#[derive(Default)]
+pub struct InboundTransfer {
+    /// Drained table rows by key; `None` marks a key that was not live.
+    engine_values: HashMap<u64, Option<Arc<CffiHandleTableEntry>>>,
+    /// Interned host registrations by key; `None` marks a forged kind.
+    host_values: HashMap<u64, Option<Arc<bex_project::HostValueArc>>>,
+}
+
+impl InboundTransfer {
+    pub fn capture_value(value: &InboundValue, table: &CffiHandleTable) -> Self {
+        Self::capture(std::iter::once(value), table)
+    }
+
+    pub fn capture_kwargs(kwargs: &[InboundMapEntry], table: &CffiHandleTable) -> Self {
+        Self::capture(
+            kwargs.iter().filter_map(|entry| entry.value.as_ref()),
+            table,
+        )
+    }
+
+    fn capture<'a>(
+        values: impl IntoIterator<Item = &'a InboundValue>,
+        table: &CffiHandleTable,
+    ) -> Self {
+        let mut transfer = Self::default();
+        let mut pending: Vec<&InboundValue> = values.into_iter().collect();
+        while let Some(value) = pending.pop() {
+            match &value.value {
+                Some(InboundValueVariant::Handle(handle)) => {
+                    if let Some(kind) = host_value_kind(handle.handle_type) {
+                        // Interning shares one Arc per key so release fires
+                        // exactly once; a kind that disagrees with the live
+                        // registration is forged and poisons the key.
+                        let slot = transfer.host_values.entry(handle.key).or_insert_with(|| {
+                            bex_project::HostValueArc::try_intern(handle.key, kind).ok()
+                        });
+                        if slot.as_ref().is_some_and(|arc| arc.kind != kind) {
+                            *slot = None;
+                        }
+                    } else {
+                        // One lease per occurrence: a repeated key must have
+                        // been cloned once per repetition, or it is invalid.
+                        let drained = table.drain(handle.key);
+                        transfer
+                            .engine_values
+                            .entry(handle.key)
+                            .and_modify(|slot| {
+                                if drained.is_none() {
+                                    *slot = None;
+                                }
+                            })
+                            .or_insert(drained);
+                    }
+                }
+                Some(InboundValueVariant::ListValue(list)) => pending.extend(&list.values),
+                Some(InboundValueVariant::MapValue(map)) => {
+                    pending.extend(map.entries.iter().filter_map(|entry| entry.value.as_ref()));
+                }
+                Some(InboundValueVariant::ClassValue(class)) => {
+                    pending.extend(class.fields.iter().filter_map(|entry| entry.value.as_ref()));
+                }
+                _ => {}
+            }
+        }
+        transfer
+    }
+
+    pub fn decode(self, value: InboundValue) -> Result<BexExternalValue, CtypesError> {
+        decode_value(value, &self)
+    }
+
+    pub fn decode_kwargs(
+        self,
+        kwargs: Vec<InboundMapEntry>,
+    ) -> Result<HashMap<String, BexExternalValue>, CtypesError> {
+        let mut result = HashMap::new();
+        for entry in kwargs {
+            let key = extract_string_key(&entry)?;
+            let value = entry
+                .value
+                .map(|value| decode_value(value, &self))
+                .transpose()?
+                .unwrap_or(BexExternalValue::Null);
+            result.insert(key, value);
+        }
+        Ok(result)
+    }
+}
+
+fn host_value_kind(handle_type: i32) -> Option<bex_project::HostValueKind> {
+    if handle_type == BamlHandleType::HostValueCallable as i32 {
+        Some(bex_project::HostValueKind::Callable)
+    } else if handle_type == BamlHandleType::HostValueOpaque as i32 {
+        Some(bex_project::HostValueKind::Opaque)
+    } else {
+        None
+    }
+}
+
+fn decode_value(
+    value: InboundValue,
+    transfer: &InboundTransfer,
 ) -> Result<BexExternalValue, CtypesError> {
     let value_type = value
         .value_type
@@ -68,9 +183,9 @@ pub fn inbound_to_external(
             }
             InboundValueVariant::FloatValue(f) => Ok(BexExternalValue::Float(f)),
             InboundValueVariant::BoolValue(b) => Ok(BexExternalValue::Bool(b)),
-            InboundValueVariant::ListValue(list) => convert_list(list, handle_table),
-            InboundValueVariant::MapValue(map) => convert_map(map, handle_table),
-            InboundValueVariant::ClassValue(class) => convert_class(class, handle_table),
+            InboundValueVariant::ListValue(list) => convert_list(list, transfer),
+            InboundValueVariant::MapValue(map) => convert_map(map, transfer),
+            InboundValueVariant::ClassValue(class) => convert_class(class, transfer),
             InboundValueVariant::EnumValue(e) => Ok(convert_enum(e)),
             InboundValueVariant::Uint8arrayValue(bytes) => Ok(BexExternalValue::Uint8Array(bytes)),
             // A reflected BAML type passed as an argument value.
@@ -82,33 +197,26 @@ pub fn inbound_to_external(
             InboundValueVariant::PromptAstValue(prompt) => Ok(BexExternalValue::Adt(
                 BexExternalAdt::PromptAst(Arc::new(proto_prompt_ast_to_bex_prompt_ast(prompt)?)),
             )),
-            InboundValueVariant::Handle(handle) => {
-                // HOST_VALUE_* keys do NOT live in HANDLE_TABLE. The host
-                // bridge owns the lookup; we construct the Arc stub here so
-                // last-drop fires the registered HostReleaseFn.
-                let host_value_kind =
-                    if handle.handle_type == BamlHandleType::HostValueCallable as i32 {
-                        Some(bex_project::HostValueKind::Callable)
-                    } else if handle.handle_type == BamlHandleType::HostValueOpaque as i32 {
-                        Some(bex_project::HostValueKind::Opaque)
-                    } else {
-                        None
-                    };
-                if let Some(kind) = host_value_kind {
-                    // Intern by key so repeated decodes of the same wire key
-                    // (e.g. BAML returns a host callable, the host passes it
-                    // back in) share one Arc identity. Otherwise each decode
-                    // would mint an independent Arc with its own refcount and
-                    // the first last-drop would fire HostReleaseFn, tearing the
-                    // registry entry out from under the still-live other Arc.
-                    let arc = bex_project::HostValueArc::intern(handle.key, kind);
-                    return Ok(BexExternalValue::HostValue(arc));
-                }
-                let value = handle_table
-                    .drain(handle.key)
-                    .ok_or(CtypesError::InvalidHandleKey(handle.key))?;
-                Ok(BexExternalValue::from((*value).clone()))
+            // Both kinds of key were already captured; decoding only clones
+            // out of the batch. HOST_VALUE_* keys do NOT live in HANDLE_TABLE:
+            // the host bridge owns the lookup, and the interned Arc fires the
+            // registered HostReleaseFn on its last drop.
+            InboundValueVariant::Handle(handle)
+                if host_value_kind(handle.handle_type).is_some() =>
+            {
+                transfer
+                    .host_values
+                    .get(&handle.key)
+                    .and_then(Clone::clone)
+                    .map(BexExternalValue::HostValue)
+                    .ok_or(CtypesError::InvalidHostValueKind(handle.key))
             }
+            InboundValueVariant::Handle(handle) => transfer
+                .engine_values
+                .get(&handle.key)
+                .and_then(Clone::clone)
+                .map(|entry| BexExternalValue::from((*entry).clone()))
+                .ok_or(CtypesError::InvalidHandleKey(handle.key)),
         },
     }?;
     Ok(match value_type {
@@ -221,12 +329,12 @@ fn default_scalar_union_ty() -> RuntimeTy {
 
 fn convert_list(
     list: InboundListValue,
-    handle_table: &CffiHandleTable,
+    transfer: &InboundTransfer,
 ) -> Result<BexExternalValue, CtypesError> {
     let items: Result<Vec<BexExternalValue>, CtypesError> = list
         .values
         .into_iter()
-        .map(|v| inbound_to_external(v, handle_table))
+        .map(|v| decode_value(v, transfer))
         .collect();
     Ok(BexExternalValue::Array {
         element_type: default_scalar_union_ty(),
@@ -236,14 +344,14 @@ fn convert_list(
 
 fn convert_map(
     map: InboundMapValue,
-    handle_table: &CffiHandleTable,
+    transfer: &InboundTransfer,
 ) -> Result<BexExternalValue, CtypesError> {
     let mut entries = IndexMap::new();
     for entry in map.entries {
         let key = extract_string_key(&entry)?;
         let value = entry
             .value
-            .map(|v| inbound_to_external(v, handle_table))
+            .map(|v| decode_value(v, transfer))
             .transpose()?
             .unwrap_or(BexExternalValue::Null);
         entries.insert(key, value);
@@ -257,14 +365,14 @@ fn convert_map(
 
 fn convert_class(
     class: InboundClassValue,
-    handle_table: &CffiHandleTable,
+    transfer: &InboundTransfer,
 ) -> Result<BexExternalValue, CtypesError> {
     let mut fields = IndexMap::new();
     for entry in class.fields {
         let key = extract_string_key(&entry)?;
         let value = entry
             .value
-            .map(|v| inbound_to_external(v, handle_table))
+            .map(|v| decode_value(v, transfer))
             .transpose()?
             .unwrap_or(BexExternalValue::Null);
         fields.insert(key, value);
@@ -299,17 +407,7 @@ pub fn kwargs_to_bex_values(
     kwargs: Vec<InboundMapEntry>,
     handle_table: &CffiHandleTable,
 ) -> Result<HashMap<String, BexExternalValue>, CtypesError> {
-    let mut result = HashMap::new();
-    for entry in kwargs {
-        let key = extract_string_key(&entry)?;
-        let value = entry
-            .value
-            .map(|v| inbound_to_external(v, handle_table))
-            .transpose()?
-            .unwrap_or(BexExternalValue::Null);
-        result.insert(key, value);
-    }
-    Ok(result)
+    InboundTransfer::capture_kwargs(&kwargs, handle_table).decode_kwargs(kwargs)
 }
 
 /// Decode playground run arguments from a host-call-free byte envelope.
@@ -332,13 +430,81 @@ pub fn playground_run_args_to_bex_values(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{baml_bridge::cffi::BamlHandle, handle_table::CffiHandleTableEntry};
+    use crate::baml_bridge::cffi::BamlHandle;
 
     fn typed_input(value_type: &RuntimeTy, value: InboundValueVariant) -> InboundValue {
         InboundValue {
             value_type: Some(crate::ty_encode::runtime_ty_to_proto_ty(value_type)),
             value: Some(value),
         }
+    }
+
+    /// A malformed sibling fails the aggregate after one handle was reached
+    /// and before another was. Both leases must still be consumed, and the
+    /// value they retained must be released with the batch.
+    #[test]
+    fn failed_input_aggregate_releases_visited_and_unvisited_transfers() {
+        struct Resource;
+        let resource = Arc::new(Resource);
+        let table = CffiHandleTable::new();
+        let original = table.insert(CffiHandleTableEntry::RustData(
+            crate::handle_table::BexRustData(resource.clone()),
+        ));
+        let owners = Arc::strong_count(&resource);
+        let sent = || InboundValue {
+            value_type: None,
+            value: Some(InboundValueVariant::Handle(BamlHandle {
+                key: table.clone_handle(original).unwrap(),
+                handle_type: BamlHandleType::UntaggedRustData as i32,
+            })),
+        };
+        let input = InboundValue {
+            value_type: None,
+            value: Some(InboundValueVariant::ListValue(InboundListValue {
+                values: vec![
+                    sent(),
+                    InboundValue {
+                        value_type: None,
+                        value: Some(InboundValueVariant::BigintValue("not hex".into())),
+                    },
+                    sent(),
+                ],
+            })),
+        };
+        assert_eq!(table.len(), 3, "each wire occurrence carries its own lease");
+
+        assert!(matches!(
+            inbound_to_external(input, &table),
+            Err(CtypesError::InvalidBigint { .. })
+        ));
+        assert_eq!(table.len(), 1, "only the caller's own lease remains");
+        assert_eq!(Arc::strong_count(&resource), owners);
+
+        assert!(table.release(original));
+        assert_eq!(Arc::strong_count(&resource), 1);
+    }
+
+    /// A wire discriminator that disagrees with a key's live registration is
+    /// rejected as data; it neither panics nor displaces that registration.
+    #[test]
+    fn forged_host_kind_is_rejected_without_replacing_the_live_registration() {
+        let original =
+            bex_project::HostValueArc::intern(91234, bex_project::HostValueKind::Callable);
+        let input = InboundValue {
+            value_type: None,
+            value: Some(InboundValueVariant::Handle(BamlHandle {
+                key: original.key,
+                handle_type: BamlHandleType::HostValueOpaque as i32,
+            })),
+        };
+
+        assert!(matches!(
+            inbound_to_external(input, &CffiHandleTable::new()),
+            Err(CtypesError::InvalidHostValueKind(91234))
+        ));
+        let same =
+            bex_project::HostValueArc::intern(original.key, bex_project::HostValueKind::Callable);
+        assert!(Arc::ptr_eq(&original, &same));
     }
 
     #[test]

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -10,8 +10,47 @@ use crate::{
         baml_outbound_value::Value as BamlValueVariant,
     },
     error::CtypesError,
-    handle_table::{BexRustData, CffiHandleTableEntry, CffiHandleTableOptions},
+    handle_table::{BexRustData, CffiHandleTable, CffiHandleTableEntry, CffiHandleTableOptions},
 };
+
+/// Handle-table rows inserted while encoding one outbound aggregate.
+///
+/// Every row inserted for the host owes exactly one release. Until the ledger
+/// is committed it still owns those releases and performs them on drop, so an
+/// encode that fails partway — an invalid child after valid opaque siblings —
+/// leaves no orphaned rows behind.
+struct OutboundOwnership<'a> {
+    table: &'a CffiHandleTable,
+    keys: Vec<u64>,
+}
+
+impl<'a> OutboundOwnership<'a> {
+    fn new(table: &'a CffiHandleTable) -> Self {
+        Self {
+            table,
+            keys: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, entry: CffiHandleTableEntry) -> u64 {
+        let key = self.table.insert(entry);
+        self.keys.push(key);
+        key
+    }
+
+    /// Hand every inserted row to the host: the releases are now its to make.
+    fn commit(mut self) {
+        self.keys.clear();
+    }
+}
+
+impl Drop for OutboundOwnership<'_> {
+    fn drop(&mut self) {
+        for key in self.keys.drain(..) {
+            self.table.release(key);
+        }
+    }
+}
 
 /// Convert `BexExternalValue` to `BamlOutboundValue` for FFI return.
 ///
@@ -20,9 +59,24 @@ use crate::{
 /// For `BexExternalAdt::TaggedHeapHandle { ty, .. }` the underlying type is encoded
 /// as a full `BamlTy` on the handle's `ty` field so the host sees the class FQN +
 /// concrete generic args (and an interface keeps its bindings).
+///
+/// The value is one ownership aggregate: on error, every row this call
+/// inserted is released again, so a caller may encode a fallback value in its
+/// place without leaking the failed attempt.
 pub fn external_to_outbound(
     value: &BexExternalValue,
     options: &CffiHandleTableOptions,
+) -> Result<BamlOutboundValue, CtypesError> {
+    let mut owned = OutboundOwnership::new(options.table);
+    let encoded = encode_value(value, options, &mut owned)?;
+    owned.commit();
+    Ok(encoded)
+}
+
+fn encode_value(
+    value: &BexExternalValue,
+    options: &CffiHandleTableOptions,
+    owned: &mut OutboundOwnership<'_>,
 ) -> Result<BamlOutboundValue, CtypesError> {
     let variant = match value {
         BexExternalValue::Null => None,
@@ -40,7 +94,7 @@ pub fn external_to_outbound(
         } => {
             let values: Result<Vec<BamlOutboundValue>, CtypesError> = items
                 .iter()
-                .map(|v| external_to_outbound(v, options))
+                .map(|v| encode_value(v, options, owned))
                 .collect();
             Some(BamlValueVariant::ListValue(BamlValueList {
                 item_type: Some(crate::ty_encode::runtime_ty_to_proto_ty(element_type)),
@@ -56,7 +110,7 @@ pub fn external_to_outbound(
             for (key, val) in entries {
                 baml_entries.push(BamlOutboundMapEntry {
                     key: key.clone(),
-                    value: Some(external_to_outbound(val, options)?),
+                    value: Some(encode_value(val, options, owned)?),
                 });
             }
             Some(BamlValueVariant::MapValue(BamlValueMap {
@@ -74,7 +128,7 @@ pub fn external_to_outbound(
             for (key, val) in fields {
                 baml_fields.push(BamlOutboundMapEntry {
                     key: key.clone(),
-                    value: Some(external_to_outbound(val, options)?),
+                    value: Some(encode_value(val, options, owned)?),
                 });
             }
             // Carry a generic instance's concrete class type args (De Bruijn
@@ -101,7 +155,7 @@ pub fn external_to_outbound(
         BexExternalValue::Union { value, metadata } => {
             let selected_option_index =
                 selected_union_option_index(&metadata.union_type, &metadata.selected_option)?;
-            let inner = external_to_outbound(value, options)?;
+            let inner = encode_value(value, options, owned)?;
             Some(BamlValueVariant::UnionVariantValue(Box::new(
                 BamlValueUnionVariant {
                     name: metadata.name.clone().unwrap_or_default(),
@@ -133,11 +187,11 @@ pub fn external_to_outbound(
         }
         BexExternalValue::RustData(arc) => {
             if let Some(converted) = bex_project::try_convert_rust_data(arc) {
-                return external_to_outbound(&converted, options);
+                return encode_value(&converted, options, owned);
             }
             let table_value = CffiHandleTableEntry::RustData(BexRustData(arc.clone()));
             let ht = table_value.handle_type();
-            let key = options.table.insert(table_value);
+            let key = owned.insert(table_value);
             Some(BamlValueVariant::HandleValue(BamlOutboundHandle {
                 key,
                 handle_type: ht as i32,
@@ -207,7 +261,7 @@ pub fn external_to_outbound(
                 CtypesError::InternalError(format!("handle table insertion failed: {e}"))
             })?;
             let ht = table_value.handle_type();
-            let key = options.table.insert(table_value);
+            let key = owned.insert(table_value);
             Some(BamlValueVariant::HandleValue(BamlOutboundHandle {
                 key,
                 handle_type: ht as i32,
@@ -545,10 +599,13 @@ pub fn build_to_host_call(
     optional: &IndexMap<String, BexExternalValue>,
     options: &CffiHandleTableOptions,
 ) -> Result<BamlToHostCall, CtypesError> {
+    // The whole argument list is one ownership aggregate: a later argument
+    // that fails to encode releases the rows of every argument before it.
+    let mut owned = OutboundOwnership::new(options.table);
     let mut args = Vec::with_capacity(positional.len() + optional.len());
     for v in positional {
         args.push(BamlToHostArg {
-            value: Some(external_to_outbound(v, options)?),
+            value: Some(encode_value(v, options, &mut owned)?),
             // Positional (required) args are taken by position — no name.
             arg_name: String::new(),
             is_optional_arg: false,
@@ -556,11 +613,12 @@ pub fn build_to_host_call(
     }
     for (name, v) in optional {
         args.push(BamlToHostArg {
-            value: Some(external_to_outbound(v, options)?),
+            value: Some(encode_value(v, options, &mut owned)?),
             arg_name: name.clone(),
             is_optional_arg: true,
         });
     }
+    owned.commit();
     Ok(BamlToHostCall { args })
 }
 
@@ -606,6 +664,59 @@ mod tests {
 
     fn ambiguous_numeric_union(selected: RuntimeTy, value: BexExternalValue) -> BexExternalValue {
         BexExternalValue::union(value, [RuntimeTy::int(), RuntimeTy::float()], selected)
+    }
+
+    /// An opaque sibling is inserted into the table before a later child
+    /// fails to encode. The failed aggregate must not leave that row (and the
+    /// value it retains) behind.
+    #[test]
+    fn failed_output_aggregate_rolls_back_earlier_owned_handles() {
+        struct Resource;
+        let resource = Arc::new(Resource);
+        let live = BexExternalValue::RustData(resource.clone());
+        let invalid = ambiguous_numeric_union(RuntimeTy::bool(), BexExternalValue::Bool(true));
+        let table = CffiHandleTable::new();
+        let options = CffiHandleTableOptions {
+            table: &table,
+            serialize_media: true,
+            serialize_prompt_ast: true,
+        };
+        let value = BexExternalValue::Array {
+            element_type: RuntimeTy::unknown(),
+            items: vec![
+                live.clone(),
+                BexExternalValue::Instance {
+                    class_name: "user.Record".into(),
+                    type_args: vec![],
+                    fields: IndexMap::from([
+                        ("live".to_string(), live.clone()),
+                        ("invalid".to_string(), invalid.clone()),
+                    ]),
+                },
+            ],
+        };
+        let owners = Arc::strong_count(&resource);
+        assert!(external_to_outbound(&value, &options).is_err());
+        assert!(table.is_empty());
+        assert_eq!(Arc::strong_count(&resource), owners);
+
+        // A callback's argument list is one aggregate too, optional arguments
+        // included: a bad optional rolls back the positional before it.
+        let call = build_to_host_call(
+            std::slice::from_ref(&live),
+            &IndexMap::from([("bad".to_string(), invalid)]),
+            &options,
+        );
+        assert!(call.is_err());
+        assert!(table.is_empty());
+        assert_eq!(Arc::strong_count(&resource), owners);
+
+        // The same values encode, and commit, once the aggregate is valid.
+        let encoded = external_to_outbound(&live, &options).unwrap();
+        let handle = extract_handle(encoded);
+        assert_eq!(table.len(), 1);
+        assert!(table.release(handle.key));
+        assert!(table.is_empty());
     }
 
     #[test]

--- a/baml_language/sdks/java/bridge_java/src/lib.rs
+++ b/baml_language/sdks/java/bridge_java/src/lib.rs
@@ -18,107 +18,37 @@
 
 use std::sync::{Arc, Once, OnceLock};
 
-use bex_project::{BexArgs, BexExternalAdt, CallId, MediaKind, MediaValue, RuntimeTy};
-use bridge_ctypes::{CffiHandleTableEntry, HANDLE_TABLE, kwargs_to_bex_values};
-use indexmap::IndexMap;
+use bex_project::{BexExternalAdt, MediaKind, MediaValue};
+use bridge_ctypes::{CffiHandleTableEntry, HANDLE_TABLE};
 use jni::{
     JNIEnv, JavaVM,
     objects::{GlobalRef, JByteArray, JClass, JString, JValue},
     sys::{jboolean, jint, jlong},
 };
-use prost::Message;
-
-/// Decoded `CallFunctionArgs` — the JVM analog of `bridge_python`'s
-/// `DecodedCallArgs`.
-struct DecodedCallArgs {
-    kwargs: BexArgs,
-    call_id: CallId,
-    target: bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget,
-    /// Explicit, named `TypeVar` bindings for a generic call, in De Bruijn
-    /// order (empty for non-generic calls). See `CallFunctionArgs.type_args`.
-    type_args: IndexMap<String, RuntimeTy>,
-    type_defs: IndexMap<String, bex_project::PortableTypeDef>,
-}
-
-/// Decode protobuf-encoded `CallFunctionArgs` bytes into `BexArgs`.
-///
-/// Returns a `BridgeError` (not a thrown exception) so the byte-returning
-/// call site can route the failure through `bridge_cffi::error_to_outbound`
-/// into the structured `BamlOutboundResult` envelope, exactly like
-/// `bridge_python` does — the Java side then decodes + raises uniformly.
-fn decode_args(args_proto: &[u8]) -> Result<DecodedCallArgs, bridge_cffi::BridgeError> {
-    use bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget;
-
-    let args = bridge_ctypes::baml_bridge::cffi::CallFunctionArgs::decode(args_proto)
-        .map_err(bridge_ctypes::CtypesError::from)?;
-
-    if args.call_id == 0 {
-        return Err(bridge_cffi::BridgeError::InvalidCallId);
-    }
-
-    let call_id = CallId(args.call_id);
-    let target = args
-        .call_target
-        .ok_or(bridge_cffi::BridgeError::MissingCallTarget)?;
-    if matches!(target, CallTarget::FunctionHandle(_)) && !args.type_args.is_empty() {
-        return Err(bridge_cffi::BridgeError::FunctionHandleTypeArgs);
-    }
-    let type_args = bridge_ctypes::proto_ty_args_to_named(&args.type_args)?;
-    let kwargs = kwargs_to_bex_values(args.kwargs, &HANDLE_TABLE)?;
-
-    Ok(DecodedCallArgs {
-        kwargs: kwargs.into(),
-        call_id,
-        target,
-        type_args: type_args.type_args,
-        type_defs: type_args.type_defs,
-    })
-}
 
 /// Shared synchronous call body. Mirrors `bridge_python`'s
 /// `call_function_sync`: pre-call host-boundary failures (uninitialized
 /// runtime, malformed args, no tokio runtime) are encoded into the
 /// `BamlOutboundResult` envelope rather than thrown, so the returned bytes
-/// decode + raise uniformly on the Java side. The `catch_unwind` + engine
-/// error handling already lives in `bridge_cffi::call_and_encode`.
+/// decode + raise uniformly on the Java side. Argument decoding, target
+/// pinning and the `catch_unwind` + engine error handling all live in
+/// `bridge_cffi::prepare_call` / `bridge_cffi::invoke_prepared`.
 fn call_sync_to_bytes(args_proto: &[u8]) -> Vec<u8> {
     let prepared = (|| -> Result<_, bridge_cffi::BridgeError> {
         let runtime = bridge_cffi::get_runtime()?;
-        let decoded = decode_args(args_proto)?;
+        let prepared = bridge_cffi::prepare_call(args_proto)?;
         let rt = bridge_cffi::get_tokio_runtime()?;
-        Ok((runtime, decoded, rt))
+        Ok((runtime, prepared, rt))
     })();
 
-    let (runtime, decoded, rt) = match prepared {
+    let (runtime, prepared, rt) = match prepared {
         Ok(v) => v,
         Err(e) => return bridge_cffi::error_to_outbound(e),
     };
 
-    let call_ctx = bridge_cffi::function_call_context_builder(decoded.call_id)
-        .with_type_args(decoded.type_args)
-        .with_type_defs(decoded.type_defs)
-        .build();
-
     // Block on the shared multi-thread tokio runtime, like the pyo3 sync path
     // (`rt.block_on(...)`). Returns the encoded `BamlOutboundResult` bytes.
-    match decoded.target {
-        bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionName(
-            function_name,
-        ) => rt.block_on(bridge_cffi::call_and_encode(
-            runtime,
-            function_name,
-            decoded.kwargs,
-            call_ctx,
-        )),
-        bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionHandle(
-            handle_key,
-        ) => rt.block_on(bridge_cffi::call_handle_and_encode(
-            runtime,
-            handle_key,
-            decoded.kwargs,
-            call_ctx,
-        )),
-    }
+    rt.block_on(bridge_cffi::invoke_prepared(runtime, prepared))
 }
 
 /// `baml_bridge.BamlFfi.nativeInitFromBytecode(byte[] bytecode, String metadata, String runtimeVersion, String toolchainVersion)`.
@@ -370,12 +300,12 @@ pub extern "system" fn Java_baml_1bridge_BamlFfi_nativeCallAsync<'local>(
 fn spawn_async_call(call_id: u64, args_proto: Vec<u8>) {
     let prepared = (|| -> Result<_, bridge_cffi::BridgeError> {
         let runtime = bridge_cffi::get_runtime()?;
-        let decoded = decode_args(&args_proto)?;
+        let prepared = bridge_cffi::prepare_call(&args_proto)?;
         let rt = bridge_cffi::get_tokio_runtime()?;
-        Ok((runtime, decoded, rt))
+        Ok((runtime, prepared, rt))
     })();
 
-    let (runtime, decoded, rt) = match prepared {
+    let (runtime, prepared, rt) = match prepared {
         Ok(v) => v,
         Err(e) => {
             // Same envelope bytes the sync path returns, delivered on this
@@ -385,34 +315,13 @@ fn spawn_async_call(call_id: u64, args_proto: Vec<u8>) {
         }
     };
 
-    let DecodedCallArgs {
-        kwargs,
-        call_id: engine_call_id,
-        target,
-        type_args,
-        type_defs,
-    } = decoded;
-    let call_ctx = bridge_cffi::function_call_context_builder(engine_call_id)
-        .with_type_args(type_args)
-        .with_type_defs(type_defs)
-        .build();
-
     rt.spawn(async move {
         // Inner task so a panic during result *encoding* is caught (via the
         // JoinError) and still delivered as an SdkPanic envelope, rather than
-        // silently dropping the task and hanging the future. `call_and_encode`
+        // silently dropping the task and hanging the future. `invoke_prepared`
         // already turns an engine-call panic into that envelope itself; this
         // guards the rarer encode-time panic, exactly as the C-ABI path does.
-        let inner = tokio::spawn(async move {
-            match target {
-                bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionName(function_name) => {
-                    bridge_cffi::call_and_encode(runtime, function_name, kwargs, call_ctx).await
-                }
-                bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionHandle(handle_key) => {
-                    bridge_cffi::call_handle_and_encode(runtime, handle_key, kwargs, call_ctx).await
-                }
-            }
-        });
+        let inner = tokio::spawn(bridge_cffi::invoke_prepared(runtime, prepared));
         let bytes = match inner.await {
             Ok(bytes) => bytes,
             Err(join_err) => encode_task_failure(join_err),

--- a/baml_language/sdks/python/rust/bridge_python/src/runtime.rs
+++ b/baml_language/sdks/python/rust/bridge_python/src/runtime.rs
@@ -1,7 +1,5 @@
 //! BamlRuntime PyO3 class - wraps `Arc<dyn Bex>`.
 
-use bridge_ctypes::{HANDLE_TABLE, kwargs_to_bex_values};
-use prost::Message;
 use pyo3::{
     Py, Python,
     prelude::{PyResult, pyfunction, pymethods},
@@ -17,19 +15,6 @@ use crate::{
     errors::{bridge_error_to_sdk_panic, py_sdk_panic},
     types::collector::Collector,
 };
-
-struct DecodedCallArgs {
-    kwargs: bex_project::BexArgs,
-    call_id: bex_project::CallId,
-    target: bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget,
-    /// Explicit, named `TypeVar` bindings for a generic call (`_types=` + a
-    /// generic receiver's class type args): `TypeVar name -> concrete type`,
-    /// insertion order is De Bruijn order. Empty for non-generic calls. The
-    /// engine maps each name onto the entry-frame `type_args` slot by matching
-    /// the callee's generic params.
-    type_args: indexmap::IndexMap<String, bex_project::RuntimeTy>,
-    type_defs: indexmap::IndexMap<String, bex_project::PortableTypeDef>,
-}
 
 /// The main BAML runtime. A zero-sized handle: the single source of truth for
 /// the `Arc<dyn Bex>` singleton is `bridge_cffi`, fetched via
@@ -126,10 +111,12 @@ impl BamlRuntime {
         // raise — they become a structured BamlOutboundResult envelope so the
         // future yields bytes that decode_call_result raises uniformly (same
         // BamlError(baml.errors.*) as an engine failure).
+        // `prepare_call` pins a handle target before we yield to the event
+        // loop, so a Python-side release of that handle cannot race the call.
         let prepared = (|| -> Result<_, bridge_cffi::BridgeError> {
             let runtime = bridge_cffi::get_runtime()?;
-            let decoded = decode_args(&args_proto)?;
-            Ok((runtime, decoded))
+            let prepared = bridge_cffi::prepare_call(&args_proto)?;
+            Ok((runtime, prepared))
         })();
 
         // Tracing is a no-op: `ctx`/`collectors` are accepted for ABI
@@ -141,20 +128,7 @@ impl BamlRuntime {
         // return the encoded envelope bytes for Python to decode + raise.
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let bytes = match prepared {
-                Ok((runtime, decoded)) => {
-                    let call_ctx = bridge_cffi::function_call_context_builder(decoded.call_id)
-                        .with_type_args(decoded.type_args)
-                        .with_type_defs(decoded.type_defs)
-                        .build();
-                    match decoded.target {
-                        bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionName(function_name) => {
-                            bridge_cffi::call_and_encode(runtime, function_name, decoded.kwargs, call_ctx).await
-                        }
-                        bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionHandle(handle_key) => {
-                            bridge_cffi::call_handle_and_encode(runtime, handle_key, decoded.kwargs, call_ctx).await
-                        }
-                    }
-                }
+                Ok((runtime, prepared)) => bridge_cffi::invoke_prepared(runtime, prepared).await,
                 Err(e) => bridge_cffi::error_to_outbound(e),
             };
             Ok(bytes)
@@ -182,12 +156,12 @@ impl BamlRuntime {
         // returned bytes decode + raise uniformly via decode_call_result.
         let prepared = (|| -> Result<_, bridge_cffi::BridgeError> {
             let runtime = bridge_cffi::get_runtime()?;
-            let decoded = decode_args(&args_proto)?;
+            let prepared = bridge_cffi::prepare_call(&args_proto)?;
             let rt = bridge_cffi::get_tokio_runtime()?;
-            Ok((runtime, decoded, rt))
+            Ok((runtime, prepared, rt))
         })();
 
-        let (runtime, decoded, rt) = match prepared {
+        let (runtime, prepared, rt) = match prepared {
             Ok(v) => v,
             Err(e) => return Ok(bridge_cffi::error_to_outbound(e)),
         };
@@ -195,67 +169,12 @@ impl BamlRuntime {
         // Tracing is a no-op: `ctx`/`collectors` are accepted for ABI
         // stability but no longer wired into the call context.
         let _ = (&ctx, &collectors);
-        let call_ctx = bridge_cffi::function_call_context_builder(decoded.call_id)
-            .with_type_args(decoded.type_args)
-            .with_type_defs(decoded.type_defs)
-            .build();
 
-        // Same shared call_and_encode as the async + C-ABI paths — returns the
+        // Same shared invoke_prepared as the async + C-ABI paths — returns the
         // encoded BamlOutboundResult envelope bytes.
-        let bytes = py.detach(|| match decoded.target {
-            bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionName(
-                function_name,
-            ) => rt.block_on(bridge_cffi::call_and_encode(
-                runtime,
-                function_name,
-                decoded.kwargs,
-                call_ctx,
-            )),
-            bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionHandle(
-                handle_key,
-            ) => rt.block_on(bridge_cffi::call_handle_and_encode(
-                runtime,
-                handle_key,
-                decoded.kwargs,
-                call_ctx,
-            )),
-        });
+        let bytes = py.detach(|| rt.block_on(bridge_cffi::invoke_prepared(runtime, prepared)));
         Ok(bytes)
     }
-}
-
-/// Decode protobuf-encoded function arguments into `BexArgs`.
-///
-/// Returns a `BridgeError` (not a `PyErr`) so the byte-returning call sites can
-/// route the failure through `bridge_cffi::error_to_outbound` into the
-/// structured `BamlOutboundResult` envelope (32c) rather than raising.
-fn decode_args(args_proto: &[u8]) -> Result<DecodedCallArgs, bridge_cffi::BridgeError> {
-    use bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget;
-
-    let args = bridge_ctypes::baml_bridge::cffi::CallFunctionArgs::decode(args_proto)
-        .map_err(bridge_ctypes::CtypesError::from)?;
-
-    if args.call_id == 0 {
-        return Err(bridge_cffi::BridgeError::InvalidCallId);
-    }
-
-    let call_id = bex_project::CallId(args.call_id);
-    let target = args
-        .call_target
-        .ok_or(bridge_cffi::BridgeError::MissingCallTarget)?;
-    if matches!(target, CallTarget::FunctionHandle(_)) && !args.type_args.is_empty() {
-        return Err(bridge_cffi::BridgeError::FunctionHandleTypeArgs);
-    }
-    let type_args = bridge_ctypes::proto_ty_args_to_named(&args.type_args)?;
-    let kwargs = kwargs_to_bex_values(args.kwargs, &HANDLE_TABLE)?;
-
-    Ok(DecodedCallArgs {
-        kwargs: kwargs.into(),
-        call_id,
-        target,
-        type_args: type_args.type_args,
-        type_defs: type_args.type_defs,
-    })
 }
 
 /// Return the process-global `BamlRuntime`, or raise `BamlError` if

--- a/baml_language/sdks/typescript/bridge_typescript/src/runtime.rs
+++ b/baml_language/sdks/typescript/bridge_typescript/src/runtime.rs
@@ -5,27 +5,13 @@
 //! at each call site (mirrors `bridge_python` after 31e-phase4), so this no
 //! longer caches its own clone.
 
-use bridge_ctypes::{HANDLE_TABLE, kwargs_to_bex_values};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use prost::Message;
 
 use crate::{
     errors::bridge_error_to_napi,
     types::{HostSpanManager, collector::Collector},
 };
-
-struct DecodedCallArgs {
-    kwargs: bex_project::BexArgs,
-    call_id: bex_project::CallId,
-    target: bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget,
-    /// Explicit TypeVar bindings for a generic call (`CallFunctionArgs.type_args`),
-    /// as a name-keyed map in wire (De Bruijn) order. Seeded into the entry
-    /// frame's `type_args` slot. Empty for non-generic calls. Mirrors
-    /// `bridge_python`'s `DecodedCallArgs::type_args`.
-    type_args: indexmap::IndexMap<String, bex_project::RuntimeTy>,
-    type_defs: indexmap::IndexMap<String, bex_project::PortableTypeDef>,
-}
 
 /// The main BAML runtime. A zero-sized handle (see module docs).
 #[napi]
@@ -77,43 +63,22 @@ impl BamlRuntime {
     ) -> napi::Result<Buffer> {
         let prepared = (|| -> std::result::Result<_, bridge_cffi::BridgeError> {
             let runtime = bridge_cffi::get_runtime()?;
-            let decoded = decode_args(args_proto.as_ref())?;
+            let prepared = bridge_cffi::prepare_call(args_proto.as_ref())?;
             let rt = bridge_cffi::get_tokio_runtime()?;
-            Ok((runtime, decoded, rt))
+            Ok((runtime, prepared, rt))
         })();
         let _ = (&ctx, &collectors);
 
-        let (runtime, decoded, rt) = match prepared {
+        let (runtime, prepared, rt) = match prepared {
             Ok(v) => v,
             Err(e) => return Ok(Buffer::from(bridge_cffi::error_to_outbound(e))),
         };
-        let call_ctx = bridge_cffi::function_call_context_builder(decoded.call_id)
-            .with_type_args(decoded.type_args)
-            .with_type_defs(decoded.type_defs)
-            .build();
 
         // The whole Result -> BamlOutboundResult translation (incl. the
         // catch_unwind -> SdkPanic boundary and error/panic routing) lives in
         // bridge_cffi; we just return the encoded envelope bytes for the TS
         // decoder to surface.
-        let bytes = match decoded.target {
-            bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionName(
-                function_name,
-            ) => rt.block_on(bridge_cffi::call_and_encode(
-                runtime,
-                function_name,
-                decoded.kwargs,
-                call_ctx,
-            )),
-            bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionHandle(
-                handle_key,
-            ) => rt.block_on(bridge_cffi::call_handle_and_encode(
-                runtime,
-                handle_key,
-                decoded.kwargs,
-                call_ctx,
-            )),
-        };
+        let bytes = rt.block_on(bridge_cffi::invoke_prepared(runtime, prepared));
 
         Ok(Buffer::from(bytes))
     }
@@ -127,31 +92,20 @@ impl BamlRuntime {
         ctx: Option<&HostSpanManager>,
         collectors: Option<Vec<&Collector>>,
     ) -> napi::Result<PromiseRaw<'e, Buffer>> {
+        // `prepare_call` pins a handle target before the future is spawned,
+        // so a JS-side release of that handle cannot race the call.
         let prepared = (|| -> std::result::Result<_, bridge_cffi::BridgeError> {
             let runtime = bridge_cffi::get_runtime()?;
-            let decoded = decode_args(args_proto.as_ref())?;
-            Ok((runtime, decoded))
+            let prepared = bridge_cffi::prepare_call(args_proto.as_ref())?;
+            Ok((runtime, prepared))
         })();
         let _ = (&ctx, &collectors);
 
-        // Same shared call_and_encode as the sync + C-ABI paths — returns the
+        // Same shared invoke_prepared as the sync + C-ABI paths — returns the
         // encoded BamlOutboundResult envelope bytes for the TS decoder.
         env.spawn_future(async move {
             let bytes = match prepared {
-                Ok((runtime, decoded)) => {
-                    let call_ctx = bridge_cffi::function_call_context_builder(decoded.call_id)
-                        .with_type_args(decoded.type_args)
-                        .with_type_defs(decoded.type_defs)
-                        .build();
-                    match decoded.target {
-                        bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionName(function_name) => {
-                            bridge_cffi::call_and_encode(runtime, function_name, decoded.kwargs, call_ctx).await
-                        }
-                        bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget::FunctionHandle(handle_key) => {
-                            bridge_cffi::call_handle_and_encode(runtime, handle_key, decoded.kwargs, call_ctx).await
-                        }
-                    }
-                }
+                Ok((runtime, prepared)) => bridge_cffi::invoke_prepared(runtime, prepared).await,
                 Err(e) => bridge_cffi::error_to_outbound(e),
             };
             Ok(Buffer::from(bytes))
@@ -173,36 +127,4 @@ pub fn get_runtime() -> napi::Result<BamlRuntime> {
         other => bridge_error_to_napi(other),
     })?;
     Ok(BamlRuntime {})
-}
-
-/// Decode protobuf-encoded function arguments into `BexArgs`.
-fn decode_args(
-    args_proto: &[u8],
-) -> std::result::Result<DecodedCallArgs, bridge_cffi::BridgeError> {
-    use bridge_ctypes::baml_bridge::cffi::call_function_args::CallTarget;
-
-    let args = bridge_ctypes::baml_bridge::cffi::CallFunctionArgs::decode(args_proto)
-        .map_err(bridge_ctypes::CtypesError::from)?;
-
-    if args.call_id == 0 {
-        return Err(bridge_cffi::BridgeError::InvalidCallId);
-    }
-
-    let call_id = bex_project::CallId(args.call_id);
-    let target = args
-        .call_target
-        .ok_or(bridge_cffi::BridgeError::MissingCallTarget)?;
-    if matches!(target, CallTarget::FunctionHandle(_)) && !args.type_args.is_empty() {
-        return Err(bridge_cffi::BridgeError::FunctionHandleTypeArgs);
-    }
-    let type_args = bridge_ctypes::proto_ty_args_to_named(&args.type_args)?;
-    let kwargs = kwargs_to_bex_values(args.kwargs, &HANDLE_TABLE)?;
-
-    Ok(DecodedCallArgs {
-        kwargs: kwargs.into(),
-        call_id,
-        target,
-        type_args: type_args.type_args,
-        type_defs: type_args.type_defs,
-    })
 }


### PR DESCRIPTION
## Summary

Four ownership fixes at the C-FFI boundary, kept to two small ledgers: an outbound insert log that rolls back on a failed encode, and an inbound capture batch that takes every handle before decoding. No sessions, receipts, or new wire tags. `prepare_call` becomes the single definition of argument decoding and target pinning, replacing per-adapter copies in the C ABI, Wasm, PyO3, JNI and napi bridges.

## Bugs fixed

- **Outbound encode leaked earlier children when a later child failed.** Rows inserted for opaque children before the failing one never reached the host and were never released. `OutboundOwnership` releases them on drop and commits only when the whole aggregate encoded.
- **Inbound decode leaked keys after a malformed sibling**, and a host key with a forged kind hit a `debug_assert` at the boundary. `InboundTransfer::capture` drains every engine key and interns every host key first; undecoded leftovers are released when the batch drops; a forged kind is `CtypesError::InvalidHostValueKind`.
- **`complete_host_call` with an invalid `is_error` flag returned before interning the payload's host keys**, leaking the bridge's registry entries. References are captured before the flag check.
- **A callable's handle-table key was resolved inside the spawned task**, racing an SDK that released it right after issuing the call ("callable handle is no longer live"). `prepare_call` pins the target synchronously; `PreparedCall` holds it until `invoke_prepared` ran.

## Tests

Rust, in-crate (these are wire and ownership assertions only Rust can express, run under nextest's process-per-test): `failed_output_aggregate_rolls_back_earlier_owned_handles`, `failed_input_aggregate_releases_visited_and_unvisited_transfers`, `forged_host_kind_is_rejected_without_replacing_the_live_registration`, `invalid_completion_flag_releases_the_parsed_payload`, `prepared_handle_call_survives_release_of_its_key`.

## Stack

Part of the split of #4797; stacked on #4809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when invoking functions and callable values across supported language bridges.
  - Ensured temporary handles and host values are released correctly when decoding or encoding fails.
  - Added validation for mismatched host-value types with clearer errors.
  - Preserved callable targets throughout asynchronous execution, even if their original handle is released.
  - Empty successful results are now handled consistently, while invalid completion payloads report clearer failures.

- **Refactor**
  - Standardized call preparation and execution across native, WebAssembly, Java, Python, and TypeScript integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core FFI ownership, host-value identity, and async call pinning across all language bridges; bugs could leak handles or break callable invocation, but behavior is covered by targeted ownership and pinning tests.
> 
> **Overview**
> This PR hardens **handle and host-value ownership** at the C-FFI boundary and **unifies how every adapter runs BAML calls**.
> 
> **Inbound:** `InboundTransfer` walks a parsed `InboundValue` (or kwargs) and **captures** every engine handle lease and host key **before** validation/decode. Failed decodes still release what was taken; forged host-value kinds use `HostValueArc::try_intern` and surface as `CtypesError::InvalidHostValueKind` instead of asserting. `complete_host_call` now captures the payload the same way **before** checking `is_error`, so rejected completions do not leak host keys.
> 
> **Outbound:** `OutboundOwnership` tracks handle-table rows inserted during one encode; **failed partial encodes roll back** inserts (including `build_to_host_call`).
> 
> **Calls:** `call_and_encode` / `call_handle_and_encode` and per-SDK decode paths are replaced by **`prepare_call`** (decode + `InboundTransfer` + **synchronous pin** of callable heap handles) and **`invoke_prepared`**. C ABI, Wasm, PyO3, JNI, and napi all use this pair, fixing the race where the SDK released a callable key between issuing a call and the async task resolving it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6854739befc183f83aa4dfb09177c6dd334094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->