### PR TITLE
Reduce GC scan overhead and add reproducible profiling

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "parking_lot",
  "thiserror 2.0.18",
  "tokio",
+ "web-time",
 ]
 
 [[package]]

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "parking_lot",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "web-time",
 ]
 

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -56,6 +56,7 @@ workspace = true
 
 [features]
 default = [ "aws-crypto" ]
+gc_profiling = [ "bex_heap/gc_profiling" ]
 # `sys_native` is a dev-dependency only, so feature propagation here would
 # be a no-op for downstream consumers; its crypto feature is set directly
 # on the `[dev-dependencies]` entry above.

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3350,18 +3350,14 @@ impl BexEngine {
         level: bex_heap::CollectionLevel,
         reason: &'static str,
     ) -> bex_heap::GcStats {
-        #[cfg(not(feature = "gc_profiling"))]
-        let _ = reason;
-        #[cfg(feature = "gc_profiling")]
-        let cycle_start = web_time::Instant::now();
+        let mut cycle = bex_heap::GcCycleProfiler::start();
         #[cfg(not(target_arch = "wasm32"))]
         let park_request_guard = ParkRequestGuard::new(Arc::clone(&self.park_requested));
         let mut heap_guard = self.heap_permit_manager.request_park().await;
         #[cfg(not(target_arch = "wasm32"))]
         drop(park_request_guard);
 
-        #[cfg(feature = "gc_profiling")]
-        let parked_at = web_time::Instant::now();
+        cycle.parked();
 
         // Collect roots from handles (objects returned to external code)
         let mut all_roots = self.heap.collect_handle_roots();
@@ -3375,16 +3371,13 @@ impl BexEngine {
             heap_guard.num_permits(),
         );
 
-        #[cfg(feature = "gc_profiling")]
-        let roots_scanned_at = web_time::Instant::now();
+        cycle.roots_scanned();
 
         // Run GC — always returns the forwarding map so we can update parked VM stacks.
-        #[allow(unused_mut)]
         let (mut stats, _remapped_roots, forwarding) =
             unsafe { self.heap.collect_garbage_generational(&all_roots, level) };
 
-        #[cfg(feature = "gc_profiling")]
-        let heap_done_at = web_time::Instant::now();
+        cycle.heap_done();
 
         // Bug H, check 1 (heap_debug only): every pointer the GC was told
         // about (`all_roots`) must end up in the forwarding map. If a
@@ -3454,8 +3447,7 @@ impl BexEngine {
             .extend(unhandled_spawn_errors);
 
         drop(heap_guard);
-        #[cfg(feature = "gc_profiling")]
-        let released_at = web_time::Instant::now();
+        cycle.released();
 
         // Flush deferred host-value releases now that the stop-the-world window
         // has closed. Collecting a dead `Object::HostClosure` runs
@@ -3480,18 +3472,7 @@ impl BexEngine {
         // moving them mid-drain.
         self.drain_finalizers().await;
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            let finished_at = web_time::Instant::now();
-            stats.profile.park_wait = parked_at - cycle_start;
-            stats.profile.root_scan = roots_scanned_at - parked_at;
-            stats.profile.holder_fixup = released_at - heap_done_at;
-            stats.profile.pause = released_at - parked_at;
-            stats.profile.post_gc = finished_at - released_at;
-            stats.profile.total = finished_at - cycle_start;
-            tracing::debug!(target: "bex_gc", reason = reason, level = ?level,
-                profile = ?stats.profile, "GC cycle");
-        }
+        cycle.finish(&mut stats, reason);
         tracing::debug!(
             "GC completed: {} live, {} collected",
             stats.live_count,

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3206,7 +3206,8 @@ impl BexEngine {
             on_leaks(&[]);
         }
 
-        self.collect_garbage(bex_heap::CollectionLevel::Major).await;
+        self.collect_garbage_with_reason(bex_heap::CollectionLevel::Major, "shutdown")
+            .await;
         shutdown.complete();
     }
 
@@ -3341,11 +3342,26 @@ impl BexEngine {
         self: &Arc<Self>,
         level: bex_heap::CollectionLevel,
     ) -> bex_heap::GcStats {
+        self.collect_garbage_with_reason(level, "explicit").await
+    }
+
+    async fn collect_garbage_with_reason(
+        self: &Arc<Self>,
+        level: bex_heap::CollectionLevel,
+        reason: &'static str,
+    ) -> bex_heap::GcStats {
+        #[cfg(not(feature = "gc_profiling"))]
+        let _ = reason;
+        #[cfg(feature = "gc_profiling")]
+        let cycle_start = web_time::Instant::now();
         #[cfg(not(target_arch = "wasm32"))]
         let park_request_guard = ParkRequestGuard::new(Arc::clone(&self.park_requested));
         let mut heap_guard = self.heap_permit_manager.request_park().await;
         #[cfg(not(target_arch = "wasm32"))]
         drop(park_request_guard);
+
+        #[cfg(feature = "gc_profiling")]
+        let parked_at = web_time::Instant::now();
 
         // Collect roots from handles (objects returned to external code)
         let mut all_roots = self.heap.collect_handle_roots();
@@ -3359,9 +3375,16 @@ impl BexEngine {
             heap_guard.num_permits(),
         );
 
+        #[cfg(feature = "gc_profiling")]
+        let roots_scanned_at = web_time::Instant::now();
+
         // Run GC — always returns the forwarding map so we can update parked VM stacks.
-        let (stats, _remapped_roots, forwarding) =
+        #[allow(unused_mut)]
+        let (mut stats, _remapped_roots, forwarding) =
             unsafe { self.heap.collect_garbage_generational(&all_roots, level) };
+
+        #[cfg(feature = "gc_profiling")]
+        let heap_done_at = web_time::Instant::now();
 
         // Bug H, check 1 (heap_debug only): every pointer the GC was told
         // about (`all_roots`) must end up in the forwarding map. If a
@@ -3431,6 +3454,8 @@ impl BexEngine {
             .extend(unhandled_spawn_errors);
 
         drop(heap_guard);
+        #[cfg(feature = "gc_profiling")]
+        let released_at = web_time::Instant::now();
 
         // Flush deferred host-value releases now that the stop-the-world window
         // has closed. Collecting a dead `Object::HostClosure` runs
@@ -3455,6 +3480,18 @@ impl BexEngine {
         // moving them mid-drain.
         self.drain_finalizers().await;
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            let finished_at = web_time::Instant::now();
+            stats.profile.park_wait = parked_at - cycle_start;
+            stats.profile.root_scan = roots_scanned_at - parked_at;
+            stats.profile.holder_fixup = released_at - heap_done_at;
+            stats.profile.pause = released_at - parked_at;
+            stats.profile.post_gc = finished_at - released_at;
+            stats.profile.total = finished_at - cycle_start;
+            tracing::debug!(target: "bex_gc", reason = reason, level = ?level,
+                profile = ?stats.profile, "GC cycle");
+        }
         tracing::debug!(
             "GC completed: {} live, {} collected",
             stats.live_count,
@@ -5095,7 +5132,7 @@ impl BexEngine {
             // We won the CAS, so we own the GC check.
             if let Some(level) = self.heap.should_collect() {
                 let inactive = permit.release();
-                self.collect_garbage(level).await;
+                self.collect_garbage_with_reason(level, "automatic").await;
                 permit = inactive.acquire().await;
             }
             self.checking_gc.store(false, Ordering::Release);
@@ -5118,7 +5155,7 @@ impl BexEngine {
             .is_ok();
         if i_am_checking {
             if let Some(level) = self.heap.should_collect() {
-                self.collect_garbage(level).await;
+                self.collect_garbage_with_reason(level, "automatic").await;
             }
             self.checking_gc.store(false, Ordering::Release);
         }

--- a/baml_language/crates/bex_engine/tests/gc_policy_experiment.rs
+++ b/baml_language/crates/bex_engine/tests/gc_policy_experiment.rs
@@ -1,0 +1,443 @@
+//! Opt-in policy experiment. No production GC policy changes.
+//! GC checkpoints are before host calls, identical for all candidate policies.
+//! Run via `GC_POLICY` / `GC_WORKLOAD` and
+//! `cargo test --test gc_policy_experiment --profile fasttest -- --ignored --nocapture`.
+#![expect(
+    clippy::print_stdout,
+    reason = "Manual experiments emit machine-readable results to the runner"
+)]
+#![expect(
+    clippy::cast_precision_loss,
+    reason = "Diagnostic rates and MiB quantities are approximate floating-point measurements"
+)]
+
+use std::{collections::VecDeque, sync::Arc, time::Instant};
+
+use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder};
+use bex_heap::CollectionLevel;
+use sys_native::SysOpsExt;
+
+const MIB: usize = 1024 * 1024;
+const SOURCE: &str = r#"
+class BenchNode { value int }
+function Identity(value: int) -> int { value }
+function Make(value: int) -> BenchNode { BenchNode { value: value } }
+function Churn(n: int) -> int {
+    let i = 0;
+    let total = 0;
+    while (i < n) {
+        let node = BenchNode { value: i };
+        total = total + node.value;
+        i = i + 1;
+    }
+    total
+}
+function Batch(n: int) -> BenchNode[] {
+    let result: BenchNode[] = [];
+    let i = 0;
+    while (i < n) {
+        result.push(BenchNode { value: i });
+        i = i + 1;
+    }
+    result
+}
+function CheckBatch(nodes: BenchNode[]) -> int {
+    let sum = 0;
+    let i = 0;
+    while (i < nodes.length()) { sum = sum + nodes[i].value; i = i + 1; }
+    sum
+}
+function Payload(text: string) -> string { text }
+function CheckPayload(text: string) -> int { text.length() }
+function AsyncBatch(n: int) -> int {
+    let nodes = Batch(n);
+    baml.sys.sleep(baml.time.Duration.from_milliseconds(1n));
+    CheckBatch(nodes)
+}
+"#;
+
+struct Policy {
+    name: String,
+    budget: usize,
+    major_goal: usize,
+}
+
+impl Policy {
+    fn new(name: String, initial_old_bytes: usize) -> Self {
+        let budget = match name.as_str() {
+            "current" => usize::MAX,
+            "fixed8" => 8 * MIB,
+            "fixed32" | "adaptive" | "full32" | "full_live" => 32 * MIB,
+            "fixed128" => 128 * MIB,
+            _ => panic!("unknown policy: {name}"),
+        };
+        Self {
+            name,
+            budget,
+            major_goal: initial_old_bytes + initial_old_bytes.max(32 * MIB),
+        }
+    }
+
+    fn decide(&self, nursery: usize, older: usize) -> Option<CollectionLevel> {
+        if self.name == "current" {
+            return None;
+        }
+        if self.name == "full32" || self.name == "full_live" {
+            return (nursery >= self.budget).then_some(CollectionLevel::Major);
+        }
+        if older >= self.major_goal {
+            return Some(CollectionLevel::Major);
+        }
+        (nursery >= self.budget).then_some(CollectionLevel::Minor)
+    }
+
+    fn after_gc(
+        &mut self,
+        level: CollectionLevel,
+        nursery_before: usize,
+        young_survivors: usize,
+        older_after: usize,
+    ) {
+        if level == CollectionLevel::Major {
+            self.major_goal = older_after + older_after.max(32 * MIB);
+            if self.name == "full_live" {
+                self.budget = older_after.max(32 * MIB);
+            }
+        } else if self.name == "adaptive" && nursery_before > 0 {
+            // Deliberately experimental, easy-to-change survival policy.
+            // Compare live Gen0 survivors with all reserved Gen0 storage.
+            if young_survivors * 2 >= nursery_before {
+                self.budget = (self.budget * 2).min(128 * MIB);
+            } else if young_survivors * 10 < nursery_before {
+                self.budget = (self.budget / 2).max(8 * MIB);
+            }
+        }
+    }
+}
+
+fn context() -> bex_engine::FunctionCallContext {
+    FunctionCallContextBuilder::new(sys_types::CallId::next())
+        .suppress_internal_profile()
+        .build()
+}
+
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+#[expect(
+    unsafe_code,
+    reason = "Mach task statistics require an FFI call with initialized output storage"
+)]
+fn rss_bytes() -> Option<usize> {
+    // Read-only task statistics; no allocation sampling subprocess in timings.
+    unsafe {
+        let mut info: libc::mach_task_basic_info = std::mem::zeroed();
+        let mut count = libc::MACH_TASK_BASIC_INFO_COUNT;
+        let result = libc::task_info(
+            libc::mach_task_self(),
+            libc::MACH_TASK_BASIC_INFO,
+            (&raw mut info).cast(),
+            &raw mut count,
+        );
+        if result == 0 {
+            usize::try_from(info.resident_size).ok()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn rss_bytes() -> Option<usize> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    let line = status.lines().find(|line| line.starts_with("VmRSS:"))?;
+    line.split_whitespace()
+        .nth(1)?
+        .parse::<usize>()
+        .ok()?
+        .checked_mul(1024)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn rss_bytes() -> Option<usize> {
+    None
+}
+
+fn rss_mib(value: Option<usize>) -> Option<f64> {
+    value.map(|bytes| bytes as f64 / MIB as f64)
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "The rounded rank is nonnegative and in bounds after validating the fraction"
+)]
+fn percentile(values: &[f64], fraction: f64) -> f64 {
+    assert!((0.0..=1.0).contains(&fraction));
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    sorted[((sorted.len() - 1) as f64 * fraction).round() as usize]
+}
+
+#[test]
+#[ignore = "manual performance experiment, not a CI assertion"]
+fn compare_gc_policy() {
+    let policy_name = std::env::var("GC_POLICY").unwrap_or_else(|_| "fixed32".into());
+    let workload = std::env::var("GC_WORKLOAD").unwrap_or_else(|_| "tiny".into());
+    let program = baml_db::testing::compile_source(SOURCE);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let engine = Arc::new(BexEngine::new(program, Arc::new(sys_native::SysOps::native()), vec![]).unwrap());
+        let slot_size = std::mem::size_of::<bex_vm_types::Object>();
+        let initial_gc = engine.collect_garbage(CollectionLevel::Major).await;
+        let mut policy = Policy::new(policy_name, initial_gc.live_count * slot_size);
+        let (default_calls, default_n, function, copy_result): (usize, usize, &str, bool) = match workload.as_str() {
+            "scalar" => (12_000, 123, "Identity", true),
+            "tiny" => (12_000, 123, "Make", true),
+            "churn" | "cache" => (1_024, 4_096, "Churn", true),
+            "retained" | "burst" | "burst_idle" => (1_024, 2_048, "Batch", false),
+            "payload" => (2_048, 65_536, "Payload", false),
+            _ => panic!("unknown workload: {workload}"),
+        };
+        let calls = setting("GC_CALLS", default_calls);
+        let n_size = setting("GC_N", default_n);
+        let n = i64::try_from(n_size).expect("GC_N must fit in a BAML int");
+        let retain = setting("GC_RETAIN", 256);
+        let warmup = setting("GC_WARMUP", 32);
+        assert!(calls > 0, "GC_CALLS must be positive");
+        let cache_n = i64::try_from(setting("GC_CACHE_N", 262_144)).expect("GC_CACHE_N must fit in a BAML int");
+        let make_args = || if workload == "payload" {
+            vec![BexExternalValue::String("x".repeat(n_size).into())]
+        } else { vec![BexExternalValue::Int(n)] };
+        for _ in 0..warmup {
+            engine.call_function(function, make_args(), context(), copy_result).await.unwrap();
+        }
+        let cache = if workload == "cache" {
+            Some(engine.call_function("Batch", vec![BexExternalValue::Int(cache_n)], context(), false).await.unwrap())
+        } else { None };
+        let warmup_gc = engine.collect_garbage(CollectionLevel::Major).await;
+        // A permanent cache is part of the survivor baseline before timings.
+        policy.after_gc(CollectionLevel::Major, 0, 0, warmup_gc.live_count * slot_size);
+        let mut cycles = Vec::new();
+        let mut kept = VecDeque::new();
+        let mut gc_ms = vec![];
+        let mut call_ms = vec![];
+        let mut minor_count = 0;
+        let mut major_count = 0;
+        let initial_rss = rss_bytes();
+        let mut peak_rss = initial_rss;
+        let mut peak_slots = engine.heap_stats().runtime_objects;
+        let mut snapshots = vec![];
+        let start = Instant::now();
+        for call in 0..calls {
+            if workload == "burst" && call == calls / 2 { kept.clear(); }
+            let stats = engine.heap_stats();
+            let nursery_slots = stats.tlab_chunks * engine.heap().tlab_size();
+            let nursery_bytes = nursery_slots * slot_size;
+            let older_bytes = stats.runtime_objects.saturating_sub(nursery_slots) * slot_size;
+            let call_start = Instant::now();
+            if let Some(level) = policy.decide(nursery_bytes, older_bytes) {
+                let gc_start = Instant::now();
+                let result = engine.collect_garbage(level).await;
+                gc_ms.push(gc_start.elapsed().as_secs_f64() * 1000.0);
+                cycles.push((call, start.elapsed().as_secs_f64(), result.clone(), nursery_bytes, policy.budget));
+                match level {
+                    CollectionLevel::Minor => minor_count += 1,
+                    CollectionLevel::Major => major_count += 1,
+                }
+                policy.after_gc(level, nursery_bytes, result.promoted_to_gen1 * slot_size,
+                    engine.heap_stats().runtime_objects * slot_size);
+            }
+            let result = engine.call_function(function, make_args(), context(), copy_result).await.unwrap();
+            match workload.as_str() {
+                "scalar" => assert_eq!(result, BexExternalValue::Int(n)),
+                "tiny" => match result {
+                    BexExternalValue::Instance { fields, .. } => assert_eq!(fields["value"], BexExternalValue::Int(n)),
+                    _ => panic!("wrong return shape"),
+                },
+                "churn" | "cache" => assert_eq!(result, BexExternalValue::Int(n * (n-1) / 2)),
+                _ => {
+                    assert!(matches!(result, BexExternalValue::Handle(_)));
+                    if workload == "retained" || workload == "payload" || workload == "burst_idle" || call < calls / 2 {
+                        kept.push_back(result);
+                        if kept.len() > retain { kept.pop_front(); }
+                    }
+                }
+            }
+            call_ms.push(call_start.elapsed().as_secs_f64() * 1000.0);
+            peak_slots = peak_slots.max(engine.heap_stats().runtime_objects);
+            if call % 32 == 0 || call == calls-1 {
+                peak_rss = peak_rss.max(rss_bytes());
+            }
+            if (call+1) % (calls/10).max(1) == 0 || call+1 == calls {
+                snapshots.push(serde_json::json!({"calls":call+1,
+                    "elapsed_seconds":start.elapsed().as_secs_f64(),
+                    "slot_mib":engine.heap_stats().runtime_objects as f64*slot_size as f64/MIB as f64,
+                    "rss_mib":rss_mib(rss_bytes()), "budget_mib":policy.budget/MIB}));
+            }
+        }
+        let elapsed = start.elapsed().as_secs_f64();
+        let end_slots = engine.heap_stats().runtime_objects;
+        let end_rss = rss_bytes();
+        let idle_observation = if workload == "burst_idle" {
+            kept.clear();
+            let before = engine.heap_stats().runtime_objects;
+            let before_rss = rss_bytes();
+            let idle_ms = setting("GC_IDLE_MS", 1000);
+            // Keep the executor alive, but make no engine call or forced GC.
+            tokio::time::sleep(std::time::Duration::from_millis(idle_ms as u64)).await;
+            Some(serde_json::json!({"idle_ms":idle_ms,
+                "before_slots":before,"after_slots":engine.heap_stats().runtime_objects,
+                "before_rss_mib":rss_mib(before_rss),"after_rss_mib":rss_mib(rss_bytes())}))
+        } else { None };
+        // Verify retained native handles after a moving collection, outside timings.
+        let validation_gc = engine.collect_garbage(CollectionLevel::Major).await;
+        if let Some(value) = &cache {
+            let checked = engine.call_function("CheckBatch", vec![value.clone()], context(), true).await.unwrap();
+            assert_eq!(checked, BexExternalValue::Int(cache_n * (cache_n-1) / 2));
+        }
+        for value in &kept {
+            let checked = engine.call_function(if workload == "payload" {"CheckPayload"} else {"CheckBatch"}, vec![value.clone()], context(), true).await.unwrap();
+            assert_eq!(checked, BexExternalValue::Int(if workload == "payload" { n } else {n*(n-1)/2}));
+        }
+        if let Ok(path) = std::env::var("GC_TRACE") {
+            let events: Vec<_> = cycles.iter().map(|(call, at, stats, nursery, budget)| serde_json::json!({
+                "call":call, "at_seconds":at, "trigger":"policy_before_host_call", "level":format!("{:?}",stats.level),
+                "nursery_reserved_bytes":nursery, "budget_bytes":budget, "profile":profile_json(stats),
+                "copied_objects":stats.live_count, "reclaimed_slots":stats.collected_count,
+                "promoted_gen1":stats.promoted_to_gen1, "promoted_gen2":stats.promoted_to_gen2,
+            })).collect();
+            std::fs::write(path, serde_json::to_vec_pretty(&events).unwrap()).unwrap();
+        }
+        println!("GC_POLICY_RESULT {}", serde_json::json!({
+            "policy":policy.name, "workload":workload, "calls":calls, "n":n, "retain":retain, "warmup":warmup, "slot_bytes":slot_size,
+            "elapsed_seconds":elapsed, "calls_per_second":calls as f64/elapsed,
+            "gc_ms_total":gc_ms.iter().sum::<f64>(), "gc_ms_p50":percentile(&gc_ms,0.5),
+            "gc_ms_p95":percentile(&gc_ms,0.95), "gc_ms_max":percentile(&gc_ms,1.0),
+            "call_ms_p50":percentile(&call_ms,0.5), "call_ms_p95":percentile(&call_ms,0.95),
+            "call_ms_p99":percentile(&call_ms,0.99), "minor_count":minor_count, "major_count":major_count,
+            "call_ms_max":percentile(&call_ms,1.0),
+            "peak_slot_mib":peak_slots as f64*slot_size as f64/MIB as f64,
+            "end_slot_mib":end_slots as f64*slot_size as f64/MIB as f64,
+            "initial_rss_mib":rss_mib(initial_rss), "peak_sampled_rss_mib":rss_mib(peak_rss),
+            "end_rss_mib":rss_mib(end_rss), "retained_handles_verified":kept.len(), "snapshots":snapshots,
+            "cache_objects":if cache.is_some() {cache_n} else {0},
+            "cache_verified":cache.is_some(), "idle_observation":idle_observation,
+            "validation_gc_live_objects":validation_gc.live_count,
+            "cycle_coverage":"harness-requested collections only; automatic cycles require engine tracing",
+        }));
+        kept.clear();
+        drop(cache);
+        engine.shutdown().await;
+    });
+}
+
+fn setting(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .map(|s| s.parse().expect("invalid integer setting"))
+        .unwrap_or(default)
+}
+
+#[cfg(not(feature = "gc_profiling"))]
+fn profile_json(_: &bex_heap::GcStats) -> serde_json::Value {
+    serde_json::Value::Null
+}
+
+#[cfg(feature = "gc_profiling")]
+fn profile_json(stats: &bex_heap::GcStats) -> serde_json::Value {
+    let p = &stats.profile;
+    serde_json::json!({
+        "before_generations":p.before.generation_slots, "after_generations":p.after.generation_slots,
+        "before_capacity":p.before.capacity_slots, "after_capacity":p.after.capacity_slots,
+        "actual_new_objects":p.before.new_objects, "roots":p.roots,
+        "prepare_ms":p.prepare.as_secs_f64()*1000.0, "trace_ms":p.trace.as_secs_f64()*1000.0,
+        "keepalive_ms":p.keepalive.as_secs_f64()*1000.0, "fixup_ms":p.fixup.as_secs_f64()*1000.0,
+        "reclaim_ms":p.reclaim.as_secs_f64()*1000.0, "bookkeeping_ms":p.bookkeeping.as_secs_f64()*1000.0,
+        "heap_total_ms":p.heap_total.as_secs_f64()*1000.0,
+        "park_wait_ms":p.park_wait.as_secs_f64()*1000.0, "root_scan_ms":p.root_scan.as_secs_f64()*1000.0,
+        "holder_fixup_ms":p.holder_fixup.as_secs_f64()*1000.0, "pause_ms":p.pause.as_secs_f64()*1000.0,
+        "post_gc_ms":p.post_gc.as_secs_f64()*1000.0, "total_ms":p.total.as_secs_f64()*1000.0,
+    })
+}
+
+#[test]
+#[ignore = "manual concurrent GC profile, not a CI performance assertion"]
+fn profile_concurrent_gc() {
+    let program = baml_db::testing::compile_source(SOURCE);
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let engine = Arc::new(
+            BexEngine::new(program, Arc::new(sys_native::SysOps::native()), vec![]).unwrap(),
+        );
+        let workers = setting("GC_WORKERS", 8);
+        let calls = setting("GC_CALLS", 200);
+        let n = i64::try_from(setting("GC_N", 512)).expect("GC_N must fit in a BAML int");
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let gc_engine = engine.clone();
+        let gc_done = done.clone();
+        let start = Instant::now();
+        let collector = tokio::spawn(async move {
+            let mut events = Vec::new();
+            while !gc_done.load(std::sync::atomic::Ordering::Relaxed) {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                let stats = gc_engine.collect_garbage(CollectionLevel::Major).await;
+                events.push(
+                    serde_json::json!({"at_seconds":start.elapsed().as_secs_f64(),
+                    "trigger":"concurrent_periodic_request", "profile":profile_json(&stats)}),
+                );
+            }
+            events
+        });
+        let mut tasks = Vec::new();
+        for _ in 0..workers {
+            let engine = engine.clone();
+            tasks.push(tokio::spawn(async move {
+                let mut latencies = Vec::new();
+                for _ in 0..calls {
+                    let start = Instant::now();
+                    let value = engine
+                        .call_function(
+                            "AsyncBatch",
+                            vec![BexExternalValue::Int(n)],
+                            context(),
+                            true,
+                        )
+                        .await
+                        .unwrap();
+                    latencies.push(start.elapsed().as_secs_f64() * 1000.0);
+                    assert_eq!(value, BexExternalValue::Int(n * (n - 1) / 2));
+                }
+                latencies
+            }));
+        }
+        let mut latencies = Vec::new();
+        tokio::time::timeout(std::time::Duration::from_secs(120), async {
+            for task in tasks {
+                latencies.extend(task.await.unwrap());
+            }
+        })
+        .await
+        .expect("concurrent GC timed out");
+        done.store(true, std::sync::atomic::Ordering::Relaxed);
+        let events = collector.await.unwrap();
+        if let Ok(path) = std::env::var("GC_TRACE") {
+            std::fs::write(path, serde_json::to_vec_pretty(&events).unwrap()).unwrap();
+        }
+        println!(
+            "GC_CONCURRENT_RESULT {}",
+            serde_json::json!({"workers":workers,"calls":workers*calls,
+            "elapsed_seconds":start.elapsed().as_secs_f64(),"explicit_collections":events.len(),
+            "call_p50_ms":percentile(&latencies,0.5),"call_p99_ms":percentile(&latencies,0.99)})
+        );
+        engine.shutdown().await;
+    });
+}

--- a/baml_language/crates/bex_engine/tests/gc_trigger_audit.rs
+++ b/baml_language/crates/bex_engine/tests/gc_trigger_audit.rs
@@ -1,0 +1,183 @@
+//! Characterization of the current native trigger policy, not desired behavior.
+//! Run explicitly with `--features gc_profiling -- --ignored --nocapture`.
+#![cfg(feature = "gc_profiling")]
+#![expect(
+    clippy::print_stdout,
+    reason = "Manual characterizations emit machine-readable results to the runner"
+)]
+
+use std::sync::Arc;
+
+use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder};
+use bex_heap::{BexHeap, CollectionLevel, Tlab};
+use sys_native::SysOpsExt;
+
+const SOURCE: &str = r#"
+class Node { value int }
+function Make() -> Node { Node { value: 1 } }
+function Churn(n: int) -> int {
+    let i = 0;
+    let sum = 0;
+    while (i < n) {
+        let node = Node { value: i };
+        sum = sum + node.value;
+        i = i + 1;
+    }
+    sum
+}
+function Yield() -> int {
+    baml.sys.sleep(baml.time.Duration.from_milliseconds(0n));
+    1
+}
+"#;
+
+async fn call(
+    engine: &Arc<BexEngine>,
+    name: &str,
+    args: Vec<BexExternalValue>,
+) -> BexExternalValue {
+    engine
+        .call_function(
+            name,
+            args,
+            FunctionCallContextBuilder::new(sys_types::CallId::next())
+                .suppress_internal_profile()
+                .build(),
+            true,
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+#[ignore = "records existing scheduling gaps; update when trigger policy changes"]
+async fn characterize_engine_gc_checkpoints() {
+    let program = baml_db::testing::compile_source(SOURCE);
+    let mut observations = Vec::new();
+    for scenario in [
+        "sparse_short_calls",
+        "short_calls_over_threshold",
+        "one_compute_call",
+    ] {
+        let engine = Arc::new(
+            BexEngine::new(
+                program.clone(),
+                Arc::new(sys_native::SysOps::native()),
+                vec![],
+            )
+            .unwrap(),
+        );
+        engine.collect_garbage(CollectionLevel::Major).await;
+        match scenario {
+            "sparse_short_calls" => {
+                for _ in 0..512 {
+                    drop(call(&engine, "Make", vec![]).await);
+                }
+                assert_eq!(engine.heap().should_collect(), None);
+                assert_eq!(engine.heap_stats().runtime_objects, 512 * 1024);
+            }
+            "short_calls_over_threshold" => {
+                for _ in 0..100 {
+                    assert_eq!(
+                        call(&engine, "Churn", vec![BexExternalValue::Int(128)]).await,
+                        BexExternalValue::Int(128 * 127 / 2)
+                    );
+                }
+                assert_eq!(engine.heap().should_collect(), Some(CollectionLevel::Minor));
+            }
+            _ => {
+                assert_eq!(
+                    call(&engine, "Churn", vec![BexExternalValue::Int(20_000)]).await,
+                    BexExternalValue::Int(20_000 * 19_999 / 2)
+                );
+                assert_eq!(engine.heap().should_collect(), Some(CollectionLevel::Minor));
+            }
+        }
+        let slots_before = engine.heap_stats().runtime_objects;
+        let decision_before = format!("{:?}", engine.heap().should_collect());
+        // This bounded observation supplements the source audit; it does not
+        // by itself prove the absence of every possible timer.
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert_eq!(engine.heap_stats().runtime_objects, slots_before);
+        assert_eq!(
+            call(&engine, "Yield", vec![]).await,
+            BexExternalValue::Int(1)
+        );
+        let slots_after_yield = engine.heap_stats().runtime_objects;
+        if scenario == "sparse_short_calls" {
+            assert!(slots_after_yield >= slots_before);
+        } else {
+            assert!(slots_after_yield < slots_before);
+            assert_eq!(engine.heap().should_collect(), None);
+        }
+        // Inspect the post-yield generations under exclusive GC access.
+        let cleanup = engine.collect_garbage(CollectionLevel::Major).await;
+        observations.push(serde_json::json!({
+            "scenario": scenario, "decision_before_yield":decision_before,
+            "slots_before_yield":slots_before, "slots_after_yield":slots_after_yield,
+            "post_yield_generations":cleanup.profile.before.generation_slots,
+            "allocations_since_gc_after_yield":cleanup.profile.before.new_objects,
+        }));
+        engine.shutdown().await;
+    }
+    println!(
+        "GC_TRIGGER_AUDIT {}",
+        serde_json::to_string(&observations).unwrap()
+    );
+}
+
+#[test]
+#[ignore = "records the moving old-generation threshold; update when policy changes"]
+#[expect(
+    unsafe_code,
+    reason = "This standalone heap has exclusive single-threaded access during collection"
+)]
+fn characterize_automatic_level_selection_under_promotion() {
+    let heap = BexHeap::new(vec![]);
+    let mut tlab = Tlab::new_empty(heap.clone());
+    let mut roots = Vec::new();
+    let mut observations = Vec::new();
+    for round in 0..12 {
+        for _ in 0..10_000 {
+            roots.push(tlab.alloc_float(1.0));
+        }
+        // Retain only the newest two batches. Older promoted objects become
+        // garbage, but a minor collection cannot reclaim existing Gen2.
+        if roots.len() > 20_000 {
+            roots.drain(..roots.len() - 20_000);
+        }
+        let selected = heap.should_collect().expect("allocation pressure");
+        assert_eq!(selected, CollectionLevel::Minor);
+        // SAFETY: standalone heap, single thread; all live pointers are roots.
+        let (stats, remapped, _) = unsafe { heap.collect_garbage_generational(&roots, selected) };
+        tlab.invalidate();
+        roots = remapped;
+        assert_eq!(heap.should_collect(), None);
+        observations.push(serde_json::json!({"round":round+1,
+            "selected":format!("{:?}", selected), "retained_roots":roots.len(),
+            "generations_after":stats.profile.after.generation_slots,
+            "decision_after":format!("{:?}", heap.should_collect()),
+        }));
+    }
+    roots.clear();
+    for _ in 0..10_000 {
+        tlab.alloc_float(0.0);
+    }
+    assert_eq!(heap.should_collect(), Some(CollectionLevel::Minor));
+    // SAFETY: no live roots remain, no concurrent heap access.
+    let (minor, _, _) = unsafe { heap.collect_garbage_minor(&[]) };
+    tlab.invalidate();
+    assert_eq!(minor.profile.after.generation_slots, [0, 0, 110_000]);
+    assert_eq!(heap.should_collect(), None);
+    // SAFETY: no live roots remain, no concurrent heap access.
+    let (major, _, _) = unsafe { heap.collect_garbage(&[]) };
+    assert_eq!(major.profile.after.generation_slots, [0, 0, 0]);
+    println!(
+        "GC_PROMOTION_AUDIT {}",
+        serde_json::json!({
+            "cycles":observations,
+            "unreachable_gen2_after_automatic_level":minor.profile.after.generation_slots[2],
+            "gen2_after_explicit_major":major.profile.after.generation_slots[2],
+        })
+    );
+}

--- a/baml_language/crates/bex_heap/Cargo.toml
+++ b/baml_language/crates/bex_heap/Cargo.toml
@@ -16,6 +16,7 @@ num-bigint = { workspace = true }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [ "sync" ] }
+tracing = { workspace = true, optional = true }
 web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -24,5 +25,5 @@ tokio = { workspace = true, features = [ "macros", "rt-multi-thread", "time" ] }
 
 [features]
 default = [  ]
-gc_profiling = [ "dep:web-time" ]
+gc_profiling = [ "dep:tracing", "dep:web-time" ]
 heap_debug = [ "bex_vm_types/heap_debug" ]

--- a/baml_language/crates/bex_heap/Cargo.toml
+++ b/baml_language/crates/bex_heap/Cargo.toml
@@ -16,6 +16,7 @@ num-bigint = { workspace = true }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [ "sync" ] }
+web-time = { workspace = true, optional = true }
 
 [dev-dependencies]
 baml_type = { workspace = true }
@@ -23,4 +24,5 @@ tokio = { workspace = true, features = [ "macros", "rt-multi-thread", "time" ] }
 
 [features]
 default = [  ]
+gc_profiling = [ "dep:web-time" ]
 heap_debug = [ "bex_vm_types/heap_debug" ]

--- a/baml_language/crates/bex_heap/src/chunked_vec.rs
+++ b/baml_language/crates/bex_heap/src/chunked_vec.rs
@@ -268,6 +268,30 @@ impl<T, const CHUNK_SIZE: usize> ChunkedVec<T, CHUNK_SIZE> {
         }
     }
 
+    /// Check backing-storage membership, including unused capacity, without
+    /// dereferencing `ptr`.
+    ///
+    /// Hold the outer-vector lock once for the scan. Taking it separately for
+    /// every chunk makes generation checks expensive as the old heap grows.
+    pub fn contains_ptr(&self, ptr: *const T) -> bool {
+        let _read = self.chunks_lock.read();
+        // SAFETY: the read lock keeps the outer Vec and its chunk descriptors
+        // stable. Each chunk has CHUNK_SIZE initialized cells; we only compare
+        // addresses, never read elements or dereference the supplied pointer.
+        unsafe {
+            let chunks = self.chunks.get();
+            let data = (*chunks).as_ptr();
+            for index in 0..(*chunks).len() {
+                let start = (*data.add(index)).as_ptr().cast::<T>();
+                let end = start.add(CHUNK_SIZE);
+                if ptr >= start && ptr < end {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Calculate chunk index and offset within chunk for a given index.
     ///
     /// Because CHUNK_SIZE is a compile-time constant power of 2, the compiler
@@ -630,6 +654,33 @@ unsafe impl<T: Sync, const CHUNK_SIZE: usize> Sync for ChunkedVec<T, CHUNK_SIZE>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn membership_covers_chunk_boundaries_and_survives_growth() {
+        let mut values = ChunkedVec::<u64, 4>::new();
+        assert!(!values.contains_ptr(std::ptr::null()));
+        values.resize_with(5, || 0);
+        let first = values.get_ptr(0);
+        for index in [0, 3, 4] {
+            assert!(values.contains_ptr(values.get_ptr(index)));
+        }
+        // Membership intentionally includes the unoccupied tail of a chunk.
+        let second_chunk = unsafe { values.chunk_start_ptr(1) };
+        assert!(values.contains_ptr(unsafe { second_chunk.add(3) }));
+        // Use an isolated one-chunk allocation for its exclusive upper bound.
+        let boundary = ChunkedVec::<u64, 4>::new();
+        boundary.resize_with(1, || 0);
+        let end = unsafe { boundary.chunk_start_ptr(0).add(4) };
+        assert!(!boundary.contains_ptr(end));
+        let other = Box::new(0_u64);
+        assert!(!values.contains_ptr(&*other));
+        values.resize_with(100, || 0);
+        assert!(values.contains_ptr(first));
+        assert!(values.contains_ptr(values.get_ptr(99)));
+        values.clear();
+        // Membership compares addresses only, including a now stale pointer.
+        assert!(!values.contains_ptr(first));
+    }
 
     #[test]
     fn test_new_chunked_vec() {

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -80,8 +80,7 @@ pub struct GcStats {
     pub promoted_to_gen1: usize,
     /// Objects promoted from Gen1 to Gen2 during this cycle.
     pub promoted_to_gen2: usize,
-    /// Optional detailed diagnostics, captured only in profiling builds.
-    #[cfg(feature = "gc_profiling")]
+    /// Detailed diagnostics in profiling builds; a zero-sized marker otherwise.
     pub profile: crate::GcProfile,
 }
 
@@ -441,15 +440,8 @@ impl BexHeap {
         &self,
         roots: &[HeapPtr],
     ) -> (GcStats, Vec<HeapPtr>, HashMap<HeapPtr, HeapPtr>) {
-        #[cfg(feature = "gc_profiling")]
-        let mut clock = crate::gc_profile::GcClock::new();
-        #[cfg(feature = "gc_profiling")]
-        let mut profile = crate::GcProfile {
-            // SAFETY: collection caller guarantees exclusive access.
-            before: unsafe { crate::GcHeapSnapshot::capture(self) },
-            roots: roots.len(),
-            ..Default::default()
-        };
+        // SAFETY: collection caller guarantees exclusive heap access.
+        let mut profile = unsafe { crate::gc_profile::GcProfiler::start(self, roots.len()) };
         // Track old -> new pointer mappings (forwarding pointers)
         let mut forwarding: HashMap<HeapPtr, HeapPtr> = HashMap::new();
 
@@ -472,10 +464,7 @@ impl BexHeap {
         // BFS from roots — copy every reachable object into inactive.
         let mut worklist: Vec<HeapPtr> = roots.to_vec();
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.prepare = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Prepare);
 
         while let Some(old_ptr) = worklist.pop() {
             // Skip already-forwarded objects.
@@ -515,10 +504,7 @@ impl BexHeap {
             self.add_references_to_worklist(obj, &mut worklist);
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.trace = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Trace);
 
         // Preserve unobserved spawn errors before reclaiming their futures.
         // SAFETY: GC safepoint; exclusive access.
@@ -535,10 +521,7 @@ impl BexHeap {
             self.keepalive_finalizers_major(&mut forwarding);
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.keepalive = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Keepalive);
 
         // Patch all intra-heap pointers in the inactive space to their new locations.
         // SAFETY: All live objects have been copied; no VMs are executing.
@@ -546,10 +529,7 @@ impl BexHeap {
             self.fixup_references_in_inactive(&forwarding);
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.fixup = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Fixup);
 
         // SAFETY: GC runs at safepoints.
         let live_count = unsafe { self.inactive_ref().len() };
@@ -595,10 +575,7 @@ impl BexHeap {
             self.debug_assert_post_major_no_dead_refs();
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.reclaim = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Reclaim);
 
         // Remap each root to its new location (or keep it if it was compile-time).
         let remapped_roots: Vec<HeapPtr> = roots
@@ -617,20 +594,13 @@ impl BexHeap {
         // check would re-trigger GC forever.
         self.reset_gc_counter();
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.bookkeeping = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Bookkeeping);
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.after = unsafe { crate::GcHeapSnapshot::capture(self) };
-            profile.heap_total = clock.elapsed();
-        }
+        // SAFETY: exclusive heap access is still held.
+        let profile = unsafe { profile.finish(self) };
         let stats = GcStats {
             live_count,
             collected_count,
-            #[cfg(feature = "gc_profiling")]
             profile,
             level: CollectionLevel::Major,
             promoted_to_gen1: 0,
@@ -1546,15 +1516,8 @@ impl BexHeap {
         &self,
         roots: &[HeapPtr],
     ) -> (GcStats, Vec<HeapPtr>, HashMap<HeapPtr, HeapPtr>) {
-        #[cfg(feature = "gc_profiling")]
-        let mut clock = crate::gc_profile::GcClock::new();
-        #[cfg(feature = "gc_profiling")]
-        let mut profile = crate::GcProfile {
-            // SAFETY: collection caller guarantees exclusive access.
-            before: unsafe { crate::GcHeapSnapshot::capture(self) },
-            roots: roots.len(),
-            ..Default::default()
-        };
+        // SAFETY: collection caller guarantees exclusive heap access.
+        let mut profile = unsafe { crate::gc_profile::GcProfiler::start(self, roots.len()) };
         let mut forwarding: HashMap<HeapPtr, HeapPtr> = HashMap::new();
 
         self.bump_epoch();
@@ -1584,10 +1547,7 @@ impl BexHeap {
 
         let mut promoted_to_gen2 = 0usize;
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.prepare = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Prepare);
 
         while let Some(old_ptr) = worklist.pop() {
             if forwarding.contains_key(&old_ptr) {
@@ -1620,10 +1580,7 @@ impl BexHeap {
             }
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.trace = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Trace);
 
         // Preserve unobserved spawn errors before reclaiming their futures.
         // SAFETY: GC safepoint; exclusive access.
@@ -1640,10 +1597,7 @@ impl BexHeap {
             self.keepalive_finalizers_minor(&mut forwarding, &mut promoted_to_gen2);
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.keepalive = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Keepalive);
 
         // Fix up references:
         // - Full fixup for inactive (new Gen1 — all objects are freshly copied).
@@ -1691,10 +1645,7 @@ impl BexHeap {
             }
         }
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.fixup = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Fixup);
 
         // Swap inactive ↔ Gen1; clear Gen0.
         // SAFETY: GC safepoint; exclusive access to all spaces.
@@ -1707,10 +1658,7 @@ impl BexHeap {
         // Poison/clear the old Gen1 (now in inactive).
         self.finalize_inactive_space();
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.reclaim = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Reclaim);
 
         let new_gen1_count = unsafe { self.gen1_ref().len() };
         let total_live = new_gen1_count + promoted_to_gen2;
@@ -1732,20 +1680,13 @@ impl BexHeap {
         // allocations, because the counter would never go below the threshold.
         self.reset_gc_counter();
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.bookkeeping = clock.lap();
-        }
+        profile.finish_phase(crate::gc_profile::HeapPhase::Bookkeeping);
 
-        #[cfg(feature = "gc_profiling")]
-        {
-            profile.after = unsafe { crate::GcHeapSnapshot::capture(self) };
-            profile.heap_total = clock.elapsed();
-        }
+        // SAFETY: exclusive heap access is still held.
+        let profile = unsafe { profile.finish(self) };
         let stats = GcStats {
             live_count: total_live,
             collected_count: total_before.saturating_sub(total_live),
-            #[cfg(feature = "gc_profiling")]
             profile,
             level: CollectionLevel::Minor,
             promoted_to_gen1: new_gen1_count,

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -72,7 +72,7 @@ pub enum CollectionLevel {
 pub struct GcStats {
     /// Objects marked as live (copied).
     pub live_count: usize,
-    /// Objects collected (not copied).
+    /// Slots reclaimed (including unused TLAB reservations), not an object-death count.
     pub collected_count: usize,
     /// Which collection level was run.
     pub level: CollectionLevel,
@@ -80,6 +80,9 @@ pub struct GcStats {
     pub promoted_to_gen1: usize,
     /// Objects promoted from Gen1 to Gen2 during this cycle.
     pub promoted_to_gen2: usize,
+    /// Optional detailed diagnostics, captured only in profiling builds.
+    #[cfg(feature = "gc_profiling")]
+    pub profile: crate::GcProfile,
 }
 
 impl BexHeap {
@@ -307,28 +310,42 @@ impl BexHeap {
     ) -> Vec<crate::UnhandledSpawnError> {
         let mut errors = Vec::new();
         for space in gens {
-            for i in 0..space.len() {
-                // SAFETY: GC safepoint and `i` is in bounds.
-                let ptr = unsafe { self.make_heap_ptr(space.get_ptr(i)) };
-                if forwarding.contains_key(&ptr) {
-                    continue;
-                }
-                // SAFETY: from-space is intact until the collection swap.
-                let Object::Future(future) = (unsafe { ptr.get() }) else {
-                    continue;
-                };
-                if future.is_observed() {
-                    continue;
-                }
-                if let FutureRead::Error(value) = future.read()
-                    && future.try_mark_reported()
-                {
-                    errors.push(crate::UnhandledSpawnError {
-                        future_id: future.id(),
-                        value,
-                        trace: future.error_trace(),
-                        cancelled: future.cancel_requested(),
-                    });
+            let len = space.len();
+            // Resolve each stable chunk once, rather than taking the storage
+            // read lock for every slot. GC has exclusive access, and this scan
+            // neither grows nor clears any of the spaces it reads.
+            for start in (0..len).step_by(ChunkedVec::<Object>::CHUNK_SIZE) {
+                // SAFETY: start < len, so this chunk exists. Its initialized
+                // slots remain valid for the entire scan (before the swap).
+                let chunk =
+                    unsafe { space.chunk_start_ptr(start / ChunkedVec::<Object>::CHUNK_SIZE) };
+                let count = (len - start).min(ChunkedVec::<Object>::CHUNK_SIZE);
+                for offset in 0..count {
+                    // SAFETY: offset is in this initialized chunk. No mutator
+                    // can write or reclaim this object while GC holds permits.
+                    let raw_ptr = unsafe { chunk.add(offset) };
+                    let Object::Future(future) = (unsafe { &*raw_ptr }) else {
+                        continue;
+                    };
+                    if future.is_observed() {
+                        continue;
+                    }
+                    // Only futures can contribute an unhandled error. In
+                    // particular, do not hash unused TLAB slots or instances.
+                    let ptr = unsafe { self.make_heap_ptr(raw_ptr.cast_mut()) };
+                    if forwarding.contains_key(&ptr) {
+                        continue;
+                    }
+                    if let FutureRead::Error(value) = future.read()
+                        && future.try_mark_reported()
+                    {
+                        errors.push(crate::UnhandledSpawnError {
+                            future_id: future.id(),
+                            value,
+                            trace: future.error_trace(),
+                            cancelled: future.cancel_requested(),
+                        });
+                    }
                 }
             }
         }
@@ -424,6 +441,15 @@ impl BexHeap {
         &self,
         roots: &[HeapPtr],
     ) -> (GcStats, Vec<HeapPtr>, HashMap<HeapPtr, HeapPtr>) {
+        #[cfg(feature = "gc_profiling")]
+        let mut clock = crate::gc_profile::GcClock::new();
+        #[cfg(feature = "gc_profiling")]
+        let mut profile = crate::GcProfile {
+            // SAFETY: collection caller guarantees exclusive access.
+            before: unsafe { crate::GcHeapSnapshot::capture(self) },
+            roots: roots.len(),
+            ..Default::default()
+        };
         // Track old -> new pointer mappings (forwarding pointers)
         let mut forwarding: HashMap<HeapPtr, HeapPtr> = HashMap::new();
 
@@ -445,6 +471,11 @@ impl BexHeap {
 
         // BFS from roots — copy every reachable object into inactive.
         let mut worklist: Vec<HeapPtr> = roots.to_vec();
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.prepare = clock.lap();
+        }
 
         while let Some(old_ptr) = worklist.pop() {
             // Skip already-forwarded objects.
@@ -484,6 +515,11 @@ impl BexHeap {
             self.add_references_to_worklist(obj, &mut worklist);
         }
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.trace = clock.lap();
+        }
+
         // Preserve unobserved spawn errors before reclaiming their futures.
         // SAFETY: GC safepoint; exclusive access.
         unsafe {
@@ -499,10 +535,20 @@ impl BexHeap {
             self.keepalive_finalizers_major(&mut forwarding);
         }
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.keepalive = clock.lap();
+        }
+
         // Patch all intra-heap pointers in the inactive space to their new locations.
         // SAFETY: All live objects have been copied; no VMs are executing.
         unsafe {
             self.fixup_references_in_inactive(&forwarding);
+        }
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.fixup = clock.lap();
         }
 
         // SAFETY: GC runs at safepoints.
@@ -549,6 +595,11 @@ impl BexHeap {
             self.debug_assert_post_major_no_dead_refs();
         }
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.reclaim = clock.lap();
+        }
+
         // Remap each root to its new location (or keep it if it was compile-time).
         let remapped_roots: Vec<HeapPtr> = roots
             .iter()
@@ -566,9 +617,21 @@ impl BexHeap {
         // check would re-trigger GC forever.
         self.reset_gc_counter();
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.bookkeeping = clock.lap();
+        }
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.after = unsafe { crate::GcHeapSnapshot::capture(self) };
+            profile.heap_total = clock.elapsed();
+        }
         let stats = GcStats {
             live_count,
             collected_count,
+            #[cfg(feature = "gc_profiling")]
+            profile,
             level: CollectionLevel::Major,
             promoted_to_gen1: 0,
             promoted_to_gen2: live_count,
@@ -1483,6 +1546,15 @@ impl BexHeap {
         &self,
         roots: &[HeapPtr],
     ) -> (GcStats, Vec<HeapPtr>, HashMap<HeapPtr, HeapPtr>) {
+        #[cfg(feature = "gc_profiling")]
+        let mut clock = crate::gc_profile::GcClock::new();
+        #[cfg(feature = "gc_profiling")]
+        let mut profile = crate::GcProfile {
+            // SAFETY: collection caller guarantees exclusive access.
+            before: unsafe { crate::GcHeapSnapshot::capture(self) },
+            roots: roots.len(),
+            ..Default::default()
+        };
         let mut forwarding: HashMap<HeapPtr, HeapPtr> = HashMap::new();
 
         self.bump_epoch();
@@ -1511,6 +1583,11 @@ impl BexHeap {
         }
 
         let mut promoted_to_gen2 = 0usize;
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.prepare = clock.lap();
+        }
 
         while let Some(old_ptr) = worklist.pop() {
             if forwarding.contains_key(&old_ptr) {
@@ -1543,6 +1620,11 @@ impl BexHeap {
             }
         }
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.trace = clock.lap();
+        }
+
         // Preserve unobserved spawn errors before reclaiming their futures.
         // SAFETY: GC safepoint; exclusive access.
         unsafe {
@@ -1556,6 +1638,11 @@ impl BexHeap {
         // SAFETY: GC safepoint; exclusive access.
         unsafe {
             self.keepalive_finalizers_minor(&mut forwarding, &mut promoted_to_gen2);
+        }
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.keepalive = clock.lap();
         }
 
         // Fix up references:
@@ -1604,6 +1691,11 @@ impl BexHeap {
             }
         }
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.fixup = clock.lap();
+        }
+
         // Swap inactive ↔ Gen1; clear Gen0.
         // SAFETY: GC safepoint; exclusive access to all spaces.
         unsafe {
@@ -1614,6 +1706,11 @@ impl BexHeap {
         self.clear_tlab_canaries();
         // Poison/clear the old Gen1 (now in inactive).
         self.finalize_inactive_space();
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.reclaim = clock.lap();
+        }
 
         let new_gen1_count = unsafe { self.gen1_ref().len() };
         let total_live = new_gen1_count + promoted_to_gen2;
@@ -1635,9 +1732,21 @@ impl BexHeap {
         // allocations, because the counter would never go below the threshold.
         self.reset_gc_counter();
 
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.bookkeeping = clock.lap();
+        }
+
+        #[cfg(feature = "gc_profiling")]
+        {
+            profile.after = unsafe { crate::GcHeapSnapshot::capture(self) };
+            profile.heap_total = clock.elapsed();
+        }
         let stats = GcStats {
             live_count: total_live,
             collected_count: total_before.saturating_sub(total_live),
+            #[cfg(feature = "gc_profiling")]
+            profile,
             level: CollectionLevel::Minor,
             promoted_to_gen1: new_gen1_count,
             promoted_to_gen2,
@@ -1675,6 +1784,63 @@ mod tests {
 
     use super::*;
     use crate::Tlab;
+
+    #[test]
+    fn unhandled_error_scan_covers_chunk_edges_and_preserves_observation() {
+        use bex_vm_types::types::{CancellationToken, FutureId};
+        for level in [CollectionLevel::Minor, CollectionLevel::Major] {
+            let heap = BexHeap::with_tlab_size(vec![], 1);
+            let mut tlab = Tlab::new(heap.clone());
+            for _ in 0..ChunkedVec::<Object>::CHUNK_SIZE - 1 {
+                tlab.alloc_float(0.0);
+            }
+            let mut rooted = None;
+            for id in 0..4 {
+                let ptr = tlab.alloc_future(Future::pending(
+                    FutureId::from_usize(id),
+                    RealizedTy::unknown(),
+                    RealizedTy::unknown(),
+                    CancellationToken::new(),
+                ));
+                let Object::Future(future) = (unsafe { ptr.get() }) else {
+                    unreachable!()
+                };
+                // SAFETY: private pending future, no producer or other holder.
+                assert!(unsafe {
+                    future.settle_error(heap.as_ref(), ptr, Value::int(id as i64), vec![])
+                });
+                if id == 2 {
+                    future.mark_observed();
+                }
+                if id == 3 {
+                    rooted = Some(ptr);
+                }
+            }
+            // The two unobserved dead errors straddle a storage chunk boundary;
+            // the remaining futures occupy a partially filled final chunk.
+            let (_, _, _) = unsafe { heap.collect_garbage_generational(&[rooted.unwrap()], level) };
+            let errors = heap.take_unhandled_spawn_errors();
+            assert_eq!(
+                errors
+                    .iter()
+                    .map(|e| e.future_id.as_usize())
+                    .collect::<Vec<_>>(),
+                vec![0, 1]
+            );
+            assert_eq!(
+                errors.iter().map(|e| e.value).collect::<Vec<_>>(),
+                vec![Value::int(0), Value::int(1)]
+            );
+            // Dropping the last root makes the remaining unobserved error
+            // reportable. Already observed/reported errors must not reappear.
+            unsafe { heap.collect_garbage(&[]) };
+            let errors = heap.take_unhandled_spawn_errors();
+            assert_eq!(errors.len(), 1);
+            assert_eq!(errors[0].future_id.as_usize(), 3);
+            unsafe { heap.collect_garbage(&[]) };
+            assert!(heap.take_unhandled_spawn_errors().is_empty());
+        }
+    }
 
     #[test]
     fn test_gc_empty_heap() {

--- a/baml_language/crates/bex_heap/src/gc_profile.rs
+++ b/baml_language/crates/bex_heap/src/gc_profile.rs
@@ -1,114 +1,271 @@
-//! Opt-in collection diagnostics. No timers or snapshots on allocation paths.
-use std::time::Duration;
+//! Compile-time GC instrumentation. Disabled builds never read clocks or snapshots.
 
-use web_time::Instant;
-
-use crate::BexHeap;
-
-/// Storage counts, not payload bytes or a measurement of reachability.
-#[derive(Clone, Debug, Default)]
-pub struct GcHeapSnapshot {
-    /// Reserved/occupied slots in Gen0, Gen1, Gen2 respectively.
-    pub generation_slots: [usize; 3],
-    /// Backing capacity in Gen0, Gen1, Gen2, scratch respectively.
-    pub capacity_slots: [usize; 4],
-    /// Actual TLAB allocations since the previous collection (excludes holes).
-    pub new_objects: usize,
+/// Disjoint phases of a heap collection, ending at each instrumentation call.
+#[derive(Clone, Copy)]
+pub(crate) enum HeapPhase {
+    Prepare,
+    Trace,
+    Keepalive,
+    Fixup,
+    Reclaim,
+    Bookkeeping,
 }
 
-impl GcHeapSnapshot {
-    /// Caller must hold exclusive GC access; generations can move otherwise.
-    pub(crate) unsafe fn capture(heap: &BexHeap) -> Self {
-        // SAFETY: caller holds exclusive GC access.
-        let spaces = unsafe {
-            [
-                heap.gen0_ref(),
-                heap.gen1_ref(),
-                heap.gen2_ref(),
-                heap.inactive_ref(),
-            ]
-        };
-        Self {
-            generation_slots: [spaces[0].len(), spaces[1].len(), spaces[2].len()],
-            capacity_slots: spaces.map(|space| space.capacity()),
-            new_objects: heap.allocs_since_gc(),
+#[cfg(not(feature = "gc_profiling"))]
+pub(crate) use disabled::NoopGcProfiler as GcProfiler;
+#[cfg(not(feature = "gc_profiling"))]
+pub use disabled::{NoopGcCycleProfiler as GcCycleProfiler, NoopGcProfile as GcProfile};
+#[cfg(feature = "gc_profiling")]
+pub(crate) use enabled::GcProfiler;
+#[cfg(feature = "gc_profiling")]
+pub use enabled::{GcCycleProfiler, GcHeapSnapshot, GcProfile};
+
+#[cfg(feature = "gc_profiling")]
+mod enabled {
+    use std::time::Duration;
+
+    use web_time::Instant;
+
+    use super::HeapPhase;
+    use crate::{BexHeap, GcStats};
+
+    /// Storage counts, not payload bytes or a measurement of reachability.
+    #[derive(Clone, Debug, Default)]
+    pub struct GcHeapSnapshot {
+        /// Reserved/occupied slots in Gen0, Gen1, Gen2 respectively.
+        pub generation_slots: [usize; 3],
+        /// Backing capacity in Gen0, Gen1, Gen2, scratch respectively.
+        pub capacity_slots: [usize; 4],
+        /// Actual TLAB allocations since the previous collection (excludes holes).
+        pub new_objects: usize,
+    }
+
+    impl GcHeapSnapshot {
+        /// Caller must hold exclusive GC access; generations can move otherwise.
+        pub(crate) unsafe fn capture(heap: &BexHeap) -> Self {
+            // SAFETY: caller holds exclusive GC access.
+            let spaces = unsafe {
+                [
+                    heap.gen0_ref(),
+                    heap.gen1_ref(),
+                    heap.gen2_ref(),
+                    heap.inactive_ref(),
+                ]
+            };
+            Self {
+                generation_slots: [spaces[0].len(), spaces[1].len(), spaces[2].len()],
+                capacity_slots: spaces.map(|space| space.capacity()),
+                new_objects: heap.allocs_since_gc(),
+            }
+        }
+    }
+
+    /// Per-cycle wall times. Heap phases are disjoint; `pause` includes them.
+    /// `park_wait` precedes exclusive access and is not a uniform application pause.
+    /// Post-GC callbacks/finalizers run after permits are released.
+    #[derive(Clone, Debug, Default)]
+    pub struct GcProfile {
+        pub before: GcHeapSnapshot,
+        pub after: GcHeapSnapshot,
+        pub roots: usize,
+        pub prepare: Duration,
+        pub trace: Duration,
+        pub keepalive: Duration,
+        pub fixup: Duration,
+        pub reclaim: Duration,
+        pub bookkeeping: Duration,
+        pub heap_total: Duration,
+        pub park_wait: Duration,
+        pub root_scan: Duration,
+        pub holder_fixup: Duration,
+        pub pause: Duration,
+        pub post_gc: Duration,
+        pub total: Duration,
+    }
+
+    /// Captures heap-local phases while the caller holds exclusive heap access.
+    pub(crate) struct GcProfiler {
+        profile: GcProfile,
+        start: Instant,
+        last: Instant,
+    }
+
+    impl GcProfiler {
+        /// Caller must hold exclusive heap access through `finish`.
+        pub(crate) unsafe fn start(heap: &BexHeap, roots: usize) -> Self {
+            let start = Instant::now();
+            Self {
+                profile: GcProfile {
+                    // SAFETY: caller holds exclusive heap access.
+                    before: unsafe { GcHeapSnapshot::capture(heap) },
+                    roots,
+                    ..Default::default()
+                },
+                start,
+                last: start,
+            }
+        }
+
+        pub(crate) fn finish_phase(&mut self, phase: HeapPhase) {
+            let now = Instant::now();
+            let elapsed = now - self.last;
+            self.last = now;
+            match phase {
+                HeapPhase::Prepare => self.profile.prepare = elapsed,
+                HeapPhase::Trace => self.profile.trace = elapsed,
+                HeapPhase::Keepalive => self.profile.keepalive = elapsed,
+                HeapPhase::Fixup => self.profile.fixup = elapsed,
+                HeapPhase::Reclaim => self.profile.reclaim = elapsed,
+                HeapPhase::Bookkeeping => self.profile.bookkeeping = elapsed,
+            }
+        }
+
+        /// Caller must still hold exclusive heap access.
+        pub(crate) unsafe fn finish(mut self, heap: &BexHeap) -> GcProfile {
+            // SAFETY: caller holds exclusive heap access.
+            self.profile.after = unsafe { GcHeapSnapshot::capture(heap) };
+            self.profile.heap_total = self.start.elapsed();
+            self.profile
+        }
+    }
+
+    /// Engine-level timing across permit acquisition, heap collection and callbacks.
+    /// Start before requesting exclusive access; record boundaries in lifecycle order.
+    pub struct GcCycleProfiler {
+        start: Instant,
+        parked_at: Instant,
+        roots_scanned_at: Instant,
+        heap_done_at: Instant,
+        released_at: Instant,
+    }
+
+    impl GcCycleProfiler {
+        pub fn start() -> Self {
+            let start = Instant::now();
+            Self {
+                start,
+                parked_at: start,
+                roots_scanned_at: start,
+                heap_done_at: start,
+                released_at: start,
+            }
+        }
+
+        pub fn parked(&mut self) {
+            self.parked_at = Instant::now();
+        }
+        pub fn roots_scanned(&mut self) {
+            self.roots_scanned_at = Instant::now();
+        }
+        pub fn heap_done(&mut self) {
+            self.heap_done_at = Instant::now();
+        }
+        pub fn released(&mut self) {
+            self.released_at = Instant::now();
+        }
+
+        pub fn finish(self, stats: &mut GcStats, reason: &'static str) {
+            let finished_at = Instant::now();
+            let profile = &mut stats.profile;
+            profile.park_wait = self.parked_at - self.start;
+            profile.root_scan = self.roots_scanned_at - self.parked_at;
+            profile.holder_fixup = self.released_at - self.heap_done_at;
+            profile.pause = self.released_at - self.parked_at;
+            profile.post_gc = finished_at - self.released_at;
+            profile.total = finished_at - self.start;
+            tracing::debug!(target: "bex_gc", reason = reason, level = ?stats.level,
+            profile = ?profile, "GC cycle");
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::{CollectionLevel, Tlab};
+
+        #[test]
+        fn reports_allocations_separately_from_reserved_slots() {
+            let heap = BexHeap::with_tlab_size(vec![], 16);
+            let mut tlab = Tlab::new(heap.clone());
+            let live = tlab.alloc_string("live");
+            tlab.alloc_string("dead");
+            // SAFETY: this standalone heap has no concurrent holders.
+            let (minor, roots, _) = unsafe { heap.collect_garbage_minor(&[live]) };
+            assert_eq!(minor.profile.before.generation_slots, [16, 0, 0]);
+            assert_eq!(minor.profile.before.new_objects, 2);
+            assert_eq!(minor.profile.after.generation_slots, [0, 1, 0]);
+            assert_eq!(minor.profile.after.new_objects, 0);
+            assert_eq!(minor.collected_count, 15); // 1 dead object + 14 holes.
+            assert_eq!(minor.profile.roots, 1);
+            let p = &minor.profile;
+            assert!(
+                p.heap_total
+                    >= p.prepare + p.trace + p.keepalive + p.fixup + p.reclaim + p.bookkeeping
+            );
+            // SAFETY: roots were forwarded by the preceding collection; no mutator.
+            let (major, _, _) = unsafe { heap.collect_garbage(&roots) };
+            assert_eq!(major.level, CollectionLevel::Major);
+            assert_eq!(major.profile.before.generation_slots, [0, 1, 0]);
+            assert_eq!(major.profile.after.generation_slots, [0, 0, 1]);
         }
     }
 }
 
-/// Per-cycle wall times. Heap phases are disjoint; `pause` includes them.
-/// `park_wait` precedes exclusive access and is not a uniform application pause.
-/// Post-GC callbacks/finalizers run after permits are released.
-#[derive(Clone, Debug, Default)]
-pub struct GcProfile {
-    pub before: GcHeapSnapshot,
-    pub after: GcHeapSnapshot,
-    pub roots: usize,
-    pub prepare: Duration,
-    pub trace: Duration,
-    pub keepalive: Duration,
-    pub fixup: Duration,
-    pub reclaim: Duration,
-    pub bookkeeping: Duration,
-    pub heap_total: Duration,
-    pub park_wait: Duration,
-    pub root_scan: Duration,
-    pub holder_fixup: Duration,
-    pub pause: Duration,
-    pub post_gc: Duration,
-    pub total: Duration,
-}
+#[cfg(not(feature = "gc_profiling"))]
+mod disabled {
+    use super::HeapPhase;
+    use crate::{BexHeap, GcStats};
 
-pub(crate) struct GcClock {
-    start: Instant,
-    last: Instant,
-}
+    /// Profiling is unavailable in this build; occupies no space in `GcStats`.
+    #[derive(Clone, Debug, Default)]
+    pub struct NoopGcProfile;
 
-impl GcClock {
-    pub(crate) fn new() -> Self {
-        let start = Instant::now();
-        Self { start, last: start }
+    pub(crate) struct NoopGcProfiler;
+
+    impl NoopGcProfiler {
+        /// Same exclusive-access contract as the enabled implementation.
+        #[inline]
+        pub(crate) unsafe fn start(_: &BexHeap, _: usize) -> Self {
+            Self
+        }
+        #[inline]
+        pub(crate) fn finish_phase(&mut self, _: HeapPhase) {}
+        /// Same exclusive-access contract as the enabled implementation.
+        #[inline]
+        pub(crate) unsafe fn finish(self, _: &BexHeap) -> NoopGcProfile {
+            NoopGcProfile
+        }
     }
 
-    pub(crate) fn lap(&mut self) -> Duration {
-        let now = Instant::now();
-        let elapsed = now - self.last;
-        self.last = now;
-        elapsed
+    /// Disabled engine instrumentation: no clock reads, logging or stored state.
+    pub struct NoopGcCycleProfiler;
+
+    impl NoopGcCycleProfiler {
+        #[inline]
+        pub fn start() -> Self {
+            Self
+        }
+        #[inline]
+        pub fn parked(&mut self) {}
+        #[inline]
+        pub fn roots_scanned(&mut self) {}
+        #[inline]
+        pub fn heap_done(&mut self) {}
+        #[inline]
+        pub fn released(&mut self) {}
+        #[inline]
+        pub fn finish(self, _: &mut GcStats, _: &'static str) {}
     }
 
-    pub(crate) fn elapsed(&self) -> Duration {
-        self.start.elapsed()
-    }
-}
+    #[cfg(test)]
+    mod tests {
+        use super::*;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{CollectionLevel, Tlab};
-
-    #[test]
-    fn reports_allocations_separately_from_reserved_slots() {
-        let heap = BexHeap::with_tlab_size(vec![], 16);
-        let mut tlab = Tlab::new(heap.clone());
-        let live = tlab.alloc_string("live");
-        tlab.alloc_string("dead");
-        // SAFETY: this standalone heap has no concurrent holders.
-        let (minor, roots, _) = unsafe { heap.collect_garbage_minor(&[live]) };
-        assert_eq!(minor.profile.before.generation_slots, [16, 0, 0]);
-        assert_eq!(minor.profile.before.new_objects, 2);
-        assert_eq!(minor.profile.after.generation_slots, [0, 1, 0]);
-        assert_eq!(minor.profile.after.new_objects, 0);
-        assert_eq!(minor.collected_count, 15); // 1 dead object + 14 holes.
-        assert_eq!(minor.profile.roots, 1);
-        let p = &minor.profile;
-        assert!(
-            p.heap_total >= p.prepare + p.trace + p.keepalive + p.fixup + p.reclaim + p.bookkeeping
-        );
-        // SAFETY: roots were forwarded by the preceding collection; no mutator.
-        let (major, _, _) = unsafe { heap.collect_garbage(&roots) };
-        assert_eq!(major.level, CollectionLevel::Major);
-        assert_eq!(major.profile.before.generation_slots, [0, 1, 0]);
-        assert_eq!(major.profile.after.generation_slots, [0, 0, 1]);
+        #[test]
+        fn disabled_instrumentation_has_no_stored_state() {
+            assert_eq!(size_of::<NoopGcProfile>(), 0);
+            assert_eq!(size_of::<NoopGcProfiler>(), 0);
+            assert_eq!(size_of::<NoopGcCycleProfiler>(), 0);
+        }
     }
 }

--- a/baml_language/crates/bex_heap/src/gc_profile.rs
+++ b/baml_language/crates/bex_heap/src/gc_profile.rs
@@ -1,0 +1,114 @@
+//! Opt-in collection diagnostics. No timers or snapshots on allocation paths.
+use std::time::Duration;
+
+use web_time::Instant;
+
+use crate::BexHeap;
+
+/// Storage counts, not payload bytes or a measurement of reachability.
+#[derive(Clone, Debug, Default)]
+pub struct GcHeapSnapshot {
+    /// Reserved/occupied slots in Gen0, Gen1, Gen2 respectively.
+    pub generation_slots: [usize; 3],
+    /// Backing capacity in Gen0, Gen1, Gen2, scratch respectively.
+    pub capacity_slots: [usize; 4],
+    /// Actual TLAB allocations since the previous collection (excludes holes).
+    pub new_objects: usize,
+}
+
+impl GcHeapSnapshot {
+    /// Caller must hold exclusive GC access; generations can move otherwise.
+    pub(crate) unsafe fn capture(heap: &BexHeap) -> Self {
+        // SAFETY: caller holds exclusive GC access.
+        let spaces = unsafe {
+            [
+                heap.gen0_ref(),
+                heap.gen1_ref(),
+                heap.gen2_ref(),
+                heap.inactive_ref(),
+            ]
+        };
+        Self {
+            generation_slots: [spaces[0].len(), spaces[1].len(), spaces[2].len()],
+            capacity_slots: spaces.map(|space| space.capacity()),
+            new_objects: heap.allocs_since_gc(),
+        }
+    }
+}
+
+/// Per-cycle wall times. Heap phases are disjoint; `pause` includes them.
+/// `park_wait` precedes exclusive access and is not a uniform application pause.
+/// Post-GC callbacks/finalizers run after permits are released.
+#[derive(Clone, Debug, Default)]
+pub struct GcProfile {
+    pub before: GcHeapSnapshot,
+    pub after: GcHeapSnapshot,
+    pub roots: usize,
+    pub prepare: Duration,
+    pub trace: Duration,
+    pub keepalive: Duration,
+    pub fixup: Duration,
+    pub reclaim: Duration,
+    pub bookkeeping: Duration,
+    pub heap_total: Duration,
+    pub park_wait: Duration,
+    pub root_scan: Duration,
+    pub holder_fixup: Duration,
+    pub pause: Duration,
+    pub post_gc: Duration,
+    pub total: Duration,
+}
+
+pub(crate) struct GcClock {
+    start: Instant,
+    last: Instant,
+}
+
+impl GcClock {
+    pub(crate) fn new() -> Self {
+        let start = Instant::now();
+        Self { start, last: start }
+    }
+
+    pub(crate) fn lap(&mut self) -> Duration {
+        let now = Instant::now();
+        let elapsed = now - self.last;
+        self.last = now;
+        elapsed
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.start.elapsed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CollectionLevel, Tlab};
+
+    #[test]
+    fn reports_allocations_separately_from_reserved_slots() {
+        let heap = BexHeap::with_tlab_size(vec![], 16);
+        let mut tlab = Tlab::new(heap.clone());
+        let live = tlab.alloc_string("live");
+        tlab.alloc_string("dead");
+        // SAFETY: this standalone heap has no concurrent holders.
+        let (minor, roots, _) = unsafe { heap.collect_garbage_minor(&[live]) };
+        assert_eq!(minor.profile.before.generation_slots, [16, 0, 0]);
+        assert_eq!(minor.profile.before.new_objects, 2);
+        assert_eq!(minor.profile.after.generation_slots, [0, 1, 0]);
+        assert_eq!(minor.profile.after.new_objects, 0);
+        assert_eq!(minor.collected_count, 15); // 1 dead object + 14 holes.
+        assert_eq!(minor.profile.roots, 1);
+        let p = &minor.profile;
+        assert!(
+            p.heap_total >= p.prepare + p.trace + p.keepalive + p.fixup + p.reclaim + p.bookkeeping
+        );
+        // SAFETY: roots were forwarded by the preceding collection; no mutator.
+        let (major, _, _) = unsafe { heap.collect_garbage(&roots) };
+        assert_eq!(major.level, CollectionLevel::Major);
+        assert_eq!(major.profile.before.generation_slots, [0, 1, 0]);
+        assert_eq!(major.profile.after.generation_slots, [0, 0, 1]);
+    }
+}

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -788,28 +788,13 @@ impl BexHeap {
     ///
     /// # Safety
     ///
-    /// The caller must ensure `vec`'s chunk layout is not growing concurrently.
-    /// `ChunkedVec` never moves existing chunks, but its internal chunk
-    /// `Vec<Box<[UnsafeCell<T>]>>` can reallocate its buffer on growth, and
-    /// `num_chunks`/`chunk_start_ptr` are non-atomic reads of that buffer. Only
-    /// call this for spaces that grow exclusively at GC safepoints (Gen1/Gen2),
-    /// or while holding exclusive access to the space being scanned.
+    /// When `vec` comes from a generation's `UnsafeCell`, the caller must keep
+    /// that generation from being swapped/cleared by GC while it is borrowed
+    /// (a heap permit or exclusive GC access). `ChunkedVec` itself synchronizes
+    /// access to its storage descriptors, including concurrent growth.
     #[inline]
     unsafe fn ptr_in_chunked_vec(vec: &ChunkedVec<Object>, raw_ptr: *const Object) -> bool {
-        // `num_chunks` and `chunk_start_ptr` now serialize on the
-        // ChunkedVec's internal RwLock, so the brief window is safe even
-        // under a concurrent grower. `chunk_start_ptr` is still `unsafe`
-        // for the bounds precondition.
-        let num_chunks = vec.num_chunks();
-        for chunk_idx in 0..num_chunks {
-            // SAFETY: `chunk_idx < num_chunks` by loop bound.
-            let chunk_start = unsafe { vec.chunk_start_ptr(chunk_idx) };
-            let chunk_end = unsafe { chunk_start.add(ChunkedVec::<Object>::CHUNK_SIZE) };
-            if raw_ptr >= chunk_start && raw_ptr < chunk_end {
-                return true;
-            }
-        }
-        false
+        vec.contains_ptr(raw_ptr)
     }
 
     /// Bug H, check 3 helper (heap_debug only): is `ptr` inside the

--- a/baml_language/crates/bex_heap/src/lib.rs
+++ b/baml_language/crates/bex_heap/src/lib.rs
@@ -62,6 +62,8 @@ mod accessor;
 pub(crate) mod card_table;
 mod chunked_vec;
 mod gc;
+#[cfg(feature = "gc_profiling")]
+mod gc_profile;
 mod heap;
 mod heap_debugger;
 mod heap_guard;
@@ -72,6 +74,8 @@ pub use accessor::{AccessError, BexClass, BexValue, BuiltinClass};
 pub use bex_external_types::{BexExternalValue, Handle};
 pub use bex_vm_types::PermitProof;
 pub use gc::{CollectionLevel, GcStats};
+#[cfg(feature = "gc_profiling")]
+pub use gc_profile::{GcHeapSnapshot, GcProfile};
 pub use heap::{BexHeap, DEFAULT_TLAB_SIZE, Generation, HeapStats, UnhandledSpawnError};
 pub(crate) use heap_debugger::{HeapDebuggerConfig, HeapDebuggerState};
 pub use heap_guard::{

--- a/baml_language/crates/bex_heap/src/lib.rs
+++ b/baml_language/crates/bex_heap/src/lib.rs
@@ -62,7 +62,6 @@ mod accessor;
 pub(crate) mod card_table;
 mod chunked_vec;
 mod gc;
-#[cfg(feature = "gc_profiling")]
 mod gc_profile;
 mod heap;
 mod heap_debugger;
@@ -75,7 +74,8 @@ pub use bex_external_types::{BexExternalValue, Handle};
 pub use bex_vm_types::PermitProof;
 pub use gc::{CollectionLevel, GcStats};
 #[cfg(feature = "gc_profiling")]
-pub use gc_profile::{GcHeapSnapshot, GcProfile};
+pub use gc_profile::GcHeapSnapshot;
+pub use gc_profile::{GcCycleProfiler, GcProfile};
 pub use heap::{BexHeap, DEFAULT_TLAB_SIZE, Generation, HeapStats, UnhandledSpawnError};
 pub(crate) use heap_debugger::{HeapDebuggerConfig, HeapDebuggerState};
 pub use heap_guard::{

--- a/baml_language/tools/gc_policy/build.py
+++ b/baml_language/tools/gc_policy/build.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Build an immutable experiment binary with its source and build provenance."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def source_state(workspace):
+    def git(*args):
+        return subprocess.check_output(['git', *args], cwd=workspace)
+    names = git('ls-files', '-z', '--cached', '--others', '--exclude-standard', '--', '.')
+    files = {}
+    for name in sorted(set(names.decode().split('\0')) - {''}):
+        path = workspace / name
+        files[name] = sha256(path) if path.is_file() else None
+    return {
+        'commit': git('rev-parse', 'HEAD').decode().strip(),
+        'files': files,
+        'tree_sha256': hashlib.sha256(json.dumps(files, sort_keys=True).encode()).hexdigest(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output', required=True, type=Path,
+                        help='New directory outside the checkout')
+    parser.add_argument('--profile', default='fasttest')
+    parser.add_argument('--features', default='gc_profiling')
+    args = parser.parse_args()
+    workspace = Path(__file__).resolve().parents[2]
+    out = args.output.resolve()
+    if out.is_relative_to(workspace):
+        parser.error('Keep build artifacts outside the source checkout')
+    out.mkdir(parents=True, exist_ok=False)
+    before = source_state(workspace)
+    diff = subprocess.check_output(['git', 'diff', '--binary', 'HEAD', '--', '.'], cwd=workspace)
+    (out / 'source.patch').write_bytes(diff)
+    untracked = subprocess.check_output(
+        ['git', 'ls-files', '-z', '--others', '--exclude-standard', '--', '.'], cwd=workspace)
+    for name in filter(None, untracked.decode().split('\0')):
+        source = workspace / name
+        if source.is_file():
+            target = out / 'untracked' / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+    command = ['cargo', 'test', '--locked', '-p', 'bex_engine', '--test',
+               'gc_policy_experiment', '--profile', args.profile, '--no-run',
+               '--message-format=json']
+    if args.features:
+        command += ['--features', args.features]
+    with (out / 'build.jsonl').open('w') as stdout, (out / 'build.log').open('w') as stderr:
+        result = subprocess.run(command, cwd=workspace, stdout=stdout, stderr=stderr)
+    if result.returncode:
+        raise SystemExit(f'Build failed; see {out / "build.log"}')
+    if source_state(workspace) != before:
+        raise SystemExit('Source changed during build; discard this build and retry')
+    artifacts = [json.loads(line) for line in (out / 'build.jsonl').read_text().splitlines()]
+    executables = [a['executable'] for a in artifacts
+                   if a.get('reason') == 'compiler-artifact' and a.get('executable')
+                   and a['target']['name'] == 'gc_policy_experiment']
+    if len(executables) != 1:
+        raise SystemExit(f'Expected one test executable, got {executables}')
+    binary = out / 'experiment'
+    shutil.copy2(executables[0], binary)
+    manifest = dict(schema_version=1, source=before, command=command,
+                    rustc=subprocess.check_output(['rustc', '-vV'], text=True),
+                    cargo=subprocess.check_output(['cargo', '-V'], text=True).strip(),
+                    platform=platform.platform(), libc=platform.libc_ver(),
+                    allocator='Not inferred: record allocator overrides with the run',
+                    build_environment={k: os.environ[k] for k in
+                                       ['RUSTFLAGS', 'CARGO_ENCODED_RUSTFLAGS', 'CARGO_BUILD_TARGET']
+                                       if k in os.environ},
+                    binary_sha256=sha256(binary))
+    (out / 'build-manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+    print(binary)
+
+
+if __name__ == '__main__':
+    main()

--- a/baml_language/tools/gc_policy/run.py
+++ b/baml_language/tools/gc_policy/run.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Run paired GC experiments in fresh processes; keep every result and cycle."""
+import argparse
+import hashlib
+import json
+import os
+import platform
+from pathlib import Path
+import random
+import shutil
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--baseline', type=Path, required=True)
+    parser.add_argument('--candidate', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--repeats', type=int, default=3)
+    parser.add_argument('--change', default='Candidate implementation supplied by the caller.')
+    parser.add_argument('--case', action='append', help='Run only named cases (repeatable)')
+    parser.add_argument('--extended', action='store_true', help='Include long-run, cache and idle cases')
+    parser.add_argument('--allow-legacy-binaries', action='store_true',
+                        help='Explicitly allow binaries without build.py provenance')
+    parser.add_argument('--allow-unprofiled', action='store_true', help='Timing-only feature-off comparison')
+    parser.add_argument('--timeout', type=float, default=300)
+    args = parser.parse_args()
+    workspace = Path(__file__).resolve().parents[2]
+    out = args.output.resolve()
+    if args.repeats < 1 or args.timeout <= 0:
+        parser.error('repeats and timeout must be positive')
+    variants = {name: path.resolve() for name, path in
+                [('baseline', args.baseline), ('candidate', args.candidate)]}
+    provenance = {}
+    for name, path in variants.items():
+        manifest_path = path.parent / 'build-manifest.json'
+        if manifest_path.exists():
+            data = json.loads(manifest_path.read_text())
+            if data['binary_sha256'] != hashlib.sha256(path.read_bytes()).hexdigest():
+                parser.error(f'{name}: binary does not match its build manifest')
+            provenance[name] = data
+        elif not args.allow_legacy_binaries:
+            parser.error(f'{name}: use build.py, or explicitly allow legacy binaries')
+    cases = [
+        ('scalar', 'full32', dict(GC_WORKLOAD='scalar', GC_CALLS=24000, GC_WARMUP=512)),
+        ('tiny', 'full32', dict(GC_WORKLOAD='tiny', GC_CALLS=24000, GC_WARMUP=512)),
+        ('churn', 'full32', dict(GC_WORKLOAD='churn')),
+        ('retained', 'full32', dict(GC_WORKLOAD='retained')),
+        ('retained_minor', 'fixed32', dict(GC_WORKLOAD='retained')),
+        ('large_live_fixed', 'full32', dict(GC_WORKLOAD='retained', GC_CALLS=768, GC_N=4096, GC_RETAIN=384)),
+        ('large_live_scaled', 'full_live', dict(GC_WORKLOAD='retained', GC_CALLS=768, GC_N=4096, GC_RETAIN=384)),
+        ('burst', 'full32', dict(GC_WORKLOAD='burst', GC_CALLS=1536)),
+        ('payload', 'full32', dict(GC_WORKLOAD='payload')),
+        ('long_call', 'full32', dict(GC_WORKLOAD='churn', GC_CALLS=4, GC_N=1048576, GC_WARMUP=1)),
+        ('concurrent', 'full32', dict(GC_WORKERS=8, GC_CALLS=100, GC_N=512)),
+    ]
+    extended = [
+        ('continuous_100k', 'full32', dict(GC_WORKLOAD='tiny', GC_CALLS=100000, GC_WARMUP=512)),
+        ('cache', 'full_live', dict(GC_WORKLOAD='cache', GC_CALLS=1024, GC_N=4096, GC_CACHE_N=262144)),
+        ('burst_idle', 'full32', dict(GC_WORKLOAD='burst_idle', GC_CALLS=512, GC_N=2048, GC_IDLE_MS=1000)),
+    ]
+    if args.extended or args.case:
+        cases += extended
+    if args.case:
+        unknown = set(args.case) - {c[0] for c in cases}
+        if unknown:
+            parser.error(f'Unknown cases: {sorted(unknown)}')
+        cases = [c for c in cases if c[0] in args.case]
+    out.mkdir(parents=True, exist_ok=False)
+    for name in provenance:
+        shutil.copy2(variants[name].parent / 'build-manifest.json', out / f'{name}-build.json')
+    manifest = dict(
+        runner_git_commit=subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=workspace, text=True).strip(),
+        platform=platform.platform(), libc=platform.libc_ver(),
+        allocator_environment={k: os.environ[k] for k in
+                               ['GLIBC_TUNABLES', 'MALLOC_CONF', 'MALLOC_ARENA_MAX',
+                                'MALLOC_TRIM_THRESHOLD_', 'MALLOC_MMAP_THRESHOLD_',
+                                'DYLD_INSERT_LIBRARIES', 'LD_PRELOAD'] if k in os.environ},
+        binaries={name: dict(path=str(path), sha256=hashlib.sha256(path.read_bytes()).hexdigest())
+                  for name, path in variants.items()},
+        seed=4202, repeats=args.repeats, cases=cases, change=args.change,
+        build_provenance={name: f'{name}-build.json' if name in provenance else None for name in variants},
+        allow_unprofiled=args.allow_unprofiled,
+    )
+    (out / 'manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+    # Keep baseline/candidate adjacent, randomize their order inside each pair,
+    # and shuffle pairs. This limits bias from drift over a long matrix.
+    rng = random.Random(4202)
+    pairs = [(repeat, case) for repeat in range(args.repeats) for case in cases]
+    rng.shuffle(pairs)
+    with (out / 'results.jsonl').open('w') as stream:
+        for pair_index, (repeat, (case, policy, settings)) in enumerate(pairs):
+            order = list(variants)
+            rng.shuffle(order)
+            for variant in order:
+                name = f'{repeat}-{case}-{variant}'
+                test = 'profile_concurrent_gc' if case == 'concurrent' else 'compare_gc_policy'
+                # Ambient experiment knobs must not silently change a matrix.
+                env = {k: v for k, v in os.environ.items() if not k.startswith('GC_')}
+                env.update({k: str(v) for k, v in settings.items()})
+                env.update(GC_POLICY=policy, GC_TRACE=str(out / f'{name}.cycles.json'))
+                try:
+                    run = subprocess.run([str(variants[variant]), '--ignored', '--nocapture', '--exact', test],
+                                         cwd=workspace, env=env, text=True, capture_output=True, timeout=args.timeout)
+                except subprocess.TimeoutExpired as error:
+                    # TimeoutExpired can carry bytes even with text=True.
+                    decode = lambda value: value.decode(errors='replace') if isinstance(value, bytes) else (value or '')
+                    (out / f'{name}.log').write_text(decode(error.stdout) + decode(error.stderr) + '\nTIMED OUT\n')
+                    raise RuntimeError(f'{name} timed out; see its log') from error
+                (out / f'{name}.log').write_text(run.stdout + run.stderr)
+                if run.returncode:
+                    raise RuntimeError(f'{name} failed: see {out / (name + ".log")}')
+                prefix = 'GC_CONCURRENT_RESULT ' if case == 'concurrent' else 'GC_POLICY_RESULT '
+                lines = [line[len(prefix):] for line in run.stdout.splitlines() if line.startswith(prefix)]
+                if len(lines) != 1:
+                    raise RuntimeError(f'{name}: missing/ambiguous result')
+                result = json.loads(lines[0])
+                cycles = json.loads((out / f'{name}.cycles.json').read_text())
+                for cycle in cycles:
+                    if cycle['profile'] is None and not args.allow_unprofiled:
+                        raise RuntimeError('Build both binaries with --features gc_profiling')
+                result.update(case=case, variant=variant, repeat=repeat, cycles_file=f'{name}.cycles.json')
+                stream.write(json.dumps(result) + '\n')
+                stream.flush()
+                print(f'{pair_index+1}/{len(pairs)} {name}: {result["elapsed_seconds"]:.3f}s, '
+                      f'{len(cycles)} recorded collections', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/baml_language/tools/gc_policy/summarize.py
+++ b/baml_language/tools/gc_policy/summarize.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Summarize paired results and export collection timelines for trace viewers."""
+import argparse
+import collections
+import json
+from pathlib import Path
+import statistics
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('directory', type=Path)
+    args = parser.parse_args()
+    root = args.directory
+    manifest = json.loads((root / 'manifest.json').read_text())
+    rows = [json.loads(line) for line in (root / 'results.jsonl').read_text().splitlines()]
+    expected = len(manifest['cases']) * manifest['repeats'] * 2
+    if len(rows) != expected:
+        parser.error(f'Matrix incomplete: {len(rows)}/{expected} runs')
+    phases = ['prepare', 'trace', 'keepalive', 'fixup', 'reclaim', 'bookkeeping']
+    groups = collections.defaultdict(dict)
+    expected_keys = {(case[0], repeat) for case in manifest['cases'] for repeat in range(manifest['repeats'])}
+    for row in rows:
+        key = (row['case'], row['repeat'])
+        assert key in expected_keys, f'Unexpected run: {key}'
+        assert row['variant'] not in groups[key], key
+        groups[key][row['variant']] = row
+        cycles = json.loads((root / row['cycles_file']).read_text())
+        profiled = [cycle for cycle in cycles if cycle['profile'] is not None]
+        sums = collections.defaultdict(float)
+        timeline = []
+        for cycle in profiled:
+            profile = cycle['profile']
+            # End timestamps are sampled by the caller immediately after the
+            # collection returns. Reconstruct relative spans; do not pretend
+            # these are scheduler events or exact cross-thread timestamps.
+            start_ms = cycle['at_seconds'] * 1000 - profile['total_ms']
+            for phase in phases + ['park_wait', 'root_scan', 'holder_fixup', 'post_gc', 'pause', 'total']:
+                sums[phase + '_ms'] += profile[phase + '_ms']
+            assert profile['heap_total_ms'] + 0.001 >= sum(profile[p + '_ms'] for p in phases)
+            assert profile['total_ms'] + 0.001 >= profile['park_wait_ms'] + profile['pause_ms'] + profile['post_gc_ms']
+            pos = start_ms
+            durations = [(phase, profile[phase + '_ms'])
+                         for phase in ['park_wait', 'root_scan'] + phases]
+            # The end snapshot and small instrumentation gaps are included in
+            # heap_total but excluded from the disjoint phase laps. Preserve
+            # that gap so later reconstructed spans are not shifted earlier.
+            durations.append(('heap_unattributed', max(0, profile['heap_total_ms'] -
+                                                       sum(profile[p + '_ms'] for p in phases))))
+            durations += [(phase, profile[phase + '_ms']) for phase in ['holder_fixup', 'post_gc']]
+            for phase, duration in durations:
+                timeline.append(dict(name=phase, cat='gc', ph='X', pid=1, tid=1,
+                                     ts=pos * 1000, dur=duration * 1000,
+                                     args=dict(trigger=cycle['trigger'])))
+                pos += duration
+            for when, sizes in [(start_ms, profile['before_generations']),
+                                (cycle['at_seconds'] * 1000, profile['after_generations'])]:
+                if 'slot_bytes' in row:
+                    timeline.append(dict(name='Object slot storage (MiB)', ph='C', pid=1, tid=1,
+                                         ts=when * 1000,
+                                         args={f'gen{i}': count * row['slot_bytes'] / 1048576
+                                               for i, count in enumerate(sizes)}))
+        row['recorded_phase_totals_ms'] = dict(sums)
+        row['recorded_max_pause_ms'] = max((c['profile']['pause_ms'] for c in profiled), default=None)
+        row['recorded_max_park_wait_ms'] = max((c['profile']['park_wait_ms'] for c in profiled), default=None)
+        row['actual_new_objects_in_recorded_cycles'] = sum(c['profile']['actual_new_objects'] for c in profiled)
+        row['reserved_gen0_slots_in_recorded_cycles'] = sum(c['profile']['before_generations'][0] for c in profiled)
+        (root / row['cycles_file'].replace('.cycles.json', '.trace.json')).write_text(
+            json.dumps(dict(traceEvents=timeline, displayTimeUnit='ms')) + '\n')
+    by_case = collections.defaultdict(list)
+    for (case, repeat), pair in groups.items():
+        assert set(pair) == {'baseline', 'candidate'}
+        by_case[case].append(pair)
+    lines = ['# Paired GC profiling results', '',
+             f'{len(rows)} successful runs, {manifest["repeats"]} repetitions per case and binary. '
+             'Each pair ran adjacent in randomized order; pairs were also shuffled. '
+             'Reported changes are medians of paired ratios, not ratios of unrelated medians.', '',
+             'Baseline and candidate are invoked with the same workload, warmup and requested policy settings. '
+             + manifest.get('change', 'The candidate optimizes the unhandled-spawn-error scan.') +
+             ' Binary hashes and experiment settings are recorded in the manifest.', '',
+             '| Case | Baseline s | Candidate s | Speedup (paired range) | Candidate peak slots MiB | Candidate longest recorded pause ms |',
+             '|---|---:|---:|---:|---:|---:|']
+    for case, pairs in sorted(by_case.items()):
+        assert len(pairs) == manifest['repeats']
+        med = lambda variant, key: statistics.median(p[variant][key] for p in pairs)
+        ratios = [p['baseline']['elapsed_seconds'] / p['candidate']['elapsed_seconds'] for p in pairs]
+        slots = '-' if case == 'concurrent' else f'{med("candidate", "peak_slot_mib"):.1f}'
+        pauses = [p['candidate']['recorded_max_pause_ms'] for p in pairs]
+        pause = f'{statistics.median(pauses):.1f}' if all(p is not None for p in pauses) else '-'
+        lines.append(f'| {case} | {med("baseline", "elapsed_seconds"):.3f} | '
+                     f'{med("candidate", "elapsed_seconds"):.3f} | {statistics.median(ratios):.2f}× '
+                     f'({min(ratios):.2f}–{max(ratios):.2f}) | {slots} | {pause} |')
+    lines += ['', '## Where collection time went', '',
+              'Medians of per-run totals for explicitly requested, measured collections. '
+              'The concurrent case can also trigger automatic collections; these are emitted by '
+              'the engine tracing target but are not included in this harness’s returned-statistics files.', '',
+              '| Case | Binary | Trace/copy ms | Error/finalizer scans ms | Pointer fixup ms | Reclaim ms | Wait to park ms |',
+              '|---|---|---:|---:|---:|---:|---:|']
+    for case, pairs in sorted(by_case.items()):
+        for variant in ['baseline', 'candidate']:
+            if any(p[variant]['recorded_max_pause_ms'] is None for p in pairs):
+                lines.append(f'| {case} | {variant} | - | - | - | - | - |')
+                continue
+            values = [statistics.median(p[variant]['recorded_phase_totals_ms'].get(k + '_ms', 0)
+                                       for p in pairs) for k in ['trace', 'keepalive', 'fixup', 'reclaim', 'park_wait']]
+            lines.append(f'| {case} | {variant} | ' + ' | '.join(f'{v:.1f}' for v in values) + ' |')
+    lines += ['', '## Reading these measurements', '',
+              '- Time and memory must be compared together. `large_live_fixed` and `large_live_scaled` use identical '
+              'workloads; the latter grants max(32 MiB, surviving slot bytes) between full collections. '
+              'This is a policy experiment, not a change to engine defaults.',
+              '- Slots include reservation slack. `actual_new_objects_in_recorded_cycles` excludes unused slots; '
+              'the original `collected_count` means reclaimed slots and must not be interpreted as dead-object count.',
+              '- The `payload` case passes 64 KiB strings and retains 256 results. Payload bytes, compiler memory, '
+              'allocator retention and scratch copies are not interchangeable with slot counts. RSS samples are in the raw results; '
+              'they are sampled every 32 calls, include startup/compilation, and can miss brief peaks.',
+              '- The long-call case allocates roughly 64 MiB of slots within each call. A 32 MiB threshold checked '
+              'only between calls cannot constrain that in-call growth. Production scheduling still needs safe allocation checkpoints.',
+              '- `park_wait` is time waiting to acquire all permits; different callers may stop at different times. '
+              '`pause` is the exclusive-permit window. Post-GC callbacks and finalizers run after it. '
+              'All are wall times, not CPU samples.',
+              '- Tiny/scalar use 512 warmup calls; most other cases use 32, long-call uses one. Warmup cleanup '
+              'and post-run collection/retained-result validation are outside measured time. Retained arrays '
+              'are checked by summing every element after a moving collection. Payload lengths and concurrent array sums are checked.',
+              '- These are synthetic engine tests, not production SDK benchmarks. Check the build manifests for '
+              'profile, features and compiler settings. A few paired repetitions identify large differences; small differences can be noise.',
+              '- Instrumentation is feature-gated. Missing phase measurements are shown as unavailable. '
+              'Compare equally instrumented builds to attribute collector changes; a feature-on/off comparison measures different overhead.',
+              '- Per-run `.trace.json` files can be opened in a Chrome Trace-compatible viewer. Phase start times are '
+              'reconstructed from measured durations and caller timestamps. They are diagnostic timelines, not exact scheduling traces.', '']
+    (root / 'RESULTS.md').write_text('\n'.join(lines))
+    (root / 'summary.json').write_text(json.dumps(rows, indent=2) + '\n')
+    print('\n'.join(lines[:lines.index('## Where collection time went')]))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Changes

BAML's existing GC spends avoidable time locking storage and checking objects that cannot contain an unhandled future error. This PR reduces that work and adds the measurements needed to decide the next GC policy.

This is the **base layer of the GC work**: faster existing collection, opt-in profiling, and reproducible experiments. Allocation thresholds and collection opportunities keep their current behavior. The memory-growth repro still needs the trigger-policy follow-up.

### Before → after

**Finding unhandled errors:** a tiny call can leave a mostly empty allocation reservation. Previously, the error scan locked storage and checked the forwarding map for every reserved slot. Now it resolves storage once per chunk and filters for relevant futures before checking the map.

```text
Before                               After
for every reserved slot:             for each chunk:
  lock storage                         resolve storage once
  look up forwarding map               for each slot:
  inspect possible future                skip non-futures / observed futures
                                         look up forwarding map
                                         preserve an unhandled error
```

The scan still examines the same initialized storage, preserves error payloads, and reports each eligible error once. Chunk-edge tests cover observed, rooted, and already-reported futures under minor and full collection.

**Checking generation membership:** normal array mutation and collection both ask which generation owns a pointer. The address-range search stays linear; it now holds the descriptor lock once for the whole search.

```diff
 check_pointer_generation(pointer):
+  acquire descriptor read lock
   for each storage chunk:
-    acquire descriptor read lock
     compare pointer with chunk address range
```

This preserves membership in unused backing capacity, stable pointers across growth, and exclusion of the range's upper bound.

### Profiling that explains the cost

The optional `gc_profiling` feature separates permit wait, exclusive pause, heap phases, and post-GC callbacks/finalizers. Snapshots distinguish actual allocations from reserved slots and backing capacity. Engine tracing labels explicit, automatic, and shutdown collections.

Instrumentation is selected at compile time in `bex_heap/src/gc_profile.rs`. Enabled builds keep the existing report fields, snapshots, phase boundaries and `bex_gc` event. Disabled builds alias the report and recorders to zero-sized no-op types. The collector and engine call the same methods in both builds:

```text
start heap recorder and capture before snapshot
prepare collection; finish_phase(Prepare)
trace survivors; finish_phase(Trace)
...
finish recorder and capture after snapshot
```

Clock reads, snapshot capture and profile logging happen inside the enabled implementation; disabled calls do not evaluate any of that work. The engine passes a cycle recorder across permit acquisition, root scanning, collection, permit release and callbacks. Detailed report consumers may still be feature-gated. The existing allocation counter is unchanged because this base layer's trigger policy uses it even without profiling.

The experiment tooling now preserves binary hashes, compiler/build settings, source patches and source inventories; rejects mismatched binaries; runs adjacent randomized pairs; and exports reconstructed diagnostic timelines. Added workloads cover a permanent cache, a real burst followed by no calls, and 100k calls. RSS reads support macOS and Linux, with unavailable readings represented as null.

## Measurements

The measurements below predate the compile-time profiler refactor; they compare the collector optimizations, not that refactor.

Both binaries use the same updated harness, compiler settings, and profiling. The reference restores only the two pre-optimization functions. Results are local ARM64/macOS engine experiments in `fasttest`, with three randomized pairs per workload—not production SDK speedup claims.

| Workload | Before | After | Median paired speedup |
|---|---:|---:|---:|
| Tiny object-producing calls | 1.164 s | 0.620 s | **1.88×** |
| 100k tiny calls | 5.008 s | 2.383 s | **2.10×** |
| Retained arrays, minor/full collections | 8.340 s | 4.375 s | **1.83×** |
| Retained string payloads | 0.130 s | 0.060 s | **2.13×** |
| Permanent cache plus transient work | 1.334 s | 1.203 s | **1.11×** |
| Concurrent async callers | 0.418 s | 0.369 s | **1.13×** |

Speedups are medians of paired ratios, not ratios of the displayed medians. The no-allocation control measured 0.96× initially; ten additional pairs measured 0.99× with a 0.96–1.16× range. Both sets are retained. Profiling-on/off comparisons are also included; they do not establish zero overhead.


## Testing

After the profiler refactor, **214 heap/engine unit tests passed in each configuration**: `heap_debug,gc_profiling` and `heap_debug` without profiling, using optimized `fasttest`. The enabled suite checks snapshot counts and phase totals; the disabled suite checks that the report and both recorders occupy zero bytes. Profiling-disabled native Clippy and repository workspace hooks passed. Final-stack validation is recorded in the dependent PRs.

- **134 heap tests** passed with profiling and heap-debug checks, including chunk boundaries, write barriers, and permit coordination.
- **36 engine integration tests** passed: GC, finalizers, spawned errors/cancellation, and concurrent future operations.
- **Two trigger characterizations** passed and still reproduce the current scheduling gaps.
- **104 measured runs** completed: 54 implementation comparisons, 30 profiling comparisons, and 20 scalar follow-ups. Retained data is checked after moving collection.
- Default-feature engine build check and profiling-disabled experiment build passed. All repository commit hooks passed, including workspace-wide, all-target, all-feature Clippy with warnings denied. Python syntax, provenance rejection, and evidence-integrity checks also passed.

## Review map and follow-up

| Area | Files |
|---|---|
| Collector changes and boundary tests | `bex_heap/src/gc.rs`, `chunked_vec.rs`, `heap.rs` |
| Opt-in measurements | `bex_heap/src/gc_profile.rs`, engine collection wrapper |
| Workloads and current-behavior characterizations | `bex_engine/tests/gc_policy_experiment.rs`, `gc_trigger_audit.rs` |
| Reproduction tooling | `tools/gc_policy/` |

The next layer will evaluate accounting, in-call safe points, full-GC budgeting, allocation chunks, quiet cleanup, and glibc trimming. This baseline makes those decisions measurable:

- The native 100k run held peak slot storage to 32 MiB under the harness's explicit collection policy, while RSS still varied substantially. The Linux/Python residual-growth question remains open.
- Burst-idle storage stayed unchanged during a one-second no-call window, then an explicit collection reclaimed it.
- The permanent-cache case still had a roughly 102 ms median longest pause; the retained-array case was roughly 504 ms. Faster collection alone does not establish an acceptable pause bound.

No tracked issue is attached to this investigation.

Benchmark reports and raw evidence remain local; they are not checked into this PR. Generate fresh artifacts with `tools/gc_policy/build.py`, `run.py`, and `summarize.py` (each supports `--help`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in garbage-collection profiling with heap snapshots, phase timings, pause metrics, and collection trigger details.
  * Added tools for running, comparing, and summarizing garbage-collection policy experiments.

* **Bug Fixes**
  * Improved heap pointer tracking across storage growth and chunk boundaries.
  * Fixed unhandled future-error detection across storage boundaries, preventing duplicate reports.

* **Tests**
  * Added coverage for garbage collection, profiling, concurrency, allocation patterns, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->