### PR TITLE
Prevent stale book styles in production builds

### DIFF
--- a/typescript2/app-developer-docs/lib/built-styles.ts
+++ b/typescript2/app-developer-docs/lib/built-styles.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const requiredSelectors = [
+  '.language-tabs-list',
+  '.language-tabs-logo',
+  '.annotated-code-actions',
+  '.annotated-code-image',
+  '.annotated-light',
+  '.annotated-dark',
+  '.new-concepts',
+  '.mobile-nav-dialog',
+];
+
+/** Check the CSS linked by the built page, not source files or unused chunks. */
+export async function validateBuiltStyles(buildDirectory: string) {
+  const html = await readFile(
+    join(buildDirectory, 'server/app/baml/book/errors.html'),
+    'utf8',
+  );
+  const stylesheets = new Set(
+    [...html.matchAll(/<link\b[^>]*>/g)]
+      .filter(([tag]) => /\brel="stylesheet"/.test(tag))
+      .map(([tag]) => tag.match(/\bhref="([^"]+)"/)?.[1])
+      .filter((href): href is string => Boolean(href)),
+  );
+  if (stylesheets.size === 0) {
+    throw new Error('Built book page does not link any stylesheets.');
+  }
+  const css = (
+    await Promise.all(
+      [...stylesheets].map((href) => {
+        const pathname = new URL(href, 'https://docs.invalid').pathname;
+        if (!pathname.startsWith('/_next/static/')) {
+          throw new Error(`Unexpected built stylesheet: ${href}`);
+        }
+        return readFile(
+          join(buildDirectory, pathname.slice('/_next/'.length)),
+          'utf8',
+        );
+      }),
+    )
+  ).join('\n');
+  const missing = requiredSelectors.filter(
+    (selector) => !css.includes(selector),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Built book stylesheet is missing ${missing.join(', ')}. Refusing to deploy stale CSS.`,
+    );
+  }
+}

--- a/typescript2/app-developer-docs/next.config.ts
+++ b/typescript2/app-developer-docs/next.config.ts
@@ -12,6 +12,11 @@ export default function createNextConfig(phase: string): NextConfig {
   return withMDX({
     // A production build must not replace chunks used by a running dev server.
     distDir: phase === PHASE_DEVELOPMENT_SERVER ? '.next-dev' : '.next',
+    experimental: {
+      // Production served new book markup with a cached pre-book stylesheet.
+      // Recompute build outputs until persistent-cache invalidation is verified.
+      turbopackFileSystemCacheForBuild: false,
+    },
     images: {
       unoptimized: true,
     },

--- a/typescript2/app-developer-docs/package.json
+++ b/typescript2/app-developer-docs/package.json
@@ -49,6 +49,7 @@
     "docs:routes:validate": "tsx --test tests/navigation.test.ts tests/generated-routes.test.ts",
     "docs:snippets:validate": "tsx scripts/validate-snippets.ts",
     "lint": "biome check . && tsx node_modules/oxlint/bin/oxlint --config .oxlintrc.json .",
+    "postbuild": "tsx scripts/validate-built-styles.ts",
     "postinstall": "fumadocs-mdx",
     "prebuild": "pnpm docs:grammar:build",
     "pretest": "pnpm docs:grammar:build",

--- a/typescript2/app-developer-docs/scripts/validate-built-styles.ts
+++ b/typescript2/app-developer-docs/scripts/validate-built-styles.ts
@@ -1,0 +1,6 @@
+import { resolve } from 'node:path';
+
+import { validateBuiltStyles } from '../lib/built-styles';
+
+await validateBuiltStyles(resolve(import.meta.dirname, '../.next'));
+console.log('Validated the book page’s compiled stylesheets.');


### PR DESCRIPTION
The deployed error-handling chapter loaded the new components with a pre-book stylesheet. Language tabs ran together, annotation controls lost their layout, and both light and dark illustrations appeared. The CSS served by production was missing every annotation and language-tab selector even though those rules were present in the merged source.

Disable Turbopack's persistent build cache for this app while investigating its production invalidation. The affected Vercel deployment restored an earlier cache; clean local production output includes the correct rules. Development caching stays enabled.

Add a postbuild check that follows the stylesheet links in the prerendered errors page and checks the actual compiled assets for the tab, annotation, theme, vocabulary, and mobile-navigation styles. It fails the build if those rules or linked assets are missing, so a successful Next.js build alone cannot admit this regression.

Validation:

- Production build and its postbuild check pass.
- The exact broken stylesheet fetched from production fails the new check.
- Production browser check: language tabs use flex layout, dark mode hides the light illustration, and the page has no horizontal overflow.
- Lint and typecheck pass; docs tests: 47 passed, one PostgreSQL integration test skipped because its database fixture is unavailable.

Production was recovered by rebuilding the exact same merged chapter commit without Vercel's build cache. The public page now loads a new stylesheet; browser verification confirms styled language tabs, only the dark illustration visible in dark mode, correctly positioned controls, and no horizontal overflow at 826px. This PR makes the prevention durable; it does not change chapter content or styling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved production build reliability by validating that generated pages reference the expected stylesheets and required styling is present.
  - Builds now detect missing, unexpected, or incorrectly linked stylesheets and report clear errors instead of producing incomplete styling.

- **Chores**
  - Added automatic stylesheet validation after production builds.
  - Disabled persistent build-cache reuse to ensure styles are regenerated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->