### PR TITLE
Expose runtime heap counters through baml.sys.heap_stats

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
@@ -227,6 +227,31 @@ function collect_garbage() -> null throws never {
     $rust_io_function
 }
 
+/// Allocator counters for the current BAML runtime, not process memory or heap bytes.
+/// Object counts include unused slots reserved by VMs and objects awaiting collection.
+/// They exclude separately allocated payload storage (for example string and array data).
+class HeapStats {
+    /// Compile-time plus runtime object slots.
+    total_objects: int,
+    /// Permanent compile-time object slots.
+    compile_time_objects: int,
+    /// Runtime object slots, including unused allocation reservations.
+    runtime_objects: int,
+    /// Registered heap handles, which act as garbage-collection roots.
+    active_handles: int,
+    /// Current nursery allocation reservations; may decrease after collection.
+    tlab_chunks: int,
+}
+
+/// Samples the calling runtime's heap without forcing garbage collection.
+/// Counters are gauges, not cumulative allocations or a count of live objects.
+/// Concurrent VMs may allocate while sampling, so fields are not an atomic snapshot.
+/// The returned object is allocated after the sample is taken.
+//baml:mut_vm
+function heap_stats() -> HeapStats throws never {
+    $rust_function
+}
+
 /// Panics with `message`.
 ///
 /// # Panics

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -274,10 +274,12 @@ function         baml.sys.start_process           <builtin>/baml/ns_sys/sys.baml
 function         baml.sys.shell                   <builtin>/baml/ns_sys/sys.baml:211
 function         baml.sys.sleep                   <builtin>/baml/ns_sys/sys.baml:219
 function         baml.sys.collect_garbage         <builtin>/baml/ns_sys/sys.baml:226
-function         baml.sys.panic                   <builtin>/baml/ns_sys/sys.baml:236
-function         baml.sys.exit                    <builtin>/baml/ns_sys/sys.baml:246
-function         baml.sys.argv                    <builtin>/baml/ns_sys/sys.baml:252
-function         baml.sys.pid                     <builtin>/baml/ns_sys/sys.baml:261
+class            baml.sys.HeapStats               <builtin>/baml/ns_sys/sys.baml:233
+function         baml.sys.heap_stats              <builtin>/baml/ns_sys/sys.baml:251
+function         baml.sys.panic                   <builtin>/baml/ns_sys/sys.baml:261
+function         baml.sys.exit                    <builtin>/baml/ns_sys/sys.baml:271
+function         baml.sys.argv                    <builtin>/baml/ns_sys/sys.baml:277
+function         baml.sys.pid                     <builtin>/baml/ns_sys/sys.baml:286
 class            baml.time.Duration               <builtin>/baml/ns_time/duration.baml:22
 class            baml.time.Instant                <builtin>/baml/ns_time/instant.baml:24
 class            baml.time.PlainDate              <builtin>/baml/ns_time/plaindate.baml:16

--- a/baml_language/crates/baml_tests/baml_src/ns_sys/heap_stats.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_sys/heap_stats.baml
@@ -1,0 +1,29 @@
+class HeapStatsAllocation {
+    value: int,
+}
+
+testset "heap_stats" {
+    test "reports the calling runtime and serializes" {
+        let stats = baml.sys.heap_stats();
+        assert.is_true(stats.compile_time_objects > 0);
+        assert.is_true(stats.runtime_objects >= 0);
+        assert.is_true(stats.tlab_chunks >= 0);
+        assert.is_true(stats.active_handles >= 0);
+        assert.equal(stats.total_objects, stats.compile_time_objects + stats.runtime_objects);
+        let decoded = baml.json.from_string<baml.sys.HeapStats>(baml.json.to_string(stats));
+        assert.equal(decoded, stats);
+    }
+
+    test "reflects allocations in the calling VM" {
+        let before = baml.sys.heap_stats();
+        let values: HeapStatsAllocation[] = [];
+        for (let i = 0; i < 4096; i += 1) {
+            values.push(HeapStatsAllocation { value: i });
+        }
+        let after = baml.sys.heap_stats();
+        assert.is_true(after.runtime_objects > before.runtime_objects);
+        assert.is_true(after.tlab_chunks > before.tlab_chunks);
+        assert.equal(after.compile_time_objects, before.compile_time_objects);
+        assert.equal(values[4095].value, 4095);
+    }
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_sys/heap_stats.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_sys/heap_stats.baml
@@ -14,15 +14,16 @@ testset "heap_stats" {
         assert.equal(decoded, stats);
     }
 
-    test "reflects allocations in the calling VM" {
+    test "includes live allocations in the calling VM" {
         let before = baml.sys.heap_stats();
         let values: HeapStatsAllocation[] = [];
         for (let i = 0; i < 4096; i += 1) {
             values.push(HeapStatsAllocation { value: i });
         }
         let after = baml.sys.heap_stats();
-        assert.is_true(after.runtime_objects > before.runtime_objects);
-        assert.is_true(after.tlab_chunks > before.tlab_chunks);
+        // A concurrent collection may reduce the counters since `before`, but
+        // these distinct instances remain rooted by `values` across collection.
+        assert.is_true(after.runtime_objects >= values.length());
         assert.equal(after.compile_time_objects, before.compile_time_objects);
         assert.equal(values[4095].value, 4095);
     }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/bytecode.snap
@@ -679,6 +679,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_sys/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_sys/bytecode.snap
@@ -1,0 +1,14 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+function sys.$init_test_ns_sys_heap_stats(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.sys"
+    load_const "heap_stats"
+    make_closure .<lambda($init_test_ns_sys_heap_stats, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_set_at
+    pop 1
+    load_const null
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -5962,6 +5962,9 @@ function baml.sys.exit(code: int) -> never {
     throw
 }
 
+function baml.sys.heap_stats() -> baml.sys.HeapStats {
+}
+
 function baml.sys.panic(message: string) -> never {
     load_var message
     init_instance baml.panics.UserPanic .message

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -9489,6 +9489,8 @@ fn baml.sys.sleep = builtin(io)
 
 fn baml.sys.collect_garbage = builtin(io)
 
+fn baml.sys.heap_stats = builtin(vm)
+
 fn baml.sys.panic(message: string) -> never {
     // Locals:
     let _0: never // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
@@ -1905,6 +1905,20 @@ function baml.spawn.set_limit(self: ?, limit: int) -> void  [builtin]
 lambda (params) in options: captures [group, cancel, detach]
 
 --- <builtin>/baml/ns_sys/sys.baml ---
+class baml.sys.HeapStats {
+  total_objects: int
+  compile_time_objects: int
+  runtime_objects: int
+  active_handles: int
+  tlab_chunks: int
+}
+class baml.sys.HeapStats$stream {
+  total_objects: int | null
+  compile_time_objects: int | null
+  runtime_objects: int | null
+  active_handles: int | null
+  tlab_chunks: int | null
+}
 class baml.sys.Process {
   _handle: $rust_type
   stdin: baml.sys.WritePipe
@@ -1983,6 +1997,7 @@ function baml.sys.exit(code: int) -> never  [expr] {
   { throw root.panics.Exit { code: code } }
 }
 function baml.sys.flush(self: ?) -> void  [builtin]
+function baml.sys.heap_stats() -> baml.sys.HeapStats  [builtin]
 function baml.sys.iter(self: ?) -> root.iter.Iterator<Item = string, Error = root.errors.Io>  [expr] {
   {  } self
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -283,6 +283,7 @@ namespace baml.spawn:
   class TaskGroup { methods: [new, cancel, set_limit, limit, name, active_count, queued_count] }
   function options<T, E>
 namespace baml.sys:
+  class HeapStats { methods: [] }
   class Process { methods: [wait, kill, close] }
   class ProcessExit { methods: [ok] }
   class ProcessOptions { methods: [] }
@@ -296,6 +297,7 @@ namespace baml.sys:
   function collect_garbage
   function exec
   function exit
+  function heap_stats
   function panic
   function pid
   function shell

--- a/baml_language/crates/bex_vm/src/package_baml/sys.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/sys.rs
@@ -1,7 +1,23 @@
-use super::{BamlNamespaceSys, PackageBamlImpl};
+use bex_vm_types::types::Value;
+
+use super::{BamlNamespaceSys, PackageBamlImpl, copy};
 use crate::vm::BexVm;
 
 impl BamlNamespaceSys for PackageBamlImpl {
+    fn heap_stats(vm: &mut BexVm) -> Value {
+        // Native builtins run with the VM's active heap permit, excluding GC.
+        // Sample before allocating the result so it does not count itself.
+        let stats = vm.heap.stats();
+        copy::sys::HeapStats {
+            total_objects: stats.total_objects as i64,
+            compile_time_objects: stats.compile_time_objects as i64,
+            runtime_objects: stats.runtime_objects as i64,
+            active_handles: stats.active_handles as i64,
+            tlab_chunks: stats.tlab_chunks as i64,
+        }
+        .to_value(vm)
+    }
+
     fn argv(vm: &mut BexVm) -> Vec<bex_str::BexStr> {
         vm.argv
             .iter()

--- a/baml_language/crates/bex_vm/src/package_baml/sys.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/sys.rs
@@ -8,12 +8,13 @@ impl BamlNamespaceSys for PackageBamlImpl {
         // Native builtins run with the VM's active heap permit, excluding GC.
         // Sample before allocating the result so it does not count itself.
         let stats = vm.heap.stats();
+        let count = |n| i64::try_from(n).expect("heap counters fit in addressable storage");
         copy::sys::HeapStats {
-            total_objects: stats.total_objects as i64,
-            compile_time_objects: stats.compile_time_objects as i64,
-            runtime_objects: stats.runtime_objects as i64,
-            active_handles: stats.active_handles as i64,
-            tlab_chunks: stats.tlab_chunks as i64,
+            total_objects: count(stats.total_objects),
+            compile_time_objects: count(stats.compile_time_objects),
+            runtime_objects: count(stats.runtime_objects),
+            active_handles: count(stats.active_handles),
+            tlab_chunks: count(stats.tlab_chunks),
         }
         .to_value(vm)
     }


### PR DESCRIPTION
BAML programs can now call `baml.sys.heap_stats()` to sample the runtime that executes them. Packed HTTP servers and generated SDKs can export allocator gauges without modifying the pack host or starting another runtime.

The VM builtin returns total, compile-time, and runtime object slots, registered handles, and current nursery reservations. It uses the calling VM’s existing heap permit and does not force GC. The API documents unused reservations, uncollected objects, excluded payload allocations, concurrent sampling, and the distinction from heap-used bytes and live-object counts.

Validation:

- Focused BAML tests pass for field consistency, JSON round trips, and live allocations retained across sampling.
- Compiler corpus, builtin listing, and package-item snapshots updated and their focused tests pass.
- `cargo clippy -p bex_vm --lib -- -D warnings` and `cargo check --target wasm32-unknown-unknown -p bridge_wasm` pass.
- Native HTTP smoke test passes for the hello-world response, Prometheus gauges, content type, and metrics route/method handling.
- Linux arm64 release integration passes a 60-second Docker run: five servers each returned 6,000 successful requests at approximately 100 RPS, with no new errors or restarts. All 11 Prometheus targets, 15 BAML gauge series, and 23 Grafana panels passed verification; the three new charts were visually checked.
- CI runs the compiler/runtime and SDK suites. The broad local library run encountered missing SDK prerequisites (C++ protobuf, C# setup, Ruby Bundler, Node dependencies, and Python dylib) and cross-commit generated artifacts; it is not reported as a passing full-workspace run.

The Docker/Grafana consumer lives in the separate `BoundaryML/baml-demos` repository and exports the same five gauges from packed BAML, Node, and Python. This branch uses the dedicated `baml-e2e-bench` worktree; the original local BAML checkout is unchanged.
