### PR TITLE
ci: acknowledge packed-program growth from the content-block stdlib

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -66,14 +66,20 @@ policy.max_delta_pct = 3.0
 # 12 native BAML provider clients replaced the Rust `sys_llm` shim: their
 # bytecode ships in every packed program. Each ceiling is ~3% above the
 # re-recorded baseline in `.ci/size-gate`.
+#
+# Bumped again (PR #4807, content-block journal): every client lowers
+# rendered prompts, user turns, tool results and model turns through one
+# block path, plus the Degrade rewrite and the `UserMessage` /
+# `ToolCompleted` constructors — ~4% more stdlib bytecode. Ceilings are ~3%
+# above the CI-measured baselines recorded alongside.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = "25.3 MiB"
+max_file_bytes = "26.4 MiB"
 
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "28.1 MiB"
+max_file_bytes = "29.2 MiB"
 
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "30.4 MiB"
+max_file_bytes = "31.7 MiB"
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -8,5 +8,5 @@ stripped_bytes = "60.4 MiB"
 gzip_bytes = "24.0 MiB"
 
 [artifacts.packed-program]
-file_bytes = "24.6 MiB"
-gzip_bytes = "9.7 MiB"
+file_bytes = "25.6 MiB"
+gzip_bytes = "10.1 MiB"

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -8,5 +8,5 @@ stripped_bytes = "79.2 MiB"
 gzip_bytes = "26.6 MiB"
 
 [artifacts.packed-program]
-file_bytes = "29.5 MiB"
-gzip_bytes = "10.3 MiB"
+file_bytes = "30.8 MiB"
+gzip_bytes = "10.7 MiB"

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -8,5 +8,5 @@ stripped_bytes = "69.5 MiB"
 gzip_bytes = "26.2 MiB"
 
 [artifacts.packed-program]
-file_bytes = "27.3 MiB"
-gzip_bytes = "10.4 MiB"
+file_bytes = "28.4 MiB"
+gzip_bytes = "10.8 MiB"


### PR DESCRIPTION
## Summary

#4807 grew the packed stdlib program by ~4% on every platform (per-client block lowering, the Degrade journal rewrite, and the `UserMessage` / `ToolCompleted` constructors and projections, ~+900 net lines of BAML). It merged with the size gate red, so canary now carries the growth against the old `packed-program` baselines and ceilings, and every subsequent PR's gate fails on it.

This records the CI-measured sizes as the new `packed-program` baselines (`.ci/size-gate/*.toml`) and re-pegs the per-platform `max_file_bytes` ceilings in `.cargo/size-gate.toml` ~3% above them, as that file's policy prescribes. `baml-cli` and `bridge_wasm` were within limits and are unchanged.

## Stack

Follow-up to #4807 (merged); unblocks the size gate for #4808–#4811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CI threshold and baseline updates; no runtime or product code changes.
> 
> **Overview**
> After **#4807** (~4% more stdlib bytecode from the content-block journal path), CI was failing the **packed-program** size gate against stale baselines. This PR **records the new measured sizes** in `.ci/size-gate` for macOS, Linux, and Windows and **raises per-platform `max_file_bytes` ceilings** in `.cargo/size-gate.toml` (~3% above those baselines), with a comment tying the bump to #4807.
> 
> **`baml-cli`** and **`bridge_wasm`** limits are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4c67137488c253b1c239d75897122c0726070c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact size thresholds for macOS, Linux, and Windows builds.
  * Increased permitted packed-program sizes to accommodate the latest build output.
  * Updated platform-specific compressed-size baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->