### PR TITLE
Defer completion GC and reclaim idle native heaps

### DIFF
--- a/baml_language/crates/bex_engine/src/bex_work.rs
+++ b/baml_language/crates/bex_engine/src/bex_work.rs
@@ -74,7 +74,8 @@ pub(crate) struct BexWork {
     wake: Arc<Notify>,
 }
 
-/// Owned by each root call, registered future, and spawned task until it ends.
+/// Counts root-call and producer lifetimes, and registry work until settlement
+/// or removal. A retained settled entry can stay rooted without its guard.
 /// Future and task guards deliberately overlap: cancellation can settle the
 /// future while its producer is still unwinding or waiting for admission.
 /// This prevents idle cleanup; heap access still requires a heap permit.
@@ -628,6 +629,141 @@ mod tests {
             advance(IDLE_DELAY).await;
             assert_eq!(engine.heap.gc_budget().full_collections, outcome + 1);
         }
+        engine.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retained_engine_errors_allow_idle_gc_and_late_removal_rearms_it() {
+        for spawn_fallback in [false, true] {
+            let engine = engine();
+            drop(tiny(&engine).await);
+            let producer = engine.bex_work.register_work();
+            let permit = engine
+                .heap_permit_manager
+                .new_permit(())
+                .await
+                .acquire()
+                .await;
+            let original = crate::EngineError::Other("retained engine error".into());
+            let id = {
+                let mut futures = engine.futures.acquire(permit.proof()).await;
+                let (id, _) = futures.new_future(
+                    RealizedTy::int(),
+                    RealizedTy::never(),
+                    CancellationToken::new(),
+                    "retained-error-test".into(),
+                );
+                if spawn_fallback {
+                    futures.settle_spawn_engine_error(id, original.clone());
+                } else {
+                    futures.internal_error_future(id, original.clone()).unwrap();
+                }
+                assert_eq!(futures.active_future_count(), 1);
+                id
+            };
+            drop(permit);
+            assert_eq!(engine.bex_work.lock().work, 1, "producer still counts");
+            advance(IDLE_DELAY * 2).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, 0);
+
+            drop(producer);
+            advance(IDLE_DELAY).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, 1);
+            assert_eq!(engine.bex_work.lock().work, 0);
+
+            // Read through the registry after moving GC, with no host handle
+            // rooting the future. Repeated settlement must preserve the error
+            // and must not release a second work guard.
+            let permit = engine
+                .heap_permit_manager
+                .new_permit(())
+                .await
+                .acquire()
+                .await;
+            let waiter = {
+                let mut futures = engine.futures.acquire(permit.proof()).await;
+                assert_eq!(futures.active_future_count(), 1);
+                futures.settle_spawn_engine_error(id, crate::EngineError::Other("ignored".into()));
+                futures.future_ready(id).unwrap()
+            };
+            drop(permit);
+            assert_eq!(waiter.await, Err(original));
+            advance(IDLE_DELAY * 2).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, 1);
+
+            // Shutdown can prune retained roots, then be cancelled before its
+            // final GC. The root-release atomic must preserve that cleanup.
+            let epoch = engine.heap.root_release_epoch();
+            let shutdown = engine.begin_shutdown().await.unwrap();
+            assert!(
+                engine
+                    .futures
+                    .pending_join_handles(&engine.heap_permit_manager)
+                    .await
+                    .is_empty()
+            );
+            assert_eq!(engine.heap.root_release_epoch(), epoch.wrapping_add(1));
+            drop(shutdown);
+            advance(IDLE_DELAY).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, 2);
+            engine.shutdown().await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_future_releases_registry_work_on_spawn_error() {
+        let engine = engine();
+        drop(tiny(&engine).await);
+        let producer = engine.bex_work.register_work();
+        let permit = engine
+            .heap_permit_manager
+            .new_permit(())
+            .await
+            .acquire()
+            .await;
+        let id = {
+            let mut futures = engine.futures.acquire(permit.proof()).await;
+            let (id, ptr) = futures.new_future(
+                RealizedTy::int(),
+                RealizedTy::never(),
+                CancellationToken::new(),
+                "cancelled-error-test".into(),
+            );
+            // Model f.cancel() winning before the producer's engine-error
+            // fallback. It settles the heap object without removing the entry.
+            // SAFETY: the registry roots ptr and permit excludes moving GC.
+            let bex_vm_types::Object::Future(future) = (unsafe { ptr.get() }) else {
+                panic!("expected a future");
+            };
+            assert!(future.settle_cancelled());
+            futures.settle_spawn_engine_error(id, crate::EngineError::Other("lost race".into()));
+            id
+        };
+        drop(permit);
+        assert_eq!(engine.bex_work.lock().work, 1);
+        advance(IDLE_DELAY * 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 0);
+        drop(producer);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+
+        let epoch = engine.heap.root_release_epoch();
+        let permit = engine
+            .heap_permit_manager
+            .new_permit(())
+            .await
+            .acquire()
+            .await;
+        {
+            let mut futures = engine.futures.acquire(permit.proof()).await;
+            futures.cancel_future(id).unwrap();
+            futures.cancel_future(id).unwrap();
+            assert_eq!(futures.active_future_count(), 0);
+        }
+        drop(permit);
+        assert_eq!(engine.heap.root_release_epoch(), epoch.wrapping_add(1));
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 2);
         engine.shutdown().await;
     }
 

--- a/baml_language/crates/bex_engine/src/bex_work.rs
+++ b/baml_language/crates/bex_engine/src/bex_work.rs
@@ -1,5 +1,6 @@
-//! Opportunistic cleanup after work stops. Scheduling state contains no heap
-//! pointers and can be inspected without a heap permit. Moving GC cannot.
+//! Engine work registration, handle-release observation, and opportunistic GC.
+//! Scheduling state contains no heap pointers and can be inspected without a
+//! heap permit. Moving GC cannot.
 use std::sync::{Arc, Mutex, Weak};
 
 use bex_heap::{BexHeap, CollectionLevel};
@@ -66,36 +67,37 @@ struct State {
     worker: Option<tokio::task::JoinHandle<()>>,
 }
 
-pub(crate) struct IdleGc {
+/// Per-engine work tracking and idle-collection scheduling.
+pub(crate) struct BexWork {
     state: Mutex<State>,
     heap: Weak<BexHeap>,
     wake: Arc<Notify>,
 }
 
 /// Owned by each root call, registered future, and spawned task until it ends.
-/// Future and task permits deliberately overlap: cancellation can settle the
+/// Future and task guards deliberately overlap: cancellation can settle the
 /// future while its producer is still unwinding or waiting for admission.
 /// This prevents idle cleanup; heap access still requires a heap permit.
-#[must_use = "work must own its permit until its entire lifecycle ends"]
-pub(crate) struct WorkPermit {
-    idle: Arc<IdleGc>,
+#[must_use = "work must own its guard until its entire lifecycle ends"]
+pub(crate) struct BexWorkGuard {
+    bex_work: Arc<BexWork>,
     idle_due_on_entry: bool,
 }
 
-impl Drop for WorkPermit {
+impl Drop for BexWorkGuard {
     fn drop(&mut self) {
-        let mut s = self.idle.lock();
+        let mut s = self.bex_work.lock();
         s.work -= 1;
         s.revision = s.revision.wrapping_add(1);
         if s.work == 0 && s.scheduling.is_running() {
             s.scheduling = Scheduling::Waiting(Instant::now() + IDLE_DELAY);
         }
         drop(s);
-        self.idle.wake.notify_one();
+        self.bex_work.wake.notify_one();
     }
 }
 
-impl IdleGc {
+impl BexWork {
     pub(crate) fn new(heap: &Arc<BexHeap>) -> Arc<Self> {
         Arc::new(Self {
             state: Mutex::new(State {
@@ -149,7 +151,8 @@ impl IdleGc {
         }
     }
 
-    pub(crate) fn acquire_work_permit(self: &Arc<Self>) -> WorkPermit {
+    /// Registers work until the returned guard drops.
+    pub(crate) fn register_work(self: &Arc<Self>) -> BexWorkGuard {
         let mut s = self.lock();
         self.refresh(&mut s);
         let idle_due_on_entry = s.work == 0
@@ -159,8 +162,8 @@ impl IdleGc {
         s.scheduling.disarm();
         drop(s);
         self.wake.notify_one();
-        WorkPermit {
-            idle: Arc::clone(self),
+        BexWorkGuard {
+            bex_work: Arc::clone(self),
             idle_due_on_entry,
         }
     }
@@ -278,7 +281,7 @@ impl IdleGc {
 impl BexEngine {
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn ensure_idle_gc_worker(self: &Arc<Self>) {
-        let mut s = self.idle_gc.lock();
+        let mut s = self.bex_work.lock();
         if s.scheduling == Scheduling::Closed
             || s.worker
                 .as_ref()
@@ -291,10 +294,10 @@ impl BexEngine {
         let Ok(runtime) = tokio::runtime::Handle::try_current() else {
             return;
         };
-        s.worker = Some(runtime.spawn(Arc::clone(&self.idle_gc).run(Arc::downgrade(self))));
+        s.worker = Some(runtime.spawn(Arc::clone(&self.bex_work).run(Arc::downgrade(self))));
     }
 
-    pub(crate) async fn collect_before_call(self: &Arc<Self>, work: &WorkPermit) {
+    pub(crate) async fn collect_before_call(self: &Arc<Self>, work: &BexWorkGuard) {
         let idle_due = cfg!(target_arch = "wasm32") && work.idle_due_on_entry;
         if !idle_due && !self.heap.should_gc() {
             return;
@@ -328,10 +331,10 @@ impl BexEngine {
 
     #[cfg(not(target_arch = "wasm32"))]
     async fn try_idle_gc(self: &Arc<Self>) {
-        let changed = self.idle_gc.wake.notified();
+        let changed = self.bex_work.wake.notified();
         tokio::pin!(changed);
         changed.as_mut().enable();
-        if !self.idle_gc.due()
+        if !self.bex_work.due()
             || self
                 .checking_gc
                 .compare_exchange(
@@ -356,9 +359,9 @@ impl BexEngine {
                 guard
             }
         };
-        // Admission updates the same lifecycle state before obtaining a permit.
+        // Admission updates the same lifecycle state before obtaining a heap permit.
         // Once this check succeeds, a later caller can wait for this collection.
-        if !self.idle_gc.due() {
+        if !self.bex_work.due() {
             return;
         }
         self.collect_garbage_parked(CollectionLevel::Major, "idle", guard, cycle)
@@ -426,53 +429,53 @@ mod tests {
         settle().await;
     }
 
-    struct WorkDropProbe(Arc<IdleGc>);
+    struct WorkDropProbe(Arc<BexWork>);
 
     impl Drop for WorkDropProbe {
         fn drop(&mut self) {
             assert_eq!(
                 self.0.lock().work,
                 1,
-                "task cleanup must still own its permit"
+                "task cleanup must still own its work guard"
             );
         }
     }
 
     #[tokio::test(start_paused = true)]
-    async fn spawned_work_owns_permit_before_poll_and_through_cancellation() {
+    async fn spawned_work_owns_guard_before_poll_and_through_cancellation() {
         let heap = BexHeap::new(vec![]);
-        let idle = IdleGc::new(&heap);
+        let bex_work = BexWork::new(&heap);
         for poll_first in [false, true] {
-            let probe = WorkDropProbe(Arc::clone(&idle));
-            let work = crate::SpawnedWork::new(idle.acquire_work_permit(), async move {
+            let probe = WorkDropProbe(Arc::clone(&bex_work));
+            let work = crate::SpawnedWork::new(bex_work.register_work(), async move {
                 let _probe = probe;
                 std::future::pending::<()>().await;
             });
             let mut task = Box::pin(work.run());
-            assert_eq!(idle.lock().work, 1);
+            assert_eq!(bex_work.lock().work, 1);
             if poll_first {
                 assert!(futures::poll!(task.as_mut()).is_pending());
             }
             drop(task);
-            assert_eq!(idle.lock().work, 0);
-            assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+            assert_eq!(bex_work.lock().work, 0);
+            assert!(matches!(bex_work.lock().scheduling, Scheduling::Waiting(_)));
         }
     }
 
     #[tokio::test(start_paused = true)]
-    async fn spawned_work_releases_permit_after_success_or_error_cleanup() {
+    async fn spawned_work_releases_guard_after_success_or_error_cleanup() {
         let heap = BexHeap::new(vec![]);
-        let idle = IdleGc::new(&heap);
+        let bex_work = BexWork::new(&heap);
         for outcome in [Ok(()), Err(())] {
-            let probe = WorkDropProbe(Arc::clone(&idle));
-            let work = crate::SpawnedWork::new(idle.acquire_work_permit(), async move {
+            let probe = WorkDropProbe(Arc::clone(&bex_work));
+            let work = crate::SpawnedWork::new(bex_work.register_work(), async move {
                 let _probe = probe;
                 outcome?;
                 Ok(())
             });
             assert_eq!(work.run().await, outcome);
-            assert_eq!(idle.lock().work, 0);
-            assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+            assert_eq!(bex_work.lock().work, 0);
+            assert!(matches!(bex_work.lock().scheduling, Scheduling::Waiting(_)));
         }
     }
 
@@ -480,16 +483,16 @@ mod tests {
     async fn burst_uses_one_worker_and_handle_release_rearms_cleanup() {
         let engine = engine();
         let kept = tiny(&engine).await;
-        let worker = engine.idle_gc.lock().worker.as_ref().unwrap().id();
+        let worker = engine.bex_work.lock().worker.as_ref().unwrap().id();
         for _ in 0..20 {
             drop(tiny(&engine).await);
-            assert_eq!(engine.idle_gc.lock().worker.as_ref().unwrap().id(), worker);
+            assert_eq!(engine.bex_work.lock().worker.as_ref().unwrap().id(), worker);
         }
         advance(IDLE_DELAY / 2).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 0);
         advance(IDLE_DELAY / 2).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
-        assert_eq!(engine.idle_gc.lock().scheduling, Scheduling::Disarmed);
+        assert_eq!(engine.bex_work.lock().scheduling, Scheduling::Disarmed);
         assert_eq!(engine.heap.stats().active_handles, 1);
         advance(IDLE_DELAY * 10).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
@@ -499,9 +502,9 @@ mod tests {
         advance(IDLE_DELAY).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 2);
         assert_eq!(engine.heap.stats().active_handles, 0);
-        assert_eq!(engine.idle_gc.lock().scheduling, Scheduling::Disarmed);
+        assert_eq!(engine.bex_work.lock().scheduling, Scheduling::Disarmed);
         engine.shutdown().await;
-        assert!(engine.idle_gc.lock().worker.is_none());
+        assert!(engine.bex_work.lock().worker.is_none());
     }
 
     #[tokio::test(start_paused = true)]
@@ -562,7 +565,7 @@ mod tests {
                 .checking_gc
                 .load(std::sync::atomic::Ordering::Acquire)
         );
-        let work = engine.idle_gc.acquire_work_permit();
+        let work = engine.bex_work.register_work();
         settle().await;
         assert!(
             !engine
@@ -583,7 +586,7 @@ mod tests {
         let engine = engine();
         drop(tiny(&engine).await);
         for outcome in 0..3 {
-            let producer = engine.idle_gc.acquire_work_permit();
+            let producer = engine.bex_work.register_work();
             let permit = engine
                 .heap_permit_manager
                 .new_permit(())
@@ -643,11 +646,11 @@ mod tests {
             .await
             .unwrap();
         settle().await;
-        assert!(engine.idle_gc.lock().work > 0);
+        assert!(engine.bex_work.lock().work > 0);
         advance(IDLE_DELAY * 2).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 0);
         advance(std::time::Duration::from_secs(1)).await;
-        assert_eq!(engine.idle_gc.lock().work, 0);
+        assert_eq!(engine.bex_work.lock().work, 0);
         advance(IDLE_DELAY).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
         engine.shutdown().await;
@@ -660,9 +663,9 @@ mod tests {
         engine.collect_garbage(CollectionLevel::Major).await;
         advance(IDLE_DELAY * 2).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
-        let collected = engine.idle_gc.cleanup_version();
+        let collected = engine.bex_work.cleanup_version();
         drop(kept);
-        engine.idle_gc.collected(collected);
+        engine.bex_work.collected(collected);
         advance(IDLE_DELAY).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 2);
         engine.shutdown().await;
@@ -672,7 +675,7 @@ mod tests {
     async fn cancelled_shutdown_resumes_worker_and_engine_drop_stops_it() {
         let engine = engine();
         drop(tiny(&engine).await);
-        let worker = engine.idle_gc.lock().worker.as_ref().unwrap().id();
+        let worker = engine.bex_work.lock().worker.as_ref().unwrap().id();
         // Exercise the same RAII transition as cancellation of shutdown().
         let shutdown = engine.begin_shutdown().await.unwrap();
         advance(IDLE_DELAY * 2).await;
@@ -680,8 +683,8 @@ mod tests {
         drop(shutdown);
         advance(IDLE_DELAY).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
-        assert_eq!(engine.idle_gc.lock().worker.as_ref().unwrap().id(), worker);
-        let idle = Arc::clone(&engine.idle_gc);
+        assert_eq!(engine.bex_work.lock().worker.as_ref().unwrap().id(), worker);
+        let bex_work = Arc::clone(&engine.bex_work);
         let weak = Arc::downgrade(&engine);
         drop(engine);
         settle().await;
@@ -689,49 +692,49 @@ mod tests {
             weak.upgrade().is_none(),
             "sleeping worker must not own engine"
         );
-        assert_eq!(idle.lock().scheduling, Scheduling::Closed);
-        assert!(idle.lock().worker.as_ref().unwrap().is_finished());
+        assert_eq!(bex_work.lock().scheduling, Scheduling::Closed);
+        assert!(bex_work.lock().worker.as_ref().unwrap().is_finished());
     }
 
     #[tokio::test(start_paused = true)]
     async fn completion_and_collection_cannot_rearm_suspended_or_closed_cleanup() {
         let heap = BexHeap::new(vec![]);
-        let idle = IdleGc::new(&heap);
-        drop(idle.acquire_work_permit());
-        assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+        let bex_work = BexWork::new(&heap);
+        drop(bex_work.register_work());
+        assert!(matches!(bex_work.lock().scheduling, Scheduling::Waiting(_)));
 
-        idle.suspend();
-        drop(idle.acquire_work_permit());
-        let collected = idle.cleanup_version();
-        idle.collected(collected);
-        assert_eq!(idle.lock().scheduling, Scheduling::Suspended);
-        idle.resume();
-        assert_eq!(idle.lock().scheduling, Scheduling::Disarmed);
+        bex_work.suspend();
+        drop(bex_work.register_work());
+        let collected = bex_work.cleanup_version();
+        bex_work.collected(collected);
+        assert_eq!(bex_work.lock().scheduling, Scheduling::Suspended);
+        bex_work.resume();
+        assert_eq!(bex_work.lock().scheduling, Scheduling::Disarmed);
 
-        drop(idle.acquire_work_permit());
-        idle.suspend();
-        idle.resume();
-        assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+        drop(bex_work.register_work());
+        bex_work.suspend();
+        bex_work.resume();
+        assert!(matches!(bex_work.lock().scheduling, Scheduling::Waiting(_)));
 
-        idle.close();
-        idle.suspend();
-        idle.resume();
-        drop(idle.acquire_work_permit());
-        idle.collected(collected);
-        assert_eq!(idle.lock().scheduling, Scheduling::Closed);
-        assert!(!idle.due());
+        bex_work.close();
+        bex_work.suspend();
+        bex_work.resume();
+        drop(bex_work.register_work());
+        bex_work.collected(collected);
+        assert_eq!(bex_work.lock().scheduling, Scheduling::Closed);
+        assert!(!bex_work.due());
     }
 
     #[tokio::test(start_paused = true)]
     async fn cooperative_entry_remembers_expired_idle_deadline() {
         // No worker: model WASM's bookkeeping and next-entry decision.
         let heap = BexHeap::new(vec![]);
-        let idle = IdleGc::new(&heap);
-        drop(idle.acquire_work_permit());
+        let bex_work = BexWork::new(&heap);
+        drop(bex_work.register_work());
         tokio::time::advance(IDLE_DELAY).await;
-        let entry = idle.acquire_work_permit();
+        let entry = bex_work.register_work();
         assert!(entry.idle_due_on_entry);
-        let overlapping = idle.acquire_work_permit();
+        let overlapping = bex_work.register_work();
         assert!(!overlapping.idle_due_on_entry);
     }
 }

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -186,18 +186,14 @@ impl FutureManagerGuard<'_> {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let id = FutureId::from_usize(id);
 
+        let work_permit = inner.idle_gc.acquire_work_permit();
         let ptr = inner
             .tlab
             .alloc_future(::bex_vm_types::Future::pending(id, returns, throws, cancel));
 
-        inner.active_futures.insert(
-            id,
-            FutureState {
-                _idle_work: inner.idle_gc.start_work(),
-                future: ptr,
-                origin,
-            },
-        );
+        inner
+            .active_futures
+            .insert(id, FutureWork::new(work_permit, ptr, origin));
         (id, ptr)
     }
 
@@ -563,7 +559,7 @@ impl HeapPermit<FutureManagerInner> for FutureManagerGuard<'_> {
 pub struct FutureManagerInner {
     tlab: Tlab,
     next_future_id: AtomicUsize,
-    active_futures: HashMap<FutureId, FutureState>,
+    active_futures: HashMap<FutureId, FutureWork>,
     // Mandatory bookkeeping on both targets. Only the native build contains
     // the background worker; WASM consumes the state at call entry.
     idle_gc: Arc<crate::idle_gc::IdleGc>,
@@ -612,9 +608,10 @@ impl TlabHolder for FutureManagerInner {
     }
 }
 
-struct FutureState {
+/// Owns a future's registry entry and its work permit until removal.
+struct FutureWork {
     // Mirrors registry ownership without making the timer inspect heap objects.
-    _idle_work: crate::idle_gc::WorkGuard,
+    _work_permit: crate::idle_gc::WorkPermit,
     /// Heap pointer to the `Object::Future`. Rooted via `RootHaver` so
     /// the heap object survives even when no awaiter / producer stack
     /// holds it directly (fire-and-forget spawn before the producer task
@@ -627,7 +624,19 @@ struct FutureState {
     /// hot-loop budget.
     origin: std::sync::Arc<str>,
 }
-impl FutureState {
+impl FutureWork {
+    fn new(
+        work_permit: crate::idle_gc::WorkPermit,
+        future: HeapPtr,
+        origin: std::sync::Arc<str>,
+    ) -> Self {
+        Self {
+            _work_permit: work_permit,
+            future,
+            origin,
+        }
+    }
+
     /// Returns an immutable reference to the heap-allocated `Future`.
     ///
     /// The [`bex_vm_types::Future`] uses interior mutability (`AtomicU8` +
@@ -650,7 +659,7 @@ impl FutureState {
         }
     }
 }
-impl RootHaver for FutureState {
+impl RootHaver for FutureWork {
     fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
         roots.push(self.future);
     }

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -193,6 +193,10 @@ impl FutureManagerGuard<'_> {
         inner.active_futures.insert(
             id,
             FutureState {
+                _idle_work: inner
+                    .idle_gc
+                    .as_ref()
+                    .map(crate::idle_gc::IdleGc::start_work),
                 future: ptr,
                 origin,
             },
@@ -563,6 +567,7 @@ pub struct FutureManagerInner {
     tlab: Tlab,
     next_future_id: AtomicUsize,
     active_futures: HashMap<FutureId, FutureState>,
+    idle_gc: Option<Arc<crate::idle_gc::IdleGc>>,
 }
 impl FutureManagerInner {
     pub fn new(tlab: Tlab) -> Self {
@@ -570,6 +575,14 @@ impl FutureManagerInner {
             tlab,
             next_future_id: AtomicUsize::new(0),
             active_futures: HashMap::new(),
+            idle_gc: None,
+        }
+    }
+
+    pub(crate) fn with_idle_gc(tlab: Tlab, idle: Arc<crate::idle_gc::IdleGc>) -> Self {
+        Self {
+            idle_gc: Some(idle),
+            ..Self::new(tlab)
         }
     }
 
@@ -608,6 +621,8 @@ impl TlabHolder for FutureManagerInner {
 }
 
 struct FutureState {
+    // Mirrors registry ownership without making the timer inspect heap objects.
+    _idle_work: Option<crate::idle_gc::WorkGuard>,
     /// Heap pointer to the `Object::Future`. Rooted via `RootHaver` so
     /// the heap object survives even when no awaiter / producer stack
     /// holds it directly (fire-and-forget spawn before the producer task

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -264,21 +264,23 @@ impl FutureManagerGuard<'_> {
     /// `Future` (and its `SetOnce`-with-error) so a later `Await` resumes
     /// against the same heap object and the engine can surface the original
     /// `EngineError` to the host. Internal errors are by-construction bugs;
-    /// the leak buys us never losing the error.
+    /// the leak buys us never losing the error. Once settled, the retained
+    /// entry releases its work guard so it cannot keep the engine busy.
     pub fn internal_error_future(
         &mut self,
         id: FutureId,
         err: EngineError,
     ) -> Result<(), EngineError> {
         let entry = self
-            .holder()
+            .holder_mut()
             .active_futures
-            .get(&id)
+            .get_mut(&id)
             .ok_or(EngineError::FutureNotFound { future_id: id })?;
         // SAFETY: caller holds the heap permit via `self.proof`.
         let fut = unsafe { entry.future_ref() }?;
         let observed = FutureType::of(fut);
         if !matches!(fut.read(), FutureRead::Pending(_)) {
+            entry.finish_work();
             debug_assert!(
                 false,
                 "internal_error_future called on non-Pending future {id:?} \
@@ -297,7 +299,7 @@ impl FutureManagerGuard<'_> {
         //
         // The CAS can lose if a concurrent `f.cancel()` (or, in the future,
         // any other non-FutureManager writer) transitioned `Pending` →
-        // `Cancelled` between the pre-check on line 209 and this call. In
+        // `Cancelled` between the pre-check and this call. In
         // that case the user-initiated cancellation already represents an
         // intentional terminal state and the awaiter will see `Cancelled`
         // — the engine error is dropped on the floor. We log it instead of
@@ -313,6 +315,7 @@ impl FutureManagerGuard<'_> {
                  transition (likely f.cancel()); engine error discarded"
             );
         }
+        entry.finish_work();
         Ok(())
     }
 
@@ -330,7 +333,7 @@ impl FutureManagerGuard<'_> {
     /// retained so a later `Await` resumes against the same heap object and
     /// surfaces the original [`EngineError`] instead of parking forever.
     pub fn settle_spawn_engine_error(&mut self, id: FutureId, err: EngineError) {
-        let Some(entry) = self.holder().active_futures.get(&id) else {
+        let Some(entry) = self.holder_mut().active_futures.get_mut(&id) else {
             tracing::error!(
                 ?id,
                 ?err,
@@ -358,6 +361,7 @@ impl FutureManagerGuard<'_> {
         // that state is the one the awaiter observes, and it is already a
         // wake-up — no parked parent is left behind either way.
         let _ = fut.settle_internal_error(Box::new(err));
+        entry.finish_work();
     }
 
     /// Remove and return the heap `Future` for `id` if it's still
@@ -388,7 +392,7 @@ impl FutureManagerGuard<'_> {
         if already_settled {
             // Heap state moved on without us — drop the bookkeeping entry
             // and return None so the caller treats this as a no-op.
-            let _ = self.holder_mut().active_futures.remove(&id);
+            let _ = self.holder_mut().remove_future(id);
             return Ok(None);
         }
         // Phase 2: still Pending. Remove and return the heap Future ref.
@@ -396,8 +400,7 @@ impl FutureManagerGuard<'_> {
         // (typically `BexThread.settles_future` or the awaiter's stack).
         let entry = self
             .holder_mut()
-            .active_futures
-            .remove(&id)
+            .remove_future(id)
             .expect("entry was present in phase 1 and we hold the `FutureManager` Mutex");
         let self_ptr = entry.future;
         // SAFETY: heap permit witnessed by `self.proof`. The returned ref
@@ -516,7 +519,7 @@ impl FutureManagerGuard<'_> {
             })
             .collect();
         for id in settled {
-            self.holder_mut().active_futures.remove(&id);
+            self.holder_mut().remove_future(id);
         }
         self.holder()
             .active_futures
@@ -574,6 +577,17 @@ impl FutureManagerInner {
         }
     }
 
+    fn remove_future(&mut self, id: FutureId) -> Option<FutureWork> {
+        let entry = self.active_futures.remove(&id)?;
+        // Pending entries notify through their work guard on drop. Retained
+        // settled entries already released it, so root removal needs its own
+        // notification even if the producer ended and GC ran long ago.
+        if entry.work_guard.is_none() {
+            self.tlab.heap().notify_root_released();
+        }
+        Some(entry)
+    }
+
     /// Number of tracked registry entries, including retained engine errors.
     /// Intended for tests and telemetry; this is not a count of only pending futures.
     pub fn active_future_count(&self) -> usize {
@@ -607,10 +621,11 @@ impl TlabHolder for FutureManagerInner {
     }
 }
 
-/// Owns a future's registry entry and its work guard until removal.
+/// Roots a registered future; counts its work until settlement or removal.
 struct FutureWork {
-    // Mirrors registry ownership without making the timer inspect heap objects.
-    _work_guard: crate::bex_work::BexWorkGuard,
+    // Every new entry starts with a guard. A retained settled entry releases
+    // it without losing its GC root or the original error for later awaiters.
+    work_guard: Option<crate::bex_work::BexWorkGuard>,
     /// Heap pointer to the `Object::Future`. Rooted via `RootHaver` so
     /// the heap object survives even when no awaiter / producer stack
     /// holds it directly (fire-and-forget spawn before the producer task
@@ -630,10 +645,14 @@ impl FutureWork {
         origin: std::sync::Arc<str>,
     ) -> Self {
         Self {
-            _work_guard: work_guard,
+            work_guard: Some(work_guard),
             future,
             origin,
         }
+    }
+
+    fn finish_work(&mut self) {
+        drop(self.work_guard.take());
     }
 
     /// Returns an immutable reference to the heap-allocated `Future`.

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -193,10 +193,7 @@ impl FutureManagerGuard<'_> {
         inner.active_futures.insert(
             id,
             FutureState {
-                _idle_work: inner
-                    .idle_gc
-                    .as_ref()
-                    .map(crate::idle_gc::IdleGc::start_work),
+                _idle_work: inner.idle_gc.start_work(),
                 future: ptr,
                 origin,
             },
@@ -567,22 +564,17 @@ pub struct FutureManagerInner {
     tlab: Tlab,
     next_future_id: AtomicUsize,
     active_futures: HashMap<FutureId, FutureState>,
-    idle_gc: Option<Arc<crate::idle_gc::IdleGc>>,
+    // Mandatory bookkeeping on both targets. Only the native build contains
+    // the background worker; WASM consumes the state at call entry.
+    idle_gc: Arc<crate::idle_gc::IdleGc>,
 }
 impl FutureManagerInner {
-    pub fn new(tlab: Tlab) -> Self {
+    pub(crate) fn new(tlab: Tlab, idle_gc: Arc<crate::idle_gc::IdleGc>) -> Self {
         Self {
             tlab,
             next_future_id: AtomicUsize::new(0),
             active_futures: HashMap::new(),
-            idle_gc: None,
-        }
-    }
-
-    pub(crate) fn with_idle_gc(tlab: Tlab, idle: Arc<crate::idle_gc::IdleGc>) -> Self {
-        Self {
-            idle_gc: Some(idle),
-            ..Self::new(tlab)
+            idle_gc,
         }
     }
 
@@ -622,7 +614,7 @@ impl TlabHolder for FutureManagerInner {
 
 struct FutureState {
     // Mirrors registry ownership without making the timer inspect heap objects.
-    _idle_work: Option<crate::idle_gc::WorkGuard>,
+    _idle_work: crate::idle_gc::WorkGuard,
     /// Heap pointer to the `Object::Future`. Rooted via `RootHaver` so
     /// the heap object survives even when no awaiter / producer stack
     /// holds it directly (fire-and-forget spawn before the producer task
@@ -684,7 +676,10 @@ mod tests {
         let heap = BexHeap::new(Vec::new());
         let permit_manager = Arc::new(HeapPermitManager::new());
         let permit = permit_manager
-            .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap))))
+            .new_permit(FutureManagerInner::new(
+                Tlab::new_empty(Arc::clone(&heap)),
+                crate::idle_gc::IdleGc::new(&heap),
+            ))
             .await;
         (FutureManager::new(permit), permit_manager)
     }

--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -107,7 +107,7 @@ impl FutureManager {
         }
     }
 
-    /// Number of `Pending` futures currently tracked.
+    /// Number of tracked registry entries, including retained engine errors.
     ///
     /// Takes a one-shot heap permit internally so external diagnostic callers
     /// (notably tests) don't need to construct a `PermitProof` themselves.
@@ -158,7 +158,7 @@ pub struct FutureManagerGuard<'a> {
 }
 
 impl FutureManagerGuard<'_> {
-    /// Number of `Pending` futures currently tracked by the manager.
+    /// Number of tracked registry entries, including retained engine errors.
     pub fn active_future_count(&self) -> usize {
         self.holder().active_future_count()
     }
@@ -186,14 +186,14 @@ impl FutureManagerGuard<'_> {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let id = FutureId::from_usize(id);
 
-        let work_permit = inner.idle_gc.acquire_work_permit();
+        let work_guard = inner.bex_work.register_work();
         let ptr = inner
             .tlab
             .alloc_future(::bex_vm_types::Future::pending(id, returns, throws, cancel));
 
         inner
             .active_futures
-            .insert(id, FutureWork::new(work_permit, ptr, origin));
+            .insert(id, FutureWork::new(work_guard, ptr, origin));
         (id, ptr)
     }
 
@@ -562,21 +562,20 @@ pub struct FutureManagerInner {
     active_futures: HashMap<FutureId, FutureWork>,
     // Mandatory bookkeeping on both targets. Only the native build contains
     // the background worker; WASM consumes the state at call entry.
-    idle_gc: Arc<crate::idle_gc::IdleGc>,
+    bex_work: Arc<crate::bex_work::BexWork>,
 }
 impl FutureManagerInner {
-    pub(crate) fn new(tlab: Tlab, idle_gc: Arc<crate::idle_gc::IdleGc>) -> Self {
+    pub(crate) fn new(tlab: Tlab, bex_work: Arc<crate::bex_work::BexWork>) -> Self {
         Self {
             tlab,
             next_future_id: AtomicUsize::new(0),
             active_futures: HashMap::new(),
-            idle_gc,
+            bex_work,
         }
     }
 
-    /// Number of `Pending` futures currently tracked by the manager. This is
-    /// the same as the number of futures whose heap object is in
-    /// `Future::Pending(_)`. Intended for tests and telemetry.
+    /// Number of tracked registry entries, including retained engine errors.
+    /// Intended for tests and telemetry; this is not a count of only pending futures.
     pub fn active_future_count(&self) -> usize {
         self.active_futures.len()
     }
@@ -608,10 +607,10 @@ impl TlabHolder for FutureManagerInner {
     }
 }
 
-/// Owns a future's registry entry and its work permit until removal.
+/// Owns a future's registry entry and its work guard until removal.
 struct FutureWork {
     // Mirrors registry ownership without making the timer inspect heap objects.
-    _work_permit: crate::idle_gc::WorkPermit,
+    _work_guard: crate::bex_work::BexWorkGuard,
     /// Heap pointer to the `Object::Future`. Rooted via `RootHaver` so
     /// the heap object survives even when no awaiter / producer stack
     /// holds it directly (fire-and-forget spawn before the producer task
@@ -626,12 +625,12 @@ struct FutureWork {
 }
 impl FutureWork {
     fn new(
-        work_permit: crate::idle_gc::WorkPermit,
+        work_guard: crate::bex_work::BexWorkGuard,
         future: HeapPtr,
         origin: std::sync::Arc<str>,
     ) -> Self {
         Self {
-            _work_permit: work_permit,
+            _work_guard: work_guard,
             future,
             origin,
         }
@@ -687,7 +686,7 @@ mod tests {
         let permit = permit_manager
             .new_permit(FutureManagerInner::new(
                 Tlab::new_empty(Arc::clone(&heap)),
-                crate::idle_gc::IdleGc::new(&heap),
+                crate::bex_work::BexWork::new(&heap),
             ))
             .await;
         (FutureManager::new(permit), permit_manager)

--- a/baml_language/crates/bex_engine/src/idle_gc.rs
+++ b/baml_language/crates/bex_engine/src/idle_gc.rs
@@ -21,14 +21,47 @@ pub(crate) struct CleanupVersion {
     releases: usize,
 }
 
+/// Only a running coordinator can have a deadline. Suspending or closing it
+/// removes that deadline as part of the state transition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Scheduling {
+    Disarmed,
+    Waiting(Instant),
+    Suspended,
+    Closed,
+}
+
+impl Scheduling {
+    fn is_running(self) -> bool {
+        matches!(self, Self::Disarmed | Self::Waiting(_))
+    }
+
+    fn deadline(self) -> Option<Instant> {
+        match self {
+            Self::Waiting(deadline) => Some(deadline),
+            Self::Disarmed | Self::Suspended | Self::Closed => None,
+        }
+    }
+
+    fn arm(&mut self, deadline: Instant) {
+        if matches!(self, Self::Disarmed) {
+            *self = Self::Waiting(deadline);
+        }
+    }
+
+    fn disarm(&mut self) {
+        if matches!(self, Self::Waiting(_)) {
+            *self = Self::Disarmed;
+        }
+    }
+}
+
 struct State {
     work: usize,
     revision: u64,
     collected: CleanupVersion,
     observed_releases: usize,
-    deadline: Option<Instant>,
-    suspended: bool,
-    closed: bool,
+    scheduling: Scheduling,
     #[cfg(not(target_arch = "wasm32"))]
     worker: Option<tokio::task::JoinHandle<()>>,
 }
@@ -52,8 +85,8 @@ impl Drop for WorkGuard {
         let mut s = self.idle.lock();
         s.work -= 1;
         s.revision = s.revision.wrapping_add(1);
-        if s.work == 0 && !s.suspended && !s.closed {
-            s.deadline = Some(Instant::now() + IDLE_DELAY);
+        if s.work == 0 && s.scheduling.is_running() {
+            s.scheduling = Scheduling::Waiting(Instant::now() + IDLE_DELAY);
         }
         drop(s);
         self.idle.wake.notify_one();
@@ -71,9 +104,7 @@ impl IdleGc {
                     releases: heap.root_release_epoch(),
                 },
                 observed_releases: heap.root_release_epoch(),
-                deadline: None,
-                suspended: false,
-                closed: false,
+                scheduling: Scheduling::Disarmed,
                 #[cfg(not(target_arch = "wasm32"))]
                 worker: None,
             }),
@@ -104,14 +135,14 @@ impl IdleGc {
             s.observed_releases = current.releases;
             // A release while already waiting must not postpone the existing
             // deadline. On WASM it may only be observed at the next admission.
-            if s.work == 0 && !s.suspended && !s.closed && current != s.collected {
+            if s.work == 0 && current != s.collected {
                 #[cfg(not(target_arch = "wasm32"))]
                 let deadline = Instant::now() + IDLE_DELAY;
                 // WASM has no observer while idle: service newly observed root
                 // releases at this admission instead of delaying another call.
                 #[cfg(target_arch = "wasm32")]
                 let deadline = Instant::now();
-                s.deadline.get_or_insert(deadline);
+                s.scheduling.arm(deadline);
             }
         }
     }
@@ -120,12 +151,10 @@ impl IdleGc {
         let mut s = self.lock();
         self.refresh(&mut s);
         let idle_due_on_entry = s.work == 0
-            && !s.suspended
-            && !s.closed
-            && s.deadline.is_some_and(|d| d <= Instant::now())
+            && s.scheduling.deadline().is_some_and(|d| d <= Instant::now())
             && self.version(&s) != s.collected;
         s.work += 1;
-        s.deadline = None;
+        s.scheduling.disarm();
         drop(s);
         self.wake.notify_one();
         WorkGuard {
@@ -144,41 +173,46 @@ impl IdleGc {
         let mut s = self.lock();
         s.collected = version;
         if self.version(&s) == version {
-            s.deadline = None;
-        } else if s.work == 0 && !s.suspended && !s.closed {
-            s.deadline.get_or_insert(Instant::now() + IDLE_DELAY);
+            s.scheduling.disarm();
+        } else if s.work == 0 {
+            s.scheduling.arm(Instant::now() + IDLE_DELAY);
         }
         drop(s);
         self.wake.notify_one();
     }
 
-    pub(crate) fn suspend(&self, suspended: bool) {
+    pub(crate) fn suspend(&self) {
         let mut s = self.lock();
-        s.suspended = suspended;
-        s.deadline = if !suspended && !s.closed && s.work == 0 && self.version(&s) != s.collected {
-            Some(Instant::now() + IDLE_DELAY)
-        } else {
-            None
-        };
+        if s.scheduling != Scheduling::Closed {
+            s.scheduling = Scheduling::Suspended;
+        }
+        drop(s);
+        self.wake.notify_one();
+    }
+
+    pub(crate) fn resume(&self) {
+        let mut s = self.lock();
+        if s.scheduling == Scheduling::Suspended {
+            s.scheduling = if s.work == 0 && self.version(&s) != s.collected {
+                Scheduling::Waiting(Instant::now() + IDLE_DELAY)
+            } else {
+                Scheduling::Disarmed
+            };
+        }
         drop(s);
         self.wake.notify_one();
     }
 
     pub(crate) fn close(&self) {
-        let mut s = self.lock();
-        s.closed = true;
-        s.deadline = None;
-        drop(s);
+        self.lock().scheduling = Scheduling::Closed;
         self.wake.notify_one();
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) async fn join_worker(&self) {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let worker = self.lock().worker.take();
-            if let Some(worker) = worker {
-                let _ = worker.await;
-            }
+        let worker = self.lock().worker.take();
+        if let Some(worker) = worker {
+            let _ = worker.await;
         }
     }
 
@@ -186,10 +220,8 @@ impl IdleGc {
     fn due(&self) -> bool {
         let mut s = self.lock();
         self.refresh(&mut s);
-        !s.closed
-            && !s.suspended
-            && s.work == 0
-            && s.deadline.is_some_and(|d| d <= Instant::now())
+        s.work == 0
+            && s.scheduling.deadline().is_some_and(|d| d <= Instant::now())
             && self.version(&s) != s.collected
     }
 
@@ -205,11 +237,11 @@ impl IdleGc {
                 notified.as_mut().enable();
                 let deadline = {
                     let mut s = self.lock();
-                    if s.closed {
+                    if s.scheduling == Scheduling::Closed {
                         return;
                     }
                     self.refresh(&mut s);
-                    s.deadline
+                    s.scheduling.deadline()
                 };
                 match deadline {
                     Some(deadline) => tokio::select! {
@@ -232,34 +264,32 @@ impl IdleGc {
             Box::pin(engine.try_idle_gc()).await;
             drop(engine); // No strong engine reference across a timer/event wait.
             let mut s = self.lock();
-            if s.deadline.is_some_and(|d| d <= Instant::now()) {
+            if s.scheduling.deadline().is_some_and(|d| d <= Instant::now()) {
                 // Keep cleanup pending after timeout/contention; one bounded
                 // retry per idle delay, not a busy loop at an expired deadline.
-                s.deadline = Some(Instant::now() + IDLE_DELAY);
+                s.scheduling = Scheduling::Waiting(Instant::now() + IDLE_DELAY);
             }
         }
     }
 }
 
 impl BexEngine {
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn ensure_idle_gc_worker(self: &Arc<Self>) {
-        #[cfg(not(target_arch = "wasm32"))]
+        let mut s = self.idle_gc.lock();
+        if s.scheduling == Scheduling::Closed
+            || s.worker
+                .as_ref()
+                .is_some_and(|worker| !worker.is_finished())
         {
-            let mut s = self.idle_gc.lock();
-            if s.closed
-                || s.worker
-                    .as_ref()
-                    .is_some_and(|worker| !worker.is_finished())
-            {
-                return;
-            }
-            // Embedders without a Tokio runtime still get entry/safe-point GC.
-            // A later call on a runtime can start the single idle worker.
-            let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-                return;
-            };
-            s.worker = Some(runtime.spawn(Arc::clone(&self.idle_gc).run(Arc::downgrade(self))));
+            return;
         }
+        // Embedders without a Tokio runtime still get entry/safe-point GC.
+        // A later call on a runtime can start the single idle worker.
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        s.worker = Some(runtime.spawn(Arc::clone(&self.idle_gc).run(Arc::downgrade(self))));
     }
 
     pub(crate) async fn collect_before_call(self: &Arc<Self>, work: &WorkGuard) {
@@ -412,7 +442,7 @@ mod tests {
         assert_eq!(engine.heap.gc_budget().full_collections, 0);
         advance(IDLE_DELAY / 2).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
-        assert!(engine.idle_gc.lock().deadline.is_none());
+        assert_eq!(engine.idle_gc.lock().scheduling, Scheduling::Disarmed);
         assert_eq!(engine.heap.stats().active_handles, 1);
         advance(IDLE_DELAY * 10).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 1);
@@ -422,7 +452,7 @@ mod tests {
         advance(IDLE_DELAY).await;
         assert_eq!(engine.heap.gc_budget().full_collections, 2);
         assert_eq!(engine.heap.stats().active_handles, 0);
-        assert!(engine.idle_gc.lock().deadline.is_none());
+        assert_eq!(engine.idle_gc.lock().scheduling, Scheduling::Disarmed);
         engine.shutdown().await;
         assert!(engine.idle_gc.lock().worker.is_none());
     }
@@ -612,8 +642,37 @@ mod tests {
             weak.upgrade().is_none(),
             "sleeping worker must not own engine"
         );
-        assert!(idle.lock().closed);
+        assert_eq!(idle.lock().scheduling, Scheduling::Closed);
         assert!(idle.lock().worker.as_ref().unwrap().is_finished());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn completion_and_collection_cannot_rearm_suspended_or_closed_cleanup() {
+        let heap = BexHeap::new(vec![]);
+        let idle = IdleGc::new(&heap);
+        drop(idle.start_work());
+        assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+
+        idle.suspend();
+        drop(idle.start_work());
+        let collected = idle.cleanup_version();
+        idle.collected(collected);
+        assert_eq!(idle.lock().scheduling, Scheduling::Suspended);
+        idle.resume();
+        assert_eq!(idle.lock().scheduling, Scheduling::Disarmed);
+
+        drop(idle.start_work());
+        idle.suspend();
+        idle.resume();
+        assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+
+        idle.close();
+        idle.suspend();
+        idle.resume();
+        drop(idle.start_work());
+        idle.collected(collected);
+        assert_eq!(idle.lock().scheduling, Scheduling::Closed);
+        assert!(!idle.due());
     }
 
     #[tokio::test(start_paused = true)]

--- a/baml_language/crates/bex_engine/src/idle_gc.rs
+++ b/baml_language/crates/bex_engine/src/idle_gc.rs
@@ -359,13 +359,8 @@ impl BexEngine {
         if !self.idle_gc.due() {
             return;
         }
-        self.collect_garbage_parked(
-            CollectionLevel::Major,
-            "idle",
-            guard,
-            cycle,
-        )
-        .await;
+        self.collect_garbage_parked(CollectionLevel::Major, "idle", guard, cycle)
+            .await;
     }
 }
 

--- a/baml_language/crates/bex_engine/src/idle_gc.rs
+++ b/baml_language/crates/bex_engine/src/idle_gc.rs
@@ -1,0 +1,631 @@
+//! Opportunistic cleanup after work stops. Scheduling state contains no heap
+//! pointers and can be inspected without a heap permit. Moving GC cannot.
+use std::sync::{Arc, Mutex, Weak};
+
+use bex_heap::{BexHeap, CollectionLevel};
+use tokio::sync::Notify;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
+
+use crate::{BexEngine, GcCheckGuard};
+
+const IDLE_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
+#[cfg(not(target_arch = "wasm32"))]
+const PARK_WAIT: std::time::Duration = std::time::Duration::from_millis(5);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CleanupVersion {
+    work: u64,
+    releases: usize,
+}
+
+struct State {
+    work: usize,
+    revision: u64,
+    collected: CleanupVersion,
+    observed_releases: usize,
+    deadline: Option<Instant>,
+    suspended: bool,
+    closed: bool,
+    #[cfg(not(target_arch = "wasm32"))]
+    worker: Option<tokio::task::JoinHandle<()>>,
+}
+
+pub(crate) struct IdleGc {
+    state: Mutex<State>,
+    heap: Weak<BexHeap>,
+    wake: Arc<Notify>,
+}
+
+/// Counts a root call, a registry entry, or a child producer's entire lifetime.
+/// Registry and producer guards deliberately overlap: cancellation can settle
+/// the future while its producer is still unwinding or waiting for admission.
+pub(crate) struct WorkGuard {
+    idle: Arc<IdleGc>,
+    idle_due_on_entry: bool,
+}
+
+impl Drop for WorkGuard {
+    fn drop(&mut self) {
+        let mut s = self.idle.lock();
+        s.work -= 1;
+        s.revision = s.revision.wrapping_add(1);
+        if s.work == 0 && !s.suspended && !s.closed {
+            s.deadline = Some(Instant::now() + IDLE_DELAY);
+        }
+        drop(s);
+        self.idle.wake.notify_one();
+    }
+}
+
+impl IdleGc {
+    pub(crate) fn new(heap: &Arc<BexHeap>) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(State {
+                work: 0,
+                revision: 0,
+                collected: CleanupVersion {
+                    work: 0,
+                    releases: heap.root_release_epoch(),
+                },
+                observed_releases: heap.root_release_epoch(),
+                deadline: None,
+                suspended: false,
+                closed: false,
+                #[cfg(not(target_arch = "wasm32"))]
+                worker: None,
+            }),
+            heap: Arc::downgrade(heap),
+            wake: heap.gc_activity(),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn version(&self, s: &State) -> CleanupVersion {
+        CleanupVersion {
+            work: s.revision,
+            releases: self
+                .heap
+                .upgrade()
+                .map_or(s.observed_releases, |h| h.root_release_epoch()),
+        }
+    }
+
+    fn refresh(&self, s: &mut State) {
+        let current = self.version(s);
+        if current.releases != s.observed_releases {
+            s.observed_releases = current.releases;
+            // A release while already waiting must not postpone the existing
+            // deadline. On WASM it may only be observed at the next admission.
+            if s.work == 0 && !s.suspended && !s.closed && current != s.collected {
+                #[cfg(not(target_arch = "wasm32"))]
+                let deadline = Instant::now() + IDLE_DELAY;
+                // WASM has no observer while idle: service newly observed root
+                // releases at this admission instead of delaying another call.
+                #[cfg(target_arch = "wasm32")]
+                let deadline = Instant::now();
+                s.deadline.get_or_insert(deadline);
+            }
+        }
+    }
+
+    pub(crate) fn start_work(self: &Arc<Self>) -> WorkGuard {
+        let mut s = self.lock();
+        self.refresh(&mut s);
+        let idle_due_on_entry = s.work == 0
+            && !s.suspended
+            && !s.closed
+            && s.deadline.is_some_and(|d| d <= Instant::now())
+            && self.version(&s) != s.collected;
+        s.work += 1;
+        s.deadline = None;
+        drop(s);
+        self.wake.notify_one();
+        WorkGuard {
+            idle: Arc::clone(self),
+            idle_due_on_entry,
+        }
+    }
+
+    pub(crate) fn cleanup_version(&self) -> CleanupVersion {
+        self.version(&self.lock())
+    }
+
+    /// Called for every full GC while it still owns exclusive heap access.
+    /// Never consume a root release or work completion newer than this token.
+    pub(crate) fn collected(&self, version: CleanupVersion) {
+        let mut s = self.lock();
+        s.collected = version;
+        if self.version(&s) == version {
+            s.deadline = None;
+        } else if s.work == 0 && !s.suspended && !s.closed {
+            s.deadline.get_or_insert(Instant::now() + IDLE_DELAY);
+        }
+        drop(s);
+        self.wake.notify_one();
+    }
+
+    pub(crate) fn suspend(&self, suspended: bool) {
+        let mut s = self.lock();
+        s.suspended = suspended;
+        s.deadline = if !suspended && !s.closed && s.work == 0 && self.version(&s) != s.collected {
+            Some(Instant::now() + IDLE_DELAY)
+        } else {
+            None
+        };
+        drop(s);
+        self.wake.notify_one();
+    }
+
+    pub(crate) fn close(&self) {
+        let mut s = self.lock();
+        s.closed = true;
+        s.deadline = None;
+        drop(s);
+        self.wake.notify_one();
+    }
+
+    pub(crate) async fn join_worker(&self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let worker = self.lock().worker.take();
+            if let Some(worker) = worker {
+                let _ = worker.await;
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn due(&self) -> bool {
+        let mut s = self.lock();
+        self.refresh(&mut s);
+        !s.closed
+            && !s.suspended
+            && s.work == 0
+            && s.deadline.is_some_and(|d| d <= Instant::now())
+            && self.version(&s) != s.collected
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn run(self: Arc<Self>, engine: Weak<BexEngine>) {
+        loop {
+            // Arm the notification before reading state; notifications are
+            // coalesced, state is authoritative. Drop this waiter before the
+            // acquisition attempt creates its own waiter.
+            let fired = {
+                let notified = self.wake.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                let deadline = {
+                    let mut s = self.lock();
+                    if s.closed {
+                        return;
+                    }
+                    self.refresh(&mut s);
+                    s.deadline
+                };
+                match deadline {
+                    Some(deadline) => tokio::select! {
+                        biased;
+                        () = &mut notified => false,
+                        () = tokio::time::sleep_until(deadline) => true,
+                    },
+                    None => {
+                        notified.await;
+                        false
+                    }
+                }
+            };
+            if !fired {
+                continue;
+            }
+            let Some(engine) = engine.upgrade() else {
+                return;
+            };
+            Box::pin(engine.try_idle_gc()).await;
+            drop(engine); // No strong engine reference across a timer/event wait.
+            let mut s = self.lock();
+            if s.deadline.is_some_and(|d| d <= Instant::now()) {
+                // Keep cleanup pending after timeout/contention; one bounded
+                // retry per idle delay, not a busy loop at an expired deadline.
+                s.deadline = Some(Instant::now() + IDLE_DELAY);
+            }
+        }
+    }
+}
+
+impl BexEngine {
+    pub(crate) fn ensure_idle_gc_worker(self: &Arc<Self>) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut s = self.idle_gc.lock();
+            if s.closed
+                || s.worker
+                    .as_ref()
+                    .is_some_and(|worker| !worker.is_finished())
+            {
+                return;
+            }
+            // Embedders without a Tokio runtime still get entry/safe-point GC.
+            // A later call on a runtime can start the single idle worker.
+            let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+                return;
+            };
+            s.worker = Some(runtime.spawn(Arc::clone(&self.idle_gc).run(Arc::downgrade(self))));
+        }
+    }
+
+    pub(crate) async fn collect_before_call(self: &Arc<Self>, work: &WorkGuard) {
+        let idle_due = cfg!(target_arch = "wasm32") && work.idle_due_on_entry;
+        if !idle_due && !self.heap.should_gc() {
+            return;
+        }
+        if self
+            .checking_gc
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::Acquire,
+                std::sync::atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            return;
+        }
+        let _checking = GcCheckGuard(&self.checking_gc);
+        // No active heap permit yet. Incoming external values/handles own roots.
+        if idle_due || self.heap.should_gc() {
+            self.collect_garbage_with_reason(
+                CollectionLevel::Major,
+                if idle_due {
+                    "idle_on_entry"
+                } else {
+                    "allocation_on_entry"
+                },
+            )
+            .await;
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn try_idle_gc(self: &Arc<Self>) {
+        let changed = self.idle_gc.wake.notified();
+        tokio::pin!(changed);
+        changed.as_mut().enable();
+        if !self.idle_gc.due()
+            || self
+                .checking_gc
+                .compare_exchange(
+                    false,
+                    true,
+                    std::sync::atomic::Ordering::Acquire,
+                    std::sync::atomic::Ordering::Relaxed,
+                )
+                .is_err()
+        {
+            return;
+        }
+        let _checking = GcCheckGuard(&self.checking_gc);
+        let cycle = bex_heap::GcCycleProfiler::start();
+        // Idle GC is passive: do not set the VM park-request flag. If an active
+        // permit remains, cancel this request instead of forcing its VM to yield.
+        let guard = tokio::select! {
+            biased;
+            () = &mut changed => return,
+            acquired = tokio::time::timeout(PARK_WAIT, self.heap_permit_manager.request_park()) => {
+                let Ok(guard) = acquired else { return; };
+                guard
+            }
+        };
+        // Admission updates the same lifecycle state before obtaining a permit.
+        // Once this check succeeds, a later caller can wait for this collection.
+        if !self.idle_gc.due() {
+            return;
+        }
+        self.collect_garbage_parked(
+            CollectionLevel::Major,
+            "idle",
+            guard,
+            cycle,
+        )
+        .await;
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use bex_heap::HeapPermit;
+    use bex_vm_types::{RealizedTy, Value};
+    use sys_native::SysOpsExt;
+
+    use super::*;
+    use crate::{BexExternalValue as Ext, CancellationToken, FunctionCallContextBuilder};
+
+    fn engine() -> Arc<BexEngine> {
+        Arc::new(
+            BexEngine::new(
+                baml_db::testing::compile_source(
+                    r#"
+                    class Node { value int }
+                    function Tiny() -> Node { Node { value: 7 } }
+                    function Detached() -> int {
+                        spawn with baml.spawn.options(detach = true) {
+                            baml.sys.sleep(baml.time.Duration.from_milliseconds(1000n));
+                            Tiny()
+                        };
+                        1
+                    }
+                    "#,
+                ),
+                Arc::new(sys_native::SysOps::native()),
+                vec![],
+            )
+            .unwrap(),
+        )
+    }
+
+    async fn tiny(engine: &Arc<BexEngine>) -> Ext {
+        engine
+            .call_function(
+                "Tiny",
+                vec![],
+                FunctionCallContextBuilder::new(sys_types::CallId::next())
+                    .suppress_internal_profile()
+                    .build(),
+                false,
+            )
+            .await
+            .unwrap()
+    }
+
+    // Advance the paused clock only after spawned tasks have consumed queued
+    // notifications. Yielding never waits for a timer or advances time itself.
+    async fn settle() {
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    async fn advance(duration: std::time::Duration) {
+        settle().await;
+        tokio::time::advance(duration).await;
+        settle().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn burst_uses_one_worker_and_handle_release_rearms_cleanup() {
+        let engine = engine();
+        let kept = tiny(&engine).await;
+        let worker = engine.idle_gc.lock().worker.as_ref().unwrap().id();
+        for _ in 0..20 {
+            drop(tiny(&engine).await);
+            assert_eq!(engine.idle_gc.lock().worker.as_ref().unwrap().id(), worker);
+        }
+        advance(IDLE_DELAY / 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 0);
+        advance(IDLE_DELAY / 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+        assert!(engine.idle_gc.lock().deadline.is_none());
+        assert_eq!(engine.heap.stats().active_handles, 1);
+        advance(IDLE_DELAY * 10).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+
+        // No BAML call follows this bridge-handle release.
+        drop(kept);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 2);
+        assert_eq!(engine.heap.stats().active_handles, 0);
+        assert!(engine.idle_gc.lock().deadline.is_none());
+        engine.shutdown().await;
+        assert!(engine.idle_gc.lock().worker.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn blocked_heap_times_out_without_parking_vms_and_retries() {
+        let engine = engine();
+        drop(tiny(&engine).await);
+        let held = engine
+            .heap_permit_manager
+            .new_permit(())
+            .await
+            .acquire()
+            .await;
+        advance(IDLE_DELAY).await;
+        assert!(
+            engine
+                .checking_gc
+                .load(std::sync::atomic::Ordering::Acquire)
+        );
+        assert!(
+            !engine
+                .park_requested
+                .load(std::sync::atomic::Ordering::Acquire)
+        );
+        advance(PARK_WAIT).await;
+        assert!(
+            !engine
+                .checking_gc
+                .load(std::sync::atomic::Ordering::Acquire)
+        );
+        assert_eq!(engine.heap.gc_budget().full_collections, 0);
+        // Cancellation of acquire_many must release partial semaphore claims.
+        let another = engine
+            .heap_permit_manager
+            .new_permit(())
+            .await
+            .acquire()
+            .await;
+        drop(another);
+        drop(held);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+        engine.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn arriving_work_cancels_wait_and_restarts_quiet_interval() {
+        let engine = engine();
+        drop(tiny(&engine).await);
+        let held = engine
+            .heap_permit_manager
+            .new_permit(())
+            .await
+            .acquire()
+            .await;
+        advance(IDLE_DELAY).await;
+        assert!(
+            engine
+                .checking_gc
+                .load(std::sync::atomic::Ordering::Acquire)
+        );
+        let work = engine.idle_gc.start_work();
+        settle().await;
+        assert!(
+            !engine
+                .checking_gc
+                .load(std::sync::atomic::Ordering::Acquire)
+        );
+        drop(held);
+        advance(IDLE_DELAY * 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 0);
+        drop(work);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+        engine.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn registry_and_producer_must_both_finish_including_cancel_and_error() {
+        let engine = engine();
+        drop(tiny(&engine).await);
+        for outcome in 0..3 {
+            let producer = engine.idle_gc.start_work();
+            let permit = engine
+                .heap_permit_manager
+                .new_permit(())
+                .await
+                .acquire()
+                .await;
+            let id = {
+                let mut futures = engine.futures.acquire(permit.proof()).await;
+                let (id, _) = futures.new_future(
+                    RealizedTy::int(),
+                    RealizedTy::never(),
+                    CancellationToken::new(),
+                    "idle-gc-test".into(),
+                );
+                id
+            };
+            drop(permit);
+            advance(IDLE_DELAY * 2).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, outcome);
+            let permit = engine
+                .heap_permit_manager
+                .new_permit(())
+                .await
+                .acquire()
+                .await;
+            {
+                let mut futures = engine.futures.acquire(permit.proof()).await;
+                match outcome {
+                    0 => futures.fulfill_future(id, Value::int(1)).unwrap(),
+                    1 => futures.cancel_future(id).unwrap(),
+                    _ => futures.err_future(id, Value::int(2), vec![]).unwrap(),
+                }
+            }
+            drop(permit);
+            // Settlement alone cannot claim a queued/cancelling producer exited.
+            advance(IDLE_DELAY * 2).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, outcome);
+            drop(producer);
+            advance(IDLE_DELAY).await;
+            assert_eq!(engine.heap.gc_budget().full_collections, outcome + 1);
+        }
+        engine.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn detached_child_completion_rearms_after_root_has_returned() {
+        let engine = engine();
+        engine
+            .call_function(
+                "Detached",
+                vec![],
+                FunctionCallContextBuilder::new(sys_types::CallId::next())
+                    .suppress_internal_profile()
+                    .build(),
+                true,
+            )
+            .await
+            .unwrap();
+        settle().await;
+        assert!(engine.idle_gc.lock().work > 0);
+        advance(IDLE_DELAY * 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 0);
+        advance(std::time::Duration::from_secs(1)).await;
+        assert_eq!(engine.idle_gc.lock().work, 0);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+        engine.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn full_collection_consumes_only_the_version_it_observed() {
+        let engine = engine();
+        let kept = tiny(&engine).await;
+        engine.collect_garbage(CollectionLevel::Major).await;
+        advance(IDLE_DELAY * 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+        let collected = engine.idle_gc.cleanup_version();
+        drop(kept);
+        engine.idle_gc.collected(collected);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 2);
+        engine.shutdown().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_shutdown_resumes_worker_and_engine_drop_stops_it() {
+        let engine = engine();
+        drop(tiny(&engine).await);
+        let worker = engine.idle_gc.lock().worker.as_ref().unwrap().id();
+        // Exercise the same RAII transition as cancellation of shutdown().
+        let shutdown = engine.begin_shutdown().await.unwrap();
+        advance(IDLE_DELAY * 2).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 0);
+        drop(shutdown);
+        advance(IDLE_DELAY).await;
+        assert_eq!(engine.heap.gc_budget().full_collections, 1);
+        assert_eq!(engine.idle_gc.lock().worker.as_ref().unwrap().id(), worker);
+        let idle = Arc::clone(&engine.idle_gc);
+        let weak = Arc::downgrade(&engine);
+        drop(engine);
+        settle().await;
+        assert!(
+            weak.upgrade().is_none(),
+            "sleeping worker must not own engine"
+        );
+        assert!(idle.lock().closed);
+        assert!(idle.lock().worker.as_ref().unwrap().is_finished());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cooperative_entry_remembers_expired_idle_deadline() {
+        // No worker: model WASM's bookkeeping and next-entry decision.
+        let heap = BexHeap::new(vec![]);
+        let idle = IdleGc::new(&heap);
+        drop(idle.start_work());
+        tokio::time::advance(IDLE_DELAY).await;
+        let entry = idle.start_work();
+        assert!(entry.idle_due_on_entry);
+        let overlapping = idle.start_work();
+        assert!(!overlapping.idle_due_on_entry);
+    }
+}

--- a/baml_language/crates/bex_engine/src/idle_gc.rs
+++ b/baml_language/crates/bex_engine/src/idle_gc.rs
@@ -72,15 +72,17 @@ pub(crate) struct IdleGc {
     wake: Arc<Notify>,
 }
 
-/// Counts a root call, a registry entry, or a child producer's entire lifetime.
-/// Registry and producer guards deliberately overlap: cancellation can settle
-/// the future while its producer is still unwinding or waiting for admission.
-pub(crate) struct WorkGuard {
+/// Owned by each root call, registered future, and spawned task until it ends.
+/// Future and task permits deliberately overlap: cancellation can settle the
+/// future while its producer is still unwinding or waiting for admission.
+/// This prevents idle cleanup; heap access still requires a heap permit.
+#[must_use = "work must own its permit until its entire lifecycle ends"]
+pub(crate) struct WorkPermit {
     idle: Arc<IdleGc>,
     idle_due_on_entry: bool,
 }
 
-impl Drop for WorkGuard {
+impl Drop for WorkPermit {
     fn drop(&mut self) {
         let mut s = self.idle.lock();
         s.work -= 1;
@@ -147,7 +149,7 @@ impl IdleGc {
         }
     }
 
-    pub(crate) fn start_work(self: &Arc<Self>) -> WorkGuard {
+    pub(crate) fn acquire_work_permit(self: &Arc<Self>) -> WorkPermit {
         let mut s = self.lock();
         self.refresh(&mut s);
         let idle_due_on_entry = s.work == 0
@@ -157,7 +159,7 @@ impl IdleGc {
         s.scheduling.disarm();
         drop(s);
         self.wake.notify_one();
-        WorkGuard {
+        WorkPermit {
             idle: Arc::clone(self),
             idle_due_on_entry,
         }
@@ -292,7 +294,7 @@ impl BexEngine {
         s.worker = Some(runtime.spawn(Arc::clone(&self.idle_gc).run(Arc::downgrade(self))));
     }
 
-    pub(crate) async fn collect_before_call(self: &Arc<Self>, work: &WorkGuard) {
+    pub(crate) async fn collect_before_call(self: &Arc<Self>, work: &WorkPermit) {
         let idle_due = cfg!(target_arch = "wasm32") && work.idle_due_on_entry;
         if !idle_due && !self.heap.should_gc() {
             return;
@@ -424,6 +426,56 @@ mod tests {
         settle().await;
     }
 
+    struct WorkDropProbe(Arc<IdleGc>);
+
+    impl Drop for WorkDropProbe {
+        fn drop(&mut self) {
+            assert_eq!(
+                self.0.lock().work,
+                1,
+                "task cleanup must still own its permit"
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn spawned_work_owns_permit_before_poll_and_through_cancellation() {
+        let heap = BexHeap::new(vec![]);
+        let idle = IdleGc::new(&heap);
+        for poll_first in [false, true] {
+            let probe = WorkDropProbe(Arc::clone(&idle));
+            let work = crate::SpawnedWork::new(idle.acquire_work_permit(), async move {
+                let _probe = probe;
+                std::future::pending::<()>().await;
+            });
+            let mut task = Box::pin(work.run());
+            assert_eq!(idle.lock().work, 1);
+            if poll_first {
+                assert!(futures::poll!(task.as_mut()).is_pending());
+            }
+            drop(task);
+            assert_eq!(idle.lock().work, 0);
+            assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn spawned_work_releases_permit_after_success_or_error_cleanup() {
+        let heap = BexHeap::new(vec![]);
+        let idle = IdleGc::new(&heap);
+        for outcome in [Ok(()), Err(())] {
+            let probe = WorkDropProbe(Arc::clone(&idle));
+            let work = crate::SpawnedWork::new(idle.acquire_work_permit(), async move {
+                let _probe = probe;
+                outcome?;
+                Ok(())
+            });
+            assert_eq!(work.run().await, outcome);
+            assert_eq!(idle.lock().work, 0);
+            assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn burst_uses_one_worker_and_handle_release_rearms_cleanup() {
         let engine = engine();
@@ -510,7 +562,7 @@ mod tests {
                 .checking_gc
                 .load(std::sync::atomic::Ordering::Acquire)
         );
-        let work = engine.idle_gc.start_work();
+        let work = engine.idle_gc.acquire_work_permit();
         settle().await;
         assert!(
             !engine
@@ -531,7 +583,7 @@ mod tests {
         let engine = engine();
         drop(tiny(&engine).await);
         for outcome in 0..3 {
-            let producer = engine.idle_gc.start_work();
+            let producer = engine.idle_gc.acquire_work_permit();
             let permit = engine
                 .heap_permit_manager
                 .new_permit(())
@@ -645,18 +697,18 @@ mod tests {
     async fn completion_and_collection_cannot_rearm_suspended_or_closed_cleanup() {
         let heap = BexHeap::new(vec![]);
         let idle = IdleGc::new(&heap);
-        drop(idle.start_work());
+        drop(idle.acquire_work_permit());
         assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
 
         idle.suspend();
-        drop(idle.start_work());
+        drop(idle.acquire_work_permit());
         let collected = idle.cleanup_version();
         idle.collected(collected);
         assert_eq!(idle.lock().scheduling, Scheduling::Suspended);
         idle.resume();
         assert_eq!(idle.lock().scheduling, Scheduling::Disarmed);
 
-        drop(idle.start_work());
+        drop(idle.acquire_work_permit());
         idle.suspend();
         idle.resume();
         assert!(matches!(idle.lock().scheduling, Scheduling::Waiting(_)));
@@ -664,7 +716,7 @@ mod tests {
         idle.close();
         idle.suspend();
         idle.resume();
-        drop(idle.start_work());
+        drop(idle.acquire_work_permit());
         idle.collected(collected);
         assert_eq!(idle.lock().scheduling, Scheduling::Closed);
         assert!(!idle.due());
@@ -675,11 +727,11 @@ mod tests {
         // No worker: model WASM's bookkeeping and next-entry decision.
         let heap = BexHeap::new(vec![]);
         let idle = IdleGc::new(&heap);
-        drop(idle.start_work());
+        drop(idle.acquire_work_permit());
         tokio::time::advance(IDLE_DELAY).await;
-        let entry = idle.start_work();
+        let entry = idle.acquire_work_permit();
         assert!(entry.idle_due_on_entry);
-        let overlapping = idle.start_work();
+        let overlapping = idle.acquire_work_permit();
         assert!(!overlapping.idle_due_on_entry);
     }
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -71,6 +71,7 @@
 mod conversion;
 mod function_call_context;
 mod future;
+mod idle_gc;
 pub use future::LeakedFuture;
 mod inbound_config;
 pub mod logger;
@@ -672,6 +673,7 @@ struct ActiveCall {
 }
 
 struct ActiveCallGuard {
+    idle_work: idle_gc::WorkGuard,
     engine: Arc<BexEngine>,
     call_id: CallId,
 }
@@ -689,6 +691,7 @@ impl ShutdownGuard {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = EngineLifecycle::Closed;
         self.completed = true;
+        self.engine.idle_gc.close();
         self.engine.lifecycle_changed.notify_waiters();
     }
 }
@@ -705,6 +708,7 @@ impl Drop for ShutdownGuard {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if *lifecycle == EngineLifecycle::Closing {
             *lifecycle = EngineLifecycle::Running;
+            self.engine.idle_gc.suspend(false);
         }
         drop(lifecycle);
         self.engine.lifecycle_changed.notify_waiters();
@@ -748,9 +752,18 @@ impl ActiveCallGuard {
                 cancel
             }
         };
+        let idle_work = engine.idle_gc.start_work();
         drop(map);
         drop(lifecycle);
-        Ok((Self { engine, call_id }, cancel))
+        engine.ensure_idle_gc_worker();
+        Ok((
+            Self {
+                idle_work,
+                engine,
+                call_id,
+            },
+            cancel,
+        ))
     }
 
     fn reserve_cancelled(engine: &BexEngine, call_id: CallId) {
@@ -1098,6 +1111,7 @@ pub struct BexEngine {
     active_calls: Mutex<HashMap<CallId, ActiveCall>>,
     lifecycle: Mutex<EngineLifecycle>,
     lifecycle_changed: tokio::sync::Notify,
+    idle_gc: Arc<idle_gc::IdleGc>,
     shutdown_required: AtomicBool,
 
     futures: FutureManager,
@@ -1145,6 +1159,7 @@ impl Drop for BexEngine {
     /// candidate) drops quietly: it was never registered, so it must not
     /// emit a close notification.
     fn drop(&mut self) {
+        self.idle_gc.close();
         let rooted = self
             .rooted_unhandled_spawn_errors
             .get_mut()
@@ -2270,6 +2285,7 @@ impl BexEngine {
         let class_definitions = Self::extract_class_definitions(&resolved_class_names);
         let enum_definitions = Self::extract_enum_definitions(&resolved_enum_names);
 
+        let idle_gc = idle_gc::IdleGc::new(&heap);
         let heap_permit_manager = Arc::new(HeapPermitManager::new());
         // We just created the permit manager so `new_permit` will not block:
         // the only synchronization inside is the `holders` mutex which is
@@ -2280,10 +2296,12 @@ impl BexEngine {
         // If `new_permit` ever takes a real lock or schedules async work,
         // this assumption breaks and the constructor would deadlock — at
         // which point we'd have to make `BexEngine::new` async (TODO).
-        let futures_permit = futures::executor::block_on(
-            heap_permit_manager
-                .new_permit(FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)))),
-        );
+        let futures_permit = futures::executor::block_on(heap_permit_manager.new_permit(
+            FutureManagerInner::with_idle_gc(
+                Tlab::new_empty(Arc::clone(&heap)),
+                Arc::clone(&idle_gc),
+            ),
+        ));
 
         // Register the frozen globals pool as its own permit holder so the
         // GC traces and forwards `Value::object(HeapPtr)` entries (e.g.
@@ -2361,6 +2379,7 @@ impl BexEngine {
             active_calls: Mutex::new(HashMap::new()),
             lifecycle: Mutex::new(EngineLifecycle::Running),
             lifecycle_changed: tokio::sync::Notify::new(),
+            idle_gc,
             shutdown_required: AtomicBool::new(false),
             futures: FutureManager::new(futures_permit),
             rooted_unhandled_spawn_errors: Mutex::new(VecDeque::new()),
@@ -3017,6 +3036,7 @@ impl BexEngine {
                 match *lifecycle {
                     EngineLifecycle::Running => {
                         *lifecycle = EngineLifecycle::Closing;
+                        self.idle_gc.suspend(true);
                         return Some(ShutdownGuard {
                             engine: Arc::clone(self),
                             completed: false,
@@ -3217,6 +3237,7 @@ impl BexEngine {
         self.collect_garbage_with_reason(bex_heap::CollectionLevel::Major, "shutdown")
             .await;
         shutdown.complete();
+        self.idle_gc.join_worker().await;
     }
 
     fn enqueue_unhandled_spawn_errors(
@@ -3358,13 +3379,24 @@ impl BexEngine {
         level: bex_heap::CollectionLevel,
         reason: &'static str,
     ) -> bex_heap::GcStats {
-        let mut cycle = bex_heap::GcCycleProfiler::start();
+        let cycle = bex_heap::GcCycleProfiler::start();
         #[cfg(not(target_arch = "wasm32"))]
         let park_request_guard = ParkRequestGuard::new(Arc::clone(&self.park_requested));
-        let mut heap_guard = self.heap_permit_manager.request_park().await;
+        let heap_guard = self.heap_permit_manager.request_park().await;
         #[cfg(not(target_arch = "wasm32"))]
         drop(park_request_guard);
 
+        self.collect_garbage_parked(level, reason, heap_guard, cycle).await
+    }
+
+    async fn collect_garbage_parked(
+        self: &Arc<Self>,
+        level: bex_heap::CollectionLevel,
+        reason: &'static str,
+        mut heap_guard: HeapGuard<'_>,
+        mut cycle: bex_heap::GcCycleProfiler,
+    ) -> bex_heap::GcStats {
+        let cleanup_version = self.idle_gc.cleanup_version();
         cycle.parked();
 
         // Collect roots from handles (objects returned to external code)
@@ -3454,6 +3486,9 @@ impl BexEngine {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .extend(unhandled_spawn_errors);
 
+        if level == bex_heap::CollectionLevel::Major {
+            self.idle_gc.collected(cleanup_version);
+        }
         drop(heap_guard);
         cycle.released();
 
@@ -3586,7 +3621,7 @@ impl BexEngine {
         // target it. The RAII guard removes the entry on drop (including
         // panic unwind). Insertion and guard construction are atomic, so a
         // panic here cannot leak registry entries.
-        let (_call_guard, cancel) =
+        let (call_guard, cancel) =
             ActiveCallGuard::register(Arc::clone(self), host_call_id, cancel)?;
 
         // Fail fast if already cancelled — guarantees pre-cancelled IDs
@@ -3595,6 +3630,7 @@ impl BexEngine {
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
+        Box::pin(self.collect_before_call(&call_guard.idle_work)).await;
 
         let (function_index, kind) = self.lookup_function(function_name)?;
         if matches!(kind, bex_vm_types::FunctionKind::NativeUnresolved) {
@@ -4338,11 +4374,12 @@ impl BexEngine {
         }: FunctionCallContext,
         copy_objects: bool,
     ) -> Result<BexCallResult, EngineError> {
-        let (_call_guard, cancel) =
+        let (call_guard, cancel) =
             ActiveCallGuard::register(Arc::clone(self), host_call_id, cancel)?;
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
+        Box::pin(self.collect_before_call(&call_guard.idle_work)).await;
         let mut thread = self.new_root_thread(cancel.clone()).await;
 
         // Resolve the handle to the live heap object. The handle keeps it rooted.
@@ -5748,6 +5785,9 @@ impl BexEngine {
         call_capture: Option<CallValueCaptureContext>,
         log_capture: Option<LogCaptureContext>,
     ) -> Result<(), EngineError> {
+        // Count the producer until its task exits, even if its future was
+        // cancelled or removed earlier. Created before the task is scheduled.
+        let idle_work = self.idle_gc.start_work();
         // BEP-034 spawn options: link a user-provided `CancelToken`
         // (`with baml.spawn.options(cancel = ...)`) into this spawn's effective
         // token. Firing the user token cancels the child; the watcher
@@ -5834,7 +5874,8 @@ impl BexEngine {
             attr: baml_type::TyAttr::default(),
         };
         let task = async move {
-            // Declared first so it drops last: if this future is dropped at
+            let _idle_work = idle_work;
+            // Outlives the execution locals (but not the idle guard): if dropped at
             // any await below (before the event loop takes over), the closer
             // emits the child's EndFunction/EndThread (follow-up 11).
             let mut prof_closer = SpawnProfCloser {
@@ -6007,9 +6048,6 @@ impl BexEngine {
                 copy_objects,
             )
             .await;
-        // The outcome is now externally rooted (or the child future is settled),
-        // and the VM has released its permit. Short calls must service pressure too.
-        Box::pin(self.maybe_collect_garbage()).await;
         if profile_thread {
             let status = match &result {
                 Ok(ThreadOutcome::SettledChild(ChildSettleKind::Cancelled)) => {

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -672,10 +672,50 @@ struct ActiveCall {
     pending: bool,
 }
 
-struct ActiveCallGuard {
-    idle_work: idle_gc::WorkGuard,
+/// Owns root-call registration and its work permit through completion or cancellation.
+struct RootCallWork {
+    work_permit: idle_gc::WorkPermit,
     engine: Arc<BexEngine>,
     call_id: CallId,
+}
+
+/// Owns a producer future and its work permit, including time spent queued.
+/// Keep the future first so its captures are dropped before the permit.
+struct SpawnedWork<F> {
+    future: F,
+    work_permit: idle_gc::WorkPermit,
+}
+
+impl<F: std::future::Future> SpawnedWork<F> {
+    fn new(work_permit: idle_gc::WorkPermit, future: F) -> Self {
+        Self {
+            future,
+            work_permit,
+        }
+    }
+
+    async fn run(self) -> F::Output {
+        let result = self.future.await;
+        drop(self.work_permit);
+        result
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn spawn(self)
+    where
+        F: Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::spawn(self.run());
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn spawn(self)
+    where
+        F: std::future::Future<Output = ()> + 'static,
+    {
+        wasm_bindgen_futures::spawn_local(self.run());
+    }
 }
 
 struct ShutdownGuard {
@@ -715,7 +755,7 @@ impl Drop for ShutdownGuard {
     }
 }
 
-impl ActiveCallGuard {
+impl RootCallWork {
     /// Atomically reserve `call_id` in `engine.active_calls` and return a
     /// guard that will release the slot on drop. Returns
     /// [`EngineError::DuplicateCallId`] if the id is already in flight.
@@ -752,14 +792,14 @@ impl ActiveCallGuard {
                 cancel
             }
         };
-        let idle_work = engine.idle_gc.start_work();
+        let work_permit = engine.idle_gc.acquire_work_permit();
         drop(map);
         drop(lifecycle);
         #[cfg(not(target_arch = "wasm32"))]
         engine.ensure_idle_gc_worker();
         Ok((
             Self {
-                idle_work,
+                work_permit,
                 engine,
                 call_id,
             },
@@ -796,7 +836,7 @@ impl ActiveCallGuard {
     }
 }
 
-impl Drop for ActiveCallGuard {
+impl Drop for RootCallWork {
     fn drop(&mut self) {
         // `unwrap_or_else(into_inner)` so a poisoned mutex during unwind
         // doesn't double-panic.
@@ -3621,8 +3661,7 @@ impl BexEngine {
         // target it. The RAII guard removes the entry on drop (including
         // panic unwind). Insertion and guard construction are atomic, so a
         // panic here cannot leak registry entries.
-        let (call_guard, cancel) =
-            ActiveCallGuard::register(Arc::clone(self), host_call_id, cancel)?;
+        let (call_work, cancel) = RootCallWork::register(Arc::clone(self), host_call_id, cancel)?;
 
         // Fail fast if already cancelled — guarantees pre-cancelled IDs
         // always produce a `baml.panics.Cancelled` panic regardless of
@@ -3630,7 +3669,7 @@ impl BexEngine {
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
-        Box::pin(self.collect_before_call(&call_guard.idle_work)).await;
+        Box::pin(self.collect_before_call(&call_work.work_permit)).await;
 
         let (function_index, kind) = self.lookup_function(function_name)?;
         if matches!(kind, bex_vm_types::FunctionKind::NativeUnresolved) {
@@ -4258,7 +4297,7 @@ impl BexEngine {
         // GC never ran during the call.
         bex_external_types::host_value::host_release_dispatch::drain();
 
-        // active_calls cleanup is done by ActiveCallGuard on drop.
+        // active_calls cleanup is done by RootCallWork on drop.
         //
         // Keep genuine engine errors intact. Cancellation is surfaced as a
         // `baml.panics.Cancelled` panic — either raised by the VM's `Await`
@@ -4374,12 +4413,11 @@ impl BexEngine {
         }: FunctionCallContext,
         copy_objects: bool,
     ) -> Result<BexCallResult, EngineError> {
-        let (call_guard, cancel) =
-            ActiveCallGuard::register(Arc::clone(self), host_call_id, cancel)?;
+        let (call_work, cancel) = RootCallWork::register(Arc::clone(self), host_call_id, cancel)?;
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
-        Box::pin(self.collect_before_call(&call_guard.idle_work)).await;
+        Box::pin(self.collect_before_call(&call_work.work_permit)).await;
         let mut thread = self.new_root_thread(cancel.clone()).await;
 
         // Resolve the handle to the live heap object. The handle keeps it rooted.
@@ -4759,7 +4797,7 @@ impl BexEngine {
     /// cancellation check point. If the ID is not active yet, reserve it with
     /// an already-cancelled token so the later call starts cancelled.
     pub fn cancel_function_call(&self, call_id: CallId) -> Result<(), EngineError> {
-        ActiveCallGuard::reserve_cancelled(self, call_id);
+        RootCallWork::reserve_cancelled(self, call_id);
         Ok(())
     }
 
@@ -5787,7 +5825,7 @@ impl BexEngine {
     ) -> Result<(), EngineError> {
         // Count the producer until its task exits, even if its future was
         // cancelled or removed earlier. Created before the task is scheduled.
-        let idle_work = self.idle_gc.start_work();
+        let work_permit = self.idle_gc.acquire_work_permit();
         // BEP-034 spawn options: link a user-provided `CancelToken`
         // (`with baml.spawn.options(cancel = ...)`) into this spawn's effective
         // token. Firing the user token cancels the child; the watcher
@@ -5874,8 +5912,7 @@ impl BexEngine {
             attr: baml_type::TyAttr::default(),
         };
         let task = async move {
-            let _idle_work = idle_work;
-            // Outlives the execution locals (but not the idle guard): if dropped at
+            // Outlives the execution locals (but not SpawnedWork): if dropped at
             // any await below (before the event loop takes over), the closer
             // emits the child's EndFunction/EndThread (follow-up 11).
             let mut prof_closer = SpawnProfCloser {
@@ -5997,10 +6034,7 @@ impl BexEngine {
                 }
             }
         };
-        #[cfg(not(target_arch = "wasm32"))]
-        tokio::spawn(task);
-        #[cfg(target_arch = "wasm32")]
-        wasm_bindgen_futures::spawn_local(task);
+        SpawnedWork::new(work_permit, task).spawn();
 
         Ok(())
     }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -68,10 +68,10 @@
 
 #![allow(unsafe_code)]
 
+mod bex_work;
 mod conversion;
 mod function_call_context;
 mod future;
-mod idle_gc;
 pub use future::LeakedFuture;
 mod inbound_config;
 pub mod logger;
@@ -672,31 +672,28 @@ struct ActiveCall {
     pending: bool,
 }
 
-/// Owns root-call registration and its work permit through completion or cancellation.
+/// Owns root-call registration and its work guard through completion or cancellation.
 struct RootCallWork {
-    work_permit: idle_gc::WorkPermit,
+    work_guard: bex_work::BexWorkGuard,
     engine: Arc<BexEngine>,
     call_id: CallId,
 }
 
-/// Owns a producer future and its work permit, including time spent queued.
-/// Keep the future first so its captures are dropped before the permit.
+/// Owns a producer future and its work guard, including time spent queued.
+/// Keep the future first so its captures are dropped before the work guard.
 struct SpawnedWork<F> {
     future: F,
-    work_permit: idle_gc::WorkPermit,
+    work_guard: bex_work::BexWorkGuard,
 }
 
 impl<F: std::future::Future> SpawnedWork<F> {
-    fn new(work_permit: idle_gc::WorkPermit, future: F) -> Self {
-        Self {
-            future,
-            work_permit,
-        }
+    fn new(work_guard: bex_work::BexWorkGuard, future: F) -> Self {
+        Self { future, work_guard }
     }
 
     async fn run(self) -> F::Output {
         let result = self.future.await;
-        drop(self.work_permit);
+        drop(self.work_guard);
         result
     }
 
@@ -731,7 +728,7 @@ impl ShutdownGuard {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = EngineLifecycle::Closed;
         self.completed = true;
-        self.engine.idle_gc.close();
+        self.engine.bex_work.close();
         self.engine.lifecycle_changed.notify_waiters();
     }
 }
@@ -748,7 +745,7 @@ impl Drop for ShutdownGuard {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if *lifecycle == EngineLifecycle::Closing {
             *lifecycle = EngineLifecycle::Running;
-            self.engine.idle_gc.resume();
+            self.engine.bex_work.resume();
         }
         drop(lifecycle);
         self.engine.lifecycle_changed.notify_waiters();
@@ -792,14 +789,14 @@ impl RootCallWork {
                 cancel
             }
         };
-        let work_permit = engine.idle_gc.acquire_work_permit();
+        let work_guard = engine.bex_work.register_work();
         drop(map);
         drop(lifecycle);
         #[cfg(not(target_arch = "wasm32"))]
         engine.ensure_idle_gc_worker();
         Ok((
             Self {
-                work_permit,
+                work_guard,
                 engine,
                 call_id,
             },
@@ -1152,7 +1149,7 @@ pub struct BexEngine {
     active_calls: Mutex<HashMap<CallId, ActiveCall>>,
     lifecycle: Mutex<EngineLifecycle>,
     lifecycle_changed: tokio::sync::Notify,
-    idle_gc: Arc<idle_gc::IdleGc>,
+    bex_work: Arc<bex_work::BexWork>,
     shutdown_required: AtomicBool,
 
     futures: FutureManager,
@@ -1200,7 +1197,7 @@ impl Drop for BexEngine {
     /// candidate) drops quietly: it was never registered, so it must not
     /// emit a close notification.
     fn drop(&mut self) {
-        self.idle_gc.close();
+        self.bex_work.close();
         let rooted = self
             .rooted_unhandled_spawn_errors
             .get_mut()
@@ -2326,7 +2323,7 @@ impl BexEngine {
         let class_definitions = Self::extract_class_definitions(&resolved_class_names);
         let enum_definitions = Self::extract_enum_definitions(&resolved_enum_names);
 
-        let idle_gc = idle_gc::IdleGc::new(&heap);
+        let bex_work = bex_work::BexWork::new(&heap);
         let heap_permit_manager = Arc::new(HeapPermitManager::new());
         // We just created the permit manager so `new_permit` will not block:
         // the only synchronization inside is the `holders` mutex which is
@@ -2338,7 +2335,7 @@ impl BexEngine {
         // this assumption breaks and the constructor would deadlock — at
         // which point we'd have to make `BexEngine::new` async (TODO).
         let futures_permit = futures::executor::block_on(heap_permit_manager.new_permit(
-            FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)), Arc::clone(&idle_gc)),
+            FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)), Arc::clone(&bex_work)),
         ));
 
         // Register the frozen globals pool as its own permit holder so the
@@ -2417,7 +2414,7 @@ impl BexEngine {
             active_calls: Mutex::new(HashMap::new()),
             lifecycle: Mutex::new(EngineLifecycle::Running),
             lifecycle_changed: tokio::sync::Notify::new(),
-            idle_gc,
+            bex_work,
             shutdown_required: AtomicBool::new(false),
             futures: FutureManager::new(futures_permit),
             rooted_unhandled_spawn_errors: Mutex::new(VecDeque::new()),
@@ -3074,7 +3071,7 @@ impl BexEngine {
                 match *lifecycle {
                     EngineLifecycle::Running => {
                         *lifecycle = EngineLifecycle::Closing;
-                        self.idle_gc.suspend();
+                        self.bex_work.suspend();
                         return Some(ShutdownGuard {
                             engine: Arc::clone(self),
                             completed: false,
@@ -3276,7 +3273,7 @@ impl BexEngine {
             .await;
         shutdown.complete();
         #[cfg(not(target_arch = "wasm32"))]
-        self.idle_gc.join_worker().await;
+        self.bex_work.join_worker().await;
     }
 
     fn enqueue_unhandled_spawn_errors(
@@ -3436,7 +3433,7 @@ impl BexEngine {
         mut heap_guard: HeapGuard<'_>,
         mut cycle: bex_heap::GcCycleProfiler,
     ) -> bex_heap::GcStats {
-        let cleanup_version = self.idle_gc.cleanup_version();
+        let cleanup_version = self.bex_work.cleanup_version();
         cycle.parked();
 
         // Collect roots from handles (objects returned to external code)
@@ -3527,7 +3524,7 @@ impl BexEngine {
             .extend(unhandled_spawn_errors);
 
         if level == bex_heap::CollectionLevel::Major {
-            self.idle_gc.collected(cleanup_version);
+            self.bex_work.collected(cleanup_version);
         }
         drop(heap_guard);
         cycle.released();
@@ -3669,7 +3666,7 @@ impl BexEngine {
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
-        Box::pin(self.collect_before_call(&call_work.work_permit)).await;
+        Box::pin(self.collect_before_call(&call_work.work_guard)).await;
 
         let (function_index, kind) = self.lookup_function(function_name)?;
         if matches!(kind, bex_vm_types::FunctionKind::NativeUnresolved) {
@@ -4417,7 +4414,7 @@ impl BexEngine {
         if cancel.is_cancelled() {
             return Err(cancelled_unhandled_throw());
         }
-        Box::pin(self.collect_before_call(&call_work.work_permit)).await;
+        Box::pin(self.collect_before_call(&call_work.work_guard)).await;
         let mut thread = self.new_root_thread(cancel.clone()).await;
 
         // Resolve the handle to the live heap object. The handle keeps it rooted.
@@ -5825,7 +5822,7 @@ impl BexEngine {
     ) -> Result<(), EngineError> {
         // Count the producer until its task exits, even if its future was
         // cancelled or removed earlier. Created before the task is scheduled.
-        let work_permit = self.idle_gc.acquire_work_permit();
+        let work_guard = self.bex_work.register_work();
         // BEP-034 spawn options: link a user-provided `CancelToken`
         // (`with baml.spawn.options(cancel = ...)`) into this spawn's effective
         // token. Firing the user token cancels the child; the watcher
@@ -6034,7 +6031,7 @@ impl BexEngine {
                 }
             }
         };
-        SpawnedWork::new(work_permit, task).spawn();
+        SpawnedWork::new(work_guard, task).spawn();
 
         Ok(())
     }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -708,7 +708,7 @@ impl Drop for ShutdownGuard {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if *lifecycle == EngineLifecycle::Closing {
             *lifecycle = EngineLifecycle::Running;
-            self.engine.idle_gc.suspend(false);
+            self.engine.idle_gc.resume();
         }
         drop(lifecycle);
         self.engine.lifecycle_changed.notify_waiters();
@@ -755,6 +755,7 @@ impl ActiveCallGuard {
         let idle_work = engine.idle_gc.start_work();
         drop(map);
         drop(lifecycle);
+        #[cfg(not(target_arch = "wasm32"))]
         engine.ensure_idle_gc_worker();
         Ok((
             Self {
@@ -2297,10 +2298,7 @@ impl BexEngine {
         // this assumption breaks and the constructor would deadlock — at
         // which point we'd have to make `BexEngine::new` async (TODO).
         let futures_permit = futures::executor::block_on(heap_permit_manager.new_permit(
-            FutureManagerInner::with_idle_gc(
-                Tlab::new_empty(Arc::clone(&heap)),
-                Arc::clone(&idle_gc),
-            ),
+            FutureManagerInner::new(Tlab::new_empty(Arc::clone(&heap)), Arc::clone(&idle_gc)),
         ));
 
         // Register the frozen globals pool as its own permit holder so the
@@ -3036,7 +3034,7 @@ impl BexEngine {
                 match *lifecycle {
                     EngineLifecycle::Running => {
                         *lifecycle = EngineLifecycle::Closing;
-                        self.idle_gc.suspend(true);
+                        self.idle_gc.suspend();
                         return Some(ShutdownGuard {
                             engine: Arc::clone(self),
                             completed: false,
@@ -3237,6 +3235,7 @@ impl BexEngine {
         self.collect_garbage_with_reason(bex_heap::CollectionLevel::Major, "shutdown")
             .await;
         shutdown.complete();
+        #[cfg(not(target_arch = "wasm32"))]
         self.idle_gc.join_worker().await;
     }
 

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3385,7 +3385,8 @@ impl BexEngine {
         #[cfg(not(target_arch = "wasm32"))]
         drop(park_request_guard);
 
-        self.collect_garbage_parked(level, reason, heap_guard, cycle).await
+        self.collect_garbage_parked(level, reason, heap_guard, cycle)
+            .await
     }
 
     async fn collect_garbage_parked(

--- a/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
+++ b/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
@@ -250,22 +250,26 @@ async fn cancellation_after_pressure_does_not_latch_the_checker() {
 #[tokio::test(start_paused = true)]
 async fn completed_bridge_call_leaves_debt_for_next_entry_and_preserves_its_handle() {
     let engine = engine();
-    let bytes = 40 * 1024 * 1024;
-    let retained = call(
-        &engine,
-        "Text",
-        vec![Ext::String("x".repeat(bytes).into())],
-        false,
-    )
-    .await;
+    let mut n = 0;
+    let retained = loop {
+        let value = call(&engine, "Tiny", vec![Ext::Int(n)], false).await;
+        if engine.heap().should_gc() {
+            break value;
+        }
+        n += 1;
+        assert!(
+            n < 30_000,
+            "short-call reservations must eventually exhaust the budget"
+        );
+    };
     assert_eq!(engine.heap().gc_budget().full_collections, 0);
     assert!(
         engine.heap().should_gc(),
         "completion must leave debt unpaid"
     );
     assert_eq!(
-        call(&engine, "TextSize", vec![retained], true).await,
-        Ext::Int(i64::try_from(bytes).unwrap())
+        call(&engine, "Read", vec![retained], true).await,
+        Ext::Int(n)
     );
     assert_eq!(engine.heap().gc_budget().full_collections, 1);
     engine.shutdown().await;

--- a/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
+++ b/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
@@ -69,7 +69,7 @@ async fn call(engine: &Arc<BexEngine>, name: &str, args: Vec<Ext>, copy: bool) -
 }
 
 #[tokio::test]
-async fn short_calls_service_pressure_after_export() {
+async fn short_calls_service_pressure_on_next_entry() {
     let engine = engine();
     for n in 0..30_000 {
         let result = call(&engine, "Tiny", vec![Ext::Int(n)], true).await;
@@ -77,7 +77,6 @@ async fn short_calls_service_pressure_after_export() {
             panic!("expected copied instance")
         };
         assert_eq!(fields["value"], Ext::Int(n));
-        assert!(engine.heap().should_collect().is_none());
     }
     assert!(engine.heap().gc_budget().full_collections >= 1);
     engine.shutdown().await;
@@ -245,5 +244,29 @@ async fn cancellation_after_pressure_does_not_latch_the_checker() {
         Ext::Int(2_100_000 * 2_099_999 / 2)
     );
     assert!(engine.heap().gc_budget().full_collections > before);
+    engine.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn completed_bridge_call_leaves_debt_for_next_entry_and_preserves_its_handle() {
+    let engine = engine();
+    let bytes = 40 * 1024 * 1024;
+    let retained = call(
+        &engine,
+        "Text",
+        vec![Ext::String("x".repeat(bytes).into())],
+        false,
+    )
+    .await;
+    assert_eq!(engine.heap().gc_budget().full_collections, 0);
+    assert!(
+        engine.heap().should_gc(),
+        "completion must leave debt unpaid"
+    );
+    assert_eq!(
+        call(&engine, "TextSize", vec![retained], true).await,
+        Ext::Int(i64::try_from(bytes).unwrap())
+    );
+    assert_eq!(engine.heap().gc_budget().full_collections, 1);
     engine.shutdown().await;
 }

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -229,6 +229,8 @@ pub struct BexHeap {
     tlab_size: usize,
     pub(crate) max_tlab_size: usize,
     pub(crate) gc_policy: crate::gc_policy::AllocationBudget,
+    root_release_epoch: AtomicUsize,
+    gc_activity: Arc<tokio::sync::Notify>,
 
     /// Lock for growing Gen0 (rare operation).
     ///
@@ -279,6 +281,10 @@ impl WeakHeapRef for BexHeap {
         if by_ptr.get(&ptr).is_some_and(|(key, _)| *key == handle_key) {
             by_ptr.remove(&ptr);
         }
+        self.root_release_epoch.fetch_add(1, Ordering::Release);
+        drop(by_ptr);
+        drop(handles);
+        self.gc_activity.notify_one();
     }
 
     fn resolve_handle_ptr(&self, slab_key: usize) -> Option<HeapPtr> {
@@ -356,6 +362,8 @@ impl BexHeap {
             tlab_size,
             max_tlab_size: tlab_size,
             gc_policy: crate::gc_policy::AllocationBudget::new(),
+            root_release_epoch: AtomicUsize::new(0),
+            gc_activity: Arc::new(tokio::sync::Notify::new()),
             growth_lock: Mutex::new(()),
             allocs_since_gc: AtomicUsize::new(0),
             debug_state: HeapDebuggerState::new(debug),
@@ -838,6 +846,17 @@ impl BexHeap {
             }
         }
         None
+    }
+
+    /// Monotonic change token for external roots disappearing, including after
+    /// the last engine call. No heap permit is required to read this token.
+    pub fn root_release_epoch(&self) -> usize {
+        self.root_release_epoch.load(Ordering::Acquire)
+    }
+
+    /// Dedicated wake signal for the engine's single idle-GC coordinator.
+    pub fn gc_activity(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.gc_activity)
     }
 
     /// Get the TLAB chunk size.

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -281,10 +281,9 @@ impl WeakHeapRef for BexHeap {
         if by_ptr.get(&ptr).is_some_and(|(key, _)| *key == handle_key) {
             by_ptr.remove(&ptr);
         }
-        self.root_release_epoch.fetch_add(1, Ordering::Release);
         drop(by_ptr);
         drop(handles);
-        self.gc_activity.notify_one();
+        self.notify_root_released();
     }
 
     fn resolve_handle_ptr(&self, slab_key: usize) -> Option<HeapPtr> {
@@ -848,10 +847,17 @@ impl BexHeap {
         None
     }
 
-    /// Monotonic change token for external roots disappearing, including after
+    /// Monotonic change token for GC roots disappearing, including after
     /// the last engine call. No heap permit is required to read this token.
     pub fn root_release_epoch(&self) -> usize {
         self.root_release_epoch.load(Ordering::Acquire)
+    }
+
+    /// Record a removed root and wake idle cleanup, including when no work ends.
+    /// Call after removing the root; registry callers must still hold their heap permit.
+    pub fn notify_root_released(&self) {
+        self.root_release_epoch.fetch_add(1, Ordering::Release);
+        self.gc_activity.notify_one();
     }
 
     /// Dedicated wake signal for the engine's single idle-GC coordinator.


### PR DESCRIPTION
Builds on #4840. A completed call now returns without collecting. Allocation pressure is paid before the next root call imports arguments, or at the existing safepoints inside a running VM. Native engines also clean up after 100 ms of quiet; WASM services overdue cleanup at the next call.

### Before → after

| Scenario | #4840 | This PR |
| --- | --- | --- |
| A fast bridge call exceeds the budget | Full GC before returning the result | Return immediately; next call collects before allocating |
| Calls run continuously | Completion checks + VM safepoints | Entry checks + the same VM safepoints |
| A burst ends below the budget | Garbage waits for later pressure | Native worker attempts full GC after 100 ms quiet |
| Last bridge handle is dropped after that GC | Wait for later engine activity | Native worker wakes and arms another quiet collection |
| Detached child is still running or queued | No idle policy | It prevents idle cleanup until its producer exits and its registry work settles or is removed |
| A settled internal error remains in the registry | Error retained for later awaiters | Error stays rooted and readable, but no longer counts as active work |
| WASM stops receiving calls | No background cleanup | Still no background task or timer; cleanup waits for the next call |

```text
call A uses up budget:
  before:  A runs → full GC → return A
  after:   A runs → return A
                     ├─ B arrives: full GC → import B arguments → run B
                     └─ native stays quiet 100 ms: attempt idle GC
```

### Lifecycle

```text
on root-call entry:
    RootCallWork owns a new BexWorkGuard; cancel the idle deadline
    if allocation budget is spent, or WASM observed overdue cleanup:
        full GC before importing arguments
    run the call (existing allocation safepoints still apply)

on BexWorkGuard drop:
    mark cleanup pending
    if no work guards remain: deadline = now + 100 ms
    return

native worker, at deadline:
    if work resumed or shutdown started: stop this attempt
    acquire exclusive heap access, waiting at most 5 ms
    if acquisition times out: retain pending cleanup; retry after 100 ms
    if state changed while waiting: release access and stop this attempt
    otherwise: full GC; clear only the pending version it observed
```

GC bookkeeping is mandatory when constructing a futures registry, and every new entry requires a work guard. A retained settled entry takes and drops that guard exactly once; its lifecycle `Option` does not make tracking optional at construction. The worker, startup, and join methods exist only under native target configuration. WASM retains the shared bookkeeping for cooperative entry cleanup. Scheduling is an enum: `Disarmed`, `Waiting(deadline)`, `Suspended`, or `Closed`. Only `Waiting` can carry a deadline, and resuming a closed coordinator cannot rearm it.

There is one lazily started Tokio task per engine, with at most one timer. It holds a weak engine reference while waiting. A clean or busy engine has no deadline; the worker waits for notification. If its Tokio runtime was destroyed, a later call can restart the finished worker on the current runtime. Native idle cleanup requires that runtime to keep being polled.

`BexWork` in `bex_work.rs` owns work tracking, handle-release observation, and idle scheduling. Each work lifetime has a named owner with a mandatory, non-cloneable `BexWorkGuard`: `RootCallWork` for root-call registration, `FutureWork` for registry work until settlement or removal, and `SpawnedWork` for an entire producer task. Registering work with `BexWork::register_work()` disarms the idle deadline; dropping the final guard arms it. Producer scheduling goes through `SpawnedWork::new(work_guard, task).spawn()` on both native and WASM. The owner keeps its guard through queuing, execution, and cancellation cleanup, including when dropped before its first poll; the task future is destroyed before the guard is released. Registry settlement can precede a cancelled producer's exit, so both are counted. Queued task-group children count too. Streams/outstanding work therefore cannot be mistaken for idle. A retained internal-error entry releases its guard on settlement, including when cancellation won the terminal-state race. It remains a GC root so later awaiters can read the original error. Removing that retained entry later increments the existing root-release epoch and wakes cleanup, even if no other work completes. The producer keeps its independent guard through its remaining cleanup.

Bridge handles remain ordinary GC roots. Removing the last reference to a heap handle increments a release epoch and wakes the worker, including after the last call. Releases and work completions newer than the collection's snapshot remain pending. On WASM, an expired completion deadline is remembered at entry; if no deadline was armed, a newly observed handle release is eligible immediately because there was no idle observer.

Idle acquisition does **not** set the VM park-request flag. New work cancels a waiting attempt. Once collection has begun it runs to completion, and an arriving caller may wait for that full pause: **5 ms bounds only the acquisition wait, not GC or finalizers**. Shutdown suspends the worker; cancellation of shutdown resumes it; completed shutdown closes and joins it.

### Scope and validation

The retained-error lifecycle fix passed **226 unit tests** (126 engine, 100 heap) with `heap_debug,gc_profiling` in `fasttest`, plus full native and WASM Clippy. New regressions verify that retained errors survive moving GC and remain readable, a live producer still prevents idle collection, cancellation winning settlement releases registry work exactly once, and later entry removal re-arms cleanup across cancelled shutdown. Registry-count documentation includes retained engine-error entries; the count is not a pending-only metric.

After the work ownership refactor: **187 tests passed** with `heap_debug,gc_profiling` in `fasttest`: 124 engine unit tests, 8 allocation-budget tests, and 55 cancellation, fire-and-forget, future-cleanup, and task-group integration tests. New drop-order tests verify that a producer retains its guard through cancellation before or after its first poll, and through success or error cleanup. Full native workspace Clippy, the full WASM lint task, and repository commit hooks passed. The bridge regression now exhausts the slot budget with short calls, verifies that completion leaves the debt unpaid, and checks that the next entry collects while preserving the returned handle. Large-payload and old-array-growth tests verify that backing bytes alone do not trigger pressure GC.

The full collector and allocation-budget sizing remain those from #4840: charge reserved object slots only, and set headroom after full GC to `max(32 MiB, 4 × live slot bytes)`. String/image backing and container growth do not spend that budget. Quiet cleanup still runs below budget, so it can reclaim dead large payloads after a burst; continuous payload-heavy traffic can retain them until slot pressure or explicit GC. The 100 ms idle delay and 5 ms acquisition wait are internal starting constants. This adds no concurrent collection, allocator trimming, or public policy knobs. Reclaiming BAML objects does not guarantee the allocator returns their pages to the OS.

- On the initial implementation (`4a7ca4366`), 214 tests passed, one existing compiler-gap test ignored: engine unit tests plus allocation-budget, cancellation, cleanup-finalizer, fire-and-forget, host-callable, and task-group suites. Ran with `heap_debug,gc_profiling` in the optimized `fasttest` profile.
- After the state/platform refactor: 122 engine unit tests and 8 allocation-budget tests passed with `heap_debug,gc_profiling`; native all-feature Clippy and the full `mise run clippy-wasm` task passed. The added regression checks that work completion and GC completion cannot rearm suspended or closed cleanup.
- Paused-clock tests cover one worker per engine, coalescing, no repeated clean timer, release-after-last-call, acquisition timeout/retry, arriving-work cancellation, registry/producer overlap, detached completion, cleanup version races, cancelled shutdown, and worker lifetime.
- `cargo check -p bex_engine --target wasm32-unknown-unknown --features gc_profiling` passed. WASM was compile-checked; the cooperative state transition is unit-tested on native, not run in a browser.
- Targeted all-feature Clippy passed. All repository hooks passed, including full-workspace, all-target, all-feature Clippy.

Historical benchmark check (commit `4a7ca4366`, before the state/platform refactor **and before #4840 switched to slot-only accounting**; these figures do not measure the updated policy): three randomized paired runs per workload on this macOS host, same inherited harness, `GC_POLICY=current`, optimized binaries with `gc_profiling`. Percentages below are the median of paired changes relative to #4840. CPU covers the entire test process (including compilation of the BAML source, warmup, validation, and cleanup); call-loop time excludes those phases and the idle wait.

| Workload | Process CPU | Call-loop time | Peak sampled RSS |
| --- | ---: | ---: | ---: |
| 100k tiny calls | +1.4% | +0.3% | +3.4% |
| Allocation churn | +1.4% | -0.5% | -0.2% |
| 128 retained batches | +0.5% | -2.1% | -0.5% |
| 262k-object cache | +0.2% | -1.4% | -2.7% |
| Burst, then 500 ms idle | -0.5% | -1.6% | -3.1% |

In all three burst/idle runs, the parent retained **599,511 heap slots** after handles were released; this PR reached **zero runtime slots** during the idle interval, without another engine call. RSS stayed approximately flat across that collection. This proves the idle reclamation path, not OS page return. The tiny-call RSS increase is reported above rather than treated as a memory improvement.

These short, single-thread-runtime measurements are a regression check, not tuning sign-off. Busy multithreaded hosts, calls arriving during an idle collection, repeated quiet gaps with large retained caches, and target Linux allocators still need dedicated measurements before choosing final timing constants.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic idle-time garbage collection to reclaim unused memory between engine operations.
  - Garbage collection now runs opportunistically in the background when the engine is idle.
  - Idle cleanup responds to released resources and resumes appropriately during engine lifecycle changes.

- **Bug Fixes**
  - Improved memory cleanup timing after completed calls and released handles.
  - Improved cleanup coordination during shutdown and cancelled operations.
  - Preserved active work and resource handles while cleanup runs.
  - Improved collection scheduling when memory usage carries over between engine entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

After the #4831 profiler refactor, explicit and idle collection pass the same compile-time real/no-op cycle recorder through permit acquisition and the parked collector. The engine lifecycle and collector contain no `gc_profiling` conditionals or feature-dependent parameters. After that profiler refactor, **230 heap/engine tests passed in each configuration**, with profiling enabled and disabled (`heap_debug` in both, optimized `fasttest`). This includes 100 heap tests, 122 engine unit tests, and 8 allocation-budget integration tests. Workspace native Clippy, full WASM Clippy with all features, and heap/engine WASM Clippy without profiling passed.
