### PR TITLE
chore: remove CodeRabbit from mise config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -52,23 +52,6 @@ protoc = "27.1"
 actionlint = "latest"
 ast-grep = "0.44.1"
 
-# Code review tools
-[tools.coderabbit]
-version = "0.7.2"
-
-[tools.coderabbit.platforms]
-macos-x64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-darwin-x64.zip", checksum = "sha256:1f54ea386e9f6ef5277101d54fa6f071af65f88a800a786c6f83976396aeb727" }
-macos-arm64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-darwin-arm64.zip", checksum = "sha256:29944665428720e55aa26a452e8f637858607a76f4722cabb88296f6976ee5b7" }
-linux-x64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-linux-x64.zip", checksum = "sha256:32dd3a5a1238fa68eb7cfa95cc19cf6ad4980882589c616c0e300b920f1bb865" }
-linux-arm64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-linux-arm64.zip", checksum = "sha256:cb2aa4a598fab167cdc6467f0a44be504857cc9866057bd94ea7018481937c5d" }
-
-[tool_alias]
-coderabbit = "http:coderabbit"
-
-[tasks.coderabbit-review]
-run = "coderabbit review --base canary"
-description = "Review local changes with CodeRabbit against the canary branch"
-
 [tasks.pr-unresolved]
 run = "./scripts/pr-unresolved"
 description = "Show unresolved PR review threads for the current branch PR"


### PR DESCRIPTION
## Summary
Remove CodeRabbit tool definition from mise.toml due to mise's HTTP client incompatibility with the coderabbit.ai server.

The mise `http:` provider fails with "bad protocol version" error when downloading CodeRabbit, while curl (and other HTTP clients) work fine. This is a mise-specific protocol negotiation bug that blocks `mise install` from completing.

## Test plan
- [ ] Verify `mise install` completes successfully
- [ ] Verify other tools are still installed correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the CodeRabbit CLI configuration, tool alias, platform-specific downloads, and review task from the development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->