### PR TITLE
Prevent GC starvation across spawn handoffs

### DIFF
--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -6764,6 +6764,17 @@ impl BexEngine {
                         future_ptr
                     };
                     thread.vm.stack.push(Value::object(future_ptr));
+
+                    // Spawn setup can yield to Tokio while retaining the
+                    // parent's heap permit. Cooperate only after the child
+                    // is registered and its future is rooted on our stack;
+                    // collection can now move both VMs' reachable objects.
+                    let gc_requested = self.heap.should_gc();
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let gc_requested = gc_requested || self.park_requested.load(Ordering::Relaxed);
+                    if gc_requested {
+                        thread = self.gc_safepoint(thread).await;
+                    }
                 }
 
                 VmExecState::Await(future_id) => {

--- a/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
+++ b/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bex_engine::{BexEngine, BexExternalValue as Ext, FunctionCallContextBuilder};
+use bex_engine::{BexEngine, BexExternalValue as Ext, FunctionCallContextBuilder, RuntimeTy};
 use bex_heap::CollectionLevel;
 use sys_native::SysOpsExt;
 
@@ -34,8 +34,8 @@ function Size(values: int[]) -> int { values.length() }
 function At(values: int[], i: int) -> int { values[i] }
 function Text(text: string) -> string { text }
 function TextSize(text: string) -> int { text.length() }
-function SpawnText(text: string) -> baml.future.Future<int, never> {
-    spawn { text.length() }
+function SpawnTexts(texts: string[]) -> baml.future.Future<int, never> {
+    spawn { texts.length() + texts[0].length() + texts[texts.length() - 1].length() }
 }
 function JoinText(job: baml.future.Future<int, never>) -> int { await job }
 function Async(n: int) -> int {
@@ -87,23 +87,23 @@ async fn short_calls_service_pressure_on_next_entry() {
 }
 
 // Import spends the budget after the entry check. A short spawn must service
-// that debt before returning, and preserve both the captured string and the
+// that debt before returning, and preserve both the captured strings and the
 // future handle when the child has not yet acquired its first heap permit.
 #[tokio::test(start_paused = true)]
 async fn spawn_services_pressure_after_rooting_child_and_future() {
     let engine = engine();
-    let bytes = 40 * 1024 * 1024;
-    let job = call(
-        &engine,
-        "SpawnText",
-        vec![Ext::String("x".repeat(bytes).into())],
-        false,
-    )
-    .await;
+    let count = engine.heap().gc_budget().full_budget_bytes
+        / std::mem::size_of::<bex_vm_types::Object>()
+        + 1;
+    let texts = Ext::Array {
+        element_type: RuntimeTy::string(),
+        items: vec![Ext::String("x".into()); count],
+    };
+    let job = call(&engine, "SpawnTexts", vec![texts], false).await;
     assert_eq!(engine.heap().gc_budget().full_collections, 1);
     assert_eq!(
         call(&engine, "JoinText", vec![job], true).await,
-        Ext::Int(i64::try_from(bytes).unwrap())
+        Ext::Int(i64::try_from(count + 2).unwrap())
     );
     engine.shutdown().await;
 }

--- a/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
+++ b/baml_language/crates/bex_engine/tests/gc_allocation_budget.rs
@@ -34,6 +34,10 @@ function Size(values: int[]) -> int { values.length() }
 function At(values: int[], i: int) -> int { values[i] }
 function Text(text: string) -> string { text }
 function TextSize(text: string) -> int { text.length() }
+function SpawnText(text: string) -> baml.future.Future<int, never> {
+    spawn { text.length() }
+}
+function JoinText(job: baml.future.Future<int, never>) -> int { await job }
 function Async(n: int) -> int {
     let values = Empty();
     Grow(values, n);
@@ -79,6 +83,28 @@ async fn short_calls_service_pressure_on_next_entry() {
         assert_eq!(fields["value"], Ext::Int(n));
     }
     assert!(engine.heap().gc_budget().full_collections >= 1);
+    engine.shutdown().await;
+}
+
+// Import spends the budget after the entry check. A short spawn must service
+// that debt before returning, and preserve both the captured string and the
+// future handle when the child has not yet acquired its first heap permit.
+#[tokio::test(start_paused = true)]
+async fn spawn_services_pressure_after_rooting_child_and_future() {
+    let engine = engine();
+    let bytes = 40 * 1024 * 1024;
+    let job = call(
+        &engine,
+        "SpawnText",
+        vec![Ext::String("x".repeat(bytes).into())],
+        false,
+    )
+    .await;
+    assert_eq!(engine.heap().gc_budget().full_collections, 1);
+    assert_eq!(
+        call(&engine, "JoinText", vec![job], true).await,
+        Ext::Int(i64::try_from(bytes).unwrap())
+    );
     engine.shutdown().await;
 }
 

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -636,6 +636,45 @@ pub(crate) mod tests {
         (vm, native_ptr)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn gc_polling_progress_survives_engine_handoffs() {
+        use bex_vm_types::{ConstValue, bytecode::Instruction};
+
+        let Object::Function(mut function) = native_function_object() else {
+            unreachable!()
+        };
+        function.kind = FunctionKind::Bytecode;
+        // Every iteration hands control to the engine before the backedge.
+        // No single exec call reaches the polling interval on its own.
+        function.bytecode = Bytecode {
+            instructions: vec![
+                Instruction::LoadConst(0),
+                Instruction::LoadConst(1),
+                Instruction::SendEvent,
+                Instruction::Jump(-3),
+            ],
+            constants: vec![
+                ConstValue::Object(ObjectIndex::from_raw(1)),
+                ConstValue::Int(42),
+            ],
+            ..Bytecode::default()
+        };
+        function.bytecode.compact = Some(function.bytecode.lower_to_compact());
+        let mut vm = test_vm(vec![
+            Object::Function(function),
+            Object::String("tick".into()),
+        ]);
+        let entry = vm.idx_to_ptr(ObjectIndex::from_raw(0));
+        vm.set_entry_point(entry, &[]);
+        vm.early_yield = EarlyYieldCheck::with_interval(Arc::new(AtomicBool::new(true)), 3);
+
+        for _ in 0..3 {
+            assert!(matches!(vm.exec().unwrap(), VmExecState::Event { .. }));
+        }
+        assert!(matches!(vm.exec().unwrap(), VmExecState::EarlyYield));
+    }
+
     #[test]
     fn runtime_cache_identity_unwraps_callable_allocations() {
         let (mut vm, function) = vm_with_native_entry();
@@ -7314,12 +7353,9 @@ impl BexVm {
     /// Wraps `exec_inner` to convert `InternalError` → `TracedInternalError`
     /// with a captured stack trace.
     pub fn exec(&mut self) -> Result<VmExecState, VmError> {
-        // Re-arm the long-running-loop detector at every yield boundary so
-        // each `exec()` call starts with a fresh budget; a single `exec()`
-        // call yields back to the embedder eventually (e.g. via `Await`,
-        // `EarlyYield`, etc.), which is the right granularity for the
-        // counter to reset at.
-        self.early_yield.reset();
+        // Keep GC polling progress across engine handoffs. Returning from
+        // exec (for example, to spawn a child) does not necessarily release
+        // the heap permit. The checker resets its own counter when it polls.
 
         // BAML_KPERF: read PMCs around this exec() on the current worker thread.
         let kp = crate::kperf::enabled();


### PR DESCRIPTION
A parent BAML VM spawning many short-lived children can keep GC waiting while allocation spending grows far beyond its budget. This adds a safe collection checkpoint after spawn setup and preserves GC polling progress across VM re-entry.

## Issue Reference

Next layer above #4844 (`codex/gc-idle-cleanup`).

## Changes

A workload that starts all its children before awaiting their results exposes the problem:

```baml
while (i < count) {
    jobs.push(spawn { Work(256) });
    i = i + 1;
}
for (let job in jobs) {
    sum = sum + (await job);
}
```

**Before:** each spawn returns from `BexVm::exec()`, and re-entry resets the GC polling counter. Repeated short executions can therefore avoid reaching the polling interval. Tokio can also suspend spawn setup while the parent still holds its heap permit, leaving a requested collection waiting for that parent.

**After:** the polling counter carries across re-entry and resets when it actually polls. After each successful spawn, the engine checks allocation pressure and, on native targets, the park-request flag. If either requests GC, it enters the existing `gc_safepoint` path to release its permit, collect or cooperate with another collector, and reacquire before resuming.

The checkpoint is after child registration, after the future is pushed onto the parent's GC-tracked stack, and after the futures-registry guard is dropped. Both parent and child roots can therefore be forwarded by moving GC. With neither pressure nor a park request, spawn continues without renewing its permit. This uses the existing collection policy; it adds no Tokio hooks or CPU timeslicing.

## Testing

Rebased the full four-PR stack onto `canary` at `bd85ce9de`. On the combined result, **271 tests passed** with `heap_debug,gc_profiling` in `fasttest`: 126 engine unit tests, 100 heap unit tests, 36 VM unit tests, and 9 allocation-budget integration tests. Full native workspace Clippy and the WASM Clippy task passed. The production patches rebased unchanged; the spawn regression now creates object-slot pressure.

Historical measurements from the initial implementation (`a303df192`), before rebasing onto the updated slot-only allocation policy and work-guard lifecycle. These numbers do not measure the rebased stack. Paired native repro runs, four Tokio workers, optimized builds with `gc_profiling` and without `heap_debug`. Each child retains 256 three-integer arrays until returning; the parent retains the child futures. Execution time excludes source compilation; RSS is the whole process peak. These are individual paired measurements, not a throughput guarantee.

| Workload | Before | After |
| --- | --- | --- |
| 10,000 allocating children | 752 MiB; 2.116 s; 1 full GC | 299 MiB; 2.116 s; 16 full GCs |
| 50,000 allocating children | Stopped by the 1 GiB RSS guard | 314 MiB; completed in 12.273 s; 81 full GCs |
| 10,000 children with no array elements | 0.145 s; 0 GCs | 0.145 s; 0 GCs |

The single-worker allocating case also completed with lower RSS (747 → 295 MiB). With explicit full-GC requests every 10 ms, the 50,000-child case completed at 315 MiB with 629 collections; the original hit the RSS guard while a collection was waiting. Frequent explicit collection took 19.962 s, versus 12.273 s with automatic triggering.

- 105 selected tests passed with heap safety checks enabled: VM unit tests, allocation budget, cancellation, task groups, detached work, finalizers, early yielding, and GC during future operations.
- Added regressions for polling across engine handoffs and collection after spawn while preserving captured values and the future handle. After rebasing, the spawn test imports enough short-string objects to exceed the slot budget; it no longer relies on large string backing storage to trigger GC.
- Native Clippy for all targets of `bex_vm` and `bex_engine` passed with warnings denied; WASM engine compilation passed. The commit hooks also passed formatting and full-workspace Clippy with all targets and features.

GC can now make progress through the reproduced spawn burst. Live children and retained futures still consume memory; this is not a hard RSS bound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management during concurrent task creation, helping garbage collection run reliably under allocation pressure.
  * Preserved garbage-collection polling progress when execution switches between engine handoffs.
  * Improved stability when processing large text allocations and spawned computations.

* **Tests**
  * Added coverage for garbage collection during task spawning and continued polling across repeated execution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->