### PR TITLE
ci: acknowledge packed-program growth from the content-block stdlib

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -66,6 +66,12 @@ policy.max_delta_pct = 3.0
 # 12 native BAML provider clients replaced the Rust `sys_llm` shim: their
 # bytecode ships in every packed program. Each ceiling is ~3% above the
 # re-recorded baseline in `.ci/size-gate`.
+#
+# Bumped again (PR #4807, content-block journal): every client lowers
+# rendered prompts, user turns, tool results and model turns through one
+# block path, plus the Degrade rewrite and the `UserMessage` /
+# `ToolCompleted` constructors — ~4% more stdlib bytecode. Ceilings are ~3%
+# above the CI-measured baselines recorded alongside.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
 max_file_bytes = "26.4 MiB"
 


### PR DESCRIPTION
## Summary

#4807 grew the packed stdlib program by ~4% on every platform (per-client block lowering, the Degrade journal rewrite, and the `UserMessage` / `ToolCompleted` constructors and projections, ~+900 net lines of BAML). It merged with the size gate red, so canary now carries the growth against the old `packed-program` baselines and ceilings, and every subsequent PR's gate fails on it.

This records the CI-measured sizes as the new `packed-program` baselines (`.ci/size-gate/*.toml`) and re-pegs the per-platform `max_file_bytes` ceilings in `.cargo/size-gate.toml` ~3% above them, as that file's policy prescribes. `baml-cli` and `bridge_wasm` were within limits and are unchanged.

## Stack

Follow-up to #4807 (merged); unblocks the size gate for #4808–#4811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI size-gate and baseline metadata only; no application or runtime behavior changes.
> 
> **Overview**
> **Unblocks CI** after merged #4807 enlarged the shipped `packed-program` artifact (~4% more stdlib bytecode from unified content-block lowering, Degrade journal work, and `UserMessage` / `ToolCompleted` helpers).
> 
> The PR **re-records** CI-measured `packed-program` sizes under `.ci/size-gate/` and **raises** per-platform `max_file_bytes` ceilings in `.cargo/size-gate.toml` to ~3% above those baselines (macOS **26.4 MiB**, Linux **29.2 MiB**, Windows **31.7 MiB**). A comment in that file documents the #4807 rationale. **`baml-cli`** and **`bridge_wasm`** thresholds are left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba8737d95dba3bb4a07c88e55cc6a9cdd5c25112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added context to native artifact size limits, noting updated ceilings associated with recent content-processing and standard-library changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->