### PR TITLE
refactor: clarify profiling marker and decoder names

### DIFF
--- a/TASK/baml-query-handoff.md
+++ b/TASK/baml-query-handoff.md
@@ -168,7 +168,7 @@ P0:
    exists). `EngineStarted` rides the registry-side vector, drained *after*
    the slot scan, ordered before same-engine `RootStarted`s.
 5. **`started_ns` = `admitted_ticks` sampled in `register_root`**, not the
-   `StartThread` record (emitted later, can be lost).
+   `BexThreadStart` record (emitted later, can be lost).
 6. **`Owner::Writer` has a 64 KiB minimum charge** — the writer takes one
    `meta_queue` reservation at session start, never per-record reservations.
 7. **`StreamStarted` only when `high_water().meta == 0`** — re-opened

--- a/TASK/baml-query-log.md
+++ b/TASK/baml-query-log.md
@@ -115,7 +115,7 @@ amendments, loom re-run on the P0 tree, e2e run.py + bench perf numbers.
   `maintain_ready_executions` (take_admitted → finalize → publish_if_due),
   `force_publish`, Stream/Execution checkpoints,
   `configure_global_store_root` + `BAML_PROFILE_DIR`.
-- `decoder.rs`: `ExecutionRuntime` (root/runtime_id/program_id), hand-off to
+- `decoder.rs`: `ExecutionDecodeAccumulator` (root/runtime_id/program_id), hand-off to
   the writer (no publisher, no FinalizationState), durable
   `ThreadStart`/`ThreadEnd` emission with ts/name retention through pending
   tables, `apply_batch_outcomes`, §5.6 finalization (slot released

--- a/TASK/profiling-backend-mvp.md
+++ b/TASK/profiling-backend-mvp.md
@@ -300,7 +300,7 @@ function. The selected row is the outer, user-visible LLM function. Internal
 client/sysop helpers remain CCT-only unless they independently satisfy root or
 manual policy, and their time remains inside the outer call's inclusive time.
 
-The current reserved `CallFunction.flags: u8` is sufficient for the MVP:
+The current reserved `FunctionEnter.flags: u8` is sufficient for the MVP:
 
 | Bit | Meaning |
 |---:|---|
@@ -346,7 +346,7 @@ selected the call, the profiler retains the resulting runtime-ID annotation
 on that span. If the call is CCT-only, no exact span is created solely because
 its runtime identity changed.
 
-The implementation may replace the raw `SetFunctionId` record with an
+The implementation may replace the raw `SetBoundaryLocalId` record with an
 equivalent runtime-ID annotation record only after both the call-site
 `LocalId` path and mid-call `baml.id.set` retain their existing language
 behavior and selected-span attribution.
@@ -428,7 +428,7 @@ and its protected control memory starts with profiling off.
 guard. It does not allocate
 another task, map entry, or `Arc` per call, and it is deliberately not owned by
 `BexThread`: canary consumes/drops `BexThread` before its outer event-loop
-wrapper emits the final `EndThread`.
+wrapper emits the final `BexThreadEnd`.
 
 The registry is a fixed-capacity slot array allocated when the profiler starts.
 Execution admission/release may use its bounded free list; the spawn and
@@ -487,7 +487,7 @@ the shorter engine-local pair is never used as a durable key.
 Admission attaches the host runtime token and nonoptional program ID to the
 root logical thread via the registry slot and the `RootStarted` meta record;
 there is no `StartBoundary` fact (superseded by
-TASK/profiling-backend-streams.md §5.5). `StartThread` keeps its parent
+TASK/profiling-backend-streams.md §5.5). `BexThreadStart` keeps its parent
 thread/call reference and gains an optional spawn source span. The consumer
 propagates execution ownership and the parent context through that edge. A
 child-start that drains before its parent remains in the bounded unresolved
@@ -496,7 +496,7 @@ table.
 The host runtime token is also the root span's initial runtime ID. Once
 this admission fact exists, the profiler does not need a duplicate
 host-installed root
-`SetFunctionId` record. `SetFunctionId`/its replacement is reserved for actual
+`SetBoundaryLocalId` record. `SetBoundaryLocalId`/its replacement is reserved for actual
 language runtime-ID overrides and carries the per-call annotation ordinal.
 
 The first call on a spawned thread uses:
@@ -508,20 +508,20 @@ edge kind      = Spawn
 ~~~
 
 Two spawn expressions in the same parent therefore remain distinct. This
-requires plumbing the source span into `StartThread` (or an equivalent
+requires plumbing the source span into `BexThreadStart` (or an equivalent
 self-contained spawn fact); canary does not carry it today.
 
 The acknowledged root registration creates the first lease and initializes
 `active_threads = 1`. Every spawn, including a grandchild spawn, acquires a
 child lease by checked atomic increment **before** the child becomes runnable
-or its `StartThread` is attempted. The parent owns the new lease until the
+or its `BexThreadStart` is attempted. The parent owns the new lease until the
 spawn task accepts it; a scheduling/setup failure releases it immediately.
 Inside the task, canary's existing `SpawnProfCloser` owns the lease while the
 child is queued or before its event loop starts. On an abnormal drop it emits
-the synthetic `EndFunction`/`EndThread` first and releases the lease last. On
+the synthetic `FunctionExit`/`BexThreadEnd` first and releases the lease last. On
 normal loop entry it transfers the lease into a separate outer
 `ThreadProfileCompletionGuard`; that guard is held outside the consumed
-`BexThread`, records/attempts all final value, `EndFunction`, and `EndThread`
+`BexThread`, records/attempts all final value, `FunctionExit`, and `BexThreadEnd`
 work, completes any post-loop future settlement/unhandled bookkeeping that can
 wake another VM, and then releases the lease at the end of the spawned task.
 If the task future itself is dropped mid-loop, its execution future is
@@ -539,10 +539,10 @@ task.
 Child lease acquisition is a producer-local atomic operation. It is not an
 acknowledged consumer control message and it does not create another
 admission fact, runtime token, stream, or capture-policy root. The
-existing `StartThread` parent-thread/parent-call fact carries causal ownership
+existing `BexThreadStart` parent-thread/parent-call fact carries causal ownership
 to the consumer. If that structural record is lost, the lease still prevents
 early sealing while population health reports the missing thread attribution.
-When the producer itself knows the `StartThread` push was rejected, it stops
+When the producer itself knows the `BexThreadStart` push was rejected, it stops
 further profiler emission for that child subtree but retains the lease until
 the child completes. A record accepted and later found corrupt is reconciled
 by the consumer's bounded unresolved/loss path.
@@ -712,13 +712,13 @@ The producer adds one end-record variant:
 
 ~~~rust
 enum RawCallEnd {
-    EndFunction {
+    FunctionExit {
         status: FunctionEndStatus,
         thread_id: BexThreadId,
         call_id: BexCallId,
         end_ticks: u64,
     },
-    EndFunctionAwaited {
+    FunctionExitAwaited {
         status: FunctionEndStatus,
         thread_id: BexThreadId,
         call_id: BexCallId,
@@ -729,10 +729,10 @@ enum RawCallEnd {
 }
 ~~~
 
-`EndFunctionAwaited` is an alternative encoding of the same one call-end fact,
+`FunctionExitAwaited` is an alternative encoding of the same one call-end fact,
 not a second record. Its payload is the compact end plus twelve timing bytes
 before codec framing. Calls whose total and count are both zero use the
-existing `EndFunction` byte shape. The codec is versioned and golden-tested;
+existing `FunctionExit` byte shape. The codec is versioned and golden-tested;
 Phase 0 records the measured encoded sizes rather than copying stale sizes
 from the reference proposal.
 
@@ -1226,7 +1226,7 @@ The fixed dimensions are:
 - the closed loss-reason enums in Section 8.
 
 The structural push API returns success/failure. Before attempting a selected
-`CallFunction` push, the producer increments `spans_selected` in the execution
+`FunctionEnter` push, the producer increments `spans_selected` in the execution
 health block. If the push fails, it increments
 `StructuralStartTransportExceeded` and suppresses value copying for that call.
 If the start arrives but cannot resolve a context, the consumer records
@@ -2364,7 +2364,7 @@ not restate or weaken them.
 ### Phase 0: freeze contracts and measurements
 
 - Inventory all canary call/thread producers, suspension and unwind entries,
-  `EndFunction` emitters, internal-root suppressions, host value/logging
+  `FunctionExit` emitters, internal-root suppressions, host value/logging
   injection, and `$id` call-kind support.
 - Freeze durable `CallRef`/`ThreadRef` scope, nonoptional `ProgramId`,
   `ContextKey`, `ValueCid`, awaited-end, and error-record codecs with
@@ -2380,7 +2380,7 @@ not restate or weaken them.
 - Implement the Section 11 process/store `ProfilerSession::Off | On` and sole
   per-root `begin_root(UserBoundary|SuppressInternal)` interface.
 - Put the Section 4 resolver inside active roots and encode its result in the
-  reserved `CallFunction.flags` byte.
+  reserved `FunctionEnter.flags` byte.
 - Remove the independent `FunctionCallContext` value-capture path and move
   CLI/exec/LSP/WASM logging to its own optional logger interface.
 - Preserve all language IDs, `LocalId` mutation/consumption, and logging in
@@ -2397,7 +2397,7 @@ not restate or weaken them.
 - Add governor-charged active-thread/call/unresolved state and the O(1)
   publisher handles; replace fatal ring overflow with explicit nonfatal loss.
 - Implement Section 5.4's sparse await accumulator and single
-  `EndFunctionAwaited` variant across every declared suspension seam.
+  `FunctionExitAwaited` variant across every declared suspension seam.
 - Keep old output only as an oracle; transcode the awaited variant as an
   ordinary legacy end until Phase 7.
 
@@ -2489,9 +2489,9 @@ gates remain in force verbatim.
   each submit exactly one barrier through the same last-owner path.
 - **Child completion:** queue rejection, cancellation before first poll, task
   drop, engine error, and scheduling failure release one acquired lease.
-  Barriers placed (a) after inner-loop return but before final `EndThread` and
+  Barriers placed (a) after inner-loop return but before final `BexThreadEnd` and
   (b) during post-loop future settlement prove that neither consumed
-  `BexThread` nor early `EndThread` can release ownership before all final
+  `BexThread` nor early `BexThreadEnd` can release ownership before all final
   producer work stops.
 - **Root completion:** host drop/abort after acknowledged start yields
   `Abandoned` plus `RootAbandoned`; panic yields `Panicked`; setup/engine error
@@ -2506,7 +2506,7 @@ gates remain in force verbatim.
   immutable root result. A forever-running child honestly keeps the run open;
   profiling never cancels or joins it. Orderly engine shutdown preserves
   canary's existing wait-only behavior; this MVP adds no cancellation sweep.
-- **Loss and races:** losing child `StartThread` reports attribution loss while
+- **Loss and races:** losing child `BexThreadStart` reports attribution loss while
   its lease still prevents early seal. Counter saturation or stale generation
   makes that subtree profiler-off with
   `ProfilerThreadLeaseUnavailable` and preserves execution/identity.
@@ -2518,8 +2518,8 @@ gates remain in force verbatim.
 
 ### Timing
 
-- **Encoding:** a never-suspended call uses compact `EndFunction` with zero
-  await; one or ten waits use one `EndFunctionAwaited` carrying the summed
+- **Encoding:** a never-suspended call uses compact `FunctionExit` with zero
+  await; one or ten waits use one `FunctionExitAwaited` carrying the summed
   duration and count. Ready-inline sysops/futures allocate no sparse entry.
 - **Attribution:** async sysop, Await, AwaitAny, task-group/entry permit,
   EarlyYield, normal resume, cancellation wake-up, and OS-thread migration

--- a/TASK/profiling-backend-streams.md
+++ b/TASK/profiling-backend-streams.md
@@ -79,7 +79,7 @@ clean`; wasm = off.
 ### 2.1 Execution
 
 An **execution** is the tree of logical threads rooted at a thread whose
-`StartThread` record has `parent_thread_id == 0` (`record.rs:157-172`,
+`BexThreadStart` record has `parent_thread_id == 0` (`record.rs:157-172`,
 emitted at `bex_engine/src/lib.rs:3602-3609`). Its identity:
 
 ~~~rust
@@ -112,7 +112,7 @@ format (MVP §4.3, §12.4; `bex_engine/tests/identity.rs` passes unchanged).
 legacy history/playground plane, Section 10). Inside `prof/backend` it appears
 only as `RuntimeIdAnnotation.runtime_id`, `SpanRuntimeId.runtime_id`,
 `RootStarted.runtime_id`, `ExecutionMetadata.runtime_id`,
-`ExecutionRuntime.runtime_id` — "host/language runtime token, opaque to the
+`ExecutionDecodeAccumulator.runtime_id` — "host/language runtime token, opaque to the
 profiler". Renames (values unchanged): `BoundaryRegistry/Handle/Slot/State/
 Phase/EndStatus/Metadata` → `ExecutionRegistry/Handle/Slot/State/Phase/
 EndStatus/Metadata`; `RootProfileIntent::UserBoundary { boundary_id }` →
@@ -282,7 +282,7 @@ trailing bytes, unknown tag → `MetaUnknownTag(tag)`.
   NULL.
 - `RootStarted.started_ns = TickConverter::to_ns(admitted_ticks)` where
   `admitted_ticks = now_ticks()` sampled at the top of `register_root`
-  (Section 5.5). It is **not** derived from the root `StartThread` record
+  (Section 5.5). It is **not** derived from the root `BexThreadStart` record
   (which is emitted after admission, `lib.rs:3596-3609`, and may be lost).
   `runtime_id` = host token. There is no `entry_function_id` (Q4 resolved:
   dropped — the root span's `function_id` is in the data plane).
@@ -338,7 +338,7 @@ Tags 0–5 keep their numbers and `fact_count`/`tag`/`len` framing.
 
 | fact | change |
 |---|---|
-| `SpanStart` (0) | **remove** leading `boundary_id[16]`. Body: `CallRef(40) ‖ opt CallRef parent ‖ ThreadRef(32) ‖ ContextRef ‖ function_id u32 ‖ opt call_site ‖ edge_kind u8 ‖ started_ns u64 ‖ selection_reasons u8 ‖ roles u8 ‖ opt (annotation_ordinal u32 ‖ runtime_id[16])` (order as `evidence_codec.rs:112-134` minus the first field). The ordinal-0 annotation's source is `ExecutionRuntime.runtime_id` (today `publisher.meta().boundary_id`, `decoder.rs:1078-1083`). |
+| `SpanStart` (0) | **remove** leading `boundary_id[16]`. Body: `CallRef(40) ‖ opt CallRef parent ‖ ThreadRef(32) ‖ ContextRef ‖ function_id u32 ‖ opt call_site ‖ edge_kind u8 ‖ started_ns u64 ‖ selection_reasons u8 ‖ roles u8 ‖ opt (annotation_ordinal u32 ‖ runtime_id[16])` (order as `evidence_codec.rs:112-134` minus the first field). The ordinal-0 annotation's source is `ExecutionDecodeAccumulator.runtime_id` (today `publisher.meta().boundary_id`, `decoder.rs:1078-1083`). |
 | `SpanEnd` (1), `SpanRuntimeId` (2), `ValueOccurrence` (3), `TerminalErrorRef` (5) | unchanged |
 | `ErrorCapture` (4) | **remove** `boundary_id[16]` after `ErrorCaptureId` (`evidence.rs:182-213`); sub-codec magic `BAMLERR1`/version stay. |
 | `ContextRef` | `Overflow` = `1 ‖ reason u8 ‖ edge_kind u8` (today `1 ‖ BoundaryRef(40) ‖ reason ‖ edge`, `evidence_codec.rs:305-319`, `evidence.rs:302-317`). `BoundaryRef` type deleted; `ActiveCctEpoch.boundary` field and the `BoundaryRef` parameter of `ActiveCctEpoch::new` (`cct.rs:214-230`) deleted; `record_overflow` (`cct.rs:507-522`) builds the new variant; `BoundaryRuntime::new`/`fresh_epoch` (`decoder.rs:198-233`) adjusted; `backend/mod.rs:33` export removed. |
@@ -572,7 +572,7 @@ Inputs (consumer thread only):
    pending that is publishable (not waiting on `inflight`/`indeterminate`),
    repeat from step 3.
 
-**Health sink.** "The execution's health" means `ExecutionRuntime.health`
+**Health sink.** "The execution's health" means `ExecutionDecodeAccumulator.health`
 while `registry.validate(handle)` succeeds (slot still live); otherwise the
 pending `RootEnded(root)`'s health (which by the eligibility rule is still
 pending whenever a group of that execution can still complete or fail —
@@ -651,7 +651,7 @@ publish_interval)` when `publish_interval < 50 ms`.
 5. `registry.reserve_root(ExecutionMetadata { root_thread_ref, runtime_id, admitted_ticks })`
    → slot (with `admitted_pending = true`, new slot flag) or
    `Inactive(ExecutionStateUnavailable)` (unchanged).
-6. `publishers[slot] = Some(ExecutionRuntime::new(generation, root_thread_ref, runtime_id, program_id, process_euid, engine_id))`.
+6. `publishers[slot] = Some(ExecutionDecodeAccumulator::new(generation, root_thread_ref, runtime_id, program_id, process_euid, engine_id))`.
 7. Return `Active(ActiveRootAdmission { profiler: Active(ActiveRootProfiler { root_thread_ref }), completion })`.
 
 No store call, no lock, no I/O, no queue send. `reserve_root` stores
@@ -690,7 +690,7 @@ recorded by the registry at the one-to-zero lease release (new field set in
 `Abandoned`, as `decoder.rs:2303-2305`). Then `registry.acknowledge_terminal
 (handle, ExecutionPhase::Released)` immediately (slot cleared, generation
 bumped, free-listed; `acknowledge_terminal` accepts only `Released`); the
-`ExecutionRuntime` is dropped. `ExecutionPhase` = `Open, RootReturned,
+`ExecutionDecodeAccumulator` is dropped. `ExecutionPhase` = `Open, RootReturned,
 Closing, Released` (`Sealed`/`ReleasedIncomplete` removed). `FinalizationState`
 is removed. The nuance of today's `flush_evidence` ("on CCT `Lost`, drop the
 evidence batch", `decoder.rs:1957-1965`) disappears: CCT and evidence of one
@@ -863,7 +863,7 @@ time; `ExecutionSummary.status = Running` means "at bind time".
 ### 7.1 `bex_engine` admission call site (`lib.rs:3560-3610`)
 
 `register_root(RootProfileIntent::UserRoot { runtime_id }, root_thread_ref, program_id)`.
-`install_boundary_id_for_current_call` unchanged. Root `StartThread` record
+`install_boundary_id_for_current_call` unchanged. Root `BexThreadStart` record
 unchanged (parent 0/0).
 
 ### 7.2 Engine activation
@@ -894,16 +894,16 @@ happens once per engine, before any root of that engine can be admitted.
 - `insert_thread(resources, thread_ref, exec, parent: Option<(ThreadRef, CallRef)>, spawn_site, started_ticks, name)`
   (today `decoder.rs:1356`, signature `(resources, thread_ref, boundary,
   spawn_parent: Option<ContextKeyProjection>, spawn_site)`) pushes
-  `ThreadStart`; `EndThread` consumption pushes `ThreadEnd` (ts from the
+  `ThreadStart`; `BexThreadEnd` consumption pushes `ThreadEnd` (ts from the
   record). **New retention**: the decoder keeps `ts_ticks` and `name` of
-  `StartThread`/`StartThreadSpawn` and `ts_ticks` of `EndThread` through its
+  `BexThreadStart`/`BexThreadStartSpawned` and `ts_ticks` of `BexThreadEnd` through its
   pending tables (`insert_pending_thread` `decoder.rs:1522-1557`,
   `insert_pending_thread_end` `:1559-1600`, both of which drop them today).
 - `rollover_if_needed`, `flush_evidence`, and finalization call
   `writer.hand_off` instead of `publisher.publish_*`; the rule "seal and
   include the current CCT epoch whenever evidence is handed off"
   (`flush_evidence`, `decoder.rs:1932-2005`) is preserved.
-- `ExecutionRuntime { generation, root: ThreadRef, runtime_id: BoundaryId, cct: Option<ActiveCctEpoch>, evidence: EvidenceBatch, health: ExecutionHealthSnapshot }`.
+- `ExecutionDecodeAccumulator { generation, root: ThreadRef, runtime_id: BoundaryId, cct: Option<ActiveCctEpoch>, evidence: EvidenceBatch, health: ExecutionHealthSnapshot }`.
 - `DecoderCommand` variants carry `ExecutionHandle` (rename only).
 
 ### 7.4 Registry (`boundary.rs` → `execution.rs`)

--- a/baml_language/crates/baml_lsp_server/tests/playground_telemetry.rs
+++ b/baml_language/crates/baml_lsp_server/tests/playground_telemetry.rs
@@ -16,7 +16,7 @@ use bex_prof_store::{
             ProfilerSession, RootAdmission, RootProfileIntent,
         },
         clock,
-        record::{FunctionEndStatus, MAX_RECORD_LEN, RawRecord, ThreadEndStatus},
+        record::{FunctionEndStatus, MAX_RECORD_LEN, Marker, ThreadEndStatus},
     },
 };
 
@@ -65,7 +65,7 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
     ) else {
         panic!("root must be admitted");
     };
-    let emit = |record: RawRecord<'_>| {
+    let emit = |record: Marker<'_>| {
         let mut bytes = [0; MAX_RECORD_LEN];
         let len = record.encode(&mut bytes);
         backend::consume_engine_bytes(euid, engine_id, &bytes[..len]);
@@ -86,7 +86,7 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
     let unselected =
         backend::resolve_capture_plan(false, FunctionCaptureClass::Ordinary, None).to_call_flags();
 
-    emit(RawRecord::StartThread {
+    emit(Marker::BexThreadStart {
         flags: 0,
         thread_id: thread_ref.thread_id,
         parent_thread_id: BexThreadId(0),
@@ -94,7 +94,7 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
         ts_ticks: tick(0),
         name: b"",
     });
-    emit(RawRecord::CallFunction {
+    emit(Marker::FunctionEnter {
         flags: selected,
         thread_id: thread_ref.thread_id,
         call_id: BexCallId(6),
@@ -108,7 +108,7 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
     for (call_id, busy_ms) in [(7u64, 12), (8, 8)] {
         let start = tick(0);
         let end = tick(busy_ms);
-        emit(RawRecord::CallFunction {
+        emit(Marker::FunctionEnter {
             flags: unselected,
             thread_id: thread_ref.thread_id,
             call_id: BexCallId(call_id),
@@ -117,20 +117,20 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
             call_site: None,
             ts_ticks: start,
         });
-        emit(RawRecord::EndFunction {
+        emit(Marker::FunctionExit {
             status: FunctionEndStatus::Ok,
             thread_id: thread_ref.thread_id,
             call_id: BexCallId(call_id),
             ts_ticks: end,
         });
     }
-    emit(RawRecord::EndFunction {
+    emit(Marker::FunctionExit {
         status: FunctionEndStatus::Ok,
         thread_id: thread_ref.thread_id,
         call_id: BexCallId(6),
         ts_ticks: tick(6),
     });
-    emit(RawRecord::EndThread {
+    emit(Marker::BexThreadEnd {
         status: ThreadEndStatus::Completed,
         thread_id: thread_ref.thread_id,
         ts_ticks: tick(0),

--- a/baml_language/crates/baml_query_profiles/tests/profiles_e2e.rs
+++ b/baml_language/crates/baml_query_profiles/tests/profiles_e2e.rs
@@ -16,7 +16,7 @@ use bex_prof_store::{
             self, CodecVersion, DiskBudget, ExecutionEndStatus, FunctionCaptureClass,
             ProfilerConfig, ProfilerSession, PublishCasResult, RootAdmission, RootProfileIntent,
         },
-        record::{FunctionEndStatus, MAX_RECORD_LEN, RawRecord, ThreadEndStatus},
+        record::{FunctionEndStatus, MAX_RECORD_LEN, Marker, ThreadEndStatus},
     },
 };
 
@@ -70,12 +70,12 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
     ) else {
         panic!("root must be admitted");
     };
-    let emit = |record: RawRecord<'_>| {
+    let emit = |record: Marker<'_>| {
         let mut bytes = [0; MAX_RECORD_LEN];
         let len = record.encode(&mut bytes);
         backend::consume_engine_bytes(euid, engine_id, &bytes[..len]);
     };
-    emit(RawRecord::StartThread {
+    emit(Marker::BexThreadStart {
         flags: 0,
         thread_id: thread_ref.thread_id,
         parent_thread_id: BexThreadId(0),
@@ -83,7 +83,7 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
         ts_ticks: 10,
         name: b"",
     });
-    emit(RawRecord::CallFunction {
+    emit(Marker::FunctionEnter {
         flags: backend::resolve_capture_plan(true, FunctionCaptureClass::Ordinary, None)
             .to_call_flags(),
         thread_id: thread_ref.thread_id,
@@ -93,13 +93,13 @@ fn write_store(root: &Path, euid: ProcessEuid, engine: u64) -> ThreadRef {
         call_site: None,
         ts_ticks: 20,
     });
-    emit(RawRecord::EndFunction {
+    emit(Marker::FunctionExit {
         status: FunctionEndStatus::Ok,
         thread_id: thread_ref.thread_id,
         call_id: BexCallId(6),
         ts_ticks: 30,
     });
-    emit(RawRecord::EndThread {
+    emit(Marker::BexThreadEnd {
         status: ThreadEndStatus::Completed,
         thread_id: thread_ref.thread_id,
         ts_ticks: 40,

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -302,7 +302,7 @@ pub(crate) enum ThreadOutcome {
 }
 
 /// How a spawned child settled its future — drives the profiling
-/// `EndThread` status (children settle as `Ok(SettledChild)` even when
+/// `BexThreadEnd` status (children settle as `Ok(SettledChild)` even when
 /// cancelled or errored, so the kind must travel in the outcome).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ChildSettleKind {
@@ -349,11 +349,11 @@ impl Drop for ThreadBoundaryLeaseGuard {
 /// task future is dropped before its event loop takes over (abnormal host
 /// teardown — e.g. dropping the runtime while the task is queued on a
 /// `TaskGroup` ticket or parked on the heap permit). By that point the
-/// Spawn arm has emitted `StartThread` and `set_entry_point` the entry
+/// Spawn arm has emitted `BexThreadStart` and `set_entry_point` the entry
 /// `CallFunction`; nothing else would close them. Armed at the top of the
 /// task body; also the closer for the queued-then-cancelled early return;
 /// defused once `run_thread_event_loop` is entered (its wrapper owns
-/// `EndThread` on every return path from there). Emits via the TLS ring
+/// `BexThreadEnd` on every return path from there). Emits via the TLS ring
 /// lookup, so dropping from any thread is sound. Drops *after* the loop
 /// has started (mid-await teardown) are out of scope — the artifact is
 /// torn-tail territory there anyway.
@@ -374,7 +374,7 @@ impl SpawnProfCloser {
 
 impl Drop for SpawnProfCloser {
     fn drop(&mut self) {
-        use bex_events::prof::record::{FunctionEndStatus, RawRecord, ThreadEndStatus};
+        use bex_events::prof::record::{FunctionEndStatus, Marker, ThreadEndStatus};
         if !self.armed || !self.engine.profiler_session.is_on() {
             return;
         }
@@ -387,7 +387,7 @@ impl Drop for SpawnProfCloser {
             let ts_ticks = bex_events::prof::clock::now_ticks();
             let committed = match self.awaited {
                 Some((await_ns, await_count)) => {
-                    self.engine.prof_emit(&RawRecord::EndFunctionAwaited {
+                    self.engine.prof_emit(&Marker::FunctionExitAwaited {
                         status: FunctionEndStatus::Cancelled,
                         thread_id,
                         call_id: self.entry_call_id,
@@ -396,7 +396,7 @@ impl Drop for SpawnProfCloser {
                         await_count,
                     })
                 }
-                None => self.engine.prof_emit(&RawRecord::EndFunction {
+                None => self.engine.prof_emit(&Marker::FunctionExit {
                     // Dropped-before-run is a cancellation, not a failure.
                     status: FunctionEndStatus::Cancelled,
                     thread_id,
@@ -408,7 +408,7 @@ impl Drop for SpawnProfCloser {
                 self.engine.prof_record_transport_loss(boundary_handle);
             }
         }
-        if !self.engine.prof_emit(&RawRecord::EndThread {
+        if !self.engine.prof_emit(&Marker::BexThreadEnd {
             status: ThreadEndStatus::Cancelled,
             thread_id,
             ts_ticks: bex_events::prof::clock::now_ticks(),
@@ -2448,7 +2448,7 @@ impl BexEngine {
     /// engine arms run after `.await`s, where the task may have migrated
     /// OS threads (the VM snapshot is only valid within one exec resume).
     #[allow(unsafe_code)]
-    fn prof_emit(&self, rec: &bex_events::prof::record::RawRecord<'_>) -> bool {
+    fn prof_emit(&self, rec: &bex_events::prof::record::Marker<'_>) -> bool {
         if !self.profiler_session.is_on() {
             return true;
         }
@@ -2487,7 +2487,7 @@ impl BexEngine {
     fn prof_refresh_vm_ring(&self, vm: &mut bex_vm::BexVm) {
         vm.prof_ring = if self.profiler_session.is_on() && !vm.prof_suppressed {
             bex_events::prof::ring_for_engine(self.engine_id.0)
-                .map(bex_events::prof::RingHandle::ring)
+                .map(bex_events::prof::OSThreadMarkerRingHandle::ring)
         } else {
             None
         };
@@ -2516,11 +2516,11 @@ impl BexEngine {
         call_id: u64,
         status: bex_events::prof::record::FunctionEndStatus,
     ) {
-        use bex_events::prof::record::RawRecord;
+        use bex_events::prof::record::Marker;
         let ts_ticks = bex_events::prof::clock::now_ticks();
         let thread_id = BexThreadId(vm.prof_thread_id);
         let committed = match vm.prof_take_await(call_id) {
-            Some((await_ns, await_count)) => self.prof_emit(&RawRecord::EndFunctionAwaited {
+            Some((await_ns, await_count)) => self.prof_emit(&Marker::FunctionExitAwaited {
                 status,
                 thread_id,
                 call_id: BexCallId(call_id),
@@ -2528,7 +2528,7 @@ impl BexEngine {
                 await_ns,
                 await_count,
             }),
-            None => self.prof_emit(&RawRecord::EndFunction {
+            None => self.prof_emit(&Marker::FunctionExit {
                 status,
                 thread_id,
                 call_id: BexCallId(call_id),
@@ -3976,14 +3976,14 @@ impl BexEngine {
         // `$id` works with profiling off, and the ids it exposes are the
         // VM-minted ids the event stream records.
         vm.bex_ref_seed = Some((self.process_euid, self.engine_id));
-        // No ring snapshot and no StartThread here: the permit acquisition
+        // No ring snapshot and no BexThreadStart here: the permit acquisition
         // below awaits (the snapshot would go stale across an OS-thread
         // migration), and early-error returns between here and the run loop
-        // would leak a StartThread with no EndThread. Both happen at
-        // guaranteed-balanced points instead: the StartThread in
+        // would leak a BexThreadStart with no BexThreadEnd. Both happen at
+        // guaranteed-balanced points instead: the BexThreadStart in
         // run_entry_point right before set_entry_point (§7 decision 7 —
         // straight-line into run_thread_event_loop, whose every exit path
-        // emits the EndThread), and the snapshot at the same spot plus each
+        // emits the BexThreadEnd), and the snapshot at the same spot plus each
         // loop-head resume.
         let root_thread = BexThread::new_root(vm, cancel);
         let inactive = self.heap_permit_manager.new_permit(root_thread).await;
@@ -4092,16 +4092,16 @@ impl BexEngine {
         // D5a: the entry-frame CallFunction below pushes into the snapshot;
         // take it on THIS thread, after the last await before the push.
         self.prof_refresh_vm_ring(&mut thread.vm);
-        // §7 decision 7: the root StartThread is emitted before the entry
+        // §7 decision 7: the root BexThreadStart is emitted before the entry
         // frame's CallFunction so that every thread's first record is its
-        // StartThread — a uniform invariant for renderers (children get
+        // BexThreadStart — a uniform invariant for renderers (children get
         // theirs at the Spawn arm, before their entry push). BALANCE: the
-        // matching EndThread is emitted by run_thread_event_loop on every
+        // matching BexThreadEnd is emitted by run_thread_event_loop on every
         // exit path; no early return / `?` may be introduced between this
         // emission and the run_thread_event_loop call below, or an error
-        // path would leak an unclosed StartThread.
+        // path would leak an unclosed BexThreadStart.
         if thread.vm.prof_ring.is_some() {
-            let committed = self.prof_emit(&bex_events::prof::record::RawRecord::StartThread {
+            let committed = self.prof_emit(&bex_events::prof::record::Marker::BexThreadStart {
                 flags: 0,
                 thread_id: BexThreadId(thread.vm.prof_thread_id),
                 parent_thread_id: BexThreadId(0), // engine-root thread
@@ -5785,7 +5785,7 @@ impl BexEngine {
         // Snapshot on the spawning thread, immediately before the entry
         // frame's CallFunction lands (no await in between); the loop-head
         // refresh re-snapshots on the child task's own thread later. The
-        // StartThread (with the spawn edge) was already emitted into the
+        // BexThreadStart (with the spawn edge) was already emitted into the
         // ring at the Spawn arm.
         self.prof_refresh_vm_ring(&mut child_vm);
         child_vm.set_entry_point(closure, &[]);
@@ -5808,7 +5808,7 @@ impl BexEngine {
         let task = async move {
             // Declared first so it drops last: if this future is dropped at
             // any await below (before the event loop takes over), the closer
-            // emits the child's EndFunction/EndThread (follow-up 11).
+            // emits the child's EndFunction/BexThreadEnd (follow-up 11).
             let mut prof_closer = SpawnProfCloser {
                 engine: Arc::clone(&engine),
                 prof_thread_id,
@@ -5849,7 +5849,7 @@ impl BexEngine {
                             );
                         }
                         // The armed `prof_closer` emits the profiling
-                        // closes (EndFunction{Cancelled} + EndThread{
+                        // closes (EndFunction{Cancelled} + BexThreadEnd{
                         // Cancelled}) when it drops at this return — the
                         // event loop that would otherwise close them never
                         // runs for a queued-then-cancelled spawn.
@@ -5870,7 +5870,7 @@ impl BexEngine {
             }
             // The entry call's id was minted by set_entry_point on the
             // spawning thread; its CallFunction is already in the ring.
-            // EndThread (ring) is emitted by the run_thread_event_loop
+            // BexThreadEnd (ring) is emitted by the run_thread_event_loop
             // wrapper on every exit path from here on.
             prof_closer.defuse();
             match engine
@@ -5889,7 +5889,7 @@ impl BexEngine {
             {
                 Ok(ThreadOutcome::SettledChild(_)) => {}
                 // The abnormal arms close any spans the event loop left open
-                // before the thread ends — the ring EndThread (emitted by the
+                // before the thread ends — the ring BexThreadEnd (emitted by the
                 // run_thread_event_loop wrapper) must never strand open spans.
                 Ok(ThreadOutcome::RootValue(_)) => {
                     tracing::error!(
@@ -5937,7 +5937,7 @@ impl BexEngine {
     }
 
     /// Runs a thread's event loop (see [`Self::run_thread_event_loop_inner`])
-    /// and closes its profiling lifecycle: one `EndThread` per `StartThread`,
+    /// and closes its profiling lifecycle: one `BexThreadEnd` per `BexThreadStart`,
     /// on every exit path (the inner loop has many early returns; thread
     /// join at shutdown makes the final commits visible to the consumer per
     /// plan §1).
@@ -5960,10 +5960,10 @@ impl BexEngine {
         let profile_thread = thread.vm.prof_ring.is_some();
         let prof_thread_id = thread.vm.prof_thread_id;
         let prof_boundary_handle = thread.vm.prof_boundary_handle;
-        // StartThread was already emitted before this function: roots in
+        // BexThreadStart was already emitted before this function: roots in
         // run_entry_point (right before `set_entry_point`, §7 decision 7 —
-        // StartThread-first is a wire invariant), children at the Spawn
-        // arm. This wrapper owns the matching EndThread on every exit path;
+        // BexThreadStart-first is a wire invariant), children at the Spawn
+        // arm. This wrapper owns the matching BexThreadEnd on every exit path;
         // queued-then-cancelled spawns (which never reach this loop) close
         // their lifecycle in spawn_thread_inner's task body.
         let result = self
@@ -5998,7 +5998,7 @@ impl BexEngine {
                 }
                 Err(_) => bex_events::prof::record::ThreadEndStatus::Errored,
             };
-            let committed = self.prof_emit(&bex_events::prof::record::RawRecord::EndThread {
+            let committed = self.prof_emit(&bex_events::prof::record::Marker::BexThreadEnd {
                 status,
                 thread_id: BexThreadId(prof_thread_id),
                 ts_ticks: bex_events::prof::clock::now_ticks(),
@@ -6621,7 +6621,7 @@ impl BexEngine {
                     if child_profile_active {
                         let name = spawn_name.as_deref().unwrap_or("");
                         let committed = self.prof_emit(
-                            &bex_events::prof::record::RawRecord::StartThreadSpawn {
+                            &bex_events::prof::record::Marker::BexThreadStartSpawned {
                                 flags: 0,
                                 thread_id: BexThreadId(child_prof_thread_id),
                                 parent_thread_id: BexThreadId(thread.vm.prof_thread_id),

--- a/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
+++ b/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
@@ -780,7 +780,7 @@ mod stress {
             // SAFETY: same single consumer.
             unsafe {
                 reg.sweep(&mut |_: &'static OSThreadMarkerRing, b: &[u8]| {
-                    collect_seqs(b, &mut seen)
+                    collect_seqs(b, &mut seen);
                 })
             };
             sweeps += 1;

--- a/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
+++ b/baml_language/crates/bex_events/src/prof/concurrency_tests.rs
@@ -14,7 +14,7 @@
 #![allow(unsafe_code)]
 
 use crate::prof::{
-    ring::{Ring, RingCtx, RingState},
+    ring::{OSThreadMarkerRing, RingCtx, RingState},
     sync::thread,
 };
 
@@ -43,17 +43,18 @@ fn collect_seqs(bytes: &[u8], out: &mut Vec<u64>) {
 /// provenance) after all threads quiesce. Production never frees rings; the
 /// reclaim exists so loom iterations and miri runs stay leak-tight.
 struct TestRing {
-    ring: *mut Ring,
+    ring: *mut OSThreadMarkerRing,
 }
 
 impl TestRing {
     fn new(ctx: &'static RingCtx, seg_bytes: usize, freelist_cap: usize, engine_id: u64) -> Self {
         Self {
-            ring: Ring::alloc(ctx, seg_bytes, freelist_cap, engine_id).expect("test ring capacity"),
+            ring: OSThreadMarkerRing::alloc(ctx, seg_bytes, freelist_cap, engine_id)
+                .expect("test ring capacity"),
         }
     }
 
-    fn get(&self) -> &'static Ring {
+    fn get(&self) -> &'static OSThreadMarkerRing {
         unsafe { &*self.ring }
     }
 }
@@ -149,10 +150,14 @@ mod scenarios {
             assert_eq!(seen, vec![3, 4]);
         }
         // Behavioral leak check (miri's leak checker is off for these tests):
-        // Ring::drop must walk both the live chain and the free list back to
+        // OSThreadMarkerRing::drop must walk both the live chain and the free list back to
         // a zero balance.
         drop(tr);
-        assert_eq!(ctx.live_bytes(), 0, "Ring::drop leaked segments");
+        assert_eq!(
+            ctx.live_bytes(),
+            0,
+            "OSThreadMarkerRing::drop leaked segments"
+        );
     }
 
     /// (3) Free-list SPSC integrity: heavier producer/consumer traffic so
@@ -191,14 +196,14 @@ mod scenarios {
         let ring = tr.get();
 
         let mut tagged: Vec<(u64, u64)> = Vec::new();
-        let mut sink = |ring: &'static Ring, bytes: &[u8]| {
+        let mut sink = |ring: &'static OSThreadMarkerRing, bytes: &[u8]| {
             // SAFETY: bytes in hand are drain progress (engine_id contract).
             let engine = unsafe { ring.engine_id() };
             let mut seqs = Vec::new();
             collect_seqs(bytes, &mut seqs);
             tagged.extend(seqs.into_iter().map(|s| (engine, s)));
         };
-        let drain = |sink: &mut dyn FnMut(&'static Ring, &[u8])| {
+        let drain = |sink: &mut dyn FnMut(&'static OSThreadMarkerRing, &[u8])| {
             // SAFETY: this thread is the single consumer.
             unsafe { ring.drain(&mut |b| sink(ring, b)) }
         };
@@ -588,7 +593,7 @@ mod stress {
     use crate::{
         ids::{BexCallId, BexThreadId, FunctionId},
         prof::{
-            record::{self, RawRecord},
+            record::{self, Marker},
             registry::Registry,
             ring::RingState,
         },
@@ -625,7 +630,7 @@ mod stress {
                         .expect("test ring capacity");
                     let mut buf = [0u8; record::MAX_RECORD_LEN];
                     for seq in 1u64..=per_producer {
-                        let len = RawRecord::CallFunction {
+                        let len = Marker::FunctionEnter {
                             flags: 0,
                             thread_id: BexThreadId(engine),
                             call_id: BexCallId(seq),
@@ -652,12 +657,12 @@ mod stress {
 
         // Consumer: sweep with the D4 protocol (park flag, recheck, timeout).
         let mut per_engine: Vec<Vec<u64>> = vec![Vec::new(); producers + 1];
-        let mut sink = |ring: &'static crate::prof::ring::Ring, bytes: &[u8]| {
+        let mut sink = |ring: &'static crate::prof::ring::OSThreadMarkerRing, bytes: &[u8]| {
             // SAFETY: bytes in hand are drain progress.
             let engine = unsafe { ring.engine_id() };
             for r in record::iter(bytes) {
                 match r.expect("corrupt record in committed range") {
-                    RawRecord::CallFunction {
+                    Marker::FunctionEnter {
                         thread_id, call_id, ..
                     } => {
                         assert_eq!(
@@ -734,14 +739,14 @@ mod stress {
     #[test]
     fn bounded_drain_spreads_backlog_and_defers_orphan_pooling() {
         use super::collect_seqs;
-        use crate::prof::ring::Ring;
+        use crate::prof::ring::OSThreadMarkerRing;
 
         let ctx = leak_ctx(BIG_CAP);
         let reg_ptr = Box::into_raw(Box::new(Registry::new()));
         let reg: &'static Registry = unsafe { &*reg_ptr };
         let total: u64 = 100; // 50 two-record segments — several drain bounds
 
-        let ring: &'static Ring = std::thread::spawn(move || {
+        let ring: &'static OSThreadMarkerRing = std::thread::spawn(move || {
             let h = reg
                 .acquire(ctx, 16, 8, 1) // two 8-byte records per segment
                 .expect("test ring capacity");
@@ -758,7 +763,9 @@ mod stress {
 
         let mut seen = Vec::new();
         // SAFETY: this thread is the single consumer.
-        assert!(unsafe { reg.sweep(&mut |_: &'static Ring, b: &[u8]| collect_seqs(b, &mut seen)) });
+        assert!(unsafe {
+            reg.sweep(&mut |_: &'static OSThreadMarkerRing, b: &[u8]| collect_seqs(b, &mut seen))
+        });
         assert!(
             seen.len() < usize::try_from(total).unwrap(),
             "one sweep must not chase the whole backlog"
@@ -771,7 +778,11 @@ mod stress {
         let mut sweeps = 1;
         while ring.state() != RingState::Pooled {
             // SAFETY: same single consumer.
-            unsafe { reg.sweep(&mut |_: &'static Ring, b: &[u8]| collect_seqs(b, &mut seen)) };
+            unsafe {
+                reg.sweep(&mut |_: &'static OSThreadMarkerRing, b: &[u8]| {
+                    collect_seqs(b, &mut seen)
+                })
+            };
             sweeps += 1;
             assert!(sweeps < 100, "orphan backlog must pool in bounded sweeps");
         }

--- a/baml_language/crates/bex_events/src/prof/mod.rs
+++ b/baml_language/crates/bex_events/src/prof/mod.rs
@@ -19,7 +19,7 @@
 //! and is unrelated to the per-function-call ids that flow through these
 //! records as plain `u64`s. The id newtypes ([`crate::ids::BexCallId`],
 //! [`crate::ids::BexThreadId`], [`crate::ids::FunctionId`]) landed with the
-//! M0 `ids.rs` milestone; adopting them in [`record::RawRecord`]'s fields
+//! M0 `ids.rs` milestone; adopting them in [`record::Marker`]'s fields
 //! is the remaining follow-up. Nothing here should reuse
 //! `sys_types::CallId`.
 
@@ -72,7 +72,7 @@ pub use config::ProfConfig;
 pub use consumer::{consumer_thread_started, engine_closed, flush_and_join};
 #[cfg(not(baml_loom))]
 pub use registry::ring_for_engine;
-pub use ring::{Ring, RingHandle};
+pub use ring::{OSThreadMarkerRing, OSThreadMarkerRingHandle};
 
 // wasm32 has no native background consumer. Generic embedders keep profiling
 // off through config, while adapters such as bridge_wasm may opt into a

--- a/baml_language/crates/bex_events/src/prof/registry.rs
+++ b/baml_language/crates/bex_events/src/prof/registry.rs
@@ -18,14 +18,14 @@
 use std::ptr::null_mut;
 
 use crate::prof::{
-    ring::{Ring, RingCtx, RingHandle, RingState},
+    ring::{OSThreadMarkerRing, OSThreadMarkerRingHandle, RingCtx, RingState},
     sync::{AtomicPtr, Ordering},
 };
 
 struct RegNode {
-    /// Conceptually `&'static Ring`; kept raw so tests can reclaim with full
+    /// Conceptually `&'static OSThreadMarkerRing`; kept raw so tests can reclaim with full
     /// provenance. Production never frees it (invariant 7).
-    ring: *mut Ring,
+    ring: *mut OSThreadMarkerRing,
     next: AtomicPtr<RegNode>,
 }
 
@@ -65,27 +65,27 @@ impl Registry {
         seg_bytes: usize,
         freelist_cap: usize,
         engine_id: u64,
-    ) -> Option<RingHandle> {
+    ) -> Option<OSThreadMarkerRingHandle> {
         let mut node = self.head.load(Ordering::Acquire);
         while !node.is_null() {
             let n = unsafe { &*node };
             let ring = unsafe { &*n.ring };
             if ring.try_claim(engine_id) {
                 // SAFETY: the CAS made this thread the unique producer.
-                return Some(unsafe { RingHandle::new(ring) });
+                return Some(unsafe { OSThreadMarkerRingHandle::new(ring) });
             }
             node = n.next.load(Ordering::Acquire);
         }
         // Keep the raw pointer (not a ref-derived copy) in the node so the
         // test-only Registry::drop deallocates with original provenance.
-        let ring_ptr = Ring::alloc(ctx, seg_bytes, freelist_cap, engine_id)?;
+        let ring_ptr = OSThreadMarkerRing::alloc(ctx, seg_bytes, freelist_cap, engine_id)?;
         self.push(ring_ptr);
         // SAFETY: a freshly allocated ring is Active and owned by its
         // creating thread.
-        Some(unsafe { RingHandle::new(&*ring_ptr) })
+        Some(unsafe { OSThreadMarkerRingHandle::new(&*ring_ptr) })
     }
 
-    fn push(&self, ring: *mut Ring) {
+    fn push(&self, ring: *mut OSThreadMarkerRing) {
         let node = Box::into_raw(Box::new(RegNode {
             ring,
             next: AtomicPtr::new(null_mut()),
@@ -106,7 +106,7 @@ impl Registry {
 
     /// Walks every registered ring (any thread; Acquire loads publish the
     /// nodes and rings).
-    pub(crate) fn for_each(&self, mut f: impl FnMut(&'static Ring)) {
+    pub(crate) fn for_each(&self, mut f: impl FnMut(&'static OSThreadMarkerRing)) {
         let mut node = self.head.load(Ordering::Acquire);
         while !node.is_null() {
             let n = unsafe { &*node };
@@ -119,13 +119,16 @@ impl Registry {
     /// rings to empty and pool them; skip `Pooled` rings. Returns whether any
     /// ring yielded bytes.
     ///
-    /// `sink` may call [`Ring::engine_id`] on the ring it is handed: the
+    /// `sink` may call [`OSThreadMarkerRing::engine_id`] on the ring it is handed: the
     /// bytes in hand are proof of drain progress, which is that method's
     /// safety contract.
     ///
     /// # Safety
     /// Caller is the process's single consumer thread.
-    pub(crate) unsafe fn sweep(&self, sink: &mut impl FnMut(&'static Ring, &[u8])) -> bool {
+    pub(crate) unsafe fn sweep(
+        &self,
+        sink: &mut impl FnMut(&'static OSThreadMarkerRing, &[u8]),
+    ) -> bool {
         let mut progress = false;
         self.for_each(|ring| match ring.state() {
             RingState::Active => {
@@ -178,7 +181,7 @@ mod global {
     use super::Registry;
     use crate::prof::{
         backend::{MeasuredLayouts, ProfilerMemoryGovernor, ProfilerSizingPolicy},
-        ring::{Ring, RingCtx, RingHandle},
+        ring::{OSThreadMarkerRing, OSThreadMarkerRingHandle, RingCtx},
     };
 
     static REGISTRY: Registry = Registry::new();
@@ -238,7 +241,7 @@ mod global {
 
     /// One entry per engine this thread has produced for. The `Drop` is the
     /// D5b orphan trigger, run by the TLS destructor on thread death.
-    struct ThreadRings(RefCell<SmallVec<[(u64, &'static Ring); 2]>>);
+    struct ThreadRings(RefCell<SmallVec<[(u64, &'static OSThreadMarkerRing); 2]>>);
 
     impl Drop for ThreadRings {
         fn drop(&mut self) {
@@ -260,13 +263,13 @@ mod global {
     /// Must run on a live thread (not from TLS destructors): the returned
     /// handle's ring is orphaned by *this thread's* TLS cleanup, which is
     /// what guarantees its events eventually reach the consumer.
-    pub fn ring_for_engine(engine_id: u64) -> Option<RingHandle> {
+    pub fn ring_for_engine(engine_id: u64) -> Option<OSThreadMarkerRingHandle> {
         THREAD_RINGS.with(|tr| {
             let mut entries = tr.0.borrow_mut();
             if let Some((_, ring)) = entries.iter().find(|(id, _)| *id == engine_id) {
                 // SAFETY: this thread claimed the ring when it inserted the
                 // entry, and only this thread's death (TLS drop) releases it.
-                return Some(unsafe { RingHandle::new(ring) });
+                return Some(unsafe { OSThreadMarkerRingHandle::new(ring) });
             }
             let config = transport_config();
             // Pin the clock anchor (source detection + zero point — cheap,

--- a/baml_language/crates/bex_events/src/prof/ring.rs
+++ b/baml_language/crates/bex_events/src/prof/ring.rs
@@ -21,7 +21,7 @@
 //! # Invariants enforced here (plan §6)
 //!
 //! - The producer never blocks: no mutex, no condvar, no park, no unbounded
-//!   spin anywhere reachable from [`Ring::push`]. It runs holding an
+//!   spin anywhere reachable from [`OSThreadMarkerRing::push`]. It runs holding an
 //!   `ActiveHeapPermit`; a blocked producer is an engine-wide GC stall.
 //! - The consumer never touches the GC heap or permits.
 //! - Hitting the live-memory cap rejects the concrete record without blocking
@@ -44,7 +44,7 @@ use crate::prof::{
     wake::Wake,
 };
 
-/// Ring lifecycle states (design D5b).
+/// OSThreadMarkerRing lifecycle states (design D5b).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub(crate) enum RingState {
@@ -67,7 +67,7 @@ impl RingState {
     }
 }
 
-/// What one bounded [`Ring::drain`] call accomplished.
+/// What one bounded [`OSThreadMarkerRing::drain`] call accomplished.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DrainOutcome {
     /// Whether any bytes were consumed.
@@ -240,10 +240,10 @@ struct SegSync {
     /// the segment sits in the free list — the next free-list node. A
     /// segment is never in both places, and in-list nodes are immutable
     /// until popped, so the dual use cannot be observed concurrently.
-    next: AtomicPtr<Segment>,
+    next: AtomicPtr<OSThreadMarkerRingSegment>,
 }
 
-struct Segment {
+struct OSThreadMarkerRingSegment {
     /// D3: `{commit_len, next}` get their own cache line so producer commits
     /// and consumer polls don't false-share with the buffer pointer reads.
     sync: CachePadded<SegSync>,
@@ -252,12 +252,15 @@ struct Segment {
 }
 
 pub(crate) fn segment_footprint(seg_bytes: usize) -> usize {
-    seg_bytes + size_of::<Segment>()
+    seg_bytes + size_of::<OSThreadMarkerRingSegment>()
 }
 
-fn alloc_segment(seg_bytes: usize, ctx: &'static RingCtx) -> Option<*mut Segment> {
+fn alloc_segment(
+    seg_bytes: usize,
+    ctx: &'static RingCtx,
+) -> Option<*mut OSThreadMarkerRingSegment> {
     let charge = ctx.try_charge(segment_footprint(seg_bytes))?;
-    Some(Box::into_raw(Box::new(Segment {
+    Some(Box::into_raw(Box::new(OSThreadMarkerRingSegment {
         sync: CachePadded::new(SegSync {
             commit_len: AtomicU32::new(0),
             next: AtomicPtr::new(null_mut()),
@@ -270,19 +273,19 @@ fn alloc_segment(seg_bytes: usize, ctx: &'static RingCtx) -> Option<*mut Segment
 /// # Safety
 /// `seg` came from [`alloc_segment`], is reachable from neither the live
 /// chain nor the free list, and no thread will touch it again.
-unsafe fn free_segment(seg: *mut Segment) {
+unsafe fn free_segment(seg: *mut OSThreadMarkerRingSegment) {
     drop(unsafe { Box::from_raw(seg) });
 }
 
 /// Producer-only position fields (D3 group 1).
 struct RingProducer {
-    head: *mut Segment,
+    head: *mut OSThreadMarkerRingSegment,
     head_pos: usize,
 }
 
 /// Consumer-only position fields (D3 group 2).
 struct RingConsumer {
-    tail: *mut Segment,
+    tail: *mut OSThreadMarkerRingSegment,
     tail_pos: usize,
 }
 
@@ -291,8 +294,8 @@ struct RingShared {
     state: AtomicU8,
     /// Treiber free list of recycled segments. Single pusher (the consumer)
     /// and single popper (the producer) — see the no-ABA argument on
-    /// [`Ring::free_pop`].
-    free_head: AtomicPtr<Segment>,
+    /// [`OSThreadMarkerRing::free_pop`].
+    free_head: AtomicPtr<OSThreadMarkerRingSegment>,
     /// Approximate free-list length (Relaxed; D7). Transient off-by-one —
     /// including the brief wrap-below-zero when a pop's decrement lands
     /// between a push's CAS and its increment — only skews the recycle/free
@@ -305,7 +308,7 @@ struct RingShared {
 }
 
 /// The segmented SPSC ring. See the module docs.
-pub struct Ring {
+pub struct OSThreadMarkerRing {
     p: CachePadded<UnsafeCell<RingProducer>>,
     c: CachePadded<UnsafeCell<RingConsumer>>,
     s: CachePadded<RingShared>,
@@ -321,10 +324,10 @@ pub struct Ring {
 // publish-by-first-commit rule — with the Release/Acquire edges in the
 // module-docs table providing the happens-before. The loom suite
 // model-checks exactly these claims.
-unsafe impl Send for Ring {}
-unsafe impl Sync for Ring {}
+unsafe impl Send for OSThreadMarkerRing {}
+unsafe impl Sync for OSThreadMarkerRing {}
 
-impl Ring {
+impl OSThreadMarkerRing {
     /// Allocates a ring with one open segment, `Active` and owned by the
     /// calling thread (the creator is the claimant). The returned pointer is
     /// conceptually `&'static`: production code never frees rings
@@ -334,9 +337,9 @@ impl Ring {
         seg_bytes: usize,
         freelist_cap: usize,
         engine_id: u64,
-    ) -> Option<*mut Ring> {
+    ) -> Option<*mut OSThreadMarkerRing> {
         let seg = alloc_segment(seg_bytes, ctx)?;
-        Some(Box::into_raw(Box::new(Ring {
+        Some(Box::into_raw(Box::new(OSThreadMarkerRing {
             p: CachePadded::new(UnsafeCell::new(RingProducer {
                 head: seg,
                 head_pos: 0,
@@ -508,7 +511,7 @@ impl Ring {
     ///
     /// # Safety
     /// Caller is the ring's unique producer thread.
-    unsafe fn free_pop(&self) -> Option<*mut Segment> {
+    unsafe fn free_pop(&self) -> Option<*mut OSThreadMarkerRingSegment> {
         let mut head = self.s.free_head.load(Ordering::Acquire);
         loop {
             if head.is_null() {
@@ -542,7 +545,7 @@ impl Ring {
     /// Caller is the consumer thread, has fully drained `seg`, and has
     /// already advanced `tail` past it (the producer linked past it, so
     /// neither side can reach it again).
-    unsafe fn retire(&self, seg: *mut Segment) {
+    unsafe fn retire(&self, seg: *mut OSThreadMarkerRingSegment) {
         if self.s.free_len.load(Ordering::Relaxed) >= self.freelist_cap {
             unsafe { free_segment(seg) };
             return;
@@ -603,7 +606,7 @@ impl Ring {
     /// New-producer claim: CAS `Pooled → Active`. On success the caller is
     /// the unique producer and may push from the calling thread only.
     ///
-    /// Acquire on success: pairs with [`Ring::mark_pooled`]'s Release, so the
+    /// Acquire on success: pairs with [`OSThreadMarkerRing::mark_pooled`]'s Release, so the
     /// consumer's final drain — and, through the orphan edge before it, the
     /// dead producer's last `head`/`head_pos` writes — happen-before the new
     /// producer touches them.
@@ -632,7 +635,7 @@ impl Ring {
     /// Which engine the bytes most recently drained from this ring belong to.
     ///
     /// # Safety
-    /// Consumer thread only, and only after a [`Ring::drain`] on this ring
+    /// Consumer thread only, and only after a [`OSThreadMarkerRing::drain`] on this ring
     /// reported progress in the current sweep (that drain's Acquire is what
     /// publishes a new claimant's write).
     pub(crate) unsafe fn engine_id(&self) -> u64 {
@@ -645,7 +648,7 @@ impl Ring {
     }
 }
 
-impl Drop for Ring {
+impl Drop for OSThreadMarkerRing {
     /// Production rings are never dropped (invariant 7: `&'static`, reuse
     /// don't reclaim). This exists for tests, which reclaim rings after all
     /// producer/consumer activity has quiesced; then the live chain
@@ -672,18 +675,18 @@ impl Drop for Ring {
 /// The producer-side write handle: living proof that the holding thread
 /// claimed the ring. Created only by the claim/acquire paths on the claiming
 /// thread, and `!Send + !Sync` so it cannot leave it — which is what makes
-/// [`RingHandle::push`] safe to expose.
+/// [`OSThreadMarkerRingHandle::push`] safe to expose.
 #[derive(Clone, Copy)]
-pub struct RingHandle {
-    ring: &'static Ring,
+pub struct OSThreadMarkerRingHandle {
+    ring: &'static OSThreadMarkerRing,
     _not_send_sync: PhantomData<*mut ()>,
 }
 
-impl RingHandle {
+impl OSThreadMarkerRingHandle {
     /// # Safety
     /// `ring` is `Active` and was claimed by (or created on) the calling
     /// thread, which makes that thread the unique producer.
-    pub(crate) unsafe fn new(ring: &'static Ring) -> Self {
+    pub(crate) unsafe fn new(ring: &'static OSThreadMarkerRing) -> Self {
         Self {
             ring,
             _not_send_sync: PhantomData,
@@ -711,9 +714,9 @@ impl RingHandle {
     }
 
     /// The underlying ring, for D5a snapshots: the engine stores this
-    /// `&'static Ring` in the VM and refreshes it once per exec resume.
+    /// `&'static OSThreadMarkerRing` in the VM and refreshes it once per exec resume.
     #[must_use]
-    pub fn ring(self) -> &'static Ring {
+    pub fn ring(self) -> &'static OSThreadMarkerRing {
         self.ring
     }
 }
@@ -722,7 +725,7 @@ impl RingHandle {
 /// committed)` and advances `tail_pos`. Bytes below `committed` were
 /// published by the Acquire that read it and are immutable until recycle.
 unsafe fn consume_range(
-    seg: &Segment,
+    seg: &OSThreadMarkerRingSegment,
     tail_pos: &mut usize,
     committed: usize,
     sink: &mut impl FnMut(&[u8]),

--- a/baml_language/crates/bex_events/src/prof/ring.rs
+++ b/baml_language/crates/bex_events/src/prof/ring.rs
@@ -44,7 +44,7 @@ use crate::prof::{
     wake::Wake,
 };
 
-/// OSThreadMarkerRing lifecycle states (design D5b).
+/// `OSThreadMarkerRing` lifecycle states (design D5b).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub(crate) enum RingState {

--- a/baml_language/crates/bex_prof_store/src/prof/backend/decoder.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/decoder.rs
@@ -15,7 +15,7 @@ use crate::{
     ids::{BexCallId, BoundaryId, CallRef, EngineId, ProcessEuid, ProgramId, ThreadRef},
     prof::{
         clock::TickConverter,
-        record::{CallSiteSourceSpan, FunctionEndStatus, RawRecord, ThreadEndStatus},
+        record::{CallSiteSourceSpan, FunctionEndStatus, Marker, ThreadEndStatus},
     },
 };
 
@@ -154,7 +154,7 @@ pub struct QueueHealthSnapshot {
     pub publication_inflight: bool,
 }
 
-pub(super) struct ExecutionRuntime {
+pub(super) struct ExecutionDecodeAccumulator {
     pub generation: u32,
     /// The execution's identity: its root thread.
     pub root: ThreadRef,
@@ -166,10 +166,10 @@ pub(super) struct ExecutionRuntime {
     pub(super) health: ExecutionHealthSnapshot,
 }
 
-impl std::fmt::Debug for ExecutionRuntime {
+impl std::fmt::Debug for ExecutionDecodeAccumulator {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("ExecutionRuntime")
+            .debug_struct("ExecutionDecodeAccumulator")
             .field("generation", &self.generation)
             .field("root", &self.root)
             .field("health", &self.health)
@@ -177,7 +177,7 @@ impl std::fmt::Debug for ExecutionRuntime {
     }
 }
 
-impl ExecutionRuntime {
+impl ExecutionDecodeAccumulator {
     pub(super) fn new(
         generation: u32,
         root: ThreadRef,
@@ -283,7 +283,7 @@ impl EvidenceBatch {
 }
 
 #[derive(Debug)]
-struct ThreadState {
+struct BexThreadDecodeState {
     boundary: ExecutionHandle,
     spawn_parent: Option<ContextKeyProjection>,
     spawn_site: Option<CallSiteSourceSpan>,
@@ -297,7 +297,7 @@ struct ThreadState {
 struct ContextKeyProjection(super::ContextKey);
 
 #[derive(Debug)]
-struct CallState {
+struct CallDecodeState {
     boundary: ExecutionHandle,
     context: ContextAdmission,
     context_key: Option<ContextKeyProjection>,
@@ -313,7 +313,7 @@ struct CallState {
     _reservation: Reservation,
 }
 
-impl CallState {
+impl CallDecodeState {
     fn observe_value(&mut self, role: super::ValueRole) {
         self.values_observed |= match role {
             super::ValueRole::Input => super::RoleMask::INPUT,
@@ -485,8 +485,8 @@ struct PendingTerminalError {
 
 #[derive(Debug, Default)]
 pub(super) struct DirectDecoder {
-    threads: HashMap<ThreadRef, ThreadState>,
-    calls: HashMap<CallRef, CallState>,
+    threads: HashMap<ThreadRef, BexThreadDecodeState>,
+    calls: HashMap<CallRef, CallDecodeState>,
     /// Parked call starts, keyed by owning thread with `call_id` order
     /// inside. The per-thread split keeps `resolve_starts_for_thread` from
     /// scanning every parked start in the process on each opened call — a
@@ -509,7 +509,7 @@ pub(super) struct DecoderResources<'a> {
     pub memory: &'a ProfilerMemoryGovernor,
     pub sizing: DerivedSizing,
     pub clock: &'a TickConverter,
-    pub boundaries: &'a [std::sync::Mutex<Option<ExecutionRuntime>>],
+    pub boundaries: &'a [std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     /// The session's stream writer; hand-off target for sealed epochs and
     /// evidence batches (consumer thread only; lock order decoder → writer).
     pub writer: &'a Mutex<StreamWriter>,
@@ -523,7 +523,7 @@ impl DirectDecoder {
     /// Queue snapshot for one live execution (session checkpoint support).
     pub(super) fn queue_snapshot(
         handle: ExecutionHandle,
-        boundaries: &[std::sync::Mutex<Option<ExecutionRuntime>>],
+        boundaries: &[std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     ) -> Option<(ThreadRef, ExecutionHealthSnapshot, QueueHealthSnapshot)> {
         let slot = boundaries.get(handle.slot as usize)?;
         let runtime = slot
@@ -557,9 +557,9 @@ impl DirectDecoder {
         ))
     }
 
-    pub(super) fn consume(&mut self, resources: &DecoderResources<'_>, raw: RawRecord<'_>) {
+    pub(super) fn consume(&mut self, resources: &DecoderResources<'_>, raw: Marker<'_>) {
         match raw {
-            RawRecord::StartThread {
+            Marker::BexThreadStart {
                 thread_id,
                 parent_thread_id,
                 ts_ticks,
@@ -583,7 +583,7 @@ impl DirectDecoder {
                 );
                 self.resolve_starts_for_thread(resources, thread_ref);
             }
-            RawRecord::StartThreadSpawn {
+            Marker::BexThreadStartSpawned {
                 thread_id,
                 parent_thread_id,
                 parent_call_id,
@@ -602,7 +602,7 @@ impl DirectDecoder {
                     name,
                 );
             }
-            RawRecord::StartThread {
+            Marker::BexThreadStart {
                 thread_id,
                 parent_thread_id,
                 parent_call_id,
@@ -620,7 +620,7 @@ impl DirectDecoder {
                     name,
                 );
             }
-            RawRecord::CallFunction {
+            Marker::FunctionEnter {
                 flags,
                 thread_id,
                 call_id,
@@ -644,7 +644,7 @@ impl DirectDecoder {
                     ts_ticks,
                 },
             ),
-            RawRecord::EndFunction {
+            Marker::FunctionExit {
                 status,
                 thread_id,
                 call_id,
@@ -664,7 +664,7 @@ impl DirectDecoder {
                     await_count: 0,
                 },
             ),
-            RawRecord::EndFunctionAwaited {
+            Marker::FunctionExitAwaited {
                 status,
                 thread_id,
                 call_id,
@@ -686,7 +686,7 @@ impl DirectDecoder {
                     await_count,
                 },
             ),
-            RawRecord::EndThread {
+            Marker::BexThreadEnd {
                 thread_id,
                 status,
                 ts_ticks,
@@ -701,7 +701,7 @@ impl DirectDecoder {
                     }
                 }
             }
-            RawRecord::SetFunctionId {
+            Marker::SetBoundaryLocalId {
                 thread_id,
                 call_id,
                 id,
@@ -1159,7 +1159,7 @@ impl DirectDecoder {
         };
         self.calls.insert(
             fact.call_ref,
-            CallState {
+            CallDecodeState {
                 boundary,
                 context,
                 context_key,
@@ -1453,7 +1453,7 @@ impl DirectDecoder {
         .unwrap_or(false);
         self.threads.insert(
             thread_ref,
-            ThreadState {
+            BexThreadDecodeState {
                 boundary,
                 spawn_parent,
                 spawn_site,
@@ -2225,7 +2225,7 @@ fn flush_evidence(resources: &DecoderResources<'_>, handle: ExecutionHandle) {
 /// `ThreadStart` was pushed (dependency rule).
 fn push_thread_end(
     resources: &DecoderResources<'_>,
-    state: &ThreadState,
+    state: &BexThreadDecodeState,
     thread_ref: ThreadRef,
     ts_ticks: u64,
     status: ThreadEndStatus,
@@ -2319,7 +2319,7 @@ impl ContextAdmissionExt for ContextAdmission {
 /// Infallible: no store I/O happens on this path.
 pub(super) fn finalize_ready_execution(
     handle: ExecutionHandle,
-    runtime: &mut ExecutionRuntime,
+    runtime: &mut ExecutionDecodeAccumulator,
     decoder: &mut DirectDecoder,
     registry: &super::ExecutionRegistry,
     writer: &Mutex<StreamWriter>,
@@ -2410,7 +2410,7 @@ pub(super) fn finalize_ready_execution(
 }
 
 fn find_execution_by_root(
-    boundaries: &[std::sync::Mutex<Option<ExecutionRuntime>>],
+    boundaries: &[std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     root: ThreadRef,
 ) -> Option<ExecutionHandle> {
     boundaries.iter().enumerate().find_map(|(slot, runtime)| {
@@ -2430,9 +2430,9 @@ fn find_execution_by_root(
 }
 
 pub(super) fn with_runtime(
-    boundaries: &[std::sync::Mutex<Option<ExecutionRuntime>>],
+    boundaries: &[std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     handle: ExecutionHandle,
-    operation: impl FnOnce(&mut ExecutionRuntime),
+    operation: impl FnOnce(&mut ExecutionDecodeAccumulator),
 ) {
     let Some(slot) = boundaries.get(handle.slot as usize) else {
         return;
@@ -2447,9 +2447,9 @@ pub(super) fn with_runtime(
 }
 
 fn with_runtime_value<T>(
-    boundaries: &[std::sync::Mutex<Option<ExecutionRuntime>>],
+    boundaries: &[std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     handle: ExecutionHandle,
-    operation: impl FnOnce(&mut ExecutionRuntime) -> Option<T>,
+    operation: impl FnOnce(&mut ExecutionDecodeAccumulator) -> Option<T>,
 ) -> Option<T> {
     let slot = boundaries.get(handle.slot as usize)?;
     let mut slot = slot
@@ -2462,7 +2462,7 @@ fn with_runtime_value<T>(
 }
 
 fn record_join_capacity_exceeded(
-    boundaries: &[std::sync::Mutex<Option<ExecutionRuntime>>],
+    boundaries: &[std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     handle: Option<ExecutionHandle>,
 ) {
     if let Some(handle) = handle {
@@ -2477,7 +2477,7 @@ fn record_join_capacity_exceeded(
 /// one boundary, so every live boundary of that engine is marked as having a
 /// possibly incomplete structural stream.
 pub(super) fn record_engine_framing_error(
-    boundaries: &[std::sync::Mutex<Option<ExecutionRuntime>>],
+    boundaries: &[std::sync::Mutex<Option<ExecutionDecodeAccumulator>>],
     engine_id: EngineId,
 ) {
     for slot in boundaries {

--- a/baml_language/crates/bex_prof_store/src/prof/backend/domain.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/domain.rs
@@ -137,7 +137,7 @@ impl CapturePlan {
     const MANUAL: u8 = 1 << 6;
     const RESERVED: u8 = 1 << 7;
 
-    /// Encodes the complete plan into the reserved `CallFunction.flags` byte.
+    /// Encodes the complete plan into the reserved `FunctionEnter.flags` byte.
     #[must_use]
     pub const fn to_call_flags(self) -> u8 {
         let mut flags = self.roles.bits();

--- a/baml_language/crates/bex_prof_store/src/prof/backend/execution.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/execution.rs
@@ -55,7 +55,7 @@ pub struct ExecutionMetadata {
     /// Host runtime token (`baml_id_1_…`), opaque to the profiler.
     pub runtime_id: BoundaryId,
     /// `now_ticks()` sampled at the top of `register_root`; the durable
-    /// `RootStarted.started_ns` source (a lost `StartThread` record must not
+    /// `RootStarted.started_ns` source (a lost `BexThreadStart` record must not
     /// lose the start time).
     pub admitted_ticks: u64,
 }

--- a/baml_language/crates/bex_prof_store/src/prof/backend/session.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/session.rs
@@ -3,7 +3,9 @@ use std::sync::Mutex;
 use std::sync::{Arc, OnceLock};
 
 #[cfg(not(target_arch = "wasm32"))]
-use super::decoder::{DecoderResources, DirectDecoder, ExecutionRuntime, finalize_ready_execution};
+use super::decoder::{
+    DecoderResources, DirectDecoder, ExecutionDecodeAccumulator, finalize_ready_execution,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use super::writer::{ExecutionCheckpoint, StreamCheckpoint, StreamWriter, WriterEnv, counters};
 use super::{
@@ -104,7 +106,7 @@ struct OnSession {
     #[cfg(not(target_arch = "wasm32"))]
     store: Arc<ProfilerStore>,
     #[cfg(not(target_arch = "wasm32"))]
-    publishers: Box<[Mutex<Option<ExecutionRuntime>>]>,
+    publishers: Box<[Mutex<Option<ExecutionDecodeAccumulator>>]>,
     #[cfg(not(target_arch = "wasm32"))]
     decoder: Mutex<DirectDecoder>,
     /// Driven only by the consumer thread; checkpoint readers on other
@@ -688,7 +690,7 @@ impl ProfilerSession {
         true
     }
 
-    /// Resolve cross-ring `EndThread` facts only after the consumer has swept
+    /// Resolve cross-ring `BexThreadEnd` facts only after the consumer has swept
     /// every ring. A child start and its entry call are consecutive on the
     /// parent ring, but an earlier per-ring resolution point could still fall
     /// between them at a segment boundary.
@@ -1370,7 +1372,7 @@ impl ProfilerSession {
         #[cfg(not(target_arch = "wasm32"))]
         {
             // Step 1: the admission timestamp — the durable started_ns source
-            // (the root StartThread record is emitted later and can be lost).
+            // (the root BexThreadStart record is emitted later and can be lost).
             let admitted_ticks = crate::prof::clock::now_ticks();
             let RootProfileIntent::UserRoot { runtime_id } = intent else {
                 return RootAdmission::Inactive(RootProfiler::Inactive(InactiveReason::Suppressed));
@@ -1406,7 +1408,7 @@ impl ProfilerSession {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             debug_assert!(slot.is_none());
-            *slot = Some(ExecutionRuntime::new(
+            *slot = Some(ExecutionDecodeAccumulator::new(
                 handle.generation,
                 root_thread_ref,
                 runtime_id,
@@ -1581,7 +1583,7 @@ mod tests {
     fn final_drain_keeps_structural_end_when_value_command_was_lost() {
         use crate::{
             ids::{BexCallId, BexThreadId, CallRef, EngineId, FunctionId, ProcessEuid},
-            prof::record::{FunctionEndStatus, MAX_RECORD_LEN, RawRecord},
+            prof::record::{FunctionEndStatus, MAX_RECORD_LEN, Marker},
         };
 
         let temp = tempfile::TempDir::new().unwrap();
@@ -1609,12 +1611,12 @@ mod tests {
             thread_id: thread_ref.thread_id,
             call_id: BexCallId(6),
         };
-        let emit = |record: RawRecord<'_>| {
+        let emit = |record: Marker<'_>| {
             let mut bytes = [0; MAX_RECORD_LEN];
             let len = record.encode(&mut bytes);
             session.consume_raw_bytes(thread_ref.process_euid, thread_ref.engine_id, &bytes[..len]);
         };
-        emit(RawRecord::StartThread {
+        emit(Marker::BexThreadStart {
             flags: 0,
             thread_id: thread_ref.thread_id,
             parent_thread_id: BexThreadId(0),
@@ -1622,7 +1624,7 @@ mod tests {
             ts_ticks: 10,
             name: b"",
         });
-        emit(RawRecord::CallFunction {
+        emit(Marker::FunctionEnter {
             flags: resolve_capture_plan(true, FunctionCaptureClass::Ordinary, None).to_call_flags(),
             thread_id: thread_ref.thread_id,
             call_id: call_ref.call_id,
@@ -1631,7 +1633,7 @@ mod tests {
             call_site: None,
             ts_ticks: 20,
         });
-        emit(RawRecord::EndFunction {
+        emit(Marker::FunctionExit {
             status: FunctionEndStatus::Errored,
             thread_id: thread_ref.thread_id,
             call_id: call_ref.call_id,
@@ -1693,7 +1695,7 @@ mod tests {
     fn parked_sibling_chain_resolves_iteratively_on_a_small_stack() {
         use crate::{
             ids::{BexCallId, BexThreadId, EngineId, FunctionId, ProcessEuid},
-            prof::record::{FunctionEndStatus, MAX_RECORD_LEN, RawRecord},
+            prof::record::{FunctionEndStatus, MAX_RECORD_LEN, Marker},
         };
 
         std::thread::Builder::new()
@@ -1719,7 +1721,7 @@ mod tests {
                 ) else {
                     panic!("root must be admitted");
                 };
-                let emit = |record: RawRecord<'_>| {
+                let emit = |record: Marker<'_>| {
                     let mut bytes = [0; MAX_RECORD_LEN];
                     let len = record.encode(&mut bytes);
                     session.consume_raw_bytes(
@@ -1732,7 +1734,7 @@ mod tests {
                     .to_call_flags();
                 // Every start and end parks: the thread is not yet known.
                 for i in 0..CHAIN {
-                    emit(RawRecord::CallFunction {
+                    emit(Marker::FunctionEnter {
                         flags,
                         thread_id: thread_ref.thread_id,
                         call_id: BexCallId(10 + i),
@@ -1741,7 +1743,7 @@ mod tests {
                         call_site: None,
                         ts_ticks: 20 + 2 * i,
                     });
-                    emit(RawRecord::EndFunction {
+                    emit(Marker::FunctionExit {
                         status: FunctionEndStatus::Ok,
                         thread_id: thread_ref.thread_id,
                         call_id: BexCallId(10 + i),
@@ -1749,7 +1751,7 @@ mod tests {
                     });
                 }
                 // The thread start resolves the whole parked chain at once.
-                emit(RawRecord::StartThread {
+                emit(Marker::BexThreadStart {
                     flags: 0,
                     thread_id: thread_ref.thread_id,
                     parent_thread_id: BexThreadId(0),
@@ -1803,7 +1805,7 @@ mod tests {
             ids::{BexCallId, BexThreadId, EngineId, FunctionId, ProcessEuid},
             prof::{
                 backend::{DataState, EdgeKind, ExecutionStatus},
-                record::{FunctionEndStatus, MAX_RECORD_LEN, RawRecord, ThreadEndStatus},
+                record::{FunctionEndStatus, MAX_RECORD_LEN, Marker, ThreadEndStatus},
             },
         };
 
@@ -1828,24 +1830,23 @@ mod tests {
         ) else {
             panic!("root must be admitted");
         };
-        let emit = |record: RawRecord<'_>| {
+        let emit = |record: Marker<'_>| {
             let mut bytes = [0; MAX_RECORD_LEN];
             let len = record.encode(&mut bytes);
             session.consume_raw_bytes(euid, engine_id, &bytes[..len]);
         };
         let ordinary =
             resolve_capture_plan(false, FunctionCaptureClass::Ordinary, None).to_call_flags();
-        let call =
-            |call_id, parent_call_id, function_id, flags, ts_ticks| RawRecord::CallFunction {
-                flags,
-                thread_id: root_thread,
-                call_id: BexCallId(call_id),
-                parent_call_id: BexCallId(parent_call_id),
-                function_id: FunctionId(function_id),
-                call_site: None,
-                ts_ticks,
-            };
-        let end = |call_id, ts_ticks| RawRecord::EndFunction {
+        let call = |call_id, parent_call_id, function_id, flags, ts_ticks| Marker::FunctionEnter {
+            flags,
+            thread_id: root_thread,
+            call_id: BexCallId(call_id),
+            parent_call_id: BexCallId(parent_call_id),
+            function_id: FunctionId(function_id),
+            call_site: None,
+            ts_ticks,
+        };
+        let end = |call_id, ts_ticks| Marker::FunctionExit {
             status: FunctionEndStatus::Ok,
             thread_id: root_thread,
             call_id: BexCallId(call_id),
@@ -1871,7 +1872,7 @@ mod tests {
         }
 
         // The root thread start resolves everything parked above in one sweep.
-        emit(RawRecord::StartThread {
+        emit(Marker::BexThreadStart {
             flags: 0,
             thread_id: root_thread,
             parent_thread_id: BexThreadId(0),
@@ -1882,7 +1883,7 @@ mod tests {
         if !park_parent_end {
             emit(end(1, parent_end_ts));
         }
-        emit(RawRecord::EndThread {
+        emit(Marker::BexThreadEnd {
             status: ThreadEndStatus::Completed,
             thread_id: root_thread,
             ts_ticks: parent_end_ts + 10,
@@ -1971,7 +1972,7 @@ mod tests {
             ids::{BexCallId, BexThreadId, CallRef, EngineId, FunctionId, ProcessEuid},
             prof::{
                 backend::{ContextKey, EdgeKind},
-                record::{FunctionEndStatus, MAX_RECORD_LEN, RawRecord, ThreadEndStatus},
+                record::{FunctionEndStatus, MAX_RECORD_LEN, Marker, ThreadEndStatus},
             },
         };
 
@@ -1997,7 +1998,7 @@ mod tests {
         ) else {
             panic!("root must be admitted");
         };
-        let emit = |record: RawRecord<'_>| {
+        let emit = |record: Marker<'_>| {
             let mut bytes = [0; MAX_RECORD_LEN];
             let len = record.encode(&mut bytes);
             session.consume_raw_bytes(euid, engine_id, &bytes[..len]);
@@ -2005,7 +2006,7 @@ mod tests {
         let ordinary =
             resolve_capture_plan(false, FunctionCaptureClass::Ordinary, None).to_call_flags();
         let call = |thread_id, call_id, parent_call_id, function_id, flags, ts_ticks| {
-            RawRecord::CallFunction {
+            Marker::FunctionEnter {
                 flags,
                 thread_id,
                 call_id: BexCallId(call_id),
@@ -2015,13 +2016,13 @@ mod tests {
                 ts_ticks,
             }
         };
-        let end = |thread_id, call_id, ts_ticks| RawRecord::EndFunction {
+        let end = |thread_id, call_id, ts_ticks| Marker::FunctionExit {
             status: FunctionEndStatus::Ok,
             thread_id,
             call_id: BexCallId(call_id),
             ts_ticks,
         };
-        let end_thread = |thread_id, ts_ticks| RawRecord::EndThread {
+        let end_thread = |thread_id, ts_ticks| Marker::BexThreadEnd {
             status: ThreadEndStatus::Completed,
             thread_id,
             ts_ticks,
@@ -2034,7 +2035,7 @@ mod tests {
         emit(call(grandchild_thread, 3, 99, 31, ordinary, 320));
         emit(call(grandchild_thread, 1, 0, 20, ordinary, 290));
         emit(end(grandchild_thread, 1, 330));
-        emit(RawRecord::StartThreadSpawn {
+        emit(Marker::BexThreadStartSpawned {
             flags: 0,
             thread_id: grandchild_thread,
             parent_thread_id: child_thread,
@@ -2047,7 +2048,7 @@ mod tests {
 
         // Child thread: entry call before its own spawn fact.
         emit(call(child_thread, 1, 0, 10, ordinary, 200));
-        emit(RawRecord::StartThreadSpawn {
+        emit(Marker::BexThreadStartSpawned {
             flags: 0,
             thread_id: child_thread,
             parent_thread_id: root_thread,
@@ -2070,7 +2071,7 @@ mod tests {
 
         // Root last. Its thread start attributes the whole parked tree; its
         // call start resolves the child, which resolves the grandchild.
-        emit(RawRecord::StartThread {
+        emit(Marker::BexThreadStart {
             flags: 0,
             thread_id: root_thread,
             parent_thread_id: BexThreadId(0),
@@ -2689,7 +2690,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn thousand_roots_publish_two_meta_segments_and_bounded_data() {
-        use crate::prof::record::{MAX_RECORD_LEN, RawRecord};
+        use crate::prof::record::{MAX_RECORD_LEN, Marker};
 
         let temp = tempfile::TempDir::new().unwrap();
         let root_path = temp.path().join(".baml/profiles-v1");
@@ -2701,7 +2702,7 @@ mod tests {
             ..test_config(&root_path, euid)
         });
         assert!(diagnostic.is_none());
-        let emit = |record: RawRecord<'_>| {
+        let emit = |record: Marker<'_>| {
             let mut bytes = [0; MAX_RECORD_LEN];
             let len = record.encode(&mut bytes);
             session.consume_raw_bytes(euid, crate::ids::EngineId(1), &bytes[..len]);
@@ -2722,7 +2723,7 @@ mod tests {
             ) else {
                 panic!("root {index} must be admitted");
             };
-            emit(RawRecord::StartThread {
+            emit(Marker::BexThreadStart {
                 flags: 0,
                 thread_id,
                 parent_thread_id: crate::ids::BexThreadId(0),
@@ -2730,7 +2731,7 @@ mod tests {
                 ts_ticks: 10,
                 name: b"",
             });
-            emit(RawRecord::CallFunction {
+            emit(Marker::FunctionEnter {
                 flags: resolve_capture_plan(true, FunctionCaptureClass::Ordinary, None)
                     .to_call_flags(),
                 thread_id,
@@ -2740,13 +2741,13 @@ mod tests {
                 call_site: None,
                 ts_ticks: 20,
             });
-            emit(RawRecord::EndFunction {
+            emit(Marker::FunctionExit {
                 status: crate::prof::record::FunctionEndStatus::Ok,
                 thread_id,
                 call_id: crate::ids::BexCallId(1),
                 ts_ticks: 30,
             });
-            emit(RawRecord::EndThread {
+            emit(Marker::BexThreadEnd {
                 status: crate::prof::record::ThreadEndStatus::Completed,
                 thread_id,
                 ts_ticks: 40,
@@ -2813,13 +2814,13 @@ mod tests {
                 panic!("root must be admitted");
             };
             {
-                use crate::prof::record::{MAX_RECORD_LEN, RawRecord};
-                let emit = |record: RawRecord<'_>| {
+                use crate::prof::record::{MAX_RECORD_LEN, Marker};
+                let emit = |record: Marker<'_>| {
                     let mut bytes = [0; MAX_RECORD_LEN];
                     let len = record.encode(&mut bytes);
                     session.consume_raw_bytes(euid, crate::ids::EngineId(1), &bytes[..len]);
                 };
-                emit(RawRecord::StartThread {
+                emit(Marker::BexThreadStart {
                     flags: 0,
                     thread_id: crate::ids::BexThreadId(1),
                     parent_thread_id: crate::ids::BexThreadId(0),
@@ -2980,13 +2981,13 @@ mod tests {
             panic!("root must be admitted");
         };
         {
-            use crate::prof::record::{MAX_RECORD_LEN, RawRecord};
-            let emit = |record: RawRecord<'_>| {
+            use crate::prof::record::{MAX_RECORD_LEN, Marker};
+            let emit = |record: Marker<'_>| {
                 let mut bytes = [0; MAX_RECORD_LEN];
                 let len = record.encode(&mut bytes);
                 session.consume_raw_bytes(euid, crate::ids::EngineId(1), &bytes[..len]);
             };
-            emit(RawRecord::StartThread {
+            emit(Marker::BexThreadStart {
                 flags: 0,
                 thread_id: crate::ids::BexThreadId(1),
                 parent_thread_id: crate::ids::BexThreadId(0),
@@ -3074,9 +3075,9 @@ mod tests {
             panic!("root must be admitted");
         };
         {
-            use crate::prof::record::{MAX_RECORD_LEN, RawRecord};
+            use crate::prof::record::{MAX_RECORD_LEN, Marker};
             let mut bytes = [0; MAX_RECORD_LEN];
-            let record = RawRecord::StartThread {
+            let record = Marker::BexThreadStart {
                 flags: 0,
                 thread_id: crate::ids::BexThreadId(1),
                 parent_thread_id: crate::ids::BexThreadId(0),

--- a/baml_language/crates/bex_prof_store/src/prof/backend/sizing.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/sizing.rs
@@ -195,7 +195,7 @@ mod tests {
         ids::{CallRef, ThreadRef},
         prof::{
             backend::{CapturePlan, ContextKey, ContextTuple, RootProfiler},
-            record::{CallSiteSourceSpan, RawRecord},
+            record::{CallSiteSourceSpan, Marker},
         },
     };
 
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(size_of::<ThreadRef>(), 32);
         assert_eq!(size_of::<CallRef>(), 40);
         assert_eq!(size_of::<CallSiteSourceSpan>(), 16);
-        assert_eq!(size_of::<RawRecord<'static>>(), 72);
+        assert_eq!(size_of::<Marker<'static>>(), 72);
         assert_eq!(size_of::<CapturePlan>(), 3);
         assert_eq!(size_of::<ContextKey>(), 32);
         assert_eq!(size_of::<ContextTuple>(), 76);

--- a/baml_language/crates/bex_prof_store/src/prof/backend/writer.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/backend/writer.rs
@@ -17,7 +17,7 @@ use super::{
     DataGroup, EvidenceFact, ExecutionEndStatus, ExecutionHandle, ExecutionHealthSnapshot,
     MetaRecord, ProfilerStore, PublishBatchResult, Reservation, ResolveIndeterminateResult,
     SealedCctEpoch, StreamHighWater,
-    decoder::{DirectDecoder, EvidenceBatchStats, ExecutionRuntime, with_runtime},
+    decoder::{DirectDecoder, EvidenceBatchStats, ExecutionDecodeAccumulator, with_runtime},
     encode_cct_epoch, encode_evidence_facts,
 };
 use crate::ids::ThreadRef;
@@ -69,7 +69,7 @@ pub mod counters {
 }
 
 pub(super) struct WriterEnv<'a> {
-    pub publishers: &'a [Mutex<Option<ExecutionRuntime>>],
+    pub publishers: &'a [Mutex<Option<ExecutionDecodeAccumulator>>],
 }
 
 pub(super) struct PendingGroup {
@@ -618,7 +618,7 @@ impl StreamWriter {
         });
     }
 
-    /// The health sink (streams spec §5.3): the live `ExecutionRuntime` while
+    /// The health sink (streams spec §5.3): the live `ExecutionDecodeAccumulator` while
     /// the slot is valid, else the still-pending `RootEnded`'s snapshot.
     fn record_health(
         &mut self,
@@ -729,7 +729,7 @@ mod tests {
         platform: Arc<TestPlatform>,
         memory: ProfilerMemoryGovernor,
         writer: StreamWriter,
-        publishers: Vec<Mutex<Option<ExecutionRuntime>>>,
+        publishers: Vec<Mutex<Option<ExecutionDecodeAccumulator>>>,
         decoder: DirectDecoder,
     }
 
@@ -781,14 +781,14 @@ mod tests {
         }
     }
 
-    /// Installs a live `ExecutionRuntime` for `handle(slot)` so the writer's
+    /// Installs a live `ExecutionDecodeAccumulator` for `handle(slot)` so the writer's
     /// health sink finds it (the production invariant: a group can only be
     /// in flight while its slot is live or its `RootEnded` is pending).
     fn install_runtime(harness: &mut Harness, slot: u32, root: ThreadRef) {
         while harness.publishers.len() <= slot as usize {
             harness.publishers.push(Mutex::new(None));
         }
-        *harness.publishers[slot as usize].lock().unwrap() = Some(ExecutionRuntime::new(
+        *harness.publishers[slot as usize].lock().unwrap() = Some(ExecutionDecodeAccumulator::new(
             1,
             root,
             BoundaryId::from_bytes([7; 16]),

--- a/baml_language/crates/bex_prof_store/src/prof/record.rs
+++ b/baml_language/crates/bex_prof_store/src/prof/record.rs
@@ -1,7 +1,7 @@
 //! Raw ring records: the producer→consumer wire format (v2 §4.1).
 //!
 //! Every record is `tag: u8` followed by a fixed little-endian field layout
-//! per tag; only `StartThread` carries a variable-length tail (the thread
+//! per tag; only `BexThreadStart` carries a variable-length tail (the thread
 //! name, capped at [`MAX_THREAD_NAME_LEN`] bytes). Producer and consumer live
 //! in the same binary, so the tag→layout table is compiled in — there is no
 //! self-describing framing on the ring.
@@ -14,30 +14,30 @@
 //! `parent_call_id`/`parent_thread_id` fields. `engine_id`/`process_id` are
 //! deliberately absent — they are per-ring and per-file-header state.
 
-/// Maximum thread-name bytes carried by a [`RawRecord::StartThread`] record.
+/// Maximum thread-name bytes carried by a [`Marker::BexThreadStart`] record.
 pub const MAX_THREAD_NAME_LEN: usize = 256;
 
 /// Encoded sizes, tag byte included.
-pub const CALL_FUNCTION_LEN: usize = 54;
-/// See [`CALL_FUNCTION_LEN`].
-pub const END_FUNCTION_LEN: usize = 26;
+pub const FUNCTION_ENTER_LEN: usize = 54;
+/// See [`FUNCTION_ENTER_LEN`].
+pub const FUNCTION_EXIT_LEN: usize = 26;
 /// Awaited call-end variant: compact end plus `await_ns: u64` and
 /// `await_count: u32`.
-pub const END_FUNCTION_AWAITED_LEN: usize = END_FUNCTION_LEN + 12;
-/// Fixed prefix of a `StartThread` record; the name bytes follow.
+pub const FUNCTION_EXIT_AWAITED_LEN: usize = FUNCTION_EXIT_LEN + 12;
+/// Fixed prefix of a `BexThreadStart` record; the name bytes follow.
 pub const START_THREAD_FIXED_LEN: usize = 36;
 /// Fixed prefix of a spawned-thread start, including its source span.
 pub const START_THREAD_SPAWN_FIXED_LEN: usize = START_THREAD_FIXED_LEN + 16;
-/// See [`CALL_FUNCTION_LEN`].
+/// See [`FUNCTION_ENTER_LEN`].
 pub const END_THREAD_LEN: usize = 18;
-/// See [`CALL_FUNCTION_LEN`].
+/// See [`FUNCTION_ENTER_LEN`].
 pub const SET_FUNCTION_ID_LEN: usize = 41;
 
 /// Upper bound on any encoded record; sizes producer-side stack buffers.
 pub const MAX_RECORD_LEN: usize = START_THREAD_SPAWN_FIXED_LEN + MAX_THREAD_NAME_LEN;
 
 /// Caps a thread name at [`MAX_THREAD_NAME_LEN`] bytes without splitting a
-/// UTF-8 character — the producer-side capture helper for `StartThread`.
+/// UTF-8 character — the producer-side capture helper for `BexThreadStart`.
 #[must_use]
 pub fn capped_name_bytes(name: &str) -> &[u8] {
     if name.len() <= MAX_THREAD_NAME_LEN {
@@ -52,12 +52,12 @@ pub fn capped_name_bytes(name: &str) -> &[u8] {
 
 use crate::ids::{BexCallId, BexThreadId, FunctionId};
 
-const TAG_CALL_FUNCTION: u8 = 0x01;
-const TAG_END_FUNCTION: u8 = 0x02;
+const TAG_FUNCTION_ENTER: u8 = 0x01;
+const TAG_FUNCTION_EXIT: u8 = 0x02;
 const TAG_START_THREAD: u8 = 0x03;
 const TAG_END_THREAD: u8 = 0x04;
 const TAG_SET_FUNCTION_ID: u8 = 0x05;
-const TAG_END_FUNCTION_AWAITED: u8 = 0x06;
+const TAG_FUNCTION_EXIT_AWAITED: u8 = 0x06;
 const TAG_START_THREAD_SPAWN: u8 = 0x07;
 const CALL_SITE_FILE_ID_NONE: u32 = u32::MAX;
 
@@ -106,9 +106,9 @@ pub enum ThreadEndStatus {
 
 /// A decoded ring record. Borrowed (`name`) from the drained byte range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RawRecord<'a> {
+pub enum Marker<'a> {
     /// Tag `0x01`: a function call began (pushed right after the frame push).
-    CallFunction {
+    FunctionEnter {
         /// Reserved flag bits (zero today).
         flags: u8,
         /// Logical BEX thread id (not the OS thread).
@@ -128,24 +128,24 @@ pub enum RawRecord<'a> {
         ts_ticks: u64,
     },
     /// Tag `0x02`: a function call ended (return, unwind, or cancel drain).
-    EndFunction {
+    FunctionExit {
         /// How the frame ended (see [`FunctionEndStatus`]).
         status: FunctionEndStatus,
         /// Logical BEX thread id.
         thread_id: BexThreadId,
-        /// Matches the `CallFunction` it closes.
+        /// Matches the `FunctionEnter` it closes.
         call_id: BexCallId,
         /// Raw clock ticks; converted to ns by the consumer at transcode.
         ts_ticks: u64,
     },
     /// Tag `0x06`: the alternative call-end encoding used only when the call
     /// suspended at least once. This is one end fact, not an additional event.
-    EndFunctionAwaited {
+    FunctionExitAwaited {
         /// How the frame ended.
         status: FunctionEndStatus,
         /// Logical BEX thread id.
         thread_id: BexThreadId,
-        /// Matches the `CallFunction` it closes.
+        /// Matches the `FunctionEnter` it closes.
         call_id: BexCallId,
         /// Raw clock ticks; converted to ns by the consumer.
         ts_ticks: u64,
@@ -155,7 +155,7 @@ pub enum RawRecord<'a> {
         await_count: u32,
     },
     /// Tag `0x03`: a logical thread started (root or spawn).
-    StartThread {
+    BexThreadStart {
         /// Reserved flag bits (zero today).
         flags: u8,
         /// Logical BEX thread id.
@@ -171,9 +171,9 @@ pub enum RawRecord<'a> {
         name: &'a [u8],
     },
     /// Tag `0x07`: spawned logical thread start with the spawn expression's
-    /// source span. This remains distinct from root `StartThread` so the
+    /// source span. This remains distinct from root `BexThreadStart` so the
     /// legacy root record retains its frozen byte shape.
-    StartThreadSpawn {
+    BexThreadStartSpawned {
         flags: u8,
         thread_id: BexThreadId,
         parent_thread_id: BexThreadId,
@@ -183,7 +183,7 @@ pub enum RawRecord<'a> {
         name: &'a [u8],
     },
     /// Tag `0x04`: a logical thread ended.
-    EndThread {
+    BexThreadEnd {
         /// How the thread ended.
         status: ThreadEndStatus,
         /// Logical BEX thread id.
@@ -193,7 +193,7 @@ pub enum RawRecord<'a> {
     },
     /// Tag `0x05`: `$id` override for a call (reserved for the M1 language
     /// surface; the shape is fixed so the ring format doesn't change).
-    SetFunctionId {
+    SetBoundaryLocalId {
         /// Logical BEX thread id.
         thread_id: BexThreadId,
         /// The call whose `$id` is overridden.
@@ -216,32 +216,32 @@ pub enum DecodeError {
     Truncated,
     /// A status byte holds an undefined value.
     InvalidStatus(u8),
-    /// A `StartThread` name length exceeds [`MAX_THREAD_NAME_LEN`].
+    /// A `BexThreadStart` name length exceeds [`MAX_THREAD_NAME_LEN`].
     NameTooLong(u16),
 }
 
-impl RawRecord<'_> {
+impl Marker<'_> {
     /// Encoded length of this record in bytes.
     #[must_use]
     pub fn encoded_len(&self) -> usize {
         match self {
-            RawRecord::CallFunction { .. } => CALL_FUNCTION_LEN,
-            RawRecord::EndFunction { .. } => END_FUNCTION_LEN,
-            RawRecord::EndFunctionAwaited { .. } => END_FUNCTION_AWAITED_LEN,
-            RawRecord::StartThread { name, .. } => {
+            Marker::FunctionEnter { .. } => FUNCTION_ENTER_LEN,
+            Marker::FunctionExit { .. } => FUNCTION_EXIT_LEN,
+            Marker::FunctionExitAwaited { .. } => FUNCTION_EXIT_AWAITED_LEN,
+            Marker::BexThreadStart { name, .. } => {
                 START_THREAD_FIXED_LEN + name.len().min(MAX_THREAD_NAME_LEN)
             }
-            RawRecord::StartThreadSpawn { name, .. } => {
+            Marker::BexThreadStartSpawned { name, .. } => {
                 START_THREAD_SPAWN_FIXED_LEN + name.len().min(MAX_THREAD_NAME_LEN)
             }
-            RawRecord::EndThread { .. } => END_THREAD_LEN,
-            RawRecord::SetFunctionId { .. } => SET_FUNCTION_ID_LEN,
+            Marker::BexThreadEnd { .. } => END_THREAD_LEN,
+            Marker::SetBoundaryLocalId { .. } => SET_FUNCTION_ID_LEN,
         }
     }
 
     /// Encodes into the front of `buf`, returning the encoded length.
     ///
-    /// `StartThread` names are truncated to [`MAX_THREAD_NAME_LEN`] bytes
+    /// `BexThreadStart` names are truncated to [`MAX_THREAD_NAME_LEN`] bytes
     /// defensively; callers are expected to cap (UTF-8-safely) at capture
     /// time.
     #[inline]
@@ -259,13 +259,13 @@ impl RawRecord<'_> {
     /// fields are written via unchecked unaligned stores (debug-asserted, not
     /// release-checked), so an undersized `buf` is undefined behavior in
     /// release builds — not a panic. Every caller satisfies this:
-    /// [`Self::encode`] uses a [`MAX_RECORD_LEN`] buffer and `Ring::push_with`
+    /// [`Self::encode`] uses a [`MAX_RECORD_LEN`] buffer and `OSThreadMarkerRing::push_with`
     /// reserves exactly `encoded_len()`.
     #[inline]
     pub fn encode_to(&self, buf: &mut [u8]) -> usize {
         let mut w = Writer { buf, pos: 0 };
         match *self {
-            RawRecord::CallFunction {
+            Marker::FunctionEnter {
                 flags,
                 thread_id,
                 call_id,
@@ -274,7 +274,7 @@ impl RawRecord<'_> {
                 call_site,
                 ts_ticks,
             } => {
-                w.u8(TAG_CALL_FUNCTION);
+                w.u8(TAG_FUNCTION_ENTER);
                 w.u8(flags);
                 w.u64(thread_id.0);
                 w.u64(call_id.0);
@@ -293,19 +293,19 @@ impl RawRecord<'_> {
                     w.u32(0);
                 }
             }
-            RawRecord::EndFunction {
+            Marker::FunctionExit {
                 status,
                 thread_id,
                 call_id,
                 ts_ticks,
             } => {
-                w.u8(TAG_END_FUNCTION);
+                w.u8(TAG_FUNCTION_EXIT);
                 w.u8(status as u8);
                 w.u64(thread_id.0);
                 w.u64(call_id.0);
                 w.u64(ts_ticks);
             }
-            RawRecord::EndFunctionAwaited {
+            Marker::FunctionExitAwaited {
                 status,
                 thread_id,
                 call_id,
@@ -313,7 +313,7 @@ impl RawRecord<'_> {
                 await_ns,
                 await_count,
             } => {
-                w.u8(TAG_END_FUNCTION_AWAITED);
+                w.u8(TAG_FUNCTION_EXIT_AWAITED);
                 w.u8(status as u8);
                 w.u64(thread_id.0);
                 w.u64(call_id.0);
@@ -321,7 +321,7 @@ impl RawRecord<'_> {
                 w.u64(await_ns);
                 w.u32(await_count);
             }
-            RawRecord::StartThread {
+            Marker::BexThreadStart {
                 flags,
                 thread_id,
                 parent_thread_id,
@@ -339,7 +339,7 @@ impl RawRecord<'_> {
                 w.u16(u16::try_from(name.len()).expect("thread name is capped at 256 bytes"));
                 w.bytes(name);
             }
-            RawRecord::StartThreadSpawn {
+            Marker::BexThreadStartSpawned {
                 flags,
                 thread_id,
                 parent_thread_id,
@@ -369,7 +369,7 @@ impl RawRecord<'_> {
                 w.u16(u16::try_from(name.len()).expect("thread name is capped at 256 bytes"));
                 w.bytes(name);
             }
-            RawRecord::EndThread {
+            Marker::BexThreadEnd {
                 status,
                 thread_id,
                 ts_ticks,
@@ -379,7 +379,7 @@ impl RawRecord<'_> {
                 w.u64(thread_id.0);
                 w.u64(ts_ticks);
             }
-            RawRecord::SetFunctionId {
+            Marker::SetBoundaryLocalId {
                 thread_id,
                 call_id,
                 id,
@@ -399,11 +399,11 @@ impl RawRecord<'_> {
 
 /// Decodes the record at the front of `buf`, returning it and its encoded
 /// length. Never panics on malformed input.
-pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
+pub fn decode(buf: &[u8]) -> Result<(Marker<'_>, usize), DecodeError> {
     let mut r = Reader { buf, pos: 0 };
     let tag = r.u8()?;
     let rec = match tag {
-        TAG_CALL_FUNCTION => {
+        TAG_FUNCTION_ENTER => {
             let flags = r.u8()?;
             let thread_id = BexThreadId(r.u64()?);
             let call_id = BexCallId(r.u64()?);
@@ -414,7 +414,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             let call_site_start_offset = r.u32()?;
             let call_site_end_offset = r.u32()?;
             let call_site_line = r.u32()?;
-            RawRecord::CallFunction {
+            Marker::FunctionEnter {
                 flags,
                 thread_id,
                 call_id,
@@ -431,7 +431,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
                 ts_ticks,
             }
         }
-        TAG_END_FUNCTION => RawRecord::EndFunction {
+        TAG_FUNCTION_EXIT => Marker::FunctionExit {
             status: match r.u8()? {
                 0 => FunctionEndStatus::Ok,
                 1 => FunctionEndStatus::Errored,
@@ -443,7 +443,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             call_id: BexCallId(r.u64()?),
             ts_ticks: r.u64()?,
         },
-        TAG_END_FUNCTION_AWAITED => RawRecord::EndFunctionAwaited {
+        TAG_FUNCTION_EXIT_AWAITED => Marker::FunctionExitAwaited {
             status: match r.u8()? {
                 0 => FunctionEndStatus::Ok,
                 1 => FunctionEndStatus::Errored,
@@ -467,7 +467,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             if usize::from(name_len) > MAX_THREAD_NAME_LEN {
                 return Err(DecodeError::NameTooLong(name_len));
             }
-            RawRecord::StartThread {
+            Marker::BexThreadStart {
                 flags,
                 thread_id,
                 parent_thread_id,
@@ -496,7 +496,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             if usize::from(name_len) > MAX_THREAD_NAME_LEN {
                 return Err(DecodeError::NameTooLong(name_len));
             }
-            RawRecord::StartThreadSpawn {
+            Marker::BexThreadStartSpawned {
                 flags,
                 thread_id,
                 parent_thread_id,
@@ -506,7 +506,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
                 name: r.bytes(usize::from(name_len))?,
             }
         }
-        TAG_END_THREAD => RawRecord::EndThread {
+        TAG_END_THREAD => Marker::BexThreadEnd {
             status: match r.u8()? {
                 0 => ThreadEndStatus::Completed,
                 1 => ThreadEndStatus::Cancelled,
@@ -516,7 +516,7 @@ pub fn decode(buf: &[u8]) -> Result<(RawRecord<'_>, usize), DecodeError> {
             thread_id: BexThreadId(r.u64()?),
             ts_ticks: r.u64()?,
         },
-        TAG_SET_FUNCTION_ID => RawRecord::SetFunctionId {
+        TAG_SET_FUNCTION_ID => Marker::SetBoundaryLocalId {
             thread_id: BexThreadId(r.u64()?),
             call_id: BexCallId(r.u64()?),
             id: {
@@ -543,7 +543,7 @@ pub struct RecordIter<'a> {
 }
 
 impl<'a> Iterator for RecordIter<'a> {
-    type Item = Result<RawRecord<'a>, DecodeError>;
+    type Item = Result<Marker<'a>, DecodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.buf.is_empty() {
@@ -578,7 +578,7 @@ impl Writer<'_> {
     fn u16(&mut self, v: u16) {
         debug_assert!(self.pos + 2 <= self.buf.len());
         // SAFETY: callers size `buf` >= `encoded_len()` (producer reserves
-        // exactly that via `Ring::push_with`), so `pos + 2` is in bounds.
+        // exactly that via `OSThreadMarkerRing::push_with`), so `pos + 2` is in bounds.
         #[expect(
             unsafe_code,
             reason = "in-bounds unaligned store; avoids non-inlined copy"
@@ -680,7 +680,7 @@ impl<'a> Reader<'a> {
 mod tests {
     use super::*;
 
-    fn roundtrip(rec: RawRecord<'_>) {
+    fn roundtrip(rec: Marker<'_>) {
         let mut buf = [0u8; MAX_RECORD_LEN];
         let len = rec.encode(&mut buf);
         assert_eq!(len, rec.encoded_len());
@@ -700,7 +700,7 @@ mod tests {
     )]
     fn roundtrip_all_variants() {
         for v in [0u64, 1, 42, u64::MAX] {
-            roundtrip(RawRecord::CallFunction {
+            roundtrip(Marker::FunctionEnter {
                 flags: v as u8,
                 thread_id: BexThreadId(v),
                 call_id: BexCallId(v.wrapping_add(1)),
@@ -709,13 +709,13 @@ mod tests {
                 call_site: None,
                 ts_ticks: v,
             });
-            roundtrip(RawRecord::EndFunction {
+            roundtrip(Marker::FunctionExit {
                 status: FunctionEndStatus::Ok,
                 thread_id: BexThreadId(v),
                 call_id: BexCallId(v),
                 ts_ticks: v,
             });
-            roundtrip(RawRecord::EndFunctionAwaited {
+            roundtrip(Marker::FunctionExitAwaited {
                 status: FunctionEndStatus::Ok,
                 thread_id: BexThreadId(v),
                 call_id: BexCallId(v),
@@ -723,12 +723,12 @@ mod tests {
                 await_ns: v.wrapping_mul(3),
                 await_count: v as u32,
             });
-            roundtrip(RawRecord::EndThread {
+            roundtrip(Marker::BexThreadEnd {
                 status: ThreadEndStatus::Cancelled,
                 thread_id: BexThreadId(v),
                 ts_ticks: v,
             });
-            roundtrip(RawRecord::SetFunctionId {
+            roundtrip(Marker::SetBoundaryLocalId {
                 thread_id: BexThreadId(v),
                 call_id: BexCallId(v),
                 id: [v as u8; 16],
@@ -740,24 +740,24 @@ mod tests {
             FunctionEndStatus::Cancelled,
             FunctionEndStatus::Exited,
         ] {
-            roundtrip(RawRecord::EndFunction {
+            roundtrip(Marker::FunctionExit {
                 status,
                 thread_id: BexThreadId(7),
                 call_id: BexCallId(9),
                 ts_ticks: 11,
             });
         }
-        roundtrip(RawRecord::EndThread {
+        roundtrip(Marker::BexThreadEnd {
             status: ThreadEndStatus::Completed,
             thread_id: BexThreadId(7),
             ts_ticks: 11,
         });
-        roundtrip(RawRecord::EndThread {
+        roundtrip(Marker::BexThreadEnd {
             status: ThreadEndStatus::Errored,
             thread_id: BexThreadId(7),
             ts_ticks: 11,
         });
-        roundtrip(RawRecord::CallFunction {
+        roundtrip(Marker::FunctionEnter {
             flags: 0,
             thread_id: BexThreadId(1),
             call_id: BexCallId(2),
@@ -777,7 +777,7 @@ mod tests {
     fn roundtrip_thread_names() {
         for len in [0usize, 1, 100, 255, 256] {
             let name = vec![b'x'; len];
-            roundtrip(RawRecord::StartThread {
+            roundtrip(Marker::BexThreadStart {
                 flags: 1,
                 thread_id: BexThreadId(2),
                 parent_thread_id: BexThreadId(0),
@@ -785,7 +785,7 @@ mod tests {
                 ts_ticks: 4,
                 name: &name,
             });
-            roundtrip(RawRecord::StartThreadSpawn {
+            roundtrip(Marker::BexThreadStartSpawned {
                 flags: 1,
                 thread_id: BexThreadId(3),
                 parent_thread_id: BexThreadId(2),
@@ -805,7 +805,7 @@ mod tests {
     #[test]
     fn encode_truncates_oversized_name() {
         let name = vec![b'y'; 300];
-        let rec = RawRecord::StartThread {
+        let rec = Marker::BexThreadStart {
             flags: 0,
             thread_id: BexThreadId(1),
             parent_thread_id: BexThreadId(0),
@@ -818,7 +818,7 @@ mod tests {
         assert_eq!(len, START_THREAD_FIXED_LEN + MAX_THREAD_NAME_LEN);
         let (decoded, _) = decode(&buf[..len]).expect("decode");
         match decoded {
-            RawRecord::StartThread { name, .. } => assert_eq!(name.len(), MAX_THREAD_NAME_LEN),
+            Marker::BexThreadStart { name, .. } => assert_eq!(name.len(), MAX_THREAD_NAME_LEN),
             other => panic!("wrong variant: {other:?}"),
         }
     }
@@ -826,7 +826,7 @@ mod tests {
     #[test]
     fn fixed_sizes_match_spec() {
         let mut buf = [0u8; MAX_RECORD_LEN];
-        let call = RawRecord::CallFunction {
+        let call = Marker::FunctionEnter {
             flags: 0,
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
@@ -836,14 +836,14 @@ mod tests {
             ts_ticks: 0,
         };
         assert_eq!(call.encode(&mut buf), 54);
-        let end = RawRecord::EndFunction {
+        let end = Marker::FunctionExit {
             status: FunctionEndStatus::Ok,
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
             ts_ticks: 0,
         };
         assert_eq!(end.encode(&mut buf), 26);
-        let awaited_end = RawRecord::EndFunctionAwaited {
+        let awaited_end = Marker::FunctionExitAwaited {
             status: FunctionEndStatus::Ok,
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
@@ -852,7 +852,7 @@ mod tests {
             await_count: 2,
         };
         assert_eq!(awaited_end.encode(&mut buf), 38);
-        let start_thread = RawRecord::StartThread {
+        let start_thread = Marker::BexThreadStart {
             flags: 0,
             thread_id: BexThreadId(1),
             parent_thread_id: BexThreadId(0),
@@ -861,7 +861,7 @@ mod tests {
             name: b"",
         };
         assert_eq!(start_thread.encode(&mut buf), 36);
-        let spawned_thread = RawRecord::StartThreadSpawn {
+        let spawned_thread = Marker::BexThreadStartSpawned {
             flags: 0,
             thread_id: BexThreadId(2),
             parent_thread_id: BexThreadId(1),
@@ -871,13 +871,13 @@ mod tests {
             name: b"",
         };
         assert_eq!(spawned_thread.encode(&mut buf), 52);
-        let end_thread = RawRecord::EndThread {
+        let end_thread = Marker::BexThreadEnd {
             status: ThreadEndStatus::Completed,
             thread_id: BexThreadId(1),
             ts_ticks: 0,
         };
         assert_eq!(end_thread.encode(&mut buf), 18);
-        let set_id = RawRecord::SetFunctionId {
+        let set_id = Marker::SetBoundaryLocalId {
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
             id: [0; 16],
@@ -893,7 +893,7 @@ mod tests {
         assert_eq!(decode(&[]), Err(DecodeError::Truncated));
 
         let mut buf = [0u8; MAX_RECORD_LEN];
-        let len = RawRecord::EndFunction {
+        let len = Marker::FunctionExit {
             status: FunctionEndStatus::Ok,
             thread_id: BexThreadId(1),
             call_id: BexCallId(1),
@@ -907,7 +907,7 @@ mod tests {
     #[test]
     fn awaited_end_golden_bytes_are_stable() {
         let mut buf = [0u8; MAX_RECORD_LEN];
-        let len = RawRecord::EndFunctionAwaited {
+        let len = Marker::FunctionExitAwaited {
             status: FunctionEndStatus::Cancelled,
             thread_id: BexThreadId(0x0102_0304_0506_0708),
             call_id: BexCallId(0x1112_1314_1516_1718),
@@ -929,7 +929,7 @@ mod tests {
     #[test]
     fn spawned_thread_golden_bytes_are_stable() {
         let mut buf = [0u8; MAX_RECORD_LEN];
-        let len = RawRecord::StartThreadSpawn {
+        let len = Marker::BexThreadStartSpawned {
             flags: 0xAB,
             thread_id: BexThreadId(0x0102_0304_0506_0708),
             parent_thread_id: BexThreadId(0x1112_1314_1516_1718),
@@ -958,7 +958,7 @@ mod tests {
     #[test]
     fn decode_rejects_oversized_name_len() {
         let mut buf = [0u8; MAX_RECORD_LEN];
-        let len = RawRecord::StartThread {
+        let len = Marker::BexThreadStart {
             flags: 0,
             thread_id: BexThreadId(1),
             parent_thread_id: BexThreadId(0),
@@ -977,7 +977,7 @@ mod tests {
     fn every_truncation_errors_without_panicking() {
         let name = vec![b'n'; 17];
         let records = [
-            RawRecord::CallFunction {
+            Marker::FunctionEnter {
                 flags: 1,
                 thread_id: BexThreadId(2),
                 call_id: BexCallId(3),
@@ -991,7 +991,7 @@ mod tests {
                 }),
                 ts_ticks: 6,
             },
-            RawRecord::StartThread {
+            Marker::BexThreadStart {
                 flags: 0,
                 thread_id: BexThreadId(1),
                 parent_thread_id: BexThreadId(2),
@@ -999,7 +999,7 @@ mod tests {
                 ts_ticks: 4,
                 name: &name,
             },
-            RawRecord::StartThreadSpawn {
+            Marker::BexThreadStartSpawned {
                 flags: 0,
                 thread_id: BexThreadId(1),
                 parent_thread_id: BexThreadId(2),
@@ -1013,13 +1013,13 @@ mod tests {
                 }),
                 name: &name,
             },
-            RawRecord::SetFunctionId {
+            Marker::SetBoundaryLocalId {
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(2),
                 id: [3; 16],
                 ts_ticks: 4,
             },
-            RawRecord::EndFunctionAwaited {
+            Marker::FunctionExitAwaited {
                 status: FunctionEndStatus::Errored,
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(2),
@@ -1045,7 +1045,7 @@ mod tests {
     fn iterates_packed_records() {
         let name = b"worker".as_slice();
         let records = vec![
-            RawRecord::StartThread {
+            Marker::BexThreadStart {
                 flags: 0,
                 thread_id: BexThreadId(1),
                 parent_thread_id: BexThreadId(0),
@@ -1053,7 +1053,7 @@ mod tests {
                 ts_ticks: 1,
                 name,
             },
-            RawRecord::CallFunction {
+            Marker::FunctionEnter {
                 flags: 0,
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(1),
@@ -1062,13 +1062,13 @@ mod tests {
                 call_site: None,
                 ts_ticks: 2,
             },
-            RawRecord::EndFunction {
+            Marker::FunctionExit {
                 status: FunctionEndStatus::Ok,
                 thread_id: BexThreadId(1),
                 call_id: BexCallId(1),
                 ts_ticks: 3,
             },
-            RawRecord::EndThread {
+            Marker::BexThreadEnd {
                 status: ThreadEndStatus::Completed,
                 thread_id: BexThreadId(1),
                 ts_ticks: 4,

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1270,7 +1270,7 @@ pub struct BexVm {
     /// OS thread, refreshed by the engine at the top of every exec resume
     /// (`run_thread_event_loop`) and **never valid across an `.await`**.
     /// `None` = profiling off. Pushes go through `prof_push_record`.
-    pub prof_ring: Option<&'static bex_events::prof::Ring>,
+    pub prof_ring: Option<&'static bex_events::prof::OSThreadMarkerRing>,
 
     /// Per-root execution suppression for project/catalog work that must not
     /// become visible run/profile state. `$id` call ids are still minted.
@@ -5951,14 +5951,14 @@ impl BexVm {
 
     /// Encodes one profiling record directly into a reserved slot of the
     /// supplied per-resume ring snapshot. Callers do the profiling-off gate
-    /// (they pass the already-unwrapped `&Ring`); the slot is sized from
-    /// [`bex_events::prof::record::RawRecord::encoded_len`] and initialized in
+    /// (they pass the already-unwrapped `&OSThreadMarkerRing`); the slot is sized from
+    /// [`bex_events::prof::record::Marker::encoded_len`] and initialized in
     /// place by `encode_to` — no intermediate stack buffer, no zeroing.
     #[inline]
     fn prof_push_record(
         &self,
-        ring: &bex_events::prof::Ring,
-        rec: &bex_events::prof::record::RawRecord<'_>,
+        ring: &bex_events::prof::OSThreadMarkerRing,
+        rec: &bex_events::prof::record::Marker<'_>,
     ) -> bool {
         // Encode straight into the ring slot: no intermediate stack buffer,
         // no 41-byte zeroing, and one copy instead of two (encode→buf→ring).
@@ -5998,7 +5998,7 @@ impl BexVm {
     /// latter owns a boundary handle, and every record it would have pushed is
     /// one `StructuralTransportExceeded` loss (§8.4), not one per exec resume.
     #[inline]
-    fn prof_ring_for_push(&self) -> Option<&'static bex_events::prof::Ring> {
+    fn prof_ring_for_push(&self) -> Option<&'static bex_events::prof::OSThreadMarkerRing> {
         if self.prof_ring.is_none() {
             self.prof_note_transport_loss();
         }
@@ -6060,7 +6060,7 @@ impl BexVm {
         let start_accepted = self.prof_ring_for_push().is_some_and(|ring| {
             self.prof_push_record(
                 ring,
-                &bex_events::prof::record::RawRecord::CallFunction {
+                &bex_events::prof::record::Marker::FunctionEnter {
                     flags: capture_plan.to_call_flags(),
                     thread_id: BexThreadId(self.prof_thread_id),
                     call_id: BexCallId(call_id),
@@ -6100,7 +6100,7 @@ impl BexVm {
             let ts_ticks = bex_events::prof::clock::now_ticks();
             let record = match awaited {
                 Some((await_ns, await_count)) => {
-                    bex_events::prof::record::RawRecord::EndFunctionAwaited {
+                    bex_events::prof::record::Marker::FunctionExitAwaited {
                         status,
                         thread_id: BexThreadId(self.prof_thread_id),
                         call_id: BexCallId(call_id),
@@ -6109,7 +6109,7 @@ impl BexVm {
                         await_count,
                     }
                 }
-                None => bex_events::prof::record::RawRecord::EndFunction {
+                None => bex_events::prof::record::Marker::FunctionExit {
                     status,
                     thread_id: BexThreadId(self.prof_thread_id),
                     call_id: BexCallId(call_id),
@@ -6304,7 +6304,7 @@ impl BexVm {
         let start_accepted = self.prof_ring_for_push().is_some_and(|ring| {
             self.prof_push_record(
                 ring,
-                &bex_events::prof::record::RawRecord::CallFunction {
+                &bex_events::prof::record::Marker::FunctionEnter {
                     flags: capture_plan.to_call_flags(),
                     thread_id: BexThreadId(self.prof_thread_id),
                     call_id: BexCallId(call_id),
@@ -6331,7 +6331,7 @@ impl BexVm {
         if let Some(ring) = self.prof_ring_for_push() {
             self.prof_push_record(
                 ring,
-                &bex_events::prof::record::RawRecord::SetFunctionId {
+                &bex_events::prof::record::Marker::SetBoundaryLocalId {
                     thread_id: BexThreadId(self.prof_thread_id),
                     call_id: BexCallId(call_id),
                     id,
@@ -6366,9 +6366,9 @@ impl BexVm {
         };
         // Both records in one push: one bounds check + one Release store
         // for the pair (the ring moves whole records; two at once is fine).
-        let mut buf = [0u8; bex_events::prof::record::CALL_FUNCTION_LEN
-            + bex_events::prof::record::END_FUNCTION_LEN];
-        let call_len = bex_events::prof::record::RawRecord::CallFunction {
+        let mut buf = [0u8; bex_events::prof::record::FUNCTION_ENTER_LEN
+            + bex_events::prof::record::FUNCTION_EXIT_LEN];
+        let call_len = bex_events::prof::record::Marker::FunctionEnter {
             flags: 0,
             thread_id: BexThreadId(self.prof_thread_id),
             call_id: BexCallId(call_id),
@@ -6378,7 +6378,7 @@ impl BexVm {
             ts_ticks: start_ticks,
         }
         .encode_to(&mut buf);
-        let end_len = bex_events::prof::record::RawRecord::EndFunction {
+        let end_len = bex_events::prof::record::Marker::FunctionExit {
             status,
             thread_id: BexThreadId(self.prof_thread_id),
             call_id: BexCallId(call_id),

--- a/documents/profiling-design-concerns.md
+++ b/documents/profiling-design-concerns.md
@@ -1,0 +1,15 @@
+# Profiling design concerns
+
+Open questions to revisit, not approved implementation changes.
+
+- [ ] **Function ID assignment separate from function entry.** Why emit a
+  separate marker when the initial boundary ID is assigned at entry? Consider
+  including it in `FunctionEnter`. Verify whether later reassignment is still
+  needed: the legacy `baml.id.set()` API currently permits it.
+- [ ] **128-bit boundary IDs: overkill?** Establish the actual uniqueness scope
+  and generation volume. Distinguish the public ID format from how IDs need to
+  be represented inside the profiling buffer.
+- [ ] **Two different thread-start markers.** `BexThreadStart` and
+  `BexThreadStartSpawned` both record a thread starting; the latter adds the
+  spawn source location. Consider one `BexThreadStart` with an optional spawn site.
+  Check whether preserving the two wire encodings is still necessary.


### PR DESCRIPTION
## Summary

Naming-only refactor of the agreed profiling types:

- `RawRecord` -> `Marker`; function variants -> `FunctionEnter`, `FunctionExit`, `FunctionExitAwaited`.
- Thread variants -> `BexThreadStart`, `BexThreadStartSpawned`, `BexThreadEnd`; `SetFunctionId` -> `SetBoundaryLocalId`.
- Ring types -> `OSThreadMarkerRing`, `OSThreadMarkerRingSegment`, `OSThreadMarkerRingHandle`.
- Decoder types -> `CallDecodeState`, `BexThreadDecodeState`, `ExecutionDecodeAccumulator`.
- Update references, tests, and documentation; record open design concerns in `documents/profiling-design-concerns.md`.

Wire tags, payload layouts, and behavior are unchanged. Calling-context, evidence, publication, and reader types are not renamed.

## Validation

- Rust 1.98.0: `cargo test --locked --no-fail-fast -p bex_prof_store -p bex_events -p bex_vm -p bex_engine -p baml_query_profiles -p baml_lsp_server`
- 735 tests passed, 0 failed, 4 ignored across these six crates.
- Rustfmt parsing/format checks passed for all changed Rust files.
- Reference scan and wire tag/size constant comparison passed.
- `git diff --check` passed.

macOS linker warnings about large unwind tables were non-fatal. The first build was blocked by an untrusted mise shim; the successful run used system tools instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized profiling terminology across runtime, storage, virtual-machine, and event-processing components.
  - Updated profiling event, thread lifecycle, ring, and decoding names without changing behavior, data formats, or semantics.

- **Documentation**
  - Updated profiling specifications and implementation notes to reflect current terminology.
  - Added a document outlining open profiling design considerations.

- **Tests**
  - Updated profiling test coverage to use the standardized terminology while preserving existing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->