### PR TITLE
Add isolated Btel replay benchmarks and reproducible plots

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1777,6 +1777,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "btel_bench"
+version = "0.0.0-beta"
+dependencies = [
+ "btel_core",
+ "btel_transport",
+ "clap",
+ "libc",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "btel_core"
+version = "0.0.0-beta"
+dependencies = [
+ "base64",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "btel_transport"
+version = "0.0.0-beta"
+dependencies = [
+ "btel_core",
+ "crossbeam-utils",
+ "loom",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -66,6 +66,8 @@ license = "Apache-2.0"
 version = "0.0.0-beta"
 
 [workspace.dependencies]
+btel_core = { path = "crates/btel_core" }
+btel_transport = { path = "crates/btel_transport" }
 #  Internal dependencies (baml_*)
 bex_str = { path = "crates/bex_str" }
 baml_base = { path = "crates/baml_base" }
@@ -506,3 +508,11 @@ inherits = "release"
 # size-minimizing settings — so the size-gate ceilings carry it explicitly
 # (`.cargo/size-gate.toml`). wasm32 is unaffected: it has no unwinding and
 # behaves as `abort` regardless of this setting.
+
+# Iteration profile for the isolated telemetry replay harness.
+[profile.btel]
+inherits = "release"
+opt-level = 3
+lto = "thin"
+codegen-units = 16
+strip = false

--- a/baml_language/crates/btel_bench/Cargo.toml
+++ b/baml_language/crates/btel_bench/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "btel_bench"
+description = "Standalone Btel marker replay and no-op pipeline benchmarks"
+version.workspace = true
+publish = false
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+btel_core.workspace = true
+btel_transport.workspace = true
+clap = { workspace = true, features = [ "derive" ] }
+serde = { workspace = true, features = [ "derive" ] }
+serde_json.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[package.metadata.ci]
+wasm_support = false

--- a/baml_language/crates/btel_bench/plots/plot.py
+++ b/baml_language/crates/btel_bench/plots/plot.py
@@ -1,0 +1,167 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["matplotlib==3.10.9"]
+# ///
+"""Regenerate the standard Btel benchmark plots from saved measurements.
+
+Usage from baml_language:
+    uv run crates/btel_bench/plots/plot.py /path/to/results --output /path/to/plots
+
+Input: identity.json and runs.json emitted by the paired replay sweep harness.
+Warmups are excluded. Every scenario must have all declared repetitions of
+encode-clock and feeder-only, with matching source manifests and load settings.
+Rate sweeps have requested_calls_per_second on each run and
+target_calls_per_second/calls_per_run in identity.json; volume sweeps vary calls.
+
+Output: summary.json, plus PNG and SVG versions of the established charts.
+Without --output, writes to RESULTS/plots. No benchmarks or Rust builds are run.
+Medians/min-max and paired CPU differences are preserved; no outliers are removed.
+Results describe the synthetic drain-only benchmark, not isolated VM overhead.
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def load_results(directory):
+    identity = json.loads((directory / "identity.json").read_text())
+    records = json.loads((directory / "runs.json").read_text())
+    repetitions = identity["repetitions"]
+    require(
+        isinstance(repetitions, int) and repetitions > 0, "Invalid repetition count"
+    )
+    runs = [r for r in records if not r.get("warmup", False)]
+    require(runs, "No measured runs")
+    is_rate = "requested_calls_per_second" in runs[0]
+    dimension = "requested_calls_per_second" if is_rate else "calls"
+    lookup = {}
+    transport_settings = set()
+    for run in runs:
+        require(("requested_calls_per_second" in run) == is_rate, "Mixed sweep types")
+        require(run["exit_code"] == 0, "Dataset contains a failed measured run")
+        require(run["mode"] in ("encode-clock", "feeder-only"), "Unsupported mode")
+        require(
+            run["threads"] > 0 and run["calls"] > 0 and run[dimension] > 0,
+            "Threads, calls and requested rates must be positive",
+        )
+        require(run["rep"] in range(repetitions), "Unexpected repetition index")
+        key = (run["threads"], run[dimension], run["rep"], run["mode"])
+        require(key not in lookup, f"Duplicate measurement: {key}")
+        result = run["result"]
+        require(result["producer_mode"] == run["mode"], "Producer mode mismatch")
+        require(result["source_threads"] == run["threads"], "Thread count mismatch")
+        require(
+            sum(s["calls"] for s in result["sources"]) == run["calls"],
+            "Source manifests do not match the total call count",
+        )
+        baseline = run["mode"] == "feeder-only"
+        require(
+            result["preset"] == ("feeder-only" if baseline else "drain-only"),
+            "This chart's stage labels currently describe the drain-only benchmark",
+        )
+        require(
+            result["consumer_threads"] == (0 if baseline else 1),
+            "Unexpected drainer count",
+        )
+        require(len(result["loads"]) == run["threads"], "Source load count mismatch")
+        for metric in (
+            "replay_seconds",
+            "replay_cpu_seconds",
+            "peak_rss_bytes_including_preparation",
+        ):
+            value = result[metric]
+            require(
+                isinstance(value, (int, float)) and math.isfinite(value) and value >= 0,
+                f"Missing or invalid metric: {metric}",
+            )
+        require(result["replay_seconds"] > 0, "Elapsed time must be positive")
+        for load in result["loads"]:
+            require(
+                load["start_delay_ms"] == 0 and load["burst_pause_ms"] == 0,
+                "Standard plots require no startup delay or burst pause",
+            )
+            expected_rate = run[dimension] * 80 // run["threads"] if is_rate else 0
+            require(
+                load["bytes_per_second"] == expected_rate,
+                "Source pacing differs from the plotted rate (80 bytes/call)",
+            )
+            transport_settings.add(
+                (
+                    result["memory_budget_bytes"],
+                    result["segment_bytes"],
+                    result["freelist_segments"],
+                    result["source_budget"],
+                    result["idle_timeout_micros"],
+                    result["idle_rings"],
+                    load["batch_markers"],
+                )
+            )
+        lookup[key] = run
+    require(
+        len(transport_settings) == 1, "Mixed transport/pacing settings in one sweep"
+    )
+    threads = sorted({r["threads"] for r in runs})
+    values = sorted({r[dimension] for r in runs})
+    if is_rate:
+        require(
+            values == sorted(identity["target_calls_per_second"]),
+            "Rate grid does not match identity.json",
+        )
+        require(
+            all(r["calls"] == identity["calls_per_run"] for r in runs),
+            "Rate sweep must hold the total call count fixed",
+        )
+    for count in threads:
+        for value in values:
+            for rep in range(repetitions):
+                keys = [
+                    (count, value, rep, mode)
+                    for mode in ("encode-clock", "feeder-only")
+                ]
+                require(
+                    all(k in lookup for k in keys),
+                    f"Missing pair: {count}, {value}, {rep}",
+                )
+                full, baseline = (lookup[k]["result"] for k in keys)
+                require(
+                    full["sources"] == baseline["sources"]
+                    and full["loads"] == baseline["loads"],
+                    f"Mismatched workload in pair: {count}, {value}, {rep}",
+                )
+    return identity, runs, is_rate
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "results", type=Path, help="Directory containing identity.json and runs.json"
+    )
+    parser.add_argument(
+        "--output", type=Path, help="Output directory (default: RESULTS/plots)"
+    )
+    args = parser.parse_args()
+    try:
+        identity, runs, is_rate = load_results(args.results)
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        parser.error(str(error))
+    output = args.output or args.results / "plots"
+    output.mkdir(parents=True, exist_ok=True)
+    if is_rate:
+        from rate import render
+    else:
+        from volume import render
+    render(identity, runs, output)
+    print(f"Plots and summary saved to {output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/baml_language/crates/btel_bench/plots/rate.py
+++ b/baml_language/crates/btel_bench/plots/rate.py
@@ -1,0 +1,231 @@
+"""Preserved rate benchmark chart layout. Use plot.py as the entry point."""
+
+import json
+import statistics as stats
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+
+def render(identity, runs, root):
+    threads_list = sorted({r["threads"] for r in runs})
+    max_rate = max(identity["target_calls_per_second"]) / 1e6
+    lookup = {
+        (r["threads"], r["requested_calls_per_second"], r["rep"], r["mode"]): r[
+            "result"
+        ]
+        for r in runs
+    }
+    summary = []
+
+    def describe(values):
+        return {
+            "median": stats.median(values),
+            "min": min(values),
+            "max": max(values),
+            "samples": values,
+        }
+
+    for threads in threads_list:
+        for rate in identity["target_calls_per_second"]:
+            pairs = [
+                (
+                    lookup[threads, rate, i, "encode-clock"],
+                    lookup[threads, rate, i, "feeder-only"],
+                )
+                for i in range(identity["repetitions"])
+            ]
+            row = {
+                "threads": threads,
+                "requested_calls_per_second": rate,
+                "calls": identity["calls_per_run"],
+            }
+            for index, mode in ((0, "full"), (1, "baseline")):
+                row[f"{mode}_achieved_calls_per_second"] = describe(
+                    [row["calls"] / p[index]["replay_seconds"] for p in pairs]
+                )
+                row[f"{mode}_cpu_ns_per_call"] = describe(
+                    [p[index]["replay_cpu_seconds"] * 1e9 / row["calls"] for p in pairs]
+                )
+                row[f"{mode}_elapsed_seconds"] = describe(
+                    [p[index]["replay_seconds"] for p in pairs]
+                )
+                row[f"{mode}_peak_rss_bytes_including_preparation"] = describe(
+                    [p[index]["peak_rss_bytes_including_preparation"] for p in pairs]
+                )
+            row["paired_difference_cpu_ns_per_call"] = describe(
+                [
+                    (a["replay_cpu_seconds"] - b["replay_cpu_seconds"])
+                    * 1e9
+                    / row["calls"]
+                    for a, b in pairs
+                ]
+            )
+            summary.append(row)
+    (root / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    plt.rcParams.update(
+        {
+            "font.family": "DejaVu Sans",
+            "font.size": 10.5,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.titleweight": "bold",
+        }
+    )
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10.8), dpi=180)
+    fig.patch.set_facecolor("#fafbfc")
+    colors = {n: plt.get_cmap("tab10")(i % 10) for i, n in enumerate(threads_list)}
+    colors.update({1: "#7c3aed", 4: "#2563eb", 32: "#0d9488"})
+    metrics = [
+        (
+            axes[0, 0],
+            "full_achieved_calls_per_second",
+            1e-6,
+            "Can the pipeline keep up?",
+            "Achieved function calls / second (millions)",
+        ),
+        (
+            axes[0, 1],
+            "full_cpu_ns_per_call",
+            1,
+            "Total CPU cost",
+            "Process CPU ns / function call",
+        ),
+        (
+            axes[1, 0],
+            "full_peak_rss_bytes_including_preparation",
+            1 / 2**30,
+            "Process peak memory, including prepared inputs",
+            "Peak RSS (GiB)",
+        ),
+        (
+            axes[1, 1],
+            "paired_difference_cpu_ns_per_call",
+            1,
+            "Estimated additional CPU above feeder baseline",
+            "Full − baseline CPU ns / function call",
+        ),
+    ]
+    for threads in threads_list:
+        rows = [r for r in summary if r["threads"] == threads]
+        x = [r["requested_calls_per_second"] / 1e6 for r in rows]
+        for ax, key, factor, title, ylabel in metrics:
+            values = [r[key] for r in rows]
+            ax.plot(
+                x,
+                [v["median"] * factor for v in values],
+                "o-",
+                color=colors[threads],
+                linewidth=2,
+                markersize=4.5,
+                label=f"{threads} producer" + ("s" if threads != 1 else ""),
+            )
+            ax.fill_between(
+                x,
+                [v["min"] * factor for v in values],
+                [v["max"] * factor for v in values],
+                color=colors[threads],
+                alpha=0.10,
+            )
+        axes[0, 1].plot(
+            x,
+            [r["baseline_cpu_ns_per_call"]["median"] for r in rows],
+            ":",
+            color=colors[threads],
+            linewidth=1.8,
+        )
+    axes[0, 0].plot(
+        [0, max_rate],
+        [0, max_rate],
+        "--",
+        color="#94a3b8",
+        linewidth=1.2,
+        label="Keeping up (y = x)",
+    )
+    axes[0, 0].legend(frameon=False, loc="upper left", fontsize=9)
+    axes[0, 1].legend(
+        handles=[
+            Line2D([0], [0], color="#475569", linewidth=2, label="Full replay"),
+            Line2D(
+                [0],
+                [0],
+                color="#475569",
+                linestyle=":",
+                linewidth=1.8,
+                label="Feeder baseline",
+            ),
+        ],
+        frameon=False,
+        fontsize=9,
+    )
+    for ax, key, factor, title, ylabel in metrics:
+        ax.set_title(title, loc="left", pad=12, fontsize=12)
+        ax.set_ylabel(ylabel)
+        ax.set_xlabel("Requested function calls / second (millions, total)")
+        ax.set_xlim(0, max_rate * 1.0625)
+        ax.set_xticks([max_rate * i / 8 for i in range(9)])
+        ax.set_facecolor("#fafbfc")
+        ax.grid(axis="y", alpha=0.18)
+        ax.set_axisbelow(True)
+        if key != "paired_difference_cpu_ns_per_call":
+            ax.set_ylim(bottom=0)
+        else:
+            ax.axhline(0, color="#94a3b8", linewidth=0.8)
+    fig.suptitle(
+        "Function-call rate: where do we stop keeping up?",
+        x=0.075,
+        y=0.978,
+        ha="left",
+        fontsize=20,
+        fontweight="bold",
+    )
+    fig.text(
+        0.075,
+        0.937,
+        f"{identity['calls_per_run'] / 1e6:g} million calls per run • requested rate split evenly across producers • clock + encoding + rings + discard drainer",
+        fontsize=10.5,
+        color="#475569",
+    )
+    fig.text(
+        0.075,
+        0.118,
+        "1 call = enter + exit. Achieved rate = total calls / elapsed time through complete drain; this is not span-builder throughput.",
+        fontsize=10,
+        color="#475569",
+    )
+    fig.text(
+        0.075,
+        0.088,
+        f"Pacing uses batches of {runs[0]['result']['loads'][0]['batch_markers']:,} markers. {runs[0]['result']['memory_budget_bytes'] / 2**20:g} MiB transport budget. RSS includes prepared inputs and other process memory.",
+        fontsize=10,
+        color="#475569",
+    )
+    fig.text(
+        0.075,
+        0.058,
+        f"Points: medians of {identity['repetitions']} runs/pairs. Bands: observed min–max, not confidence intervals. Dotted CPU curves: feeder baseline.",
+        fontsize=10,
+        color="#475569",
+    )
+    fig.text(
+        0.075,
+        0.028,
+        "CPU subtraction is an estimate: pacing, scheduling, cache behavior and backpressure can differ between paired runs.",
+        fontsize=10,
+        color="#475569",
+    )
+    fig.subplots_adjust(
+        left=0.075, right=0.985, top=0.868, bottom=0.215, wspace=0.27, hspace=0.41
+    )
+    for ext in ("png", "svg"):
+        fig.savefig(root / f"call-rate-sweep.{ext}", facecolor=fig.get_facecolor())
+    for threads in threads_list:
+        rows = [r for r in summary if r["threads"] == threads]
+        print(f"{threads} producers:")
+        for row in rows:
+            print(
+                f"  requested={row['requested_calls_per_second'] / 1e6:.0f}M/s achieved={row['full_achieved_calls_per_second']['median'] / 1e6:.1f}M/s cpu={row['full_cpu_ns_per_call']['median']:.1f}ns/call extra={row['paired_difference_cpu_ns_per_call']['median']:.1f}ns/call RSS={row['full_peak_rss_bytes_including_preparation']['median'] / 2**30:.2f}GiB"
+            )

--- a/baml_language/crates/btel_bench/plots/volume.py
+++ b/baml_language/crates/btel_bench/plots/volume.py
@@ -1,0 +1,251 @@
+"""Preserved volume benchmark chart layout. Use plot.py as the entry point."""
+
+import json
+import statistics as stats
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def render(identity, runs, root):
+    threads_list = sorted({r["threads"] for r in runs})
+    calls_list = sorted({r["calls"] for r in runs})
+    lookup = {
+        (r["threads"], r["calls"], r["rep"], r["mode"]): r["result"] for r in runs
+    }
+    summary = []
+    for n in threads_list:
+        for calls in calls_list:
+            pairs = [
+                (
+                    lookup[n, calls, rep, "encode-clock"],
+                    lookup[n, calls, rep, "feeder-only"],
+                )
+                for rep in range(identity["repetitions"])
+            ]
+            entry = {
+                "threads": n,
+                "calls": calls,
+                "equivalent_marker_bytes": pairs[0][0]["input_bytes"],
+            }
+            for key, label in [
+                ("replay_cpu_seconds", "cpu"),
+                ("replay_seconds", "elapsed"),
+            ]:
+                for idx, mode in [(0, "full"), (1, "baseline")]:
+                    values = [p[idx][key] * 1e9 / calls for p in pairs]
+                    entry[f"{mode}_{label}_ns_per_call"] = {
+                        "median": stats.median(values),
+                        "min": min(values),
+                        "max": max(values),
+                    }
+                differences = [(a[key] - b[key]) * 1e9 / calls for a, b in pairs]
+                entry[f"paired_difference_{label}_ns_per_call"] = {
+                    "median": stats.median(differences),
+                    "min": min(differences),
+                    "max": max(differences),
+                    "samples": differences,
+                }
+            entry["full_peak_rss_including_preparation_bytes"] = stats.median(
+                a["peak_rss_bytes_including_preparation"] for a, b in pairs
+            )
+            entry["baseline_peak_rss_including_preparation_bytes"] = stats.median(
+                b["peak_rss_bytes_including_preparation"] for a, b in pairs
+            )
+            summary.append(entry)
+    (root / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    plt.rcParams.update(
+        {
+            "font.family": "DejaVu Sans",
+            "font.size": 10,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.titleweight": "bold",
+        }
+    )
+    colors = {"full": "#2563eb", "baseline": "#64748b", "difference": "#0d9488"}
+    fig, axes = plt.subplots(
+        2, len(threads_list), figsize=(14, 8.6), dpi=180, squeeze=False
+    )
+    fig.patch.set_facecolor("#fafbfc")
+    for col, n in enumerate(threads_list):
+        rows = [r for r in summary if r["threads"] == n]
+        x = [r["calls"] / 1e6 for r in rows]
+        for mode in ("full", "baseline"):
+            values = [r[f"{mode}_cpu_ns_per_call"] for r in rows]
+            axes[0, col].plot(
+                x,
+                [v["median"] for v in values],
+                "o-",
+                color=colors[mode],
+                label="Full replay" if mode == "full" else "Feeder baseline",
+                linewidth=2,
+            )
+            axes[0, col].fill_between(
+                x,
+                [v["min"] for v in values],
+                [v["max"] for v in values],
+                color=colors[mode],
+                alpha=0.13,
+            )
+        axes[0, col].set_title(
+            f"{n} producer" + ("s" if n != 1 else ""), loc="left", pad=12
+        )
+        axes[0, col].legend(frameon=False, fontsize=9)
+        values = [r["paired_difference_cpu_ns_per_call"] for r in rows]
+        axes[1, col].plot(
+            x,
+            [v["median"] for v in values],
+            "o-",
+            color=colors["difference"],
+            linewidth=2,
+        )
+        axes[1, col].fill_between(
+            x,
+            [v["min"] for v in values],
+            [v["max"] for v in values],
+            color=colors["difference"],
+            alpha=0.14,
+        )
+        axes[1, col].set_title(
+            "Estimated additional CPU cost", loc="left", fontsize=11, pad=12
+        )
+        for i, (px, v) in enumerate(zip(x, values)):
+            axes[1, col].annotate(
+                f"{v['median']:.1f}",
+                (px, v["median"]),
+                xytext=(
+                    (-4, 9)
+                    if i == 0
+                    else (4, 10)
+                    if i == 1
+                    else (0, -15)
+                    if i == 3
+                    else (0, 9)
+                ),
+                textcoords="offset points",
+                ha=("right" if i == 0 else "left" if i == 1 else "center"),
+                color=colors["difference"],
+                fontsize=9,
+                fontweight="bold",
+            )
+        for row in (0, 1):
+            ax = axes[row, col]
+            ax.set_facecolor("#fafbfc")
+            ax.grid(axis="y", alpha=0.18)
+            ax.set_axisbelow(True)
+            ax.set_xlim(0, max(calls_list) / 1e6 * 1.078125)
+            ax.set_xticks(
+                [1, 4, 8, 16]
+                if max(calls_list) == 16_000_000
+                else [c / 1e6 for c in calls_list]
+            )
+            ax.set_xlabel("Total function calls (millions)")
+            ax.set_ylabel(
+                "CPU ns / synthetic call"
+                if row == 0
+                else "Full − baseline CPU ns / call"
+            )
+            ax.axhline(0, color="#94a3b8", linewidth=0.8)
+        axes[0, col].set_ylim(bottom=0)
+    # Shared scales allow direct topology comparison; retain negatives if observed.
+    for row in (0, 1):
+        ymin = min(ax.get_ylim()[0] for ax in axes[row])
+        ymax = max(ax.get_ylim()[1] for ax in axes[row])
+        for ax in axes[row]:
+            ax.set_ylim(ymin, ymax)
+    fig.suptitle(
+        "How much CPU belongs to the feeder?",
+        x=0.07,
+        y=0.98,
+        ha="left",
+        fontsize=20,
+        fontweight="bold",
+    )
+    fig.text(
+        0.07,
+        0.934,
+        "Full = feeder + clock + encoding + rings + discard drainer. Baseline = feeder with compiler barriers.",
+        color="#475569",
+        fontsize=10.5,
+    )
+    fig.text(
+        0.07,
+        0.101,
+        "1 synthetic call = enter + exit. Baseline emits no bytes and has no drainer; full replay has one round-robin drainer.",
+        color="#475569",
+        fontsize=10,
+    )
+    fig.text(
+        0.07,
+        0.070,
+        f"Points: medians of {identity['repetitions']} runs/pairs. Bands: observed min–max. Differences are computed within each adjacent pair.",
+        color="#475569",
+        fontsize=10,
+    )
+    fig.text(
+        0.07,
+        0.039,
+        "Subtraction estimates incremental CPU, not exact VM overhead: barriers, caches, scheduling and backpressure differ.",
+        color="#475569",
+        fontsize=10,
+    )
+    fig.subplots_adjust(
+        left=0.07, right=0.985, top=0.86, bottom=0.20, wspace=0.31, hspace=0.44
+    )
+    for ext in ("png", "svg"):
+        fig.savefig(root / f"cpu-baseline.{ext}", facecolor=fig.get_facecolor())
+    fig2, axs = plt.subplots(
+        1, len(threads_list), figsize=(14, 5), dpi=180, squeeze=False
+    )
+    axs = axs[0]
+    for ax, n in zip(axs, threads_list):
+        rows = [r for r in summary if r["threads"] == n]
+        x = [r["calls"] / 1e6 for r in rows]
+        for mode in ("full", "baseline"):
+            ms = lambda r, k, mode=mode: (
+                r[f"{mode}_elapsed_ns_per_call"][k] * r["calls"] / 1e6
+            )
+            ax.plot(
+                x,
+                [ms(r, "median") for r in rows],
+                "o-",
+                color=colors[mode],
+                label="Full replay" if mode == "full" else "Feeder baseline",
+            )
+            ax.fill_between(
+                x,
+                [ms(r, "min") for r in rows],
+                [ms(r, "max") for r in rows],
+                color=colors[mode],
+                alpha=0.13,
+            )
+        ax.set_title(f"{n} producer" + ("s" if n != 1 else ""), loc="left")
+        ax.set_xlabel("Total function calls (millions)")
+        ax.set_ylabel("Elapsed time (ms)")
+        ax.set_ylim(bottom=0)
+        ax.grid(axis="y", alpha=0.18)
+        ax.legend(frameon=False, fontsize=9)
+    fig2.suptitle(
+        "Time to finish: full replay vs feeder baseline",
+        x=0.07,
+        y=0.98,
+        ha="left",
+        fontsize=18,
+        fontweight="bold",
+    )
+    fig2.text(
+        0.07,
+        0.045,
+        f"Medians and observed min–max of {identity['repetitions']} runs. Elapsed measures completion time; subtracting it does not isolate stage latency.",
+        fontsize=10,
+        color="#475569",
+    )
+    fig2.subplots_adjust(left=0.07, right=0.985, top=0.81, bottom=0.20, wspace=0.32)
+    for ext in ("png", "svg"):
+        fig2.savefig(root / f"elapsed-baseline.{ext}", facecolor="#fafbfc")
+    for r in summary:
+        if r["calls"] == 16_000_000:
+            print(json.dumps(r))

--- a/baml_language/crates/btel_bench/src/feeder.rs
+++ b/baml_language/crates/btel_bench/src/feeder.rs
@@ -1,0 +1,189 @@
+//! Producer policy is selected once; replay monomorphizes each loop.
+use btel_core::marker::Marker;
+use clap::ValueEnum;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, ValueEnum, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProducerMode {
+    Prepared,
+    EncodeClock,
+    /// Traverse the live-encoding inputs without clock, encoding or transport work.
+    FeederOnly,
+}
+
+/// Change only timestamp fields; the fixture still defines exact counts/bytes.
+#[inline]
+pub fn stamp(marker: &mut Marker<'_>, ticks: u64) {
+    let (Marker::FunctionEnter { ts_ticks, .. }
+    | Marker::FunctionExit { ts_ticks, .. }
+    | Marker::FunctionExitAwaited { ts_ticks, .. }
+    | Marker::BexThreadStart { ts_ticks, .. }
+    | Marker::BexThreadStartSpawned { ts_ticks, .. }
+    | Marker::BexThreadEnd { ts_ticks, .. }
+    | Marker::SetBoundaryLocalId { ts_ticks, .. }) = marker;
+    *ts_ticks = ticks;
+}
+
+/// Keep the successful path to one attempt. A rejected attempt has committed
+/// no bytes, so retry the same marker without reading another timestamp.
+#[inline]
+pub(crate) fn write_or_wait(
+    factory: &btel_transport::SourceFactory,
+    mut write: impl FnMut() -> bool,
+) {
+    if !write() {
+        wait_for_capacity(factory, write);
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn wait_for_capacity(factory: &btel_transport::SourceFactory, mut write: impl FnMut() -> bool) {
+    loop {
+        factory.wake_consumer();
+        for _ in 0..16 {
+            std::hint::spin_loop();
+            if write() {
+                return;
+            }
+        }
+        // The drainer needs CPU time to reclaim capacity. Never spin forever
+        // without yielding, especially when source threads outnumber cores.
+        std::thread::yield_now();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use btel_core::{
+        clock, marker,
+        stage::{MarkerBatch, MarkerRange},
+    };
+    use btel_transport::{Pipeline, RangeHandler, TransportConfig, transport};
+
+    use super::stamp;
+    use crate::{
+        noop::{NoopAggregator, NoopEventBuilder, NoopPublisher},
+        workload::{Fixture, for_each_template},
+    };
+
+    #[test]
+    fn clocked_direct_encoding_matches_the_wire_codec_through_recycling() {
+        struct Capture(Rc<RefCell<Vec<u8>>>);
+        impl RangeHandler for Capture {
+            fn accept(&mut self, range: MarkerRange<'_>, _: impl FnMut(MarkerBatch)) {
+                self.0.borrow_mut().extend_from_slice(range.bytes);
+            }
+        }
+        let fixture = Fixture::prepare(7, 65, 8, None).unwrap();
+        let (factory, mut drainer) = transport(TransportConfig {
+            segment_bytes: 64,
+            ..TransportConfig::default()
+        })
+        .unwrap();
+        let mut producer = factory.producer(7).unwrap();
+        let captured = Rc::new(RefCell::new(Vec::new()));
+        let mut pipeline = Pipeline::new(
+            Capture(captured.clone()),
+            NoopEventBuilder,
+            NoopAggregator,
+            NoopPublisher,
+        );
+        let mut expected = Vec::new();
+        clock::init();
+        let before = clock::now_ticks();
+        for_each_template(&fixture.manifest, |mut record| {
+            let ticks = clock::now_ticks();
+            assert!(ticks >= before);
+            stamp(&mut record, ticks);
+            assert!(producer.write_marker(&record));
+            let mut scratch = [0; marker::MAX_RECORD_LEN];
+            let len = record.encode(&mut scratch);
+            expected.extend_from_slice(&scratch[..len]);
+            drainer.drain(&mut pipeline, 1);
+        });
+        drop(producer);
+        drainer.finish(pipeline).unwrap();
+        assert_eq!(*captured.borrow(), expected);
+        assert_eq!(expected.len() as u64, fixture.manifest.bytes);
+        assert_eq!(
+            marker::iter(&expected).count() as u64,
+            fixture.manifest.markers
+        );
+    }
+
+    #[test]
+    fn rejected_write_waits_for_draining_then_preserves_every_record() {
+        struct Sequences(Rc<RefCell<Vec<u64>>>);
+        impl RangeHandler for Sequences {
+            fn accept(&mut self, range: MarkerRange<'_>, _: impl FnMut(MarkerBatch)) {
+                let (records, remainder) = range.bytes.as_chunks::<4096>();
+                assert!(remainder.is_empty());
+                for record in records {
+                    self.0
+                        .borrow_mut()
+                        .push(u64::from_le_bytes(record[..8].try_into().unwrap()));
+                }
+            }
+        }
+        let config = TransportConfig {
+            segment_bytes: 4096,
+            memory_bytes: 16 * 1024 * 1024,
+            ..TransportConfig::default()
+        };
+        config.check_retry_capacity(1).unwrap();
+        let (factory, mut drainer) = transport(config).unwrap();
+        drainer.register_worker();
+        let (rejected_tx, rejected_rx) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let mut producer = factory.producer(1).unwrap();
+            let mut reported_rejection = false;
+            let mut record = [0; 4096];
+            for seq in 0u64..5000 {
+                record[..8].copy_from_slice(&seq.to_le_bytes());
+                super::write_or_wait(&factory, || {
+                    let accepted = producer.write(&record);
+                    if !accepted && !reported_rejection {
+                        reported_rejection = true;
+                        rejected_tx.send(()).unwrap();
+                    }
+                    accepted
+                });
+            }
+        });
+        // Deliberately withhold drainage until the real memory limit is hit.
+        rejected_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap();
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut pipeline = Pipeline::new(
+            Sequences(observed.clone()),
+            NoopEventBuilder,
+            NoopAggregator,
+            NoopPublisher,
+        );
+        while !writer.is_finished() {
+            drainer.drain(&mut pipeline, 1);
+            std::thread::yield_now();
+        }
+        writer.join().unwrap();
+        drainer.finish(pipeline).unwrap();
+        assert_eq!(*observed.borrow(), (0..5000).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn retry_preflight_rejects_a_budget_that_rings_can_permanently_retain() {
+        let config = TransportConfig {
+            memory_bytes: 16 * 1024 * 1024,
+            ..TransportConfig::default()
+        };
+        config.check_retry_capacity(4).unwrap();
+        assert_eq!(
+            config.check_retry_capacity(16),
+            Err(btel_transport::TransportError::InsufficientRetryCapacity)
+        );
+    }
+}

--- a/baml_language/crates/btel_bench/src/lib.rs
+++ b/baml_language/crates/btel_bench/src/lib.rs
@@ -1,0 +1,6 @@
+//! Replay support; production stage contracts live in the Btel libraries.
+pub mod noop;
+pub mod replay;
+pub mod workload;
+
+pub mod feeder;

--- a/baml_language/crates/btel_bench/src/main.rs
+++ b/baml_language/crates/btel_bench/src/main.rs
@@ -1,0 +1,107 @@
+//! One binary, one preset for Phase A. Start with `--help`.
+use std::{io, path::PathBuf, time::Duration};
+
+use btel_bench::{
+    feeder::ProducerMode,
+    replay::{self, ReplayConfig, SourceLoad},
+    workload::Fixture,
+};
+use btel_transport::TransportConfig;
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(about = "Measure Btel ring producers and all-no-op pipeline (drain-only)")]
+struct Args {
+    /// Live clock/encoding, prepared-byte replay, or a feeder-only baseline.
+    #[arg(long, value_enum, default_value_t = ProducerMode::EncodeClock)]
+    producer_mode: ProducerMode,
+    #[arg(long, default_value_t = 4)]
+    threads: usize,
+    #[arg(long, default_value_t = 1_000_000)]
+    calls_per_source: u64,
+    /// Optional per-source call counts; exactly --threads comma-separated entries.
+    #[arg(long, value_delimiter = ',')]
+    source_calls: Vec<u64>,
+    /// Per-source byte rates. Zero is unpaced. Omit for all unpaced.
+    #[arg(long, value_delimiter = ',')]
+    source_rates: Vec<u64>,
+    #[arg(long, value_delimiter = ',')]
+    source_delays_ms: Vec<u64>,
+    #[arg(long, default_value_t = 1)]
+    depth: usize,
+    #[arg(long, default_value_t = 0)]
+    idle_rings: usize,
+    #[arg(long, default_value_t = 262_144)]
+    segment_bytes: usize,
+    #[arg(long, default_value_t = 2)]
+    freelist_segments: usize,
+    #[arg(long, default_value_t = 256)]
+    memory_mib: u64,
+    #[arg(long, default_value_t = 16)]
+    source_budget: usize,
+    #[arg(long, default_value_t = 1024)]
+    batch_markers: usize,
+    #[arg(long, default_value_t = 0)]
+    burst_pause_ms: u64,
+    #[arg(long, default_value_t = 200)]
+    idle_timeout_micros: u64,
+    /// Generate reusable fixtures here on first use; validate and load on later runs.
+    #[arg(long)]
+    fixture_dir: Option<PathBuf>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    if args.threads == 0 {
+        return Err("--threads must be positive".into());
+    }
+    for (name, count) in [
+        ("source-calls", args.source_calls.len()),
+        ("source-rates", args.source_rates.len()),
+        ("source-delays-ms", args.source_delays_ms.len()),
+    ] {
+        if count != 0 && count != args.threads {
+            return Err(format!("--{name} needs exactly --threads entries").into());
+        }
+    }
+    let mut fixtures = Vec::new();
+    for i in 0..args.threads {
+        let fixture = Fixture::prepare(
+            i as u64 + 1,
+            args.source_calls
+                .get(i)
+                .copied()
+                .unwrap_or(args.calls_per_source),
+            args.depth,
+            args.fixture_dir.as_deref(),
+        )?;
+        fixtures.push((
+            fixture,
+            SourceLoad {
+                bytes_per_second: args.source_rates.get(i).copied().unwrap_or(0),
+                start_delay_ms: args.source_delays_ms.get(i).copied().unwrap_or(0),
+                batch_markers: args.batch_markers,
+                burst_pause_ms: args.burst_pause_ms,
+            },
+        ));
+    }
+    let result = replay::run(
+        ReplayConfig {
+            producer_mode: args.producer_mode,
+            transport: TransportConfig {
+                segment_bytes: args.segment_bytes,
+                freelist_segments: args.freelist_segments,
+                memory_bytes: args
+                    .memory_mib
+                    .checked_mul(1024 * 1024)
+                    .ok_or("memory budget overflow")?,
+            },
+            source_budget: args.source_budget,
+            idle_rings: args.idle_rings,
+            idle_timeout: Duration::from_micros(args.idle_timeout_micros),
+        },
+        fixtures,
+    )?;
+    serde_json::to_writer_pretty(io::stdout().lock(), &result)?;
+    Ok(())
+}

--- a/baml_language/crates/btel_bench/src/noop.rs
+++ b/baml_language/crates/btel_bench/src/noop.rs
@@ -1,0 +1,66 @@
+//! No-op range handling and semantic stages; the concrete Drainer still polls rings.
+use btel_core::stage::{Aggregator, EventBuilder, MarkerBatch, MarkerRange, Publisher};
+use btel_transport::{Pipeline, RangeHandler};
+
+#[derive(Default)]
+pub struct DiscardRanges;
+impl RangeHandler for DiscardRanges {
+    fn accept(&mut self, _input: MarkerRange<'_>, _emit: impl FnMut(MarkerBatch)) {}
+}
+
+#[derive(Default)]
+pub struct NoopEventBuilder;
+impl EventBuilder for NoopEventBuilder {
+    type Event = ();
+    fn build(&mut self, _input: MarkerRange<'_>, _emit: impl FnMut(())) {}
+}
+
+#[derive(Default)]
+pub struct NoopAggregator;
+impl Aggregator<()> for NoopAggregator {
+    type Aggregate = ();
+    fn observe(&mut self, _event: &(), _emit: impl FnMut(())) {}
+}
+
+#[derive(Default)]
+pub struct NoopPublisher;
+impl Publisher<(), ()> for NoopPublisher {
+    fn event(&mut self, (): ()) {}
+    fn aggregate(&mut self, (): ()) {}
+}
+
+pub type NoopPipeline = Pipeline<DiscardRanges, NoopEventBuilder, NoopAggregator, NoopPublisher>;
+
+pub fn pipeline() -> NoopPipeline {
+    Pipeline::new(
+        DiscardRanges,
+        NoopEventBuilder,
+        NoopAggregator,
+        NoopPublisher,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_noops_accept_input_without_emitting_semantic_work() {
+        let range = MarkerRange {
+            source_id: 1,
+            bytes: &[1, 2, 3],
+        };
+        DiscardRanges.accept(range, |_| panic!("discard must not manufacture a batch"));
+        NoopEventBuilder.build(range, |()| panic!("no-op builder emitted"));
+        NoopAggregator.observe(&(), |()| panic!("no-op aggregator emitted"));
+        let (factory, mut drainer) =
+            btel_transport::transport(btel_transport::TransportConfig::default()).unwrap();
+        let mut producer = factory.producer(1).unwrap();
+        assert!(producer.write(range.bytes));
+        let mut pipeline = pipeline();
+        assert!(drainer.drain(&mut pipeline, 1));
+        assert!(!drainer.drain(&mut pipeline, 1));
+        drop(producer);
+        drainer.finish(pipeline).unwrap();
+    }
+}

--- a/baml_language/crates/btel_bench/src/replay.rs
+++ b/baml_language/crates/btel_bench/src/replay.rs
@@ -1,0 +1,437 @@
+//! Concurrent replay. Source setup precedes the start gate; shutdown drains to completion.
+use std::{
+    sync::{
+        Arc, Condvar, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use btel_core::{clock, marker::Marker};
+use btel_transport::{TransportConfig, transport};
+use serde::Serialize;
+
+use crate::{
+    feeder::{ProducerMode, stamp, write_or_wait},
+    noop,
+    workload::{Fixture, Manifest},
+};
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct SourceLoad {
+    pub bytes_per_second: u64,
+    pub start_delay_ms: u64,
+    pub batch_markers: usize,
+    pub burst_pause_ms: u64,
+}
+
+#[derive(Clone, Copy)]
+pub struct ReplayConfig {
+    pub producer_mode: ProducerMode,
+    pub transport: TransportConfig,
+    pub source_budget: usize,
+    pub idle_rings: usize,
+    pub idle_timeout: Duration,
+}
+
+#[derive(Serialize)]
+pub struct ReplayResult {
+    pub producer_mode: ProducerMode,
+    pub clock_kind: Option<String>,
+    pub clock_reads: u64,
+    pub preset: &'static str,
+    pub full_ring_policy: &'static str,
+    pub pipeline: &'static str,
+    pub sources: Vec<Manifest>,
+    pub loads: Vec<SourceLoad>,
+    pub source_threads: usize,
+    pub consumer_threads: usize,
+    pub idle_rings: usize,
+    pub input_bytes: u64,
+    pub markers: u64,
+    /// Actual ring traffic; zero for the feeder-only baseline. Input totals
+    /// above describe the workload even when it never reaches the ring.
+    pub ring_bytes: u64,
+    pub ring_markers: u64,
+    pub replay_seconds: f64,
+    pub producer_seconds: f64,
+    pub final_drain_seconds: f64,
+    pub bytes_per_second: Option<f64>,
+    pub replay_cpu_seconds: Option<f64>,
+    pub peak_rss_bytes_including_preparation: Option<u64>,
+    pub segment_bytes: usize,
+    pub freelist_segments: usize,
+    pub memory_budget_bytes: u64,
+    pub source_budget: usize,
+    pub idle_timeout_micros: u128,
+}
+
+#[derive(Clone, Copy)]
+enum Start {
+    Pending,
+    Run(Instant),
+    Abort,
+}
+struct Gate {
+    state: Mutex<Start>,
+    wake: Condvar,
+}
+impl Gate {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(Start::Pending),
+            wake: Condvar::new(),
+        }
+    }
+    fn release(&self, start: Start) {
+        *self.state.lock().unwrap() = start;
+        self.wake.notify_all();
+    }
+    fn wait(&self) -> Option<Instant> {
+        let mut state = self.state.lock().unwrap();
+        loop {
+            match *state {
+                Start::Run(at) => return Some(at),
+                Start::Abort => return None,
+                Start::Pending => state = self.wake.wait(state).unwrap(),
+            }
+        }
+    }
+}
+
+pub fn run(
+    config: ReplayConfig,
+    fixtures: Vec<(Fixture, SourceLoad)>,
+) -> Result<ReplayResult, String> {
+    match config.producer_mode {
+        ProducerMode::Prepared => run_with::<false, false>(config, fixtures),
+        ProducerMode::EncodeClock => run_with::<true, false>(config, fixtures),
+        ProducerMode::FeederOnly => run_with::<true, true>(config, fixtures),
+    }
+}
+
+fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
+    config: ReplayConfig,
+    fixtures: Vec<(Fixture, SourceLoad)>,
+) -> Result<ReplayResult, String> {
+    if ENCODE && !FEEDER_ONLY {
+        clock::init();
+    }
+    if fixtures.is_empty() || config.source_budget == 0 {
+        return Err("sources and source budget must be positive".into());
+    }
+    if fixtures.iter().any(|(_, load)| load.batch_markers == 0) {
+        return Err("batch markers must be positive".into());
+    }
+    if fixtures.iter().any(|(f, _)| {
+        f.lengths
+            .iter()
+            .any(|len| usize::from(*len) > config.transport.segment_bytes)
+    }) {
+        return Err("segment cannot hold the largest fixture marker".into());
+    }
+    config
+        .transport
+        .check_retry_capacity(
+            fixtures
+                .len()
+                .checked_add(config.idle_rings)
+                .ok_or("source count overflow")?,
+        )
+        .map_err(|e| {
+            format!("retry configuration: {e}; increase memory or reduce sources/freelist")
+        })?;
+    let sources: Vec<_> = fixtures.iter().map(|(f, _)| f.manifest.clone()).collect();
+    let loads: Vec<_> = fixtures.iter().map(|(_, load)| *load).collect();
+    let input_bytes = sources
+        .iter()
+        .try_fold(0u64, |n, s| n.checked_add(s.bytes))
+        .ok_or("total bytes overflow")?;
+    let markers = sources
+        .iter()
+        .try_fold(0u64, |n, s| n.checked_add(s.markers))
+        .ok_or("total markers overflow")?;
+    let (factory, mut drainer) = transport(config.transport).map_err(|e| e.to_string())?;
+    // Keep idle sources registered and Active during replay, on their owner (main) thread.
+    let mut idle = Vec::new();
+    for i in 0..config.idle_rings {
+        idle.push(
+            factory
+                .producer(u64::MAX - i as u64)
+                .map_err(|e| e.to_string())?,
+        );
+    }
+    let gate = Arc::new(Gate::new());
+    let stopped = Arc::new(AtomicBool::new(false));
+    let (ready_tx, ready_rx) = mpsc::channel();
+    // A feeder baseline has the same producer setup, but no drainer competing
+    // for CPU. Const specialization removes this choice from the marker loop.
+    let receiver = if FEEDER_ONLY {
+        None
+    } else {
+        let gate = gate.clone();
+        let stopped = stopped.clone();
+        let ready = ready_tx.clone();
+        Some(thread::spawn(move || {
+            drainer.register_worker();
+            ready.send(Ok::<_, String>(())).unwrap();
+            if gate.wait().is_none() {
+                return Ok(Instant::now());
+            }
+            let mut pipeline = noop::pipeline();
+            while !stopped.load(Ordering::Acquire) {
+                if !drainer.drain(&mut pipeline, config.source_budget) {
+                    drainer.idle(&mut pipeline, config.source_budget, config.idle_timeout);
+                }
+            }
+            drainer.finish(pipeline).map_err(|e| e.to_string())?;
+            Ok::<_, String>(Instant::now())
+        }))
+    };
+    let mut writers = Vec::new();
+    for (fixture, load) in fixtures {
+        // Prepare structural values before timing; the timed loop reads the
+        // clock and performs the real encoding directly into the ring slot.
+        let mut templates: Vec<Marker<'static>> = Vec::new();
+        if ENCODE {
+            crate::workload::for_each_template(&fixture.manifest, |m| templates.push(m));
+        }
+        let factory = factory.clone();
+        let gate = gate.clone();
+        let ready = ready_tx.clone();
+        writers.push(thread::spawn(move || {
+            let producer = factory
+                .producer(fixture.manifest.source_id)
+                .map_err(|e| e.to_string());
+            ready
+                .send(producer.as_ref().map(|_| ()).map_err(Clone::clone))
+                .unwrap();
+            let mut producer = producer?;
+            let Some(start) = gate.wait() else {
+                return Err("replay aborted during setup".into());
+            };
+            let mut offset = 0usize;
+            let delay = Duration::from_millis(load.start_delay_ms);
+            for (batch_index, batch) in fixture.lengths.chunks(load.batch_markers).enumerate() {
+                let paced_ns = if load.bytes_per_second == 0 {
+                    0
+                } else {
+                    offset as u128 * 1_000_000_000 / u128::from(load.bytes_per_second)
+                };
+                let pauses = u128::from(load.burst_pause_ms) * batch_index as u128 * 1_000_000;
+                let nanos =
+                    u64::try_from(paced_ns + pauses).map_err(|_| "pacing duration overflow")?;
+                let deadline = start
+                    .checked_add(delay)
+                    .and_then(|t| t.checked_add(Duration::from_nanos(nanos)))
+                    .ok_or("pacing deadline overflow")?;
+                // Pacing clocks are per batch; EncodeClock also stamps each marker.
+                if load.bytes_per_second != 0
+                    || load.start_delay_ms != 0
+                    || load.burst_pause_ms != 0
+                {
+                    if let Some(wait) = deadline.checked_duration_since(Instant::now()) {
+                        thread::sleep(wait);
+                    }
+                }
+                for (within_batch, &len) in batch.iter().enumerate() {
+                    let end = offset + usize::from(len);
+                    if ENCODE {
+                        let mut marker = templates[batch_index * load.batch_markers + within_batch];
+                        if FEEDER_ONLY {
+                            // Expose the local copy's contents through a
+                            // reference; passing the value caused an extra
+                            // stack copy. Keep offset work observable too.
+                            // Barriers still make subtraction an estimate.
+                            std::hint::black_box(&marker);
+                            std::hint::black_box(end);
+                        } else {
+                            stamp(&mut marker, clock::now_ticks());
+                            write_or_wait(&factory, || producer.write_marker(&marker));
+                        }
+                    } else {
+                        write_or_wait(&factory, || producer.write(&fixture.bytes[offset..end]));
+                    }
+                    offset = end;
+                }
+            }
+            // Keep prepared input alive until the thread exits, after producer
+            // drop publishes its last write. No per-marker measurement counter.
+            Ok::<_, String>((fixture, templates))
+        }));
+    }
+    drop(ready_tx);
+    let mut setup_error = None;
+    for _ in 0..writers.len() + usize::from(receiver.is_some()) {
+        match ready_rx.recv().map_err(|e| e.to_string())? {
+            Ok(()) => {}
+            Err(e) => setup_error = Some(e),
+        }
+    }
+    let cpu_start = usage().map(|u| u.0);
+    let start = Instant::now();
+    gate.release(if setup_error.is_some() {
+        Start::Abort
+    } else {
+        Start::Run(start)
+    });
+    let mut error = setup_error;
+    let mut retained_fixtures = Vec::new();
+    for writer in writers {
+        match writer.join() {
+            Ok(Ok(fixture)) => retained_fixtures.push(fixture),
+            Ok(Err(e)) => {
+                error.get_or_insert(e);
+            }
+            Err(_) => {
+                error.get_or_insert("producer panicked".into());
+            }
+        }
+    }
+    let producers_done = Instant::now();
+    drop(idle);
+    stopped.store(true, Ordering::Release);
+    factory.wake_consumer();
+    let finish = match receiver {
+        Some(receiver) => receiver.join().map_err(|_| "drainer panicked")??,
+        None => producers_done,
+    };
+    let usage_end = usage();
+    if let Some(error) = error {
+        return Err(error);
+    }
+    let elapsed = finish.duration_since(start).as_secs_f64();
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "throughput is approximate; exact byte total is reported separately"
+    )]
+    let bytes_per_second = (!FEEDER_ONLY).then_some(input_bytes as f64 / elapsed);
+    Ok(ReplayResult {
+        producer_mode: config.producer_mode,
+        clock_kind: (ENCODE && !FEEDER_ONLY).then(|| format!("{:?}", clock::meta().kind)),
+        clock_reads: if ENCODE && !FEEDER_ONLY { markers } else { 0 },
+        preset: if FEEDER_ONLY {
+            "feeder-only"
+        } else {
+            "drain-only"
+        },
+        full_ring_policy: if FEEDER_ONLY {
+            "not-applicable"
+        } else {
+            "retry-spin-then-yield"
+        },
+        pipeline: if FEEDER_ONLY {
+            "none"
+        } else {
+            std::any::type_name::<noop::NoopPipeline>()
+        },
+        source_threads: sources.len(),
+        consumer_threads: usize::from(!FEEDER_ONLY),
+        idle_rings: config.idle_rings,
+        input_bytes,
+        markers,
+        ring_bytes: if FEEDER_ONLY { 0 } else { input_bytes },
+        ring_markers: if FEEDER_ONLY { 0 } else { markers },
+        sources,
+        loads,
+        replay_seconds: elapsed,
+        producer_seconds: producers_done.duration_since(start).as_secs_f64(),
+        final_drain_seconds: finish.duration_since(producers_done).as_secs_f64(),
+        bytes_per_second,
+        replay_cpu_seconds: cpu_start.zip(usage_end).map(|(a, b)| b.0 - a),
+        peak_rss_bytes_including_preparation: usage_end.map(|u| u.1),
+        segment_bytes: config.transport.segment_bytes,
+        freelist_segments: config.transport.freelist_segments,
+        memory_budget_bytes: config.transport.memory_bytes,
+        source_budget: config.source_budget,
+        idle_timeout_micros: config.idle_timeout.as_micros(),
+    })
+}
+
+/// Two process-level observations around replay, never measurements inside stages.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn usage() -> Option<(f64, u64)> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    // SAFETY: getrusage initializes the supplied object on success.
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    let usage = unsafe { usage.assume_init() };
+    let seconds = |time: libc::timeval| -> Option<f64> {
+        Duration::from_secs(u64::try_from(time.tv_sec).ok()?)
+            .checked_add(Duration::from_micros(u64::try_from(time.tv_usec).ok()?))
+            .map(|time| time.as_secs_f64())
+    };
+    let cpu = seconds(usage.ru_utime)? + seconds(usage.ru_stime)?;
+    let rss = u64::try_from(usage.ru_maxrss).ok()?;
+    #[cfg(target_os = "macos")]
+    let bytes = rss;
+    #[cfg(not(target_os = "macos"))]
+    let bytes = rss.checked_mul(1024)?;
+    Some((cpu, bytes))
+}
+#[cfg(not(unix))]
+fn usage() -> Option<(f64, u64)> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_preserves_workload_but_reports_no_telemetry_work() {
+        let run_mode = |producer_mode| {
+            let fixtures = [(1, 25), (2, 41)]
+                .into_iter()
+                .map(|(source, calls)| {
+                    (
+                        Fixture::prepare(source, calls, 8, None).unwrap(),
+                        SourceLoad {
+                            bytes_per_second: 0,
+                            start_delay_ms: 1,
+                            batch_markers: 7,
+                            burst_pause_ms: 0,
+                        },
+                    )
+                })
+                .collect();
+            run(
+                ReplayConfig {
+                    producer_mode,
+                    transport: TransportConfig::default(),
+                    source_budget: 1,
+                    idle_rings: 1,
+                    idle_timeout: Duration::from_micros(200),
+                },
+                fixtures,
+            )
+            .unwrap()
+        };
+        let baseline = run_mode(ProducerMode::FeederOnly);
+        let full = run_mode(ProducerMode::EncodeClock);
+        assert_eq!(baseline.input_bytes, full.input_bytes);
+        assert_eq!(baseline.markers, full.markers);
+        assert_eq!(baseline.source_threads, full.source_threads);
+        assert_eq!(
+            serde_json::to_value(&baseline.sources).unwrap(),
+            serde_json::to_value(&full.sources).unwrap()
+        );
+        assert_eq!(baseline.clock_reads, 0);
+        assert!(baseline.clock_kind.is_none());
+        assert_eq!(baseline.consumer_threads, 0);
+        assert_eq!(baseline.ring_bytes, 0);
+        assert_eq!(baseline.ring_markers, 0);
+        assert!(baseline.bytes_per_second.is_none());
+        assert!(baseline.final_drain_seconds.abs() < f64::EPSILON);
+        assert!(baseline.replay_seconds >= 0.001);
+        assert_eq!(full.clock_reads, full.markers);
+        assert_eq!(full.ring_bytes, full.input_bytes);
+        assert_eq!(full.ring_markers, full.markers);
+        assert_eq!(full.consumer_threads, 1);
+        assert!(full.bytes_per_second.unwrap() > 0.0);
+    }
+}

--- a/baml_language/crates/btel_bench/src/workload.rs
+++ b/baml_language/crates/btel_bench/src/workload.rs
@@ -1,0 +1,249 @@
+//! Finite fixtures: construction, wire validation, and disk loading happen before timing.
+use std::{fs, path::Path};
+
+use btel_core::{
+    ids::{BexCallId, BexThreadId, FunctionId},
+    marker::{self, FunctionEndStatus, Marker, ThreadEndStatus},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Manifest {
+    pub version: u32,
+    pub source_id: u64,
+    pub calls: u64,
+    pub depth: usize,
+    pub markers: u64,
+    pub bytes: u64,
+}
+
+pub struct Fixture {
+    pub manifest: Manifest,
+    pub bytes: Vec<u8>,
+    /// Record lengths are preparation metadata; replay does not decode markers.
+    pub lengths: Vec<u16>,
+}
+
+impl Fixture {
+    pub fn prepare(
+        source_id: u64,
+        calls: u64,
+        depth: usize,
+        directory: Option<&Path>,
+    ) -> Result<Self, String> {
+        if depth == 0 {
+            return Err("depth must be positive".into());
+        }
+        let bytes = calls
+            .checked_mul((marker::FUNCTION_ENTER_LEN + marker::FUNCTION_EXIT_LEN) as u64)
+            .and_then(|n| {
+                n.checked_add((marker::START_THREAD_FIXED_LEN + marker::END_THREAD_LEN) as u64)
+            })
+            .ok_or("fixture byte count overflow")?;
+        let markers = calls
+            .checked_mul(2)
+            .and_then(|n| n.checked_add(2))
+            .ok_or("marker count overflow")?;
+        let manifest = Manifest {
+            version: 1,
+            source_id,
+            calls,
+            depth,
+            markers,
+            bytes,
+        };
+        let paths = directory.map(|dir| {
+            let base = format!("source-{source_id}-calls-{calls}-depth-{depth}-v1");
+            (
+                dir.join(format!("{base}.json")),
+                dir.join(format!("{base}.markers")),
+            )
+        });
+        if let Some((meta_path, byte_path)) = &paths {
+            if meta_path.exists() || byte_path.exists() {
+                let saved: Manifest =
+                    serde_json::from_slice(&fs::read(meta_path).map_err(|e| e.to_string())?)
+                        .map_err(|e| e.to_string())?;
+                if saved != manifest {
+                    return Err("fixture manifest mismatch".into());
+                }
+                return Self::validated(manifest, fs::read(byte_path).map_err(|e| e.to_string())?);
+            }
+        }
+        let capacity = usize::try_from(bytes).map_err(|_| "fixture exceeds address space")?;
+        let mut encoded = Vec::new();
+        encoded
+            .try_reserve_exact(capacity)
+            .map_err(|e| e.to_string())?;
+        let append = |record: Marker<'_>| {
+            let mut scratch = [0u8; marker::MAX_RECORD_LEN];
+            let len = record.encode(&mut scratch);
+            encoded.extend_from_slice(&scratch[..len]);
+        };
+        for_each_template(&manifest, append);
+        let fixture = Self::validated(manifest, encoded)?;
+        if let Some((meta_path, byte_path)) = paths {
+            fs::create_dir_all(meta_path.parent().ok_or("fixture parent missing")?)
+                .map_err(|e| e.to_string())?;
+            fs::write(byte_path, &fixture.bytes).map_err(|e| e.to_string())?;
+            fs::write(
+                meta_path,
+                serde_json::to_vec_pretty(&fixture.manifest).map_err(|e| e.to_string())?,
+            )
+            .map_err(|e| e.to_string())?;
+        }
+        Ok(fixture)
+    }
+
+    pub fn validated(manifest: Manifest, bytes: Vec<u8>) -> Result<Self, String> {
+        if bytes.len() as u64 != manifest.bytes {
+            return Err("fixture byte length mismatch".into());
+        }
+        let mut lengths = Vec::new();
+        let mut stack = Vec::new();
+        let mut calls = 0;
+        let mut ended = false;
+        for (index, raw) in marker::iter(&bytes).enumerate() {
+            let expected_tick = u64::try_from(index).map_err(|_| "marker index overflow")?;
+            let raw = raw.map_err(|e| format!("invalid marker: {e:?}"))?;
+            let valid = match raw {
+                Marker::BexThreadStart {
+                    thread_id,
+                    ts_ticks,
+                    parent_thread_id,
+                    parent_call_id,
+                    ..
+                } => {
+                    lengths.is_empty()
+                        && thread_id.0 == manifest.source_id
+                        && ts_ticks == 0
+                        && parent_thread_id.0 == 0
+                        && parent_call_id.0 == 0
+                }
+                Marker::FunctionEnter {
+                    thread_id,
+                    call_id,
+                    parent_call_id,
+                    ts_ticks,
+                    ..
+                } if !ended && !lengths.is_empty() => {
+                    calls += 1;
+                    let parent = stack.last().copied().unwrap_or(0);
+                    let valid = thread_id.0 == manifest.source_id
+                        && call_id.0 == calls
+                        && parent_call_id.0 == parent
+                        && ts_ticks == expected_tick;
+                    stack.push(call_id.0);
+                    valid && stack.len() <= manifest.depth
+                }
+                Marker::FunctionExit {
+                    thread_id,
+                    call_id,
+                    ts_ticks,
+                    status,
+                } if !ended => {
+                    stack.pop() == Some(call_id.0)
+                        && thread_id.0 == manifest.source_id
+                        && ts_ticks == expected_tick
+                        && status == FunctionEndStatus::Ok
+                }
+                Marker::BexThreadEnd {
+                    thread_id,
+                    ts_ticks,
+                    status,
+                } if !ended => {
+                    ended = true;
+                    stack.is_empty()
+                        && calls == manifest.calls
+                        && thread_id.0 == manifest.source_id
+                        && ts_ticks == expected_tick
+                        && status == ThreadEndStatus::Completed
+                }
+                _ => false,
+            };
+            if !valid {
+                return Err(format!(
+                    "fixture sequence invalid at marker {}",
+                    lengths.len()
+                ));
+            }
+            lengths.push(u16::try_from(raw.encoded_len()).map_err(|_| "marker length overflow")?);
+        }
+        if !ended || lengths.len() as u64 != manifest.markers {
+            return Err("fixture completion mismatch".into());
+        }
+        Ok(Self {
+            manifest,
+            bytes,
+            lengths,
+        })
+    }
+}
+
+/// Structural fields are prepared once; producer modes share this exact workload.
+pub fn for_each_template(manifest: &Manifest, mut append: impl FnMut(Marker<'static>)) {
+    let Manifest {
+        source_id,
+        calls,
+        depth,
+        ..
+    } = *manifest;
+    let thread_id = BexThreadId(source_id);
+    append(Marker::BexThreadStart {
+        flags: 0,
+        thread_id,
+        parent_thread_id: BexThreadId(0),
+        parent_call_id: BexCallId(0),
+        ts_ticks: 0,
+        name: &[],
+    });
+    let mut ticks = 0;
+    let mut first = 1;
+    while first <= calls {
+        let last = first.saturating_add(depth as u64 - 1).min(calls);
+        for call in first..=last {
+            ticks += 1;
+            append(Marker::FunctionEnter {
+                flags: 0,
+                thread_id,
+                call_id: BexCallId(call),
+                parent_call_id: BexCallId(if call == first { 0 } else { call - 1 }),
+                function_id: FunctionId(1),
+                call_site: None,
+                ts_ticks: ticks,
+            });
+        }
+        for call in (first..=last).rev() {
+            ticks += 1;
+            append(Marker::FunctionExit {
+                status: FunctionEndStatus::Ok,
+                thread_id,
+                call_id: BexCallId(call),
+                ts_ticks: ticks,
+            });
+        }
+        first = last + 1;
+    }
+    append(Marker::BexThreadEnd {
+        status: ThreadEndStatus::Completed,
+        thread_id,
+        ts_ticks: ticks + 1,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn known_nested_fixture_round_trips_and_rejects_truncation() {
+        let f = Fixture::prepare(7, 65, 8, None).unwrap();
+        assert_eq!(f.manifest.bytes, 65 * 80 + 54);
+        assert_eq!(f.manifest.markers, 132);
+        let mut bad = f.bytes.clone();
+        bad.pop();
+        assert!(Fixture::validated(f.manifest.clone(), bad).is_err());
+        let mut bad = f.bytes;
+        bad[0] = 255;
+        assert!(Fixture::validated(f.manifest, bad).is_err());
+    }
+}

--- a/baml_language/crates/btel_core/Cargo.toml
+++ b/baml_language/crates/btel_core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "btel_core"
+description = "Experimental Btel marker formats, clocks, and stage contracts"
+version.workspace = true
+publish = false
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+base64.workspace = true
+uuid = { workspace = true, features = [ "v7" ] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time.workspace = true
+uuid = { workspace = true, features = [ "js" ] }

--- a/baml_language/crates/btel_core/src/clock.rs
+++ b/baml_language/crates/btel_core/src/clock.rs
@@ -1,0 +1,785 @@
+//! The profiling clock: raw hardware ticks on the producer side, converted
+//! to nanoseconds by the consumer at transcode time.
+//!
+//! Producers stamp records with [`now_ticks`] — a raw counter read (`rdtsc`
+//! on `x86_64`, `CNTVCT_EL0` on aarch64, a monotonic-`Instant` fallback
+//! elsewhere or when the TSC is not invariant). No tick→ns conversion, no
+//! calibration, and no pre-main ctor runs on any producer path; the one-time
+//! anchor capture is two clock reads plus (on x86) a `cpuid` probe.
+//!
+//! The consumer owns conversion via [`TickConverter`]: exact rational rates
+//! where the platform states them (`CNTFRQ_EL0` for the aarch64 generic
+//! timer), and a two-point calibration refined across its own wake cadence
+//! for the x86 TSC. Disk timestamps (`timestamp_ns`) therefore stay
+//! nanoseconds —
+//! readers rebase to wall time as
+//! `wall(event) = started_at_epoch_ns + timestamp_ns`, unchanged.
+//!
+//! Tick values are absolute counter reads (since boot for TSC/CNTVCT, since
+//! the process zero point for the `Instant` fallback); the converter
+//! subtracts the process base. The per-call-pair budget (~25 ns) assumes
+//! ≤10 ns per read — `benches/prof_clock.rs` measures it.
+//!
+//! On wasm32 this module uses `web_time::Instant` as a monotonic nanosecond
+//! source. Under miri, which cannot execute `rdtsc`/`mrs`, it remains a
+//! stub and the concurrency tests stamp their own tick values.
+
+// Raw counter reads (`rdtsc`, `mrs`).
+#![allow(unsafe_code)]
+
+pub use imp::{base_ticks, init, meta, now_ticks, started_at_epoch_ns};
+
+/// Which hardware source backs [`now_ticks`]. Stored in run metadata for
+/// diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockKind {
+    /// `x86_64` invariant TSC (`rdtsc`); rate calibrated by the consumer.
+    Tsc,
+    /// aarch64 generic timer (`CNTVCT_EL0`); exact architectural rate.
+    Cntvct,
+    /// `std::time::Instant` fallback; ticks are nanoseconds, rate (1, 1).
+    Instant,
+    /// miri stub; ticks are whatever the test stamped.
+    Stub,
+}
+
+/// Static facts about the active clock source.
+#[derive(Debug, Clone, Copy)]
+pub struct ClockMeta {
+    pub kind: ClockKind,
+    /// Exact ns-per-tick as a `(numer, denom)` rational, when the platform
+    /// states it (`CNTFRQ_EL0` on aarch64, ns-backed `Instant` fallback).
+    /// `None` means the rate must be measured — x86 TSC, where the consumer
+    /// calibrates against the OS clock.
+    pub ns_per_tick: Option<(u64, u64)>,
+}
+
+#[cfg(not(any(target_arch = "wasm32", miri)))]
+mod imp {
+    use std::sync::OnceLock;
+
+    use super::{ClockKind, ClockMeta};
+
+    enum Source {
+        #[cfg(target_arch = "x86_64")]
+        Tsc,
+        #[cfg(target_arch = "aarch64")]
+        Cntvct,
+        Instant,
+    }
+
+    struct Anchor {
+        source: Source,
+        /// First raw read of the chosen source; the converter's base.
+        base_ticks: u64,
+        /// Wall-clock time of the zero point (adjacent to `base_ticks`).
+        base_unix_ns: u128,
+        /// Zero point for the `Instant` fallback's tick domain.
+        zero_instant: std::time::Instant,
+        meta: ClockMeta,
+    }
+
+    static ANCHOR: OnceLock<Anchor> = OnceLock::new();
+
+    /// The process clock anchor. Fast path is a single `OnceLock::get`
+    /// (Acquire load + branch) that inlines into `now_ticks` — and thus
+    /// into the VM's call hot path — so the raw counter read can pipeline
+    /// with the surrounding encode/push work rather than hiding behind a
+    /// cross-crate call. The one-time init is `#[cold]` and out-of-line.
+    #[inline]
+    fn anchor() -> &'static Anchor {
+        match ANCHOR.get() {
+            Some(a) => a,
+            None => anchor_init(),
+        }
+    }
+
+    #[cold]
+    fn anchor_init() -> &'static Anchor {
+        ANCHOR.get_or_init(|| {
+            let (source, ns_per_tick) = detect();
+            let kind = match source {
+                #[cfg(target_arch = "x86_64")]
+                Source::Tsc => ClockKind::Tsc,
+                #[cfg(target_arch = "aarch64")]
+                Source::Cntvct => ClockKind::Cntvct,
+                Source::Instant => ClockKind::Instant,
+            };
+            let zero_instant = std::time::Instant::now();
+            let base_unix_ns = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos());
+            let mut anchor = Anchor {
+                source,
+                base_ticks: 0,
+                base_unix_ns,
+                zero_instant,
+                meta: ClockMeta { kind, ns_per_tick },
+            };
+            anchor.base_ticks = raw_ticks(&anchor);
+            anchor
+        })
+    }
+
+    /// Pick the tick source for this process (and its exact rate, when the
+    /// platform states one). Runs once, inside the anchor init.
+    fn detect() -> (Source, Option<(u64, u64)>) {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if tsc_is_trustworthy() {
+                return (Source::Tsc, None);
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            if let Some(rate) = cntvct_ns_per_tick() {
+                return (Source::Cntvct, Some(rate));
+            }
+        }
+        (Source::Instant, Some((1, 1)))
+    }
+
+    /// Whether the TSC is safe to use for cross-thread-comparable stamps
+    /// (one logical thread's records are stamped from several OS threads,
+    /// so the per-thread sort contract needs cross-core comparability).
+    ///
+    /// CPUID.80000007H:EDX[8] only guarantees constant-rate / never-stop —
+    /// NOT cross-core/cross-socket synchronization. On Linux we therefore
+    /// also defer to the kernel, which measures TSC sync across CPUs at
+    /// boot and only offers `tsc` as a clocksource when it holds (the same
+    /// check minstant used). Elsewhere we require the invariant bit AND the
+    /// absence of a hypervisor: under virtualization the invariant bit is
+    /// still set, but a vCPU can migrate between physical cores whose TSCs
+    /// are not in lockstep, so `rdtsc` reads backwards across a thread
+    /// hand-off (observed on virtualized Windows CI). Falling back to
+    /// `Instant` there is correct, not just safe: Windows `Instant` is
+    /// `QueryPerformanceCounter`, which the OS keeps system-wide monotonic.
+    #[cfg(target_arch = "x86_64")]
+    fn tsc_is_trustworthy() -> bool {
+        if !has_invariant_tsc() {
+            return false;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            std::fs::read_to_string(
+                "/sys/devices/system/clocksource/clocksource0/available_clocksource",
+            )
+            .map(|s| s.contains("tsc"))
+            .unwrap_or(false)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            !hypervisor_present()
+        }
+    }
+
+    /// Whether a hypervisor is present: `CPUID.01H:ECX[31]`, the "hypervisor
+    /// present" bit that is reserved-zero on bare metal and set by every
+    /// mainstream VMM. Used to reject the TSC for cross-thread stamps under
+    /// virtualization, where invariant-TSC no longer implies cross-vCPU
+    /// synchronization. Conservative by design: a guest whose hypervisor
+    /// *does* synchronize the TSC still falls back to `Instant`, trading a
+    /// little per-stamp cost for guaranteed cross-thread monotonicity.
+    #[cfg(all(target_arch = "x86_64", not(target_os = "linux")))]
+    // `__cpuid` is an unsafe fn on the pinned stable toolchain but safe on
+    // newer ones — keep the block, silence the newer toolchains' lint.
+    #[allow(unused_unsafe)]
+    fn hypervisor_present() -> bool {
+        // SAFETY: cpuid leaf 1 is unprivileged and universally available.
+        unsafe { core::arch::x86_64::__cpuid(1).ecx & (1 << 31) != 0 }
+    }
+
+    /// Invariant-TSC probe: CPUID.80000007H:EDX[8] (constant rate, does not
+    /// stop in deep C-states).
+    #[cfg(target_arch = "x86_64")]
+    // `__cpuid` is an unsafe fn on the pinned stable toolchain but safe on
+    // newer ones — keep the block, silence the newer toolchains' lint.
+    #[allow(unused_unsafe)]
+    fn has_invariant_tsc() -> bool {
+        // SAFETY: cpuid is unprivileged and universally available on x86_64.
+        unsafe {
+            let max_ext = core::arch::x86_64::__cpuid(0x8000_0000).eax;
+            if max_ext < 0x8000_0007 {
+                return false;
+            }
+            core::arch::x86_64::__cpuid(0x8000_0007).edx & (1 << 8) != 0
+        }
+    }
+
+    /// Exact ns-per-tick for the aarch64 generic timer, or `None` if it
+    /// cannot be determined (falls back to `Instant`).
+    ///
+    /// The rate must describe the counter we actually stamp with —
+    /// `CNTVCT_EL0` — so we read its architectural frequency from
+    /// `CNTFRQ_EL0` on every OS, macOS included. We deliberately do **not**
+    /// use `mach_timebase_info`: that states the rate of `mach_absolute_time`,
+    /// which is only incidentally equal to the `CNTVCT_EL0` rate on M1–M3
+    /// (both 24 MHz). On M4/M5 `CNTVCT_EL0` runs at 1 GHz while
+    /// `mach_absolute_time` stays at 24 MHz, so applying the mach rational
+    /// (125/3) to raw `CNTVCT_EL0` reads inflates every timestamp ~41.7×.
+    #[cfg(target_arch = "aarch64")]
+    fn cntvct_ns_per_tick() -> Option<(u64, u64)> {
+        // CNTFRQ_EL0 states the CNTVCT_EL0 frequency in Hz.
+        let freq: u64;
+        // SAFETY: EL0-readable system register; no memory or flags.
+        unsafe {
+            core::arch::asm!(
+                "mrs {f}, cntfrq_el0",
+                f = out(reg) freq,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        if freq == 0 {
+            return None;
+        }
+        Some((1_000_000_000, freq))
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[inline]
+    fn cntvct() -> u64 {
+        let ticks: u64;
+        // SAFETY: CNTVCT_EL0 is EL0-readable on every supported OS; the
+        // read touches no memory and preserves flags. No `isb` barrier: a
+        // few ns of speculation skew is irrelevant for span timestamps and
+        // the barrier would cost more than the read.
+        unsafe {
+            core::arch::asm!(
+                "mrs {t}, cntvct_el0",
+                t = out(reg) ticks,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        ticks
+    }
+
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "u128 nanos since process start; wraps after ~584 years"
+    )]
+    fn raw_ticks(a: &Anchor) -> u64 {
+        match a.source {
+            #[cfg(target_arch = "x86_64")]
+            // SAFETY: rdtsc is unprivileged; gated on invariant-TSC detect.
+            Source::Tsc => unsafe { core::arch::x86_64::_rdtsc() },
+            #[cfg(target_arch = "aarch64")]
+            Source::Cntvct => cntvct(),
+            Source::Instant => a.zero_instant.elapsed().as_nanos() as u64,
+        }
+    }
+
+    /// Pins the anchor (source detection + zero point). Cheap: two clock
+    /// reads and, on x86, a `cpuid` probe — there is no calibration here.
+    ///
+    /// Called from ring acquisition; `now_ticks` also forces it, so every
+    /// stamped tick is `>= base_ticks` regardless of call order.
+    pub fn init() {
+        let _ = anchor();
+    }
+
+    /// Raw ticks of the active source. Absolute counter reads (since boot
+    /// for TSC/CNTVCT); the consumer's [`super::TickConverter`] subtracts
+    /// the process base and applies the rate.
+    #[inline]
+    pub fn now_ticks() -> u64 {
+        // Forcing the anchor first guarantees ticks >= base_ticks for every
+        // value that ever reaches a record (engine stamps can happen before
+        // ring acquisition, so init-on-acquire alone is not enough).
+        let a = anchor();
+        raw_ticks(a)
+    }
+
+    /// First raw tick of this process — the converter's zero point.
+    pub fn base_ticks() -> u64 {
+        anchor().base_ticks
+    }
+
+    /// Static facts about the active source (kind + exact rate if known).
+    pub fn meta() -> ClockMeta {
+        anchor().meta
+    }
+
+    /// Wall-clock time of the zero point, in nanoseconds since the Unix
+    /// epoch. Stored in run metadata.
+    pub fn started_at_epoch_ns() -> u128 {
+        anchor().base_unix_ns
+    }
+}
+
+// wasm32: use web_time's browser/worker-safe Instant as a monotonic
+// nanosecond source for target-neutral direct-consumer timing.
+#[cfg(target_arch = "wasm32")]
+mod imp {
+    use std::sync::OnceLock;
+
+    use super::{ClockKind, ClockMeta};
+
+    struct Anchor {
+        zero_instant: web_time::Instant,
+        base_unix_ns: u128,
+    }
+
+    static ANCHOR: OnceLock<Anchor> = OnceLock::new();
+
+    fn anchor() -> &'static Anchor {
+        ANCHOR.get_or_init(|| Anchor {
+            zero_instant: web_time::Instant::now(),
+            base_unix_ns: web_time::SystemTime::now()
+                .duration_since(web_time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos()),
+        })
+    }
+
+    pub fn init() {
+        let _ = anchor();
+    }
+
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "ns since wasm module start; wraps after ~584 years"
+    )]
+    pub fn now_ticks() -> u64 {
+        anchor().zero_instant.elapsed().as_nanos() as u64
+    }
+
+    pub fn base_ticks() -> u64 {
+        0
+    }
+
+    pub fn meta() -> ClockMeta {
+        ClockMeta {
+            kind: ClockKind::Instant,
+            ns_per_tick: Some((1, 1)),
+        }
+    }
+
+    pub fn started_at_epoch_ns() -> u128 {
+        anchor().base_unix_ns
+    }
+}
+
+// miri: rdtsc and `mrs` are intrinsics/asm miri cannot execute, and the
+// concurrency tests miri runs stamp their own tick values.
+#[cfg(all(miri, not(target_arch = "wasm32")))]
+mod imp {
+    use super::{ClockKind, ClockMeta};
+
+    /// No-op in miri stub builds.
+    pub fn init() {}
+
+    /// Always `0` in stub builds (nothing reads this).
+    #[inline]
+    pub fn now_ticks() -> u64 {
+        0
+    }
+
+    /// Always `0` in stub builds.
+    pub fn base_ticks() -> u64 {
+        0
+    }
+
+    /// Stub meta: tick == ns so any converter built from it is an identity.
+    pub fn meta() -> ClockMeta {
+        ClockMeta {
+            kind: ClockKind::Stub,
+            ns_per_tick: Some((1, 1)),
+        }
+    }
+
+    /// Always `0` in stub builds (nothing reads this).
+    pub fn started_at_epoch_ns() -> u128 {
+        0
+    }
+}
+
+/// How trustworthy the tick→ns rate is. Stored in run metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockQuality {
+    /// Platform-stated rational rate (CNTVCT, Instant, Stub).
+    Exact,
+    /// x86 TSC rate refined over a ≥1 s window on the consumer thread.
+    Calibrated,
+    /// x86 TSC rate from the initial ~2 ms two-point estimate only
+    /// (~0.1% rate error; affects at most the first second of events).
+    Coarse,
+}
+
+/// Consumer-side tick→ns conversion.
+///
+/// Built on the consumer thread ([`TickConverter::from_clock`]); producers
+/// never touch it. Conversion is piecewise-linear: when the x86 TSC rate is
+/// refined, the new segment starts at the previous segment's converted
+/// value for the switch tick, so per-thread `timestamp_ns` stays monotone
+/// across the swap, and ticks older than the switch keep converting through
+/// the previous segment (in-flight ring events drain up to seconds late).
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct TickConverter {
+    kind: ClockKind,
+    seg_base_ticks: u64,
+    seg_base_ns: u64,
+    /// ns-per-tick as (numer, denom).
+    rate: (u64, u64),
+    /// Fixed-point reciprocal of `rate` for the hot path: `numer << SCALE_SHIFT
+    /// / denom`, so `to_ns` is a `dt * scale >> SCALE_SHIFT` multiply-shift
+    /// instead of a per-record u128 divide (~20-40 non-pipelined cycles). Kept
+    /// in sync with `rate` at every install site. Exact for rate (1,1)
+    /// (scale = `2^SCALE_SHIFT` → ns == dt); ≤1 ns rounding for measured TSC
+    /// rates, which is below tracing-timestamp resolution and preserves
+    /// monotonicity.
+    scale: u128,
+    /// Previous segment `(base_ticks, base_ns, rate)`, kept after a
+    /// refinement so pre-switch ticks still convert on their original line.
+    prev: Option<(u64, u64, (u64, u64))>,
+    refined: bool,
+    /// First calibration sample (x86 TSC only): adjacent OS-clock + tick
+    /// reads taken at converter construction.
+    sample0: Option<(std::time::Instant, u64)>,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone)]
+pub struct TickConverter;
+
+/// Fixed-point precision of [`TickConverter::scale`]. 2^48 keeps the rounding
+/// error below 1 ns for any realistic `dt` (ticks since the segment base) while
+/// leaving headroom against u128 overflow in `dt * scale`.
+#[cfg(not(target_arch = "wasm32"))]
+const SCALE_SHIFT: u32 = 48;
+
+/// `numer << SCALE_SHIFT / denom` — the reciprocal computed once per rate
+/// install (the only divide), consumed branchlessly per record.
+#[cfg(not(target_arch = "wasm32"))]
+fn scale_of(rate: (u64, u64)) -> u128 {
+    (u128::from(rate.0) << SCALE_SHIFT) / u128::from(rate.1.max(1))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl TickConverter {
+    /// Identity conversion (tests): synthetic tick values pass through.
+    pub fn identity() -> Self {
+        TickConverter {
+            kind: ClockKind::Instant,
+            seg_base_ticks: 0,
+            seg_base_ns: 0,
+            rate: (1, 1),
+            scale: scale_of((1, 1)),
+            prev: None,
+            refined: true,
+            sample0: None,
+        }
+    }
+
+    /// Build from the process clock. Call on the consumer thread only: for
+    /// the x86 TSC this blocks ~2 ms taking a coarse two-point rate
+    /// estimate (producers only buffer meanwhile); exact-rate sources
+    /// return immediately.
+    pub fn from_clock() -> Self {
+        let m = meta();
+        match m.ns_per_tick {
+            Some(rate) => TickConverter {
+                kind: m.kind,
+                seg_base_ticks: base_ticks(),
+                seg_base_ns: 0,
+                rate,
+                scale: scale_of(rate),
+                prev: None,
+                refined: true,
+                sample0: None,
+            },
+            None => {
+                // x86 TSC: two-point coarse estimate over ~2 ms.
+                let sample0 = (std::time::Instant::now(), now_ticks());
+                std::thread::sleep(std::time::Duration::from_millis(2));
+                let elapsed_ns = sample0.0.elapsed().as_nanos();
+                let tick_delta = now_ticks().wrapping_sub(sample0.1).max(1);
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "~2ms window; fits u64 by construction"
+                )]
+                let rate = (elapsed_ns as u64, tick_delta);
+                TickConverter {
+                    kind: m.kind,
+                    seg_base_ticks: base_ticks(),
+                    seg_base_ns: 0,
+                    rate,
+                    scale: scale_of(rate),
+                    prev: None,
+                    refined: false,
+                    sample0: Some(sample0),
+                }
+            }
+        }
+    }
+
+    /// Convert a raw tick stamp to nanoseconds since the process zero point
+    /// (the domain `started_at_epoch_ns` rebases to wall time).
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "ns since process start; wraps after ~584 years"
+    )]
+    pub fn to_ns(&self, ticks: u64) -> u64 {
+        if ticks < self.seg_base_ticks {
+            if let Some((base_ticks, base_ns, (numer, denom))) = self.prev {
+                let dt = u128::from(ticks.saturating_sub(base_ticks));
+                return base_ns + (dt * u128::from(numer) / u128::from(denom)) as u64;
+            }
+        }
+        let dt = u128::from(ticks.saturating_sub(self.seg_base_ticks));
+        // Hot path: multiply-shift by the precomputed reciprocal, no divide.
+        self.seg_base_ns + ((dt * self.scale) >> SCALE_SHIFT) as u64
+    }
+
+    /// Refine the x86 TSC rate once the window since `sample0` spans ≥1 s.
+    /// Installs the new rate with anchor continuity (see type docs). Cheap
+    /// no-op for exact-rate sources or once refined; call at heartbeat
+    /// cadence.
+    pub fn maybe_refine(&mut self) {
+        if self.refined {
+            return;
+        }
+        let Some((i0, t0)) = self.sample0 else {
+            self.refined = true;
+            return;
+        };
+        let window_ns = i0.elapsed().as_nanos();
+        if window_ns < 1_000_000_000 {
+            return;
+        }
+        let now_t = now_ticks();
+        let tick_delta = now_t.wrapping_sub(t0).max(1);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "refine window is seconds; fits u64"
+        )]
+        let new_rate = (window_ns as u64, tick_delta);
+        let switch_ns = self.to_ns(now_t);
+        self.prev = Some((self.seg_base_ticks, self.seg_base_ns, self.rate));
+        self.seg_base_ticks = now_t;
+        self.seg_base_ns = switch_ns;
+        self.rate = new_rate;
+        self.scale = scale_of(new_rate);
+        self.refined = true;
+    }
+
+    pub fn kind(&self) -> ClockKind {
+        self.kind
+    }
+
+    /// ns-per-tick rational currently in effect (header diagnostics).
+    pub fn rate(&self) -> (u64, u64) {
+        self.rate
+    }
+
+    pub fn quality(&self) -> ClockQuality {
+        match self.kind {
+            ClockKind::Tsc => {
+                if self.refined {
+                    ClockQuality::Calibrated
+                } else {
+                    ClockQuality::Coarse
+                }
+            }
+            ClockKind::Cntvct | ClockKind::Instant | ClockKind::Stub => ClockQuality::Exact,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TickConverter {
+    /// Identity conversion for the wasm substrate: `now_ticks` already returns
+    /// monotonic nanoseconds from `web_time::Instant`.
+    pub fn identity() -> Self {
+        Self
+    }
+
+    pub fn from_clock() -> Self {
+        Self
+    }
+
+    #[inline]
+    pub fn to_ns(&self, ticks: u64) -> u64 {
+        ticks
+    }
+
+    pub fn maybe_refine(&mut self) {}
+
+    pub fn kind(&self) -> ClockKind {
+        ClockKind::Instant
+    }
+
+    pub fn rate(&self) -> (u64, u64) {
+        (1, 1)
+    }
+
+    pub fn quality(&self) -> ClockQuality {
+        ClockQuality::Exact
+    }
+}
+
+#[cfg(all(test, not(miri), not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monotonic_nondecreasing() {
+        init();
+        let mut prev = now_ticks();
+        for _ in 0..10_000 {
+            let next = now_ticks();
+            assert!(next >= prev, "clock went backwards: {prev} -> {next}");
+            prev = next;
+        }
+    }
+
+    #[test]
+    fn cross_thread_ordering() {
+        // A stamp taken on one
+        // OS thread, handed off, then re-stamped on another thread must not
+        // go backwards (invariant TSC / system-wide CNTVCT).
+        init();
+        let (tx, rx) = std::sync::mpsc::sync_channel::<u64>(0);
+        let handle = std::thread::spawn(move || {
+            for t_a in rx {
+                let t_b = now_ticks();
+                assert!(t_b >= t_a, "cross-thread regression: {t_a} -> {t_b}");
+            }
+        });
+        for _ in 0..1_000 {
+            if tx.send(now_ticks()).is_err() {
+                break;
+            }
+        }
+        drop(tx);
+        handle.join().expect("stamping thread panicked");
+    }
+
+    #[test]
+    fn zero_point_matches_wall_clock() {
+        // Deliberately goes through the conversion path: with raw ticks a
+        // direct arithmetic check could silently pass on garbage (a small
+        // elapsed value keeps even a ~3x unit error inside tolerance).
+        init();
+        let conv = TickConverter::from_clock();
+        let wall_now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let prof_now = started_at_epoch_ns() + u128::from(conv.to_ns(now_ticks()));
+        let drift = wall_now.abs_diff(prof_now);
+        // Generous tolerance: coarse-rate error + scheduling between the
+        // reads. Catches "anchor or rate is garbage", not clock quality.
+        assert!(
+            drift < 5_000_000_000,
+            "prof clock and wall clock disagree by {drift} ns"
+        );
+    }
+
+    #[test]
+    fn converter_rate_sane() {
+        // Convert a measured ~50ms window and require agreement within 10%:
+        // catches a wrong rational (e.g. mach timebase numer/denom swapped)
+        // on any platform, which the 5s wall tolerance above would miss.
+        init();
+        let conv = TickConverter::from_clock();
+        let wall = std::time::Instant::now();
+        let t0 = now_ticks();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let t1 = now_ticks();
+        let wall_ns = u64::try_from(wall.elapsed().as_nanos()).expect("window fits u64");
+        let conv_ns = conv.to_ns(t1) - conv.to_ns(t0);
+        let err = conv_ns.abs_diff(wall_ns);
+        assert!(
+            err * 10 < wall_ns,
+            "converted window {conv_ns} ns vs wall {wall_ns} ns"
+        );
+    }
+
+    #[test]
+    fn identity_passthrough() {
+        let conv = TickConverter::identity();
+        for v in [0u64, 1, 42, 10_000, u64::MAX] {
+            assert_eq!(conv.to_ns(v), v);
+        }
+    }
+
+    #[test]
+    fn reciprocal_matches_exact_divide() {
+        // The fixed-point reciprocal (multiply-shift) must track the exact
+        // dt*numer/denom divide within 1 ns across a range of ticks, for
+        // representative non-unit rates (CNTVCT 24 MHz = 125/3; a fast TSC
+        // ~3.2 GHz ≈ 5/16). Catches a gross reciprocal/SCALE_SHIFT bug that
+        // the identity-rate (1/1) test cannot.
+        for &(numer, denom) in &[(125u64, 3u64), (5, 16), (1_000_000_000, 24_000_000)] {
+            let conv = TickConverter {
+                kind: ClockKind::Cntvct,
+                seg_base_ticks: 0,
+                seg_base_ns: 0,
+                rate: (numer, denom),
+                scale: scale_of((numer, denom)),
+                prev: None,
+                refined: true,
+                sample0: None,
+            };
+            for dt in [0u64, 1, 3, 7, 1_000, 1_000_003, 50_000_000] {
+                let exact = u64::try_from(u128::from(dt) * u128::from(numer) / u128::from(denom))
+                    .expect("test dt*rate fits u64");
+                let approx = conv.to_ns(dt);
+                assert!(
+                    approx.abs_diff(exact) <= 1,
+                    "rate {numer}/{denom} dt {dt}: reciprocal {approx} vs exact {exact}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn refinement_keeps_monotonicity() {
+        // A deliberately-wrong coarse rate, then a refine: converted values
+        // sampled across the boundary must never step backwards, and ticks
+        // older than the switch keep converting through the old segment.
+        let mut conv = TickConverter {
+            kind: ClockKind::Tsc,
+            seg_base_ticks: 0,
+            seg_base_ns: 0,
+            rate: (3, 1), // 3 ns/tick, deliberately ~3x off
+            scale: scale_of((3, 1)),
+            prev: None,
+            refined: false,
+            sample0: Some((std::time::Instant::now(), now_ticks())),
+        };
+        let before_switch = now_ticks();
+        let ns_before = conv.to_ns(before_switch);
+        // Force the refine path regardless of wall time elapsed.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        conv.sample0 = Some((
+            std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(2))
+                .expect("process started more than 2s after boot"),
+            conv.sample0.unwrap().1,
+        ));
+        conv.maybe_refine();
+        assert!(conv.refined, "refine did not trigger");
+        // Old-tick conversion is unchanged (previous segment).
+        assert_eq!(conv.to_ns(before_switch), ns_before);
+        // Post-switch ticks continue from at least the switch value.
+        let after = now_ticks();
+        assert!(
+            conv.to_ns(after) >= ns_before,
+            "monotonicity broken across rate swap"
+        );
+    }
+
+    #[test]
+    fn pre_base_ticks_clamp() {
+        init();
+        let conv = TickConverter::from_clock();
+        // A tick below the process base (defensive: should never be
+        // emitted) clamps to the segment base instead of underflowing.
+        assert_eq!(conv.to_ns(0), 0);
+        assert_eq!(conv.to_ns(base_ticks()), 0);
+    }
+}

--- a/baml_language/crates/btel_core/src/ids.rs
+++ b/baml_language/crates/btel_core/src/ids.rs
@@ -1,0 +1,587 @@
+//! BEX runtime identity: the quad-scoped local IDs and their reversible,
+//! versioned string encodings.
+//!
+//! # Scoping model
+//!
+//! Events carry *local* IDs only; global identity is the quad
+//! `(process_euid, engine_id, thread_id, call_id)`:
+//!
+//! - [`BexThreadId`] is allocated per engine (restarts at 1 for each
+//!   [`EngineId`]); [`BexCallId`] is allocated per thread (restarts at 1 for
+//!   each thread, the root call is always 1).
+//! - The process/engine half lives once per artifact in the file/batch
+//!   header (`pb::EventFileHeaderV1`), never on events.
+//!
+//! # Encodings
+//!
+//! [`ThreadRef`] / [`CallRef`] / [`BoundaryId`] / [`RuntimeId`] encode to prefixed,
+//! versioned, base64url strings (`baml_thread_1_…`, `baml_call_1_…`,
+//! `baml_id_1_…`) and decode losslessly back; decoding validates prefix,
+//! base64, payload length, and version, and never panics on malformed
+//! input. The typed decoders reject each other's prefixes.
+
+#[cfg(target_arch = "wasm32")]
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{fmt, sync::OnceLock};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+
+const CALL_REF_PREFIX: &str = "baml_call_1_";
+const THREAD_REF_PREFIX: &str = "baml_thread_1_";
+const BOUNDARY_ID_PREFIX: &str = "baml_id_1_";
+const PAYLOAD_VERSION: u8 = 1;
+const CALL_REF_LEN: usize = 1 + 16 + 8 + 8 + 8;
+const THREAD_REF_LEN: usize = 1 + 16 + 8 + 8;
+const BOUNDARY_ID_LEN: usize = 16;
+
+#[cfg(target_arch = "wasm32")]
+// Workerd forbids access to crypto/random while a Worker isolate is starting,
+// and it may reuse that isolate for an arbitrary number of requests. The
+// workerd-only loader sets this flag before WASM startup so every identity
+// minted by that isolate consistently uses the workerd-safe UUID source.
+static WORKERD_RUNTIME: AtomicBool = AtomicBool::new(false);
+
+/// Select the workerd-safe UUID source before any runtime identity is minted.
+#[cfg(target_arch = "wasm32")]
+pub fn configure_workerd_runtime() {
+    WORKERD_RUNTIME.store(true, Ordering::Relaxed);
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn zero_random_uuid_v7(millis: u64) -> uuid::Uuid {
+    let mut builder = uuid::Builder::from_unix_timestamp_millis(millis, &[0; 10]);
+    builder
+        .set_variant(uuid::Variant::RFC4122)
+        .set_version(uuid::Version::SortRand);
+    builder.into_uuid()
+}
+
+fn new_uuid_v7() -> uuid::Uuid {
+    let timestamp = uuid::Timestamp::now(uuid::NoContext);
+
+    #[cfg(target_arch = "wasm32")]
+    if WORKERD_RUNTIME.load(Ordering::Relaxed) {
+        let (seconds, nanos) = timestamp.to_unix();
+        let millis = seconds
+            .saturating_mul(1_000)
+            .saturating_add(u64::from(nanos) / 1_000_000);
+        // UUIDs minted in the same millisecond collide because their suffix is
+        // zero. This is a known, tolerated temporary compromise; distinctness
+        // is intentionally deferred while this path avoids workerd's
+        // startup-time restriction on crypto/random access.
+        return zero_random_uuid_v7(millis);
+    }
+
+    uuid::Uuid::new_v7(timestamp)
+}
+
+/// Effectively unique process identifier used as the outermost scope of the
+/// identity quad. Workerd uses a temporary zero-random `UUIDv7` implementation
+/// that may collide with another process initialized in the same millisecond.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ProcessEuid(pub [u8; 16]);
+
+impl ProcessEuid {
+    #[must_use]
+    pub fn new_random() -> Self {
+        Self(*new_uuid_v7().as_bytes())
+    }
+
+    #[must_use]
+    pub fn current() -> Self {
+        static PROCESS_EUID: OnceLock<ProcessEuid> = OnceLock::new();
+        *PROCESS_EUID.get_or_init(Self::new_random)
+    }
+}
+
+/// Process-local engine counter (starts at 1). Two engines in one process
+/// always get distinct ids; the id is only meaningful together with the
+/// [`ProcessEuid`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EngineId(pub u64);
+
+/// Identity of a compiled program. Workerd uses a temporary zero-random
+/// `UUIDv7` implementation that may collide with another program initialized in
+/// the same millisecond.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ProgramId(pub [u8; 16]);
+
+impl ProgramId {
+    #[must_use]
+    pub fn new_random() -> Self {
+        Self(*new_uuid_v7().as_bytes())
+    }
+}
+
+/// Identity of the source snapshot a program was compiled from. Modeled for
+/// the metadata join path but not yet populated by the runtime — consumers
+/// must tolerate `None`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SourceSnapshotId(pub [u8; 32]);
+
+/// Engine-local BEX thread id (starts at 1 per engine; the root call's
+/// thread first, spawned children after).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BexThreadId(pub u64);
+
+/// Index into the engine's function metadata table
+/// (`bex_events::FunctionMetadataTable`) — 1-based sequential in object-pool
+/// walk order (0 = unassigned). NOT stable across recompiles: joins are
+/// valid only against the same artifact's header (cross-run joins use the
+/// FQN). Synthetic rows (spawn-closure, unknown-function) sit just past
+/// the real functions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct FunctionId(pub u32);
+
+/// Thread-local call counter (starts at 1 per thread; the thread's root
+/// call is always 1). Minted for every bytecode call whether or not an
+/// event sink is configured — `$id` depends on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BexCallId(pub u64);
+
+/// Fully-scoped thread identity (the quad minus `call_id`); encodes to a
+/// reversible `baml_thread_1_…` string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ThreadRef {
+    pub process_euid: ProcessEuid,
+    pub engine_id: EngineId,
+    pub thread_id: BexThreadId,
+}
+
+/// An execution's identity: its root (parentless) logical thread. Wire form
+/// is the `ThreadRef` wire form (`baml_thread_1_…`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ExecutionId(pub ThreadRef);
+
+impl ExecutionId {
+    #[must_use]
+    pub fn encode(&self) -> String {
+        self.0.encode()
+    }
+
+    pub fn decode(value: &str) -> Result<Self, DecodeError> {
+        ThreadRef::decode(value).map(Self)
+    }
+}
+
+/// Fully-scoped call identity (the complete quad); encodes to a reversible
+/// `baml_call_1_…` string — the default value of `$id`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CallRef {
+    pub process_euid: ProcessEuid,
+    pub engine_id: EngineId,
+    pub thread_id: BexThreadId,
+    pub call_id: BexCallId,
+}
+
+/// Public execution boundary identity, allocated by the host before BEX
+/// execution starts. It intentionally keeps the existing `baml_id_1_` raw
+/// 16-byte encoding so runtime-id overrides and boundary history share one
+/// typed payload shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct BoundaryId([u8; 16]);
+
+/// The value of `$id`: either the call's default [`CallRef`], or the active
+/// execution [`BoundaryId`] / explicit child boundary (`baml_id_1_…`). A
+/// boundary override applies to exactly one call; without a runtime-ID
+/// annotation, `$id` is the [`CallRef`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RuntimeId {
+    DefaultCall(CallRef),
+    Boundary(BoundaryId),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    InvalidPrefix,
+    InvalidBase64,
+    InvalidLength { expected: usize, actual: usize },
+    UnsupportedVersion(u8),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPrefix => write!(f, "invalid BAML runtime ID prefix"),
+            Self::InvalidBase64 => write!(f, "invalid BAML runtime ID base64 payload"),
+            Self::InvalidLength { expected, actual } => {
+                write!(
+                    f,
+                    "invalid BAML runtime ID payload length: expected {expected}, got {actual}"
+                )
+            }
+            Self::UnsupportedVersion(version) => {
+                write!(f, "unsupported BAML runtime ID version {version}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+impl ThreadRef {
+    #[must_use]
+    pub fn encode(&self) -> String {
+        let mut payload = Vec::with_capacity(THREAD_REF_LEN);
+        payload.push(PAYLOAD_VERSION);
+        payload.extend_from_slice(&self.process_euid.0);
+        payload.extend_from_slice(&self.engine_id.0.to_be_bytes());
+        payload.extend_from_slice(&self.thread_id.0.to_be_bytes());
+        format!("{THREAD_REF_PREFIX}{}", URL_SAFE_NO_PAD.encode(payload))
+    }
+
+    pub fn decode(s: &str) -> Result<Self, DecodeError> {
+        let payload = decode_payload(s, THREAD_REF_PREFIX, THREAD_REF_LEN)?;
+        Ok(Self {
+            process_euid: ProcessEuid(payload[1..17].try_into().expect("fixed-width slice")),
+            engine_id: EngineId(u64::from_be_bytes(
+                payload[17..25].try_into().expect("fixed-width slice"),
+            )),
+            thread_id: BexThreadId(u64::from_be_bytes(
+                payload[25..33].try_into().expect("fixed-width slice"),
+            )),
+        })
+    }
+}
+
+impl CallRef {
+    #[must_use]
+    pub fn encode(&self) -> String {
+        let mut payload = Vec::with_capacity(CALL_REF_LEN);
+        payload.push(PAYLOAD_VERSION);
+        payload.extend_from_slice(&self.process_euid.0);
+        payload.extend_from_slice(&self.engine_id.0.to_be_bytes());
+        payload.extend_from_slice(&self.thread_id.0.to_be_bytes());
+        payload.extend_from_slice(&self.call_id.0.to_be_bytes());
+        format!("{CALL_REF_PREFIX}{}", URL_SAFE_NO_PAD.encode(payload))
+    }
+
+    pub fn decode(s: &str) -> Result<Self, DecodeError> {
+        let payload = decode_payload(s, CALL_REF_PREFIX, CALL_REF_LEN)?;
+        Ok(Self {
+            process_euid: ProcessEuid(payload[1..17].try_into().expect("fixed-width slice")),
+            engine_id: EngineId(u64::from_be_bytes(
+                payload[17..25].try_into().expect("fixed-width slice"),
+            )),
+            thread_id: BexThreadId(u64::from_be_bytes(
+                payload[25..33].try_into().expect("fixed-width slice"),
+            )),
+            call_id: BexCallId(u64::from_be_bytes(
+                payload[33..41].try_into().expect("fixed-width slice"),
+            )),
+        })
+    }
+}
+
+impl BoundaryId {
+    #[must_use]
+    pub fn new_random() -> Self {
+        Self(*uuid::Uuid::new_v4().as_bytes())
+    }
+
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    #[must_use]
+    pub fn as_bytes(self) -> [u8; 16] {
+        self.0
+    }
+
+    #[must_use]
+    pub fn to_wire_string(self) -> String {
+        self.encode()
+    }
+
+    #[must_use]
+    pub fn from_wire_str(value: &str) -> Option<Self> {
+        Self::decode(value).ok()
+    }
+
+    #[must_use]
+    pub fn encode(self) -> String {
+        format!("{BOUNDARY_ID_PREFIX}{}", URL_SAFE_NO_PAD.encode(self.0))
+    }
+
+    pub fn decode(s: &str) -> Result<Self, DecodeError> {
+        let encoded = s
+            .strip_prefix(BOUNDARY_ID_PREFIX)
+            .ok_or(DecodeError::InvalidPrefix)?;
+        let payload = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .map_err(|_| DecodeError::InvalidBase64)?;
+        if payload.len() != BOUNDARY_ID_LEN {
+            return Err(DecodeError::InvalidLength {
+                expected: BOUNDARY_ID_LEN,
+                actual: payload.len(),
+            });
+        }
+        Ok(Self(
+            payload.as_slice().try_into().expect("fixed-width slice"),
+        ))
+    }
+}
+
+impl RuntimeId {
+    #[must_use]
+    pub fn encode(&self) -> String {
+        match self {
+            Self::DefaultCall(call_ref) => call_ref.encode(),
+            Self::Boundary(boundary_id) => boundary_id.encode(),
+        }
+    }
+
+    pub fn decode(s: &str) -> Result<Self, DecodeError> {
+        if s.starts_with(CALL_REF_PREFIX) {
+            return CallRef::decode(s).map(Self::DefaultCall);
+        }
+        BoundaryId::decode(s).map(Self::Boundary)
+    }
+}
+
+fn decode_payload(s: &str, prefix: &str, expected_len: usize) -> Result<Vec<u8>, DecodeError> {
+    let encoded = s.strip_prefix(prefix).ok_or(DecodeError::InvalidPrefix)?;
+    let payload = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| DecodeError::InvalidBase64)?;
+    if payload.len() != expected_len {
+        return Err(DecodeError::InvalidLength {
+            expected: expected_len,
+            actual: payload.len(),
+        });
+    }
+    if payload[0] != PAYLOAD_VERSION {
+        return Err(DecodeError::UnsupportedVersion(payload[0]));
+    }
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ZERO_RANDOM_UUID_V7_SUFFIX: [u8; 10] = [0x70, 0, 0x80, 0, 0, 0, 0, 0, 0, 0];
+
+    fn assert_uuid_v7(bytes: [u8; 16]) {
+        let uuid = uuid::Uuid::from_bytes(bytes);
+        assert_eq!(uuid.get_variant(), uuid::Variant::RFC4122);
+        assert_eq!(uuid.get_version(), Some(uuid::Version::SortRand));
+    }
+
+    #[test]
+    fn zero_random_uuid_v7_encodes_the_supplied_timestamp() {
+        let uuid = zero_random_uuid_v7(0x0123_4567_89ab);
+        assert_eq!(
+            uuid.as_bytes(),
+            &[
+                1, 0x23, 0x45, 0x67, 0x89, 0xab, 0x70, 0, 0x80, 0, 0, 0, 0, 0, 0, 0
+            ]
+        );
+        assert_eq!(uuid.get_variant(), uuid::Variant::RFC4122);
+        assert_eq!(uuid.get_version(), Some(uuid::Version::SortRand));
+    }
+
+    #[test]
+    fn current_process_euid_is_stable() {
+        assert_eq!(ProcessEuid::current(), ProcessEuid::current());
+    }
+
+    #[test]
+    fn process_euid_and_program_id_use_distinct_uuid_v7_values() {
+        let process_a = ProcessEuid::new_random();
+        let process_b = ProcessEuid::new_random();
+        let program_a = ProgramId::new_random();
+        let program_b = ProgramId::new_random();
+
+        for bytes in [process_a.0, process_b.0, program_a.0, program_b.0] {
+            assert_uuid_v7(bytes);
+            assert_ne!(bytes[6..], ZERO_RANDOM_UUID_V7_SUFFIX);
+        }
+        assert_ne!(process_a, process_b);
+        assert_ne!(program_a, program_b);
+    }
+
+    fn sample_call_ref() -> CallRef {
+        CallRef {
+            process_euid: ProcessEuid([7; 16]),
+            engine_id: EngineId(2),
+            thread_id: BexThreadId(3),
+            call_id: BexCallId(4),
+        }
+    }
+
+    #[test]
+    fn call_ref_round_trips() {
+        let call_ref = sample_call_ref();
+        assert_eq!(CallRef::decode(&call_ref.encode()).unwrap(), call_ref);
+    }
+
+    #[test]
+    fn thread_ref_round_trips() {
+        let thread_ref = ThreadRef {
+            process_euid: ProcessEuid([9; 16]),
+            engine_id: EngineId(10),
+            thread_id: BexThreadId(11),
+        };
+        assert_eq!(ThreadRef::decode(&thread_ref.encode()).unwrap(), thread_ref);
+    }
+
+    #[test]
+    fn boundary_id_round_trips_with_existing_wire_shape() {
+        let boundary_id = BoundaryId::from_bytes([11; 16]);
+        assert_eq!(
+            boundary_id.to_wire_string(),
+            "baml_id_1_CwsLCwsLCwsLCwsLCwsLCw"
+        );
+        assert_eq!(
+            BoundaryId::decode(&boundary_id.encode()).unwrap(),
+            boundary_id
+        );
+        assert_eq!(
+            BoundaryId::from_wire_str(&boundary_id.to_wire_string()),
+            Some(boundary_id)
+        );
+    }
+
+    #[test]
+    fn runtime_ids_round_trip_default_and_boundary_forms() {
+        let default = RuntimeId::DefaultCall(sample_call_ref());
+        assert_eq!(RuntimeId::decode(&default.encode()).unwrap(), default);
+
+        let override_id = RuntimeId::Boundary(BoundaryId::from_bytes([11; 16]));
+        assert_eq!(
+            RuntimeId::decode(&override_id.encode()).unwrap(),
+            override_id
+        );
+    }
+
+    #[test]
+    fn each_call_ref_component_affects_encoding() {
+        let base = sample_call_ref();
+        let encoded = base.encode();
+        assert_ne!(
+            CallRef {
+                process_euid: ProcessEuid([8; 16]),
+                ..base
+            }
+            .encode(),
+            encoded
+        );
+        assert_ne!(
+            CallRef {
+                engine_id: EngineId(5),
+                ..base
+            }
+            .encode(),
+            encoded
+        );
+        assert_ne!(
+            CallRef {
+                thread_id: BexThreadId(5),
+                ..base
+            }
+            .encode(),
+            encoded
+        );
+        assert_ne!(
+            CallRef {
+                call_id: BexCallId(5),
+                ..base
+            }
+            .encode(),
+            encoded
+        );
+    }
+
+    #[test]
+    fn malformed_ids_fail_cleanly() {
+        assert_eq!(CallRef::decode("bad"), Err(DecodeError::InvalidPrefix));
+        assert!(matches!(
+            CallRef::decode("baml_call_1_!"),
+            Err(DecodeError::InvalidBase64)
+        ));
+
+        let mut payload = vec![PAYLOAD_VERSION; CALL_REF_LEN];
+        payload[0] = 99;
+        let encoded = format!("{CALL_REF_PREFIX}{}", URL_SAFE_NO_PAD.encode(payload));
+        assert_eq!(
+            CallRef::decode(&encoded),
+            Err(DecodeError::UnsupportedVersion(99))
+        );
+    }
+
+    #[test]
+    fn malformed_thread_refs_fail_cleanly() {
+        assert_eq!(ThreadRef::decode("bad"), Err(DecodeError::InvalidPrefix));
+        assert!(matches!(
+            ThreadRef::decode("baml_thread_1_!"),
+            Err(DecodeError::InvalidBase64)
+        ));
+
+        let mut payload = vec![PAYLOAD_VERSION; THREAD_REF_LEN];
+        payload[0] = 99;
+        let encoded = format!("{THREAD_REF_PREFIX}{}", URL_SAFE_NO_PAD.encode(payload));
+        assert_eq!(
+            ThreadRef::decode(&encoded),
+            Err(DecodeError::UnsupportedVersion(99))
+        );
+    }
+
+    #[test]
+    fn truncated_payloads_fail_with_invalid_length() {
+        let truncated = vec![PAYLOAD_VERSION; CALL_REF_LEN - 1];
+        let encoded = format!("{CALL_REF_PREFIX}{}", URL_SAFE_NO_PAD.encode(truncated));
+        assert_eq!(
+            CallRef::decode(&encoded),
+            Err(DecodeError::InvalidLength {
+                expected: CALL_REF_LEN,
+                actual: CALL_REF_LEN - 1,
+            })
+        );
+
+        let truncated = vec![PAYLOAD_VERSION; THREAD_REF_LEN - 1];
+        let encoded = format!("{THREAD_REF_PREFIX}{}", URL_SAFE_NO_PAD.encode(truncated));
+        assert_eq!(
+            ThreadRef::decode(&encoded),
+            Err(DecodeError::InvalidLength {
+                expected: THREAD_REF_LEN,
+                actual: THREAD_REF_LEN - 1,
+            })
+        );
+
+        // Boundary payloads are raw 16 bytes (no version byte).
+        let short = vec![0u8; BOUNDARY_ID_LEN - 1];
+        let encoded = format!("{BOUNDARY_ID_PREFIX}{}", URL_SAFE_NO_PAD.encode(short));
+        assert_eq!(
+            RuntimeId::decode(&encoded),
+            Err(DecodeError::InvalidLength {
+                expected: BOUNDARY_ID_LEN,
+                actual: BOUNDARY_ID_LEN - 1,
+            })
+        );
+    }
+
+    #[test]
+    fn cross_type_prefixes_are_rejected() {
+        let thread_ref = ThreadRef {
+            process_euid: ProcessEuid([9; 16]),
+            engine_id: EngineId(10),
+            thread_id: BexThreadId(11),
+        };
+        // A thread ref is not a runtime id (only call refs and boundary ids are).
+        assert_eq!(
+            RuntimeId::decode(&thread_ref.encode()),
+            Err(DecodeError::InvalidPrefix)
+        );
+        // And the typed decoders reject each other's prefixes.
+        assert_eq!(
+            CallRef::decode(&thread_ref.encode()),
+            Err(DecodeError::InvalidPrefix)
+        );
+        assert_eq!(
+            ThreadRef::decode(&sample_call_ref().encode()),
+            Err(DecodeError::InvalidPrefix)
+        );
+    }
+}

--- a/baml_language/crates/btel_core/src/lib.rs
+++ b/baml_language/crates/btel_core/src/lib.rs
@@ -1,0 +1,5 @@
+//! Isolated experimental marker definitions and statically dispatched stage contracts.
+pub mod clock;
+pub mod ids;
+pub mod marker;
+pub mod stage;

--- a/baml_language/crates/btel_core/src/marker.rs
+++ b/baml_language/crates/btel_core/src/marker.rs
@@ -1,0 +1,1113 @@
+//! Raw ring records: the producer→consumer wire format (v2 §4.1).
+//!
+//! Every record is `tag: u8` followed by a fixed little-endian field layout
+//! per tag; only `BexThreadStart` carries a variable-length tail (the thread
+//! name, capped at [`MAX_THREAD_NAME_LEN`] bytes). Producer and consumer live
+//! in the same binary, so the tag→layout table is compiled in — there is no
+//! self-describing framing on the ring.
+//!
+//! Producers commit whole records (the ring's `commit_len` always lands on a
+//! record boundary) and never split a record across segments, so a drained
+//! byte range is always a whole number of records.
+//!
+//! Id conventions: `call_id` counters start at 1, so `0` means "none" in
+//! `parent_call_id`/`parent_thread_id` fields. `engine_id`/`process_id` are
+//! deliberately absent — they are per-ring and per-file-header state.
+
+/// Maximum thread-name bytes carried by a [`Marker::BexThreadStart`] record.
+pub const MAX_THREAD_NAME_LEN: usize = 256;
+
+/// Encoded sizes, tag byte included.
+pub const FUNCTION_ENTER_LEN: usize = 54;
+/// See [`FUNCTION_ENTER_LEN`].
+pub const FUNCTION_EXIT_LEN: usize = 26;
+/// Awaited call-end variant: compact end plus `await_ns: u64` and
+/// `await_count: u32`.
+pub const FUNCTION_EXIT_AWAITED_LEN: usize = FUNCTION_EXIT_LEN + 12;
+/// Fixed prefix of a `BexThreadStart` record; the name bytes follow.
+pub const START_THREAD_FIXED_LEN: usize = 36;
+/// Fixed prefix of a spawned-thread start, including its source span.
+pub const START_THREAD_SPAWN_FIXED_LEN: usize = START_THREAD_FIXED_LEN + 16;
+/// See [`FUNCTION_ENTER_LEN`].
+pub const END_THREAD_LEN: usize = 18;
+/// See [`FUNCTION_ENTER_LEN`].
+pub const SET_FUNCTION_ID_LEN: usize = 41;
+
+/// Upper bound on any encoded record; sizes producer-side stack buffers.
+pub const MAX_RECORD_LEN: usize = START_THREAD_SPAWN_FIXED_LEN + MAX_THREAD_NAME_LEN;
+
+/// Caps a thread name at [`MAX_THREAD_NAME_LEN`] bytes without splitting a
+/// UTF-8 character — the producer-side capture helper for `BexThreadStart`.
+#[must_use]
+pub fn capped_name_bytes(name: &str) -> &[u8] {
+    if name.len() <= MAX_THREAD_NAME_LEN {
+        return name.as_bytes();
+    }
+    let mut end = MAX_THREAD_NAME_LEN;
+    while end > 0 && !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    &name.as_bytes()[..end]
+}
+
+use crate::ids::{BexCallId, BexThreadId, FunctionId};
+
+const TAG_FUNCTION_ENTER: u8 = 0x01;
+const TAG_FUNCTION_EXIT: u8 = 0x02;
+const TAG_START_THREAD: u8 = 0x03;
+const TAG_END_THREAD: u8 = 0x04;
+const TAG_SET_FUNCTION_ID: u8 = 0x05;
+const TAG_FUNCTION_EXIT_AWAITED: u8 = 0x06;
+const TAG_START_THREAD_SPAWN: u8 = 0x07;
+const CALL_SITE_FILE_ID_NONE: u32 = u32::MAX;
+
+/// Caller-side source span captured at a profiled call site.
+///
+/// This is the raw source-map projection from the VM: file id plus byte offsets
+/// and the 1-indexed line cached in the bytecode line table. File path and
+/// retained source text remain `ProjectStore` concerns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CallSiteSourceSpan {
+    pub file_id: u32,
+    pub start_offset: u32,
+    pub end_offset: u32,
+    pub line: u32,
+}
+
+/// How a function call ended — a closed taxonomy of the ways a frame can be
+/// popped. Statuses describe the frame's fate, not the program's outcome (a
+/// frame unwound by an exit that is later caught still ended `Exited`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FunctionEndStatus {
+    /// Normal return.
+    Ok = 0,
+    /// Unwound by exception propagation.
+    Errored = 1,
+    /// Closed by cancellation: unwound by a `baml.panics.Cancelled` panic,
+    /// or drained open by the engine when its thread was cancelled.
+    Cancelled = 2,
+    /// Unwound by a `baml.panics.Exit` panic (`baml.sys.exit`). The exit
+    /// code is a thread-level fact (see [`ThreadEndStatus`]).
+    Exited = 3,
+}
+
+/// How a logical BEX thread ended. Minimal by design; extensible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ThreadEndStatus {
+    /// Ran to completion.
+    Completed = 0,
+    /// Cancelled before completion.
+    Cancelled = 1,
+    /// Terminated by an error.
+    Errored = 2,
+}
+
+/// A decoded ring record. Borrowed (`name`) from the drained byte range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Marker<'a> {
+    /// Tag `0x01`: a function call began (pushed right after the frame push).
+    FunctionEnter {
+        /// Reserved flag bits (zero today).
+        flags: u8,
+        /// Logical BEX thread id (not the OS thread).
+        thread_id: BexThreadId,
+        /// Per-logical-thread call id (counters start at 1; always
+        /// interpret together with `thread_id` — `(thread_id, call_id)` is
+        /// the unique key).
+        call_id: BexCallId,
+        /// Intra-thread caller; `0` = thread-root call.
+        parent_call_id: BexCallId,
+        /// Per-run function id (see the header's function table; 0 = unattributable).
+        function_id: FunctionId,
+        /// Caller-side source span for the invocation that produced this call.
+        call_site: Option<CallSiteSourceSpan>,
+        /// Raw clock ticks ([`crate::clock::now_ticks`]); the consumer
+        /// converts to nanoseconds at transcode.
+        ts_ticks: u64,
+    },
+    /// Tag `0x02`: a function call ended (return, unwind, or cancel drain).
+    FunctionExit {
+        /// How the frame ended (see [`FunctionEndStatus`]).
+        status: FunctionEndStatus,
+        /// Logical BEX thread id.
+        thread_id: BexThreadId,
+        /// Matches the `FunctionEnter` it closes.
+        call_id: BexCallId,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
+    },
+    /// Tag `0x06`: the alternative call-end encoding used only when the call
+    /// suspended at least once. This is one end fact, not an additional event.
+    FunctionExitAwaited {
+        /// How the frame ended.
+        status: FunctionEndStatus,
+        /// Logical BEX thread id.
+        thread_id: BexThreadId,
+        /// Matches the `FunctionEnter` it closes.
+        call_id: BexCallId,
+        /// Raw clock ticks; converted to ns by the consumer.
+        ts_ticks: u64,
+        /// Sum of successfully measured declared VM suspension intervals.
+        await_ns: u64,
+        /// Number of successfully measured declared VM suspension intervals.
+        await_count: u32,
+    },
+    /// Tag `0x03`: a logical thread started (root or spawn).
+    BexThreadStart {
+        /// Reserved flag bits (zero today).
+        flags: u8,
+        /// Logical BEX thread id.
+        thread_id: BexThreadId,
+        /// Spawning thread; `0` = engine-root thread.
+        parent_thread_id: BexThreadId,
+        /// Spawning call in the parent thread; `0` = none.
+        parent_call_id: BexCallId,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
+        /// User-defined thread name, ≤ [`MAX_THREAD_NAME_LEN`] bytes of UTF-8
+        /// (validated only at transcode time).
+        name: &'a [u8],
+    },
+    /// Tag `0x07`: spawned logical thread start with the spawn expression's
+    /// source span. This remains distinct from root `BexThreadStart` so the
+    /// legacy root record retains its frozen byte shape.
+    BexThreadStartSpawned {
+        flags: u8,
+        thread_id: BexThreadId,
+        parent_thread_id: BexThreadId,
+        parent_call_id: BexCallId,
+        ts_ticks: u64,
+        spawn_site: Option<CallSiteSourceSpan>,
+        name: &'a [u8],
+    },
+    /// Tag `0x04`: a logical thread ended.
+    BexThreadEnd {
+        /// How the thread ended.
+        status: ThreadEndStatus,
+        /// Logical BEX thread id.
+        thread_id: BexThreadId,
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
+    },
+    /// Tag `0x05`: `$id` override for a call (reserved for the M1 language
+    /// surface; the shape is fixed so the ring format doesn't change).
+    SetBoundaryLocalId {
+        /// Logical BEX thread id.
+        thread_id: BexThreadId,
+        /// The call whose `$id` is overridden.
+        call_id: BexCallId,
+        /// The override UUID bytes (`baml.id.new()`).
+        id: [u8; 16],
+        /// Raw clock ticks; converted to ns by the consumer at transcode.
+        ts_ticks: u64,
+    },
+}
+
+/// Why a byte range failed to decode. In a drained, committed range any of
+/// these means producer-side corruption — the consumer treats them as fatal
+/// for that ring, never as skippable noise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeError {
+    /// First byte is not a known record tag.
+    UnknownTag(u8),
+    /// The buffer ends mid-record.
+    Truncated,
+    /// A status byte holds an undefined value.
+    InvalidStatus(u8),
+    /// A `BexThreadStart` name length exceeds [`MAX_THREAD_NAME_LEN`].
+    NameTooLong(u16),
+}
+
+impl Marker<'_> {
+    /// Encoded length of this record in bytes.
+    #[must_use]
+    pub fn encoded_len(&self) -> usize {
+        match self {
+            Marker::FunctionEnter { .. } => FUNCTION_ENTER_LEN,
+            Marker::FunctionExit { .. } => FUNCTION_EXIT_LEN,
+            Marker::FunctionExitAwaited { .. } => FUNCTION_EXIT_AWAITED_LEN,
+            Marker::BexThreadStart { name, .. } => {
+                START_THREAD_FIXED_LEN + name.len().min(MAX_THREAD_NAME_LEN)
+            }
+            Marker::BexThreadStartSpawned { name, .. } => {
+                START_THREAD_SPAWN_FIXED_LEN + name.len().min(MAX_THREAD_NAME_LEN)
+            }
+            Marker::BexThreadEnd { .. } => END_THREAD_LEN,
+            Marker::SetBoundaryLocalId { .. } => SET_FUNCTION_ID_LEN,
+        }
+    }
+
+    /// Encodes into the front of `buf`, returning the encoded length.
+    ///
+    /// `BexThreadStart` names are truncated to [`MAX_THREAD_NAME_LEN`] bytes
+    /// defensively; callers are expected to cap (UTF-8-safely) at capture
+    /// time.
+    #[inline]
+    pub fn encode(&self, buf: &mut [u8; MAX_RECORD_LEN]) -> usize {
+        self.encode_to(buf)
+    }
+
+    /// Encodes into the front of `buf`, returning the encoded length, for
+    /// producers that write straight into a ring slot sized to the record
+    /// ([`Self::encoded_len`]) instead of zeroing [`MAX_RECORD_LEN`] bytes on a
+    /// hot path.
+    ///
+    /// # Safety / precondition
+    /// `buf.len()` MUST be at least [`Self::encoded_len`]. The fixed integer
+    /// fields are written via unchecked unaligned stores (debug-asserted, not
+    /// release-checked), so an undersized `buf` is undefined behavior in
+    /// release builds — not a panic. Every caller satisfies this:
+    /// [`Self::encode`] uses a [`MAX_RECORD_LEN`] buffer and `OSThreadMarkerRing::push_with`
+    /// reserves exactly `encoded_len()`.
+    #[inline]
+    pub fn encode_to(&self, buf: &mut [u8]) -> usize {
+        let mut w = Writer { buf, pos: 0 };
+        match *self {
+            Marker::FunctionEnter {
+                flags,
+                thread_id,
+                call_id,
+                parent_call_id,
+                function_id,
+                call_site,
+                ts_ticks,
+            } => {
+                w.u8(TAG_FUNCTION_ENTER);
+                w.u8(flags);
+                w.u64(thread_id.0);
+                w.u64(call_id.0);
+                w.u64(parent_call_id.0);
+                w.u32(function_id.0);
+                w.u64(ts_ticks);
+                if let Some(call_site) = call_site {
+                    w.u32(call_site.file_id);
+                    w.u32(call_site.start_offset);
+                    w.u32(call_site.end_offset);
+                    w.u32(call_site.line);
+                } else {
+                    w.u32(CALL_SITE_FILE_ID_NONE);
+                    w.u32(0);
+                    w.u32(0);
+                    w.u32(0);
+                }
+            }
+            Marker::FunctionExit {
+                status,
+                thread_id,
+                call_id,
+                ts_ticks,
+            } => {
+                w.u8(TAG_FUNCTION_EXIT);
+                w.u8(status as u8);
+                w.u64(thread_id.0);
+                w.u64(call_id.0);
+                w.u64(ts_ticks);
+            }
+            Marker::FunctionExitAwaited {
+                status,
+                thread_id,
+                call_id,
+                ts_ticks,
+                await_ns,
+                await_count,
+            } => {
+                w.u8(TAG_FUNCTION_EXIT_AWAITED);
+                w.u8(status as u8);
+                w.u64(thread_id.0);
+                w.u64(call_id.0);
+                w.u64(ts_ticks);
+                w.u64(await_ns);
+                w.u32(await_count);
+            }
+            Marker::BexThreadStart {
+                flags,
+                thread_id,
+                parent_thread_id,
+                parent_call_id,
+                ts_ticks,
+                name,
+            } => {
+                let name = &name[..name.len().min(MAX_THREAD_NAME_LEN)];
+                w.u8(TAG_START_THREAD);
+                w.u8(flags);
+                w.u64(thread_id.0);
+                w.u64(parent_thread_id.0);
+                w.u64(parent_call_id.0);
+                w.u64(ts_ticks);
+                w.u16(u16::try_from(name.len()).expect("thread name is capped at 256 bytes"));
+                w.bytes(name);
+            }
+            Marker::BexThreadStartSpawned {
+                flags,
+                thread_id,
+                parent_thread_id,
+                parent_call_id,
+                ts_ticks,
+                spawn_site,
+                name,
+            } => {
+                let name = &name[..name.len().min(MAX_THREAD_NAME_LEN)];
+                w.u8(TAG_START_THREAD_SPAWN);
+                w.u8(flags);
+                w.u64(thread_id.0);
+                w.u64(parent_thread_id.0);
+                w.u64(parent_call_id.0);
+                w.u64(ts_ticks);
+                if let Some(spawn_site) = spawn_site {
+                    w.u32(spawn_site.file_id);
+                    w.u32(spawn_site.start_offset);
+                    w.u32(spawn_site.end_offset);
+                    w.u32(spawn_site.line);
+                } else {
+                    w.u32(CALL_SITE_FILE_ID_NONE);
+                    w.u32(0);
+                    w.u32(0);
+                    w.u32(0);
+                }
+                w.u16(u16::try_from(name.len()).expect("thread name is capped at 256 bytes"));
+                w.bytes(name);
+            }
+            Marker::BexThreadEnd {
+                status,
+                thread_id,
+                ts_ticks,
+            } => {
+                w.u8(TAG_END_THREAD);
+                w.u8(status as u8);
+                w.u64(thread_id.0);
+                w.u64(ts_ticks);
+            }
+            Marker::SetBoundaryLocalId {
+                thread_id,
+                call_id,
+                id,
+                ts_ticks,
+            } => {
+                w.u8(TAG_SET_FUNCTION_ID);
+                w.u64(thread_id.0);
+                w.u64(call_id.0);
+                w.bytes(&id);
+                w.u64(ts_ticks);
+            }
+        }
+        debug_assert_eq!(w.pos, self.encoded_len());
+        w.pos
+    }
+}
+
+/// Decodes the record at the front of `buf`, returning it and its encoded
+/// length. Never panics on malformed input.
+pub fn decode(buf: &[u8]) -> Result<(Marker<'_>, usize), DecodeError> {
+    let mut r = Reader { buf, pos: 0 };
+    let tag = r.u8()?;
+    let rec = match tag {
+        TAG_FUNCTION_ENTER => {
+            let flags = r.u8()?;
+            let thread_id = BexThreadId(r.u64()?);
+            let call_id = BexCallId(r.u64()?);
+            let parent_call_id = BexCallId(r.u64()?);
+            let function_id = FunctionId(r.u32()?);
+            let ts_ticks = r.u64()?;
+            let call_site_file_id = r.u32()?;
+            let call_site_start_offset = r.u32()?;
+            let call_site_end_offset = r.u32()?;
+            let call_site_line = r.u32()?;
+            Marker::FunctionEnter {
+                flags,
+                thread_id,
+                call_id,
+                parent_call_id,
+                function_id,
+                call_site: (call_site_file_id != CALL_SITE_FILE_ID_NONE).then_some(
+                    CallSiteSourceSpan {
+                        file_id: call_site_file_id,
+                        start_offset: call_site_start_offset,
+                        end_offset: call_site_end_offset,
+                        line: call_site_line,
+                    },
+                ),
+                ts_ticks,
+            }
+        }
+        TAG_FUNCTION_EXIT => Marker::FunctionExit {
+            status: match r.u8()? {
+                0 => FunctionEndStatus::Ok,
+                1 => FunctionEndStatus::Errored,
+                2 => FunctionEndStatus::Cancelled,
+                3 => FunctionEndStatus::Exited,
+                bad => return Err(DecodeError::InvalidStatus(bad)),
+            },
+            thread_id: BexThreadId(r.u64()?),
+            call_id: BexCallId(r.u64()?),
+            ts_ticks: r.u64()?,
+        },
+        TAG_FUNCTION_EXIT_AWAITED => Marker::FunctionExitAwaited {
+            status: match r.u8()? {
+                0 => FunctionEndStatus::Ok,
+                1 => FunctionEndStatus::Errored,
+                2 => FunctionEndStatus::Cancelled,
+                3 => FunctionEndStatus::Exited,
+                bad => return Err(DecodeError::InvalidStatus(bad)),
+            },
+            thread_id: BexThreadId(r.u64()?),
+            call_id: BexCallId(r.u64()?),
+            ts_ticks: r.u64()?,
+            await_ns: r.u64()?,
+            await_count: r.u32()?,
+        },
+        TAG_START_THREAD => {
+            let flags = r.u8()?;
+            let thread_id = BexThreadId(r.u64()?);
+            let parent_thread_id = BexThreadId(r.u64()?);
+            let parent_call_id = BexCallId(r.u64()?);
+            let ts_ticks = r.u64()?;
+            let name_len = r.u16()?;
+            if usize::from(name_len) > MAX_THREAD_NAME_LEN {
+                return Err(DecodeError::NameTooLong(name_len));
+            }
+            Marker::BexThreadStart {
+                flags,
+                thread_id,
+                parent_thread_id,
+                parent_call_id,
+                ts_ticks,
+                name: r.bytes(usize::from(name_len))?,
+            }
+        }
+        TAG_START_THREAD_SPAWN => {
+            let flags = r.u8()?;
+            let thread_id = BexThreadId(r.u64()?);
+            let parent_thread_id = BexThreadId(r.u64()?);
+            let parent_call_id = BexCallId(r.u64()?);
+            let ts_ticks = r.u64()?;
+            let file_id = r.u32()?;
+            let start_offset = r.u32()?;
+            let end_offset = r.u32()?;
+            let line = r.u32()?;
+            let spawn_site = (file_id != CALL_SITE_FILE_ID_NONE).then_some(CallSiteSourceSpan {
+                file_id,
+                start_offset,
+                end_offset,
+                line,
+            });
+            let name_len = r.u16()?;
+            if usize::from(name_len) > MAX_THREAD_NAME_LEN {
+                return Err(DecodeError::NameTooLong(name_len));
+            }
+            Marker::BexThreadStartSpawned {
+                flags,
+                thread_id,
+                parent_thread_id,
+                parent_call_id,
+                ts_ticks,
+                spawn_site,
+                name: r.bytes(usize::from(name_len))?,
+            }
+        }
+        TAG_END_THREAD => Marker::BexThreadEnd {
+            status: match r.u8()? {
+                0 => ThreadEndStatus::Completed,
+                1 => ThreadEndStatus::Cancelled,
+                2 => ThreadEndStatus::Errored,
+                bad => return Err(DecodeError::InvalidStatus(bad)),
+            },
+            thread_id: BexThreadId(r.u64()?),
+            ts_ticks: r.u64()?,
+        },
+        TAG_SET_FUNCTION_ID => Marker::SetBoundaryLocalId {
+            thread_id: BexThreadId(r.u64()?),
+            call_id: BexCallId(r.u64()?),
+            id: {
+                let bytes = r.bytes(16)?;
+                let mut id = [0u8; 16];
+                id.copy_from_slice(bytes);
+                id
+            },
+            ts_ticks: r.u64()?,
+        },
+        bad => return Err(DecodeError::UnknownTag(bad)),
+    };
+    Ok((rec, r.pos))
+}
+
+/// Iterates the records in a drained byte range.
+pub fn iter(buf: &[u8]) -> RecordIter<'_> {
+    RecordIter { buf }
+}
+
+/// See [`iter`]. Yields `Err` once and then stops.
+pub struct RecordIter<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> Iterator for RecordIter<'a> {
+    type Item = Result<Marker<'a>, DecodeError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.buf.is_empty() {
+            return None;
+        }
+        match decode(self.buf) {
+            Ok((rec, len)) => {
+                self.buf = &self.buf[len..];
+                Some(Ok(rec))
+            }
+            Err(err) => {
+                self.buf = &[];
+                Some(Err(err))
+            }
+        }
+    }
+}
+
+struct Writer<'b> {
+    buf: &'b mut [u8],
+    pos: usize,
+}
+
+impl Writer<'_> {
+    #[inline]
+    fn u8(&mut self, v: u8) {
+        self.buf[self.pos] = v;
+        self.pos += 1;
+    }
+
+    #[inline]
+    fn u16(&mut self, v: u16) {
+        debug_assert!(self.pos + 2 <= self.buf.len());
+        // SAFETY: callers size `buf` >= `encoded_len()` (producer reserves
+        // exactly that via `OSThreadMarkerRing::push_with`), so `pos + 2` is in bounds.
+        #[expect(
+            unsafe_code,
+            reason = "in-bounds unaligned store; avoids non-inlined copy"
+        )]
+        unsafe {
+            self.buf
+                .as_mut_ptr()
+                .add(self.pos)
+                .cast::<u16>()
+                .write_unaligned(v.to_le());
+        }
+        self.pos += 2;
+    }
+
+    #[inline]
+    fn u32(&mut self, v: u32) {
+        debug_assert!(self.pos + 4 <= self.buf.len());
+        // SAFETY: see `u16`.
+        #[expect(
+            unsafe_code,
+            reason = "in-bounds unaligned store; avoids non-inlined copy"
+        )]
+        unsafe {
+            self.buf
+                .as_mut_ptr()
+                .add(self.pos)
+                .cast::<u32>()
+                .write_unaligned(v.to_le());
+        }
+        self.pos += 4;
+    }
+
+    #[inline]
+    fn u64(&mut self, v: u64) {
+        debug_assert!(self.pos + 8 <= self.buf.len());
+        // SAFETY: see `u16`. A direct unaligned store lowers to one `mov` at
+        // `opt-level="s"`; routing through `copy_from_slice`/`copy_nonoverlapping`
+        // emitted a non-inlined call there (~5-8 ns/pair on the hot records).
+        #[expect(
+            unsafe_code,
+            reason = "in-bounds unaligned store; avoids non-inlined copy"
+        )]
+        unsafe {
+            self.buf
+                .as_mut_ptr()
+                .add(self.pos)
+                .cast::<u64>()
+                .write_unaligned(v.to_le());
+        }
+        self.pos += 8;
+    }
+
+    #[inline]
+    fn bytes(&mut self, b: &[u8]) {
+        self.buf[self.pos..self.pos + b.len()].copy_from_slice(b);
+        self.pos += b.len();
+    }
+}
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn u8(&mut self) -> Result<u8, DecodeError> {
+        let v = *self.buf.get(self.pos).ok_or(DecodeError::Truncated)?;
+        self.pos += 1;
+        Ok(v)
+    }
+
+    fn u16(&mut self) -> Result<u16, DecodeError> {
+        Ok(u16::from_le_bytes(self.array()?))
+    }
+
+    fn u32(&mut self) -> Result<u32, DecodeError> {
+        Ok(u32::from_le_bytes(self.array()?))
+    }
+
+    fn u64(&mut self) -> Result<u64, DecodeError> {
+        Ok(u64::from_le_bytes(self.array()?))
+    }
+
+    fn bytes(&mut self, len: usize) -> Result<&'a [u8], DecodeError> {
+        let end = self.pos.checked_add(len).ok_or(DecodeError::Truncated)?;
+        let b = self.buf.get(self.pos..end).ok_or(DecodeError::Truncated)?;
+        self.pos = end;
+        Ok(b)
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], DecodeError> {
+        let mut out = [0u8; N];
+        out.copy_from_slice(self.bytes(N)?);
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(rec: Marker<'_>) {
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let len = rec.encode(&mut buf);
+        assert_eq!(len, rec.encoded_len());
+        let (decoded, consumed) = decode(&buf[..len]).expect("roundtrip decode");
+        assert_eq!(consumed, len);
+        assert_eq!(decoded, rec);
+        // Decoding must not read past the record even with trailing bytes.
+        let (decoded, consumed) = decode(&buf).expect("decode with trailing bytes");
+        assert_eq!(consumed, len);
+        assert_eq!(decoded, rec);
+    }
+
+    #[test]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "intentionally truncating casts to vary the narrow test fields"
+    )]
+    fn roundtrip_all_variants() {
+        for v in [0u64, 1, 42, u64::MAX] {
+            roundtrip(Marker::FunctionEnter {
+                flags: v as u8,
+                thread_id: BexThreadId(v),
+                call_id: BexCallId(v.wrapping_add(1)),
+                parent_call_id: BexCallId(v / 2),
+                function_id: FunctionId(v as u32),
+                call_site: None,
+                ts_ticks: v,
+            });
+            roundtrip(Marker::FunctionExit {
+                status: FunctionEndStatus::Ok,
+                thread_id: BexThreadId(v),
+                call_id: BexCallId(v),
+                ts_ticks: v,
+            });
+            roundtrip(Marker::FunctionExitAwaited {
+                status: FunctionEndStatus::Ok,
+                thread_id: BexThreadId(v),
+                call_id: BexCallId(v),
+                ts_ticks: v,
+                await_ns: v.wrapping_mul(3),
+                await_count: v as u32,
+            });
+            roundtrip(Marker::BexThreadEnd {
+                status: ThreadEndStatus::Cancelled,
+                thread_id: BexThreadId(v),
+                ts_ticks: v,
+            });
+            roundtrip(Marker::SetBoundaryLocalId {
+                thread_id: BexThreadId(v),
+                call_id: BexCallId(v),
+                id: [v as u8; 16],
+                ts_ticks: v,
+            });
+        }
+        for status in [
+            FunctionEndStatus::Errored,
+            FunctionEndStatus::Cancelled,
+            FunctionEndStatus::Exited,
+        ] {
+            roundtrip(Marker::FunctionExit {
+                status,
+                thread_id: BexThreadId(7),
+                call_id: BexCallId(9),
+                ts_ticks: 11,
+            });
+        }
+        roundtrip(Marker::BexThreadEnd {
+            status: ThreadEndStatus::Completed,
+            thread_id: BexThreadId(7),
+            ts_ticks: 11,
+        });
+        roundtrip(Marker::BexThreadEnd {
+            status: ThreadEndStatus::Errored,
+            thread_id: BexThreadId(7),
+            ts_ticks: 11,
+        });
+        roundtrip(Marker::FunctionEnter {
+            flags: 0,
+            thread_id: BexThreadId(1),
+            call_id: BexCallId(2),
+            parent_call_id: BexCallId(1),
+            function_id: FunctionId(3),
+            call_site: Some(CallSiteSourceSpan {
+                file_id: 0,
+                start_offset: 12,
+                end_offset: 18,
+                line: 4,
+            }),
+            ts_ticks: 99,
+        });
+    }
+
+    #[test]
+    fn roundtrip_thread_names() {
+        for len in [0usize, 1, 100, 255, 256] {
+            let name = vec![b'x'; len];
+            roundtrip(Marker::BexThreadStart {
+                flags: 1,
+                thread_id: BexThreadId(2),
+                parent_thread_id: BexThreadId(0),
+                parent_call_id: BexCallId(3),
+                ts_ticks: 4,
+                name: &name,
+            });
+            roundtrip(Marker::BexThreadStartSpawned {
+                flags: 1,
+                thread_id: BexThreadId(3),
+                parent_thread_id: BexThreadId(2),
+                parent_call_id: BexCallId(4),
+                ts_ticks: 5,
+                spawn_site: Some(CallSiteSourceSpan {
+                    file_id: 6,
+                    start_offset: 7,
+                    end_offset: 8,
+                    line: 9,
+                }),
+                name: &name,
+            });
+        }
+    }
+
+    #[test]
+    fn encode_truncates_oversized_name() {
+        let name = vec![b'y'; 300];
+        let rec = Marker::BexThreadStart {
+            flags: 0,
+            thread_id: BexThreadId(1),
+            parent_thread_id: BexThreadId(0),
+            parent_call_id: BexCallId(0),
+            ts_ticks: 0,
+            name: &name,
+        };
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let len = rec.encode(&mut buf);
+        assert_eq!(len, START_THREAD_FIXED_LEN + MAX_THREAD_NAME_LEN);
+        let (decoded, _) = decode(&buf[..len]).expect("decode");
+        match decoded {
+            Marker::BexThreadStart { name, .. } => assert_eq!(name.len(), MAX_THREAD_NAME_LEN),
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fixed_sizes_match_spec() {
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let call = Marker::FunctionEnter {
+            flags: 0,
+            thread_id: BexThreadId(1),
+            call_id: BexCallId(1),
+            parent_call_id: BexCallId(0),
+            function_id: FunctionId(0),
+            call_site: None,
+            ts_ticks: 0,
+        };
+        assert_eq!(call.encode(&mut buf), 54);
+        let end = Marker::FunctionExit {
+            status: FunctionEndStatus::Ok,
+            thread_id: BexThreadId(1),
+            call_id: BexCallId(1),
+            ts_ticks: 0,
+        };
+        assert_eq!(end.encode(&mut buf), 26);
+        let awaited_end = Marker::FunctionExitAwaited {
+            status: FunctionEndStatus::Ok,
+            thread_id: BexThreadId(1),
+            call_id: BexCallId(1),
+            ts_ticks: 0,
+            await_ns: 7,
+            await_count: 2,
+        };
+        assert_eq!(awaited_end.encode(&mut buf), 38);
+        let start_thread = Marker::BexThreadStart {
+            flags: 0,
+            thread_id: BexThreadId(1),
+            parent_thread_id: BexThreadId(0),
+            parent_call_id: BexCallId(0),
+            ts_ticks: 0,
+            name: b"",
+        };
+        assert_eq!(start_thread.encode(&mut buf), 36);
+        let spawned_thread = Marker::BexThreadStartSpawned {
+            flags: 0,
+            thread_id: BexThreadId(2),
+            parent_thread_id: BexThreadId(1),
+            parent_call_id: BexCallId(1),
+            ts_ticks: 0,
+            spawn_site: None,
+            name: b"",
+        };
+        assert_eq!(spawned_thread.encode(&mut buf), 52);
+        let end_thread = Marker::BexThreadEnd {
+            status: ThreadEndStatus::Completed,
+            thread_id: BexThreadId(1),
+            ts_ticks: 0,
+        };
+        assert_eq!(end_thread.encode(&mut buf), 18);
+        let set_id = Marker::SetBoundaryLocalId {
+            thread_id: BexThreadId(1),
+            call_id: BexCallId(1),
+            id: [0; 16],
+            ts_ticks: 0,
+        };
+        assert_eq!(set_id.encode(&mut buf), 41);
+    }
+
+    #[test]
+    fn decode_rejects_unknown_tag_and_bad_status() {
+        assert_eq!(decode(&[0x00]), Err(DecodeError::UnknownTag(0x00)));
+        assert_eq!(decode(&[0x08]), Err(DecodeError::UnknownTag(0x08)));
+        assert_eq!(decode(&[]), Err(DecodeError::Truncated));
+
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let len = Marker::FunctionExit {
+            status: FunctionEndStatus::Ok,
+            thread_id: BexThreadId(1),
+            call_id: BexCallId(1),
+            ts_ticks: 0,
+        }
+        .encode(&mut buf);
+        buf[1] = 4; // first byte past the status range {Ok,Errored,Cancelled,Exited}
+        assert_eq!(decode(&buf[..len]), Err(DecodeError::InvalidStatus(4)));
+    }
+
+    #[test]
+    fn awaited_end_golden_bytes_are_stable() {
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let len = Marker::FunctionExitAwaited {
+            status: FunctionEndStatus::Cancelled,
+            thread_id: BexThreadId(0x0102_0304_0506_0708),
+            call_id: BexCallId(0x1112_1314_1516_1718),
+            ts_ticks: 0x2122_2324_2526_2728,
+            await_ns: 0x3132_3334_3536_3738,
+            await_count: 0x4142_4344,
+        }
+        .encode(&mut buf);
+        assert_eq!(
+            &buf[..len],
+            &[
+                0x06, 0x02, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x18, 0x17, 0x16, 0x15,
+                0x14, 0x13, 0x12, 0x11, 0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x38, 0x37,
+                0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0x44, 0x43, 0x42, 0x41,
+            ]
+        );
+    }
+
+    #[test]
+    fn spawned_thread_golden_bytes_are_stable() {
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let len = Marker::BexThreadStartSpawned {
+            flags: 0xAB,
+            thread_id: BexThreadId(0x0102_0304_0506_0708),
+            parent_thread_id: BexThreadId(0x1112_1314_1516_1718),
+            parent_call_id: BexCallId(0x2122_2324_2526_2728),
+            ts_ticks: 0x3132_3334_3536_3738,
+            spawn_site: Some(CallSiteSourceSpan {
+                file_id: 0x4142_4344,
+                start_offset: 0x5152_5354,
+                end_offset: 0x6162_6364,
+                line: 0x7172_7374,
+            }),
+            name: b"ok",
+        }
+        .encode(&mut buf);
+        assert_eq!(
+            &buf[..len],
+            &[
+                0x07, 0xAB, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x18, 0x17, 0x16, 0x15,
+                0x14, 0x13, 0x12, 0x11, 0x28, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x38, 0x37,
+                0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0x44, 0x43, 0x42, 0x41, 0x54, 0x53, 0x52, 0x51,
+                0x64, 0x63, 0x62, 0x61, 0x74, 0x73, 0x72, 0x71, 0x02, 0x00, b'o', b'k',
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_rejects_oversized_name_len() {
+        let mut buf = [0u8; MAX_RECORD_LEN];
+        let len = Marker::BexThreadStart {
+            flags: 0,
+            thread_id: BexThreadId(1),
+            parent_thread_id: BexThreadId(0),
+            parent_call_id: BexCallId(0),
+            ts_ticks: 0,
+            name: b"hi",
+        }
+        .encode(&mut buf);
+        // Corrupt name_len to 257 (little-endian u16 at offset 34).
+        buf[START_THREAD_FIXED_LEN - 2..START_THREAD_FIXED_LEN]
+            .copy_from_slice(&257u16.to_le_bytes());
+        assert_eq!(decode(&buf[..len]), Err(DecodeError::NameTooLong(257)));
+    }
+
+    #[test]
+    fn every_truncation_errors_without_panicking() {
+        let name = vec![b'n'; 17];
+        let records = [
+            Marker::FunctionEnter {
+                flags: 1,
+                thread_id: BexThreadId(2),
+                call_id: BexCallId(3),
+                parent_call_id: BexCallId(4),
+                function_id: FunctionId(5),
+                call_site: Some(CallSiteSourceSpan {
+                    file_id: 6,
+                    start_offset: 7,
+                    end_offset: 8,
+                    line: 9,
+                }),
+                ts_ticks: 6,
+            },
+            Marker::BexThreadStart {
+                flags: 0,
+                thread_id: BexThreadId(1),
+                parent_thread_id: BexThreadId(2),
+                parent_call_id: BexCallId(3),
+                ts_ticks: 4,
+                name: &name,
+            },
+            Marker::BexThreadStartSpawned {
+                flags: 0,
+                thread_id: BexThreadId(1),
+                parent_thread_id: BexThreadId(2),
+                parent_call_id: BexCallId(3),
+                ts_ticks: 4,
+                spawn_site: Some(CallSiteSourceSpan {
+                    file_id: 5,
+                    start_offset: 6,
+                    end_offset: 7,
+                    line: 8,
+                }),
+                name: &name,
+            },
+            Marker::SetBoundaryLocalId {
+                thread_id: BexThreadId(1),
+                call_id: BexCallId(2),
+                id: [3; 16],
+                ts_ticks: 4,
+            },
+            Marker::FunctionExitAwaited {
+                status: FunctionEndStatus::Errored,
+                thread_id: BexThreadId(1),
+                call_id: BexCallId(2),
+                ts_ticks: 4,
+                await_ns: 5,
+                await_count: 6,
+            },
+        ];
+        for rec in records {
+            let mut buf = [0u8; MAX_RECORD_LEN];
+            let len = rec.encode(&mut buf);
+            for cut in 0..len {
+                assert_eq!(
+                    decode(&buf[..cut]),
+                    Err(DecodeError::Truncated),
+                    "cut at {cut} of {len}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn iterates_packed_records() {
+        let name = b"worker".as_slice();
+        let records = vec![
+            Marker::BexThreadStart {
+                flags: 0,
+                thread_id: BexThreadId(1),
+                parent_thread_id: BexThreadId(0),
+                parent_call_id: BexCallId(0),
+                ts_ticks: 1,
+                name,
+            },
+            Marker::FunctionEnter {
+                flags: 0,
+                thread_id: BexThreadId(1),
+                call_id: BexCallId(1),
+                parent_call_id: BexCallId(0),
+                function_id: FunctionId(7),
+                call_site: None,
+                ts_ticks: 2,
+            },
+            Marker::FunctionExit {
+                status: FunctionEndStatus::Ok,
+                thread_id: BexThreadId(1),
+                call_id: BexCallId(1),
+                ts_ticks: 3,
+            },
+            Marker::BexThreadEnd {
+                status: ThreadEndStatus::Completed,
+                thread_id: BexThreadId(1),
+                ts_ticks: 4,
+            },
+        ];
+        let mut packed = Vec::new();
+        for rec in &records {
+            let mut buf = [0u8; MAX_RECORD_LEN];
+            let len = rec.encode(&mut buf);
+            packed.extend_from_slice(&buf[..len]);
+        }
+        let decoded: Vec<_> = iter(&packed).map(|r| r.expect("decode")).collect();
+        assert_eq!(decoded, records);
+
+        // A corrupt tail yields exactly one error then stops.
+        packed.push(0xFF);
+        let results: Vec<_> = iter(&packed).collect();
+        assert_eq!(results.len(), records.len() + 1);
+        assert_eq!(*results.last().unwrap(), Err(DecodeError::UnknownTag(0xFF)));
+    }
+
+    #[test]
+    #[expect(clippy::cast_possible_truncation, reason = "PRNG byte extraction")]
+    fn decode_arbitrary_prefixes_never_panic() {
+        // Cheap deterministic fuzz: pseudo-random bytes, every tag value in
+        // the first position.
+        let mut state = 0x9E37_79B9_7F4A_7C15u64;
+        let mut bytes = Vec::with_capacity(MAX_RECORD_LEN * 2);
+        for _ in 0..MAX_RECORD_LEN * 2 {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1);
+            bytes.push((state >> 33) as u8);
+        }
+        for first in 0..=u8::MAX {
+            bytes[0] = first;
+            for end in 0..bytes.len() {
+                let _ = decode(&bytes[..end]);
+            }
+        }
+    }
+}

--- a/baml_language/crates/btel_core/src/stage.rs
+++ b/baml_language/crates/btel_core/src/stage.rs
@@ -1,0 +1,39 @@
+//! Semantic stages are generic over event/output types, not tied to a future schema.
+
+/// A committed source range, borrowed only for the duration of a stage call.
+#[derive(Clone, Copy, Debug)]
+pub struct MarkerRange<'a> {
+    pub source_id: u64,
+    pub bytes: &'a [u8],
+}
+
+/// Owned handoff shape. Phase A's discard drainer never creates a batch.
+/// The later transport driver can recycle this allocation after borrowing it.
+#[derive(Debug)]
+pub struct MarkerBatch {
+    pub source_id: u64,
+    pub bytes: Vec<u8>,
+}
+
+pub trait EventBuilder {
+    type Event;
+
+    fn build(&mut self, input: MarkerRange<'_>, emit: impl FnMut(Self::Event));
+
+    fn finish(&mut self, _emit: impl FnMut(Self::Event)) {}
+}
+
+pub trait Aggregator<E> {
+    type Aggregate;
+
+    fn observe(&mut self, event: &E, emit: impl FnMut(Self::Aggregate));
+
+    fn finish(&mut self, _emit: impl FnMut(Self::Aggregate)) {}
+}
+
+/// Events and aggregates are separate branches: either may be published.
+pub trait Publisher<E, A> {
+    fn event(&mut self, event: E);
+    fn aggregate(&mut self, aggregate: A);
+    fn finish(&mut self) {}
+}

--- a/baml_language/crates/btel_transport/Cargo.toml
+++ b/baml_language/crates/btel_transport/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "btel_transport"
+description = "Experimental Btel rings and telemetry pipeline transport"
+version.workspace = true
+publish = false
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+btel_core.workspace = true
+crossbeam-utils.workspace = true
+
+[target.'cfg(baml_loom)'.dependencies]
+loom.workspace = true

--- a/baml_language/crates/btel_transport/source-provenance.json
+++ b/baml_language/crates/btel_transport/source-provenance.json
@@ -1,0 +1,66 @@
+{
+  "base_commit": "bd1fb53cda094c6cd37318cf411c40dfa72689ea",
+  "copies": [
+    {
+      "source": "crates/bex_prof_store/src/ids.rs",
+      "destination": "crates/btel_core/src/ids.rs",
+      "source_sha256": "c57ca12410187b0481a8d10cd32dff91b324f50bf7331055157f399de18b1a0b"
+    },
+    {
+      "source": "crates/bex_prof_store/src/prof/clock.rs",
+      "destination": "crates/btel_core/src/clock.rs",
+      "source_sha256": "679948aa52fde27aef7d2a08e8fb5cdda0d63b0571c723d20f0d61dfe0e00e17"
+    },
+    {
+      "source": "crates/bex_prof_store/src/prof/record.rs",
+      "destination": "crates/btel_core/src/marker.rs",
+      "source_sha256": "10f1c918a7acab47c589d7e973c83510bb7e5da3385f0c8fbd29f183db228576"
+    },
+    {
+      "source": "crates/bex_events/src/prof/ring.rs",
+      "destination": "crates/btel_transport/src/ring.rs",
+      "source_sha256": "4aebeaf6bfe2c8ea073ab8ce7a28423cea7d68d9e6f6cc482a7c3debf57d8d7e"
+    },
+    {
+      "source": "crates/bex_events/src/prof/sync.rs",
+      "destination": "crates/btel_transport/src/sync.rs",
+      "source_sha256": "92bcfc700dff2c7681b4a9a3a10074b1f325419410f1158ebede580cf67c6e7e"
+    },
+    {
+      "source": "crates/bex_events/src/prof/wake.rs",
+      "destination": "crates/btel_transport/src/wake.rs",
+      "source_sha256": "7e391bb95502c431ae0d9545a2626a6edbb5ee41a72a2af4fabb9dc978cd7677"
+    },
+    {
+      "source": "crates/bex_events/src/prof/registry.rs",
+      "destination": "crates/btel_transport/src/registry.rs",
+      "source_sha256": "7a69487d9a6441d31bd0e0fc7a6195b78ddbd29056be051bb1f2707b0d04cc75"
+    },
+    {
+      "source": "crates/bex_events/src/prof/concurrency_tests.rs",
+      "destination": "crates/btel_transport/src/concurrency_tests.rs",
+      "source_sha256": "551af143d30fdad243a010376980d670fb7ccfd23ea9ddc7a73f025b90073911"
+    },
+    {
+      "source": "crates/bex_prof_store/src/prof/backend/memory.rs",
+      "destination": "crates/btel_transport/src/memory.rs",
+      "source_sha256": "6d36c04a8749c655ca6bf3b6c5e603ed3f77186f65af0fb237ee8670829242fb"
+    },
+    {
+      "source": "crates/bex_prof_store/src/prof/backend/sizing.rs",
+      "destination": "crates/btel_transport/src/sizing.rs",
+      "source_sha256": "1fcf4f97d789e84fc57ca4f8a617ac906a5878b919e57e7077ad095aa2b6f325"
+    }
+  ],
+  "adaptations": [
+    "Imports redirected to Btel-local modules.",
+    "Old global/TLS consumer integration omitted; original production files untouched.",
+    "Sizing disk/session configuration and legacy session-layout test omitted.",
+    "Global consumer stress test omitted; primitive tests copied.",
+    "New runtime and pipeline are separate from the copied ring algorithm.",
+    "Copied transport internals are crate-private; public endpoints retain instance ownership through Arc.",
+    "Registry adds a persistent round-robin cursor and full-drain outcome for finite replay completion.",
+    "Sizing omits configuration-only tests; instance segment size determines the minimum transport reservation.",
+    "Public Producer::write_marker uses the copied direct-slot push_with and marker encode_to path for clocked encoding benchmarks."
+  ]
+}

--- a/baml_language/crates/btel_transport/src/concurrency_tests.rs
+++ b/baml_language/crates/btel_transport/src/concurrency_tests.rs
@@ -1,0 +1,882 @@
+//! Concurrency tests for the prof ring.
+//!
+//! The five [`scenarios`] are the loom checklist from the plan (§3.7):
+//! D1 hand-off, D2 recycle, free-list SPSC integrity, the
+//! orphan→drain→pool→claim lifecycle, and concurrent registry append+claim.
+//! Under `RUSTFLAGS="--cfg baml_loom"` they run inside the loom model checker
+//! (every interleaving up to the preemption bound); under plain `cargo test`
+//! — and `cargo miri test`, which checks the raw-pointer/UnsafeCell
+//! discipline — the same scenario code runs on real threads, repeatedly.
+//!
+//! The [`stress`] module adds the real-thread flood tests: record framing,
+//! forced growth/recycling, the wake/park protocol, orphan churn, and the
+//! global TLS path.
+#![allow(unsafe_code)]
+
+use crate::prof::{
+    ring::{OSThreadMarkerRing, RingCtx, RingState},
+    sync::thread,
+};
+
+/// Big enough that no ordinary scenario hits transport admission pressure.
+const BIG_CAP: usize = 1 << 40;
+
+fn leak_ctx(cap: usize) -> &'static RingCtx {
+    Box::leak(Box::new(RingCtx::new(cap)))
+}
+
+/// 8-byte sequence-number records. The ring is format-agnostic (it moves
+/// whole records of any layout); `record.rs` framing is exercised by the
+/// stress tests.
+fn rec(seq: u64) -> [u8; 8] {
+    seq.to_le_bytes()
+}
+
+fn collect_seqs(bytes: &[u8], out: &mut Vec<u64>) {
+    assert_eq!(bytes.len() % 8, 0, "drained range split a record");
+    for chunk in bytes.as_chunks::<8>().0 {
+        out.push(u64::from_le_bytes(*chunk));
+    }
+}
+
+/// Owns a ring allocation so scenarios reclaim it (with original pointer
+/// provenance) after all threads quiesce. Production never frees rings; the
+/// reclaim exists so loom iterations and miri runs stay leak-tight.
+struct TestRing {
+    ring: *mut OSThreadMarkerRing,
+}
+
+impl TestRing {
+    fn new(ctx: &'static RingCtx, seg_bytes: usize, freelist_cap: usize, engine_id: u64) -> Self {
+        Self {
+            ring: OSThreadMarkerRing::alloc(ctx, seg_bytes, freelist_cap, engine_id)
+                .expect("test ring capacity"),
+        }
+    }
+
+    fn get(&self) -> &'static OSThreadMarkerRing {
+        unsafe { &*self.ring }
+    }
+}
+
+impl Drop for TestRing {
+    fn drop(&mut self) {
+        drop(unsafe { Box::from_raw(self.ring) });
+    }
+}
+
+mod scenarios {
+    use super::*;
+    use crate::prof::registry::Registry;
+
+    /// (1) D1 hand-off: the producer links new segments mid-stream while the
+    /// consumer drains concurrently; after the producer finishes, one final
+    /// drain must account for every record, in order, exactly once.
+    pub(super) fn handoff_no_loss() {
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = TestRing::new(ctx, 16, 8, 1); // two 8-byte records per segment
+        let ring = tr.get();
+        let producer = thread::spawn(move || {
+            for seq in 0..5 {
+                // SAFETY: this thread is the creator-claimant; no other
+                // thread pushes.
+                unsafe { ring.push(&rec(seq)) };
+            }
+        });
+        let mut seen = Vec::new();
+        for _ in 0..2 {
+            // SAFETY: this thread is the single consumer.
+            unsafe { ring.drain(&mut |b| collect_seqs(b, &mut seen)) };
+        }
+        producer.join().unwrap();
+        unsafe { ring.drain(&mut |b| collect_seqs(b, &mut seen)) };
+        assert_eq!(seen, (0..5).collect::<Vec<_>>());
+    }
+
+    /// (2) D2 recycle under concurrency: one-record segments force a link on
+    /// every push, and concurrent drains retire/recycle segments back to the
+    /// producer. No interleaving may surface stale `commit_len`/`next` state
+    /// (which would show up as lost, duplicated, or reordered records).
+    pub(super) fn recycle_no_stale() {
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = TestRing::new(ctx, 8, 8, 1); // one record per segment
+        let ring = tr.get();
+        let producer = thread::spawn(move || {
+            for seq in 0..4 {
+                // SAFETY: unique producer.
+                unsafe { ring.push(&rec(seq)) };
+            }
+        });
+        let mut seen = Vec::new();
+        for _ in 0..2 {
+            // SAFETY: single consumer.
+            unsafe { ring.drain(&mut |b| collect_seqs(b, &mut seen)) };
+        }
+        producer.join().unwrap();
+        unsafe { ring.drain(&mut |b| collect_seqs(b, &mut seen)) };
+        assert_eq!(seen, (0..4).collect::<Vec<_>>());
+    }
+
+    /// (2b) D2 deterministic: recycling actually reuses free-list segments —
+    /// growth after a drain must not allocate (live bytes stay flat) and the
+    /// reused segments must carry no stale data.
+    pub(super) fn recycle_reuses_memory() {
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = TestRing::new(ctx, 8, 8, 1);
+        let ring = tr.get();
+        // Same thread plays both roles, sequentially — both contracts hold.
+        unsafe {
+            for seq in 0..3 {
+                ring.push(&rec(seq));
+            }
+            let mut seen = Vec::new();
+            ring.drain(&mut |b| collect_seqs(b, &mut seen));
+            assert_eq!(seen, vec![0, 1, 2]);
+            assert_eq!(ring.free_len(), 2, "two retired segments should be pooled");
+
+            let live_after_drain = ctx.live_bytes();
+            for seq in 3..5 {
+                ring.push(&rec(seq)); // two links — both must pop the free list
+            }
+            assert_eq!(
+                ctx.live_bytes(),
+                live_after_drain,
+                "growth should recycle, not allocate"
+            );
+            assert_eq!(ring.free_len(), 0);
+
+            let mut seen = Vec::new();
+            ring.drain(&mut |b| collect_seqs(b, &mut seen));
+            assert_eq!(seen, vec![3, 4]);
+        }
+        // Behavioral leak check (miri's leak checker is off for these tests):
+        // OSThreadMarkerRing::drop must walk both the live chain and the free list back to
+        // a zero balance.
+        drop(tr);
+        assert_eq!(
+            ctx.live_bytes(),
+            0,
+            "OSThreadMarkerRing::drop leaked segments"
+        );
+    }
+
+    /// (3) Free-list SPSC integrity: heavier producer/consumer traffic so
+    /// pops (producer) and pushes (consumer) overlap on the Treiber list.
+    /// Loom additionally proves the no-ABA argument: any stale-head reuse
+    /// would surface as a race on the segment cells or as data corruption.
+    pub(super) fn freelist_spsc() {
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = TestRing::new(ctx, 8, 2, 1); // cap 2 also exercises D7 free-at-cap
+        let ring = tr.get();
+        let producer = thread::spawn(move || {
+            for seq in 0..6 {
+                // SAFETY: unique producer.
+                unsafe { ring.push(&rec(seq)) };
+            }
+        });
+        let mut seen = Vec::new();
+        for _ in 0..3 {
+            // SAFETY: single consumer.
+            unsafe { ring.drain(&mut |b| collect_seqs(b, &mut seen)) };
+        }
+        producer.join().unwrap();
+        unsafe { ring.drain(&mut |b| collect_seqs(b, &mut seen)) };
+        assert_eq!(seen, (0..6).collect::<Vec<_>>());
+        assert!(ring.free_len() <= 2, "free list exceeded its cap");
+    }
+
+    /// (4) Lifecycle: producer A pushes and dies (orphan); the consumer
+    /// drains to empty and pools; producer B claims and pushes. Every record
+    /// must arrive, tagged with the right engine — including under the
+    /// claim-vs-drain race, where the consumer may read `engine_id` the
+    /// moment B's first commit lands.
+    pub(super) fn orphan_pool_claim() {
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = TestRing::new(ctx, 16, 8, 1);
+        let ring = tr.get();
+
+        let mut tagged: Vec<(u64, u64)> = Vec::new();
+        let mut sink = |ring: &'static OSThreadMarkerRing, bytes: &[u8]| {
+            // SAFETY: bytes in hand are drain progress (engine_id contract).
+            let engine = unsafe { ring.engine_id() };
+            let mut seqs = Vec::new();
+            collect_seqs(bytes, &mut seqs);
+            tagged.extend(seqs.into_iter().map(|s| (engine, s)));
+        };
+        let drain = |sink: &mut dyn FnMut(&'static OSThreadMarkerRing, &[u8])| {
+            // SAFETY: this thread is the single consumer.
+            unsafe { ring.drain(&mut |b| sink(ring, b)) }
+        };
+
+        let a = thread::spawn(move || {
+            // SAFETY: creator-claimant.
+            unsafe {
+                ring.push(&rec(0));
+                ring.push(&rec(1));
+            }
+            ring.orphan(); // what the TLS destructor does on thread death
+        });
+        for _ in 0..2 {
+            drain(&mut sink);
+        }
+        a.join().unwrap();
+        assert_eq!(ring.state(), RingState::Orphaned);
+        // Consumer: the orphan edge made every pre-death push visible — one
+        // drain reaches empty; then pool.
+        drain(&mut sink);
+        // SAFETY: consumer just drained the orphaned ring to empty.
+        unsafe { ring.mark_pooled() };
+
+        let b = thread::spawn(move || {
+            assert!(ring.try_claim(2), "pooled ring must be claimable");
+            // SAFETY: the claim made this thread the unique producer.
+            unsafe {
+                ring.push(&rec(2));
+                ring.push(&rec(3));
+            }
+        });
+        for _ in 0..2 {
+            drain(&mut sink);
+        }
+        b.join().unwrap();
+        drain(&mut sink);
+
+        assert_eq!(tagged, vec![(1, 0), (1, 1), (2, 2), (2, 3)]);
+    }
+
+    /// (4b) A pooled ring is claimable exactly once.
+    pub(super) fn claim_is_exclusive() {
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = TestRing::new(ctx, 16, 8, 1);
+        let ring = tr.get();
+        ring.orphan(); // producer (this thread) dies without pushing
+        // SAFETY: single consumer; ring is empty.
+        unsafe {
+            ring.drain(&mut |_| panic!("empty ring yielded bytes"));
+            ring.mark_pooled();
+        }
+        let c1 = thread::spawn(move || ring.try_claim(2));
+        let c2 = thread::spawn(move || ring.try_claim(3));
+        let (r1, r2) = (c1.join().unwrap(), c2.join().unwrap());
+        assert!(r1 ^ r2, "exactly one claimant must win (got {r1} and {r2})");
+    }
+
+    /// (5) Registry: concurrent acquires never hand two threads the same
+    /// ring, appends are lossless, and the sweep sees every ring's records.
+    pub(super) fn registry_concurrent_acquire() {
+        let ctx = leak_ctx(BIG_CAP);
+        let reg_ptr = Box::into_raw(Box::new(Registry::new()));
+        let reg: &'static Registry = unsafe { &*reg_ptr };
+
+        let t1 = thread::spawn(move || {
+            let h = reg.acquire(ctx, 16, 8, 1).expect("test ring capacity");
+            // SAFETY: the claiming thread is alive for the whole call (no TLS
+            // teardown in flight).
+            unsafe { h.push(&rec(101)) };
+            std::ptr::from_ref(h.ring()) as usize
+        });
+        let t2 = thread::spawn(move || {
+            let h = reg.acquire(ctx, 16, 8, 2).expect("test ring capacity");
+            // SAFETY: the claiming thread is alive for the whole call (no TLS
+            // teardown in flight).
+            unsafe { h.push(&rec(202)) };
+            std::ptr::from_ref(h.ring()) as usize
+        });
+        let (p1, p2) = (t1.join().unwrap(), t2.join().unwrap());
+        assert_ne!(p1, p2, "two live producers ended up sharing a ring");
+
+        let mut tagged: Vec<(u64, u64)> = Vec::new();
+        // SAFETY: single consumer thread.
+        unsafe {
+            reg.sweep(&mut |ring, bytes| {
+                let engine = ring.engine_id();
+                let mut seqs = Vec::new();
+                collect_seqs(bytes, &mut seqs);
+                tagged.extend(seqs.into_iter().map(|s| (engine, s)));
+            });
+        }
+        tagged.sort_unstable();
+        assert_eq!(tagged, vec![(1, 101), (2, 202)]);
+
+        let mut rings = 0;
+        reg.for_each(|_| rings += 1);
+        assert_eq!(rings, 2);
+
+        drop(unsafe { Box::from_raw(reg_ptr) });
+    }
+
+    /// (5a) Registry traversal preserves ring registration order. Parent
+    /// producers register before the workers they spawn; FIFO sweep order is
+    /// the bounded-memory causal fast path for cross-ring decoder joins.
+    pub(super) fn registry_preserves_registration_order() {
+        let ctx = leak_ctx(BIG_CAP);
+        let reg = Registry::new();
+        let first = reg.acquire(ctx, 16, 8, 1).expect("first test ring");
+        let second = reg.acquire(ctx, 16, 8, 2).expect("second test ring");
+        unsafe {
+            first.push(&rec(101));
+            second.push(&rec(202));
+        }
+        let mut engines = Vec::new();
+        unsafe {
+            reg.sweep(&mut |ring, _| engines.push(ring.engine_id()));
+        }
+        assert_eq!(engines, vec![1, 2]);
+        drop(reg);
+        assert_eq!(ctx.live_bytes(), 0, "Registry::drop leaked segments");
+    }
+
+    /// (5b) Registry pooling: a ring pooled after its producer dies is
+    /// claimed through `acquire` by the next producer — concurrently with
+    /// the consumer's sweeping — instead of allocating fresh.
+    pub(super) fn registry_pool_reuse() {
+        let ctx = leak_ctx(BIG_CAP);
+        let reg_ptr = Box::into_raw(Box::new(Registry::new()));
+        let reg: &'static Registry = unsafe { &*reg_ptr };
+
+        let mut tagged: Vec<(u64, u64)> = Vec::new();
+        let sweep = |tagged: &mut Vec<(u64, u64)>| {
+            // SAFETY: single consumer thread.
+            unsafe {
+                reg.sweep(&mut |ring, bytes| {
+                    let engine = ring.engine_id();
+                    let mut seqs = Vec::new();
+                    collect_seqs(bytes, &mut seqs);
+                    tagged.extend(seqs.into_iter().map(|s| (engine, s)));
+                })
+            }
+        };
+
+        // Producer 1 lives and dies on a spawned thread.
+        let p1 = thread::spawn(move || {
+            let h = reg.acquire(ctx, 16, 8, 1).expect("test ring capacity");
+            // SAFETY: the claiming thread is alive for the whole call (no TLS
+            // teardown in flight).
+            unsafe { h.push(&rec(7)) };
+            h.ring().orphan(); // TLS-destructor stand-in
+            std::ptr::from_ref(h.ring()) as usize
+        })
+        .join()
+        .unwrap();
+        // Consumer drains the orphan and pools it; a second sweep must skip
+        // the pooled ring.
+        sweep(&mut tagged);
+        sweep(&mut tagged);
+
+        // Producer 2 claims while the consumer keeps sweeping.
+        let t = thread::spawn(move || {
+            let h = reg.acquire(ctx, 16, 8, 2).expect("test ring capacity");
+            // SAFETY: the claiming thread is alive for the whole call (no TLS
+            // teardown in flight).
+            unsafe { h.push(&rec(8)) };
+            std::ptr::from_ref(h.ring()) as usize
+        });
+        sweep(&mut tagged);
+        let p2 = t.join().unwrap();
+        sweep(&mut tagged);
+
+        assert_eq!(p1, p2, "the pooled ring should have been reused");
+        let mut rings = 0;
+        reg.for_each(|_| rings += 1);
+        assert_eq!(rings, 1);
+        assert_eq!(tagged, vec![(1, 7), (2, 8)]);
+
+        drop(unsafe { Box::from_raw(reg_ptr) });
+        assert_eq!(ctx.live_bytes(), 0, "Registry::drop leaked segments");
+    }
+
+    /// (4c) `Registry::sweep` racing `orphan()`: the sweep may load `Active`
+    /// in the very step the producer dies, or see the orphan mid-walk. Every
+    /// such stale observation must be benign — no record is lost and a later
+    /// sweep pools the ring.
+    pub(super) fn sweep_races_orphan() {
+        let ctx = leak_ctx(BIG_CAP);
+        let reg_ptr = Box::into_raw(Box::new(Registry::new()));
+        let reg: &'static Registry = unsafe { &*reg_ptr };
+
+        let producer = thread::spawn(move || {
+            let h = reg.acquire(ctx, 16, 8, 1).expect("test ring capacity");
+            // SAFETY: the claiming thread is alive for the whole call (no TLS
+            // teardown in flight).
+            unsafe {
+                h.push(&rec(0));
+                h.push(&rec(1));
+            }
+            h.ring().orphan(); // TLS-destructor stand-in
+        });
+        let mut seen = Vec::new();
+        let sweep = |seen: &mut Vec<u64>| {
+            // SAFETY: this thread is the single consumer.
+            unsafe { reg.sweep(&mut |_, bytes| collect_seqs(bytes, seen)) };
+        };
+        for _ in 0..2 {
+            sweep(&mut seen); // concurrent with pushes and the orphan store
+        }
+        producer.join().unwrap();
+        // Post-join, a sweep observes Orphaned (or an earlier one already
+        // pooled): drain to empty, pool; the next sweep must skip it.
+        sweep(&mut seen);
+        sweep(&mut seen);
+        assert_eq!(seen, vec![0, 1]);
+        let mut state = None;
+        reg.for_each(|ring| state = Some(ring.state()));
+        assert_eq!(state, Some(RingState::Pooled));
+
+        drop(unsafe { Box::from_raw(reg_ptr) });
+        assert_eq!(ctx.live_bytes(), 0, "Registry::drop leaked segments");
+    }
+}
+
+// Plain std test: it drives the ring directly, so it must not run under the
+// loom cfg where the ring's primitives are loom's and need a model.
+#[cfg(not(baml_loom))]
+#[test]
+fn segment_growth_pressure_rejects_record_without_aborting() {
+    use crate::prof::ring::segment_footprint;
+
+    let ctx = leak_ctx(segment_footprint(16));
+    let ring = TestRing::new(ctx, 16, 0, 1);
+    let producer = ring.get();
+    unsafe {
+        assert!(producer.push(&rec(1)));
+        assert!(producer.push(&rec(2)));
+        assert!(!producer.push(&rec(3)));
+    }
+    let mut observed = Vec::new();
+    unsafe {
+        producer.drain(&mut |bytes| collect_seqs(bytes, &mut observed));
+    }
+    assert_eq!(observed, [1, 2]);
+    assert_eq!(ctx.live_bytes(), segment_footprint(16));
+}
+
+#[cfg(baml_loom)]
+mod loom_suite {
+    use super::scenarios;
+
+    fn model(f: impl Fn() + Send + Sync + 'static) {
+        let mut builder = loom::model::Builder::new();
+        // Exhaustive search explodes on the bigger scenarios; bound 3 keeps
+        // each test in seconds while covering every ≤3-preemption
+        // interleaving (loom's recommended operating point).
+        builder.preemption_bound = Some(3);
+        builder.check(f);
+    }
+
+    #[test]
+    fn handoff_no_loss() {
+        model(scenarios::handoff_no_loss);
+    }
+
+    #[test]
+    fn recycle_no_stale() {
+        model(scenarios::recycle_no_stale);
+    }
+
+    #[test]
+    fn recycle_reuses_memory() {
+        model(scenarios::recycle_reuses_memory);
+    }
+
+    #[test]
+    fn freelist_spsc() {
+        model(scenarios::freelist_spsc);
+    }
+
+    #[test]
+    fn orphan_pool_claim() {
+        model(scenarios::orphan_pool_claim);
+    }
+
+    #[test]
+    fn claim_is_exclusive() {
+        model(scenarios::claim_is_exclusive);
+    }
+
+    #[test]
+    fn registry_concurrent_acquire() {
+        model(scenarios::registry_concurrent_acquire);
+    }
+
+    #[test]
+    fn registry_preserves_registration_order() {
+        model(scenarios::registry_preserves_registration_order);
+    }
+
+    #[test]
+    fn registry_pool_reuse() {
+        model(scenarios::registry_pool_reuse);
+    }
+
+    #[test]
+    fn sweep_races_orphan() {
+        model(scenarios::sweep_races_orphan);
+    }
+}
+
+/// The same scenarios on real threads. miri executes these (checking the
+/// UnsafeCell/raw-pointer discipline); plain `cargo test` runs them many
+/// times as a cheap smoke for what loom checks exhaustively.
+#[cfg(not(baml_loom))]
+mod std_suite {
+    use super::scenarios;
+
+    fn many(f: impl Fn()) {
+        let iterations = if cfg!(miri) { 3 } else { 200 };
+        for _ in 0..iterations {
+            f();
+        }
+    }
+
+    #[test]
+    fn handoff_no_loss() {
+        many(scenarios::handoff_no_loss);
+    }
+
+    #[test]
+    fn recycle_no_stale() {
+        many(scenarios::recycle_no_stale);
+    }
+
+    #[test]
+    fn recycle_reuses_memory() {
+        many(scenarios::recycle_reuses_memory);
+    }
+
+    #[test]
+    fn freelist_spsc() {
+        many(scenarios::freelist_spsc);
+    }
+
+    #[test]
+    fn orphan_pool_claim() {
+        many(scenarios::orphan_pool_claim);
+    }
+
+    #[test]
+    fn claim_is_exclusive() {
+        many(scenarios::claim_is_exclusive);
+    }
+
+    #[test]
+    fn registry_concurrent_acquire() {
+        many(scenarios::registry_concurrent_acquire);
+    }
+
+    #[test]
+    fn registry_preserves_registration_order() {
+        many(scenarios::registry_preserves_registration_order);
+    }
+
+    #[test]
+    fn registry_pool_reuse() {
+        many(scenarios::registry_pool_reuse);
+    }
+
+    #[test]
+    fn sweep_races_orphan() {
+        many(scenarios::sweep_races_orphan);
+    }
+}
+
+#[cfg(not(baml_loom))]
+mod stress {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use super::{BIG_CAP, leak_ctx, rec};
+    use crate::{
+        ids::{BexCallId, BexThreadId, FunctionId},
+        prof::{
+            record::{self, Marker},
+            registry::Registry,
+            ring::RingState,
+        },
+    };
+
+    /// The 2+1-thread flood (plan §5 PR2 gate): real record framing through
+    /// deliberately tiny segments (constant growth + recycling), bursty
+    /// producers, and the real wake/park protocol on the consumer. Asserts
+    /// `consumed == produced`, exactly and in order, per engine.
+    #[test]
+    fn flood_with_growth_recycle_and_wake() {
+        let (per_producer, seg_bytes) = if cfg!(miri) {
+            (150, 128)
+        } else {
+            (200_000, 256)
+        };
+        let producers: usize = 2;
+        let freelist_cap = 4;
+
+        let ctx = leak_ctx(BIG_CAP);
+        let reg_ptr = Box::into_raw(Box::new(Registry::new()));
+        let reg: &'static Registry = unsafe { &*reg_ptr };
+        let remaining = Arc::new(AtomicUsize::new(producers));
+
+        ctx.wake().register_consumer();
+
+        let handles: Vec<_> = (1..=producers)
+            .map(|engine_idx| {
+                let remaining = Arc::clone(&remaining);
+                std::thread::spawn(move || {
+                    let engine = engine_idx as u64;
+                    let h = reg
+                        .acquire(ctx, seg_bytes, freelist_cap, engine)
+                        .expect("test ring capacity");
+                    let mut buf = [0u8; record::MAX_RECORD_LEN];
+                    for seq in 1u64..=per_producer {
+                        let len = Marker::FunctionEnter {
+                            flags: 0,
+                            thread_id: BexThreadId(engine),
+                            call_id: BexCallId(seq),
+                            parent_call_id: BexCallId(seq.saturating_sub(1)),
+                            function_id: FunctionId(u32::try_from(engine).unwrap()),
+                            call_site: None,
+                            ts_ticks: seq,
+                        }
+                        .encode(&mut buf);
+                        // SAFETY: the claiming thread is alive for the whole call (no TLS
+                        // teardown in flight).
+                        unsafe { h.push(&buf[..len]) };
+                        // Two bursts with pauses: lets the consumer catch up
+                        // (recycle path) and then fall behind again (growth
+                        // path).
+                        if seq == per_producer / 3 || seq == 2 * per_producer / 3 {
+                            std::thread::sleep(Duration::from_millis(1));
+                        }
+                    }
+                    remaining.fetch_sub(1, Ordering::Release);
+                })
+            })
+            .collect();
+
+        // Consumer: sweep with the D4 protocol (park flag, recheck, timeout).
+        let mut per_engine: Vec<Vec<u64>> = vec![Vec::new(); producers + 1];
+        let mut sink = |ring: &'static crate::prof::ring::OSThreadMarkerRing, bytes: &[u8]| {
+            // SAFETY: bytes in hand are drain progress.
+            let engine = unsafe { ring.engine_id() };
+            for r in record::iter(bytes) {
+                match r.expect("corrupt record in committed range") {
+                    Marker::FunctionEnter {
+                        thread_id, call_id, ..
+                    } => {
+                        assert_eq!(
+                            thread_id.0, engine,
+                            "record demuxed to the wrong engine's ring"
+                        );
+                        per_engine[usize::try_from(engine).unwrap()].push(call_id.0);
+                    }
+                    other => panic!("unexpected record {other:?}"),
+                }
+            }
+        };
+        loop {
+            // SAFETY: this thread is the single consumer.
+            let progress = unsafe { reg.sweep(&mut sink) };
+            if progress {
+                continue;
+            }
+            if remaining.load(Ordering::Acquire) == 0 {
+                // Producers are done (Acquire pairs with their Release), so
+                // one empty sweep means the rings are empty.
+                if !unsafe { reg.sweep(&mut sink) } {
+                    break;
+                }
+                continue;
+            }
+            ctx.wake().pre_park();
+            // Recheck after raising the flag (shrinks the benign race);
+            // the timeout bounds whatever remains of it.
+            if unsafe { reg.sweep(&mut sink) } {
+                ctx.wake().post_park();
+                continue;
+            }
+            ctx.wake().park(Duration::from_millis(1));
+            ctx.wake().post_park();
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let expected: Vec<u64> = (1..=per_producer).collect();
+        for (engine, calls) in per_engine.iter().enumerate().skip(1) {
+            assert_eq!(
+                *calls, expected,
+                "engine {engine}: lost, duplicated, or reordered records"
+            );
+        }
+
+        // D7 bound: idle memory is the open segment plus at most
+        // freelist_cap pooled segments per ring (512 B covers the segment
+        // header generously).
+        let mut rings = 0;
+        reg.for_each(|ring| {
+            rings += 1;
+            assert!(ring.free_len() <= freelist_cap);
+        });
+        assert_eq!(rings, producers);
+        assert!(
+            ctx.live_bytes() <= rings * (freelist_cap + 1) * (seg_bytes + 512),
+            "live ring memory did not shrink back after the flood: {} bytes",
+            ctx.live_bytes()
+        );
+
+        drop(unsafe { Box::from_raw(reg_ptr) });
+        assert_eq!(ctx.live_bytes(), 0, "Registry::drop leaked segments");
+    }
+
+    /// The drain's per-call segment bound: a backlog spanning many segments
+    /// drains across several sweeps instead of one unbounded chase (a flood
+    /// otherwise starves control messages and session maintenance for as
+    /// long as it lasts), an orphaned ring stays `Orphaned` until a drain
+    /// reaches its open segment, and every record still arrives exactly
+    /// once, in order.
+    #[test]
+    fn bounded_drain_spreads_backlog_and_defers_orphan_pooling() {
+        use super::collect_seqs;
+        use crate::prof::ring::OSThreadMarkerRing;
+
+        let ctx = leak_ctx(BIG_CAP);
+        let reg_ptr = Box::into_raw(Box::new(Registry::new()));
+        let reg: &'static Registry = unsafe { &*reg_ptr };
+        let total: u64 = 100; // 50 two-record segments — several drain bounds
+
+        let ring: &'static OSThreadMarkerRing = std::thread::spawn(move || {
+            let h = reg
+                .acquire(ctx, 16, 8, 1) // two 8-byte records per segment
+                .expect("test ring capacity");
+            for seq in 0..total {
+                // SAFETY: the claiming thread is alive for the whole call.
+                unsafe { h.push(&rec(seq)) };
+            }
+            let ring = h.ring();
+            ring.orphan(); // what the TLS destructor does on thread death
+            ring
+        })
+        .join()
+        .unwrap();
+
+        let mut seen = Vec::new();
+        // SAFETY: this thread is the single consumer.
+        assert!(unsafe {
+            reg.sweep(&mut |_: &'static OSThreadMarkerRing, b: &[u8]| collect_seqs(b, &mut seen))
+        });
+        assert!(
+            seen.len() < usize::try_from(total).unwrap(),
+            "one sweep must not chase the whole backlog"
+        );
+        assert_eq!(
+            ring.state(),
+            RingState::Orphaned,
+            "a bound-stopped orphan drain must not pool the ring"
+        );
+        let mut sweeps = 1;
+        while ring.state() != RingState::Pooled {
+            // SAFETY: same single consumer.
+            unsafe {
+                reg.sweep(&mut |_: &'static OSThreadMarkerRing, b: &[u8]| {
+                    collect_seqs(b, &mut seen);
+                })
+            };
+            sweeps += 1;
+            assert!(sweeps < 100, "orphan backlog must pool in bounded sweeps");
+        }
+        assert_eq!(seen, (0..total).collect::<Vec<u64>>());
+
+        drop(unsafe { Box::from_raw(reg_ptr) });
+        assert_eq!(ctx.live_bytes(), 0, "Registry::drop leaked segments");
+    }
+
+    /// Wake delivery, not just wake survival: a parked consumer must be
+    /// unparked by a producer's segment-fill wake. The producer keeps filling
+    /// segments, so the benign D4 lost-wakeup window cannot swallow every
+    /// wake — only a broken path (consumer never registered, dead flag, no
+    /// unpark call) leaves the consumer asleep for the full long timeout.
+    /// The flood test alone cannot catch that: its 1 ms park timeout makes
+    /// a broken Wake merely slow, not failing.
+    #[test]
+    #[cfg(not(miri))] // wall-clock timing under miri is meaningless
+    fn unpark_delivery() {
+        use std::sync::atomic::AtomicBool;
+
+        let ctx = leak_ctx(BIG_CAP);
+        let tr = super::TestRing::new(ctx, 16, 4, 1);
+        let ring = tr.get();
+        ctx.wake().register_consumer();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let producer = {
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Acquire) {
+                    // Two 8-byte records fill a 16-byte segment: every pair
+                    // takes the slow path and calls wake_if_parked.
+                    // SAFETY: creator-claimant thread, alive throughout.
+                    unsafe {
+                        ring.push(&rec(0));
+                        ring.push(&rec(1));
+                    }
+                    std::thread::sleep(Duration::from_micros(200));
+                }
+            })
+        };
+
+        let start = std::time::Instant::now();
+        ctx.wake().pre_park();
+        ctx.wake().park(Duration::from_secs(10));
+        ctx.wake().post_park();
+        let waited = start.elapsed();
+
+        stop.store(true, Ordering::Release);
+        producer.join().unwrap();
+
+        assert!(
+            waited < Duration::from_secs(5),
+            "consumer slept {waited:?}: segment-fill unpark was never delivered"
+        );
+    }
+
+    /// Orphan churn: short-lived producer threads in sequence must recycle
+    /// one pooled ring through the registry, not grow it.
+    #[test]
+    fn orphan_churn_reuses_rings() {
+        let ctx = leak_ctx(BIG_CAP);
+        let reg_ptr = Box::into_raw(Box::new(Registry::new()));
+        let reg: &'static Registry = unsafe { &*reg_ptr };
+
+        let rounds = if cfg!(miri) { 3 } else { 16 };
+        let mut tagged: Vec<(u64, u64)> = Vec::new();
+        for round in 1..=rounds {
+            std::thread::spawn(move || {
+                let h = reg.acquire(ctx, 64, 4, round).expect("test ring capacity");
+                // SAFETY: the claiming thread is alive for the whole call (no TLS
+                // teardown in flight).
+                unsafe { h.push(&rec(round)) };
+                h.ring().orphan(); // TLS-destructor stand-in
+            })
+            .join()
+            .unwrap();
+            // SAFETY: single consumer thread.
+            unsafe {
+                reg.sweep(&mut |ring, bytes| {
+                    let engine = ring.engine_id();
+                    let mut seqs = Vec::new();
+                    super::collect_seqs(bytes, &mut seqs);
+                    tagged.extend(seqs.into_iter().map(|s| (engine, s)));
+                });
+            }
+        }
+
+        let mut rings = 0;
+        reg.for_each(|_| rings += 1);
+        assert_eq!(rings, 1, "churned threads must reuse the pooled ring");
+        assert_eq!(tagged, (1..=rounds).map(|r| (r, r)).collect::<Vec<_>>());
+
+        drop(unsafe { Box::from_raw(reg_ptr) });
+    }
+}

--- a/baml_language/crates/btel_transport/src/lib.rs
+++ b/baml_language/crates/btel_transport/src/lib.rs
@@ -1,0 +1,39 @@
+//! Experimental fork of the producer ring plus a new no-op pipeline runtime.
+//! Start reading `pipeline.rs`, then `range_handler.rs` and `runtime.rs`.
+#[allow(
+    dead_code,
+    reason = "preserve copied governor behavior for later experiments"
+)]
+mod memory;
+#[cfg(not(baml_loom))]
+pub mod pipeline;
+#[cfg(not(baml_loom))]
+pub mod range_handler;
+mod registry;
+mod ring;
+#[cfg(not(baml_loom))]
+pub mod runtime;
+#[allow(
+    dead_code,
+    reason = "preserve copied sizing policy for baseline comparisons"
+)]
+mod sizing;
+mod sync;
+mod wake;
+#[cfg(test)]
+use btel_core::ids;
+#[cfg(not(baml_loom))]
+pub use pipeline::Pipeline;
+#[cfg(not(baml_loom))]
+pub use range_handler::RangeHandler;
+#[cfg(not(baml_loom))]
+pub use runtime::{Drainer, Producer, SourceFactory, TransportConfig, TransportError, transport};
+// Only the copied tests use this facade; production and benchmarks use Btel APIs.
+#[cfg(test)]
+mod prof {
+    pub(crate) use btel_core::marker as record;
+
+    pub(crate) use crate::{registry, ring, sync};
+}
+#[cfg(test)]
+mod concurrency_tests;

--- a/baml_language/crates/btel_transport/src/memory.rs
+++ b/baml_language/crates/btel_transport/src/memory.rs
@@ -1,0 +1,337 @@
+//! Process-wide reserve-before-allocate profiler memory governor.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+pub(crate) use crate::sizing::{DerivedSizing, MeasuredLayouts};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ReservationClass {
+    Control,
+    Manual,
+    General,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum Owner {
+    Transport,
+    Population,
+    ActiveCalls,
+    UnresolvedJoins,
+    Evidence,
+    Values,
+    Writer,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MemoryDenied {
+    pub(crate) class: ReservationClass,
+    pub(crate) owner: Owner,
+    pub(crate) requested_bytes: u64,
+    pub(crate) available_bytes: u64,
+}
+
+#[derive(Debug)]
+struct Pool {
+    limit: u64,
+    used: AtomicU64,
+}
+
+#[derive(Debug)]
+struct GovernorInner {
+    control: Pool,
+    manual: Pool,
+    general: Pool,
+    layouts: MeasuredLayouts,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProfilerMemoryGovernor {
+    inner: Arc<GovernorInner>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Reservation {
+    inner: Arc<GovernorInner>,
+    class: ReservationClass,
+    owner: Owner,
+    accounted_bytes: u64,
+}
+
+impl ProfilerMemoryGovernor {
+    #[must_use]
+    pub(crate) fn new(sizing: DerivedSizing, layouts: MeasuredLayouts) -> Self {
+        debug_assert_eq!(
+            sizing.total_bytes,
+            sizing
+                .control_reserve_bytes
+                .saturating_add(sizing.manual_reserve_bytes)
+                .saturating_add(sizing.general_bytes)
+        );
+        Self {
+            inner: Arc::new(GovernorInner {
+                control: Pool {
+                    limit: sizing.control_reserve_bytes,
+                    used: AtomicU64::new(0),
+                },
+                manual: Pool {
+                    limit: sizing.manual_reserve_bytes,
+                    used: AtomicU64::new(0),
+                },
+                general: Pool {
+                    limit: sizing.general_bytes,
+                    used: AtomicU64::new(0),
+                },
+                layouts,
+            }),
+        }
+    }
+
+    pub(crate) fn try_reserve(
+        &self,
+        class: ReservationClass,
+        owner: Owner,
+        accounted_bytes: u64,
+    ) -> Result<Reservation, MemoryDenied> {
+        let requested_bytes = accounted_bytes.max(self.minimum_charge(owner));
+        reserve(&self.inner, class, owner, requested_bytes)?;
+        Ok(Reservation {
+            inner: Arc::clone(&self.inner),
+            class,
+            owner,
+            accounted_bytes: requested_bytes,
+        })
+    }
+
+    /// Explicit-LocalId work tries shared General capacity before the protected
+    /// Manual reserve. No other path may call this helper.
+    pub(crate) fn try_reserve_manual_work(
+        &self,
+        owner: Owner,
+        accounted_bytes: u64,
+    ) -> Result<Reservation, [MemoryDenied; 2]> {
+        match self.try_reserve(ReservationClass::General, owner, accounted_bytes) {
+            Ok(reservation) => Ok(reservation),
+            Err(general) => self
+                .try_reserve(ReservationClass::Manual, owner, accounted_bytes)
+                .map_err(|manual| [general, manual]),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn used_bytes(&self, class: ReservationClass) -> u64 {
+        pool(&self.inner, class).used.load(Ordering::Acquire)
+    }
+
+    #[must_use]
+    pub(crate) fn available_bytes(&self, class: ReservationClass) -> u64 {
+        let pool = pool(&self.inner, class);
+        pool.limit.saturating_sub(pool.used.load(Ordering::Acquire))
+    }
+
+    fn minimum_charge(&self, owner: Owner) -> u64 {
+        match owner {
+            Owner::Transport => self.inner.layouts.transport_segment_bytes,
+            Owner::Population => self.inner.layouts.population_item_min_bytes,
+            Owner::ActiveCalls => self.inner.layouts.active_call_min_bytes,
+            Owner::UnresolvedJoins => self.inner.layouts.unresolved_fact_min_bytes,
+            Owner::Evidence => self.inner.layouts.evidence_item_min_bytes,
+            Owner::Values => self.inner.layouts.value_root_min_bytes,
+            Owner::Writer => self.inner.layouts.writer_batch_min_bytes,
+        }
+    }
+}
+
+impl Reservation {
+    #[must_use]
+    pub(crate) const fn class(&self) -> ReservationClass {
+        self.class
+    }
+
+    #[must_use]
+    pub(crate) const fn owner(&self) -> Owner {
+        self.owner
+    }
+
+    #[must_use]
+    pub(crate) const fn accounted_bytes(&self) -> u64 {
+        self.accounted_bytes
+    }
+
+    /// Reserves a capacity delta before the owner grows its allocation.
+    pub(crate) fn try_grow(&mut self, additional_bytes: u64) -> Result<(), MemoryDenied> {
+        if additional_bytes == 0 {
+            return Ok(());
+        }
+        reserve(&self.inner, self.class, self.owner, additional_bytes)?;
+        self.accounted_bytes = self.accounted_bytes.saturating_add(additional_bytes);
+        Ok(())
+    }
+
+    /// Transfers an independently admitted charge into this reservation.
+    /// Both reservations must belong to the same governor, class, and owner.
+    pub(crate) fn absorb(&mut self, mut other: Self) -> Result<(), Self> {
+        if !Arc::ptr_eq(&self.inner, &other.inner)
+            || self.class != other.class
+            || self.owner != other.owner
+        {
+            return Err(other);
+        }
+        let Some(accounted_bytes) = self.accounted_bytes.checked_add(other.accounted_bytes) else {
+            return Err(other);
+        };
+        self.accounted_bytes = accounted_bytes;
+        other.accounted_bytes = 0;
+        Ok(())
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        let previous = pool(&self.inner, self.class)
+            .used
+            .fetch_sub(self.accounted_bytes, Ordering::AcqRel);
+        debug_assert!(previous >= self.accounted_bytes);
+    }
+}
+
+fn pool(inner: &GovernorInner, class: ReservationClass) -> &Pool {
+    match class {
+        ReservationClass::Control => &inner.control,
+        ReservationClass::Manual => &inner.manual,
+        ReservationClass::General => &inner.general,
+    }
+}
+
+fn reserve(
+    inner: &Arc<GovernorInner>,
+    class: ReservationClass,
+    owner: Owner,
+    requested_bytes: u64,
+) -> Result<(), MemoryDenied> {
+    let pool = pool(inner, class);
+    let mut used = pool.used.load(Ordering::Acquire);
+    loop {
+        let Some(next) = used.checked_add(requested_bytes) else {
+            return Err(denied(pool, class, owner, requested_bytes, used));
+        };
+        if next > pool.limit {
+            return Err(denied(pool, class, owner, requested_bytes, used));
+        }
+        match pool
+            .used
+            .compare_exchange_weak(used, next, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => return Ok(()),
+            Err(actual) => used = actual,
+        }
+    }
+}
+
+fn denied(
+    pool: &Pool,
+    class: ReservationClass,
+    owner: Owner,
+    requested_bytes: u64,
+    used: u64,
+) -> MemoryDenied {
+    MemoryDenied {
+        class,
+        owner,
+        requested_bytes,
+        available_bytes: pool.limit.saturating_sub(used),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::sizing::ProfilerSizingPolicy;
+
+    fn governor() -> ProfilerMemoryGovernor {
+        let sizing = ProfilerSizingPolicy::derive(32 * 1024 * 1024, MeasuredLayouts::V1).unwrap();
+        ProfilerMemoryGovernor::new(sizing, MeasuredLayouts::V1)
+    }
+
+    #[test]
+    fn tiny_items_pay_the_owner_minimum_and_drop_releases_it() {
+        let governor = governor();
+        let reservation = governor
+            .try_reserve(ReservationClass::General, Owner::ActiveCalls, 1)
+            .unwrap();
+        assert_eq!(reservation.accounted_bytes(), 320);
+        assert_eq!(governor.used_bytes(ReservationClass::General), 320);
+        drop(reservation);
+        assert_eq!(governor.used_bytes(ReservationClass::General), 0);
+    }
+
+    #[test]
+    fn reservation_classes_cannot_borrow_each_others_capacity() {
+        let governor = governor();
+        let general_available = governor.available_bytes(ReservationClass::General);
+        let _general = governor
+            .try_reserve(ReservationClass::General, Owner::Writer, general_available)
+            .unwrap();
+        let denied = governor
+            .try_reserve(ReservationClass::General, Owner::Evidence, 1)
+            .unwrap_err();
+        assert_eq!(denied.available_bytes, 0);
+        assert!(
+            governor
+                .try_reserve(ReservationClass::Control, Owner::Population, 1)
+                .is_ok()
+        );
+        assert!(
+            governor
+                .try_reserve(ReservationClass::Manual, Owner::Evidence, 1)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn manual_work_falls_back_only_after_general_denial() {
+        let governor = governor();
+        let available = governor.available_bytes(ReservationClass::General);
+        let _general = governor
+            .try_reserve(ReservationClass::General, Owner::Writer, available)
+            .unwrap();
+        let manual = governor
+            .try_reserve_manual_work(Owner::Evidence, 1)
+            .unwrap();
+        assert_eq!(manual.class(), ReservationClass::Manual);
+    }
+
+    #[test]
+    fn growth_is_reserved_before_capacity_changes() {
+        let governor = governor();
+        let mut reservation = governor
+            .try_reserve(ReservationClass::General, Owner::Values, 1024)
+            .unwrap();
+        reservation.try_grow(2048).unwrap();
+        assert_eq!(reservation.accounted_bytes(), 3072);
+        assert_eq!(governor.used_bytes(ReservationClass::General), 3072);
+    }
+
+    #[test]
+    fn concurrent_reservations_never_cross_the_pool_limit() {
+        let governor = Arc::new(governor());
+        let limit = governor.available_bytes(ReservationClass::General);
+        let mut threads = Vec::new();
+        for _ in 0..16 {
+            let governor = Arc::clone(&governor);
+            threads.push(std::thread::spawn(move || {
+                governor.try_reserve(ReservationClass::General, Owner::Values, limit / 4)
+            }));
+        }
+        let reservations: Vec<_> = threads
+            .into_iter()
+            .filter_map(|thread| thread.join().unwrap().ok())
+            .collect();
+        assert_eq!(reservations.len(), 4);
+        assert_eq!(governor.used_bytes(ReservationClass::General), limit);
+    }
+}

--- a/baml_language/crates/btel_transport/src/pipeline.rs
+++ b/baml_language/crates/btel_transport/src/pipeline.rs
@@ -1,0 +1,81 @@
+//! The stage assembly. No runtime mode enum or trait objects enter this path.
+use btel_core::stage::{Aggregator, EventBuilder, MarkerBatch, MarkerRange, Publisher};
+
+use crate::RangeHandler;
+
+pub struct Pipeline<H, B, A, P> {
+    range_handler: H,
+    builder: B,
+    aggregator: A,
+    publisher: P,
+}
+
+impl<H, B, A, P> Pipeline<H, B, A, P>
+where
+    H: RangeHandler,
+    B: EventBuilder,
+    A: Aggregator<B::Event>,
+    P: Publisher<B::Event, A::Aggregate>,
+{
+    pub const fn new(range_handler: H, builder: B, aggregator: A, publisher: P) -> Self {
+        Self {
+            range_handler,
+            builder,
+            aggregator,
+            publisher,
+        }
+    }
+
+    /// Only the round-robin drainer may submit committed source ranges.
+    pub(crate) fn consume(&mut self, input: MarkerRange<'_>) {
+        let Self {
+            range_handler,
+            builder,
+            aggregator,
+            publisher,
+        } = self;
+        range_handler.accept(input, |batch| {
+            build_batch(builder, aggregator, publisher, batch);
+        });
+    }
+
+    /// Called only after the transport has consumed all final source bytes.
+    /// Flush stages in dependency order; consume self to prevent double finish.
+    pub(crate) fn finish(mut self) -> P {
+        let Self {
+            range_handler,
+            builder,
+            aggregator,
+            publisher,
+        } = &mut self;
+        range_handler.finish(|batch| build_batch(builder, aggregator, publisher, batch));
+        builder.finish(|event| {
+            aggregator.observe(&event, |aggregate| publisher.aggregate(aggregate));
+            publisher.event(event);
+        });
+        aggregator.finish(|aggregate| publisher.aggregate(aggregate));
+        publisher.finish();
+        self.publisher
+    }
+}
+
+fn build_batch<B, A, P>(builder: &mut B, aggregator: &mut A, publisher: &mut P, batch: MarkerBatch)
+where
+    B: EventBuilder,
+    A: Aggregator<B::Event>,
+    P: Publisher<B::Event, A::Aggregate>,
+{
+    builder.build(
+        MarkerRange {
+            source_id: batch.source_id,
+            bytes: &batch.bytes,
+        },
+        |event| {
+            aggregator.observe(&event, |aggregate| publisher.aggregate(aggregate));
+            publisher.event(event);
+        },
+    );
+    // The driver, not the semantic builder, owns the allocation. Phase A has
+    // no shared pool; a future copy/return driver returns this memory there.
+    drop(batch);
+}

--- a/baml_language/crates/btel_transport/src/range_handler.rs
+++ b/baml_language/crates/btel_transport/src/range_handler.rs
@@ -1,0 +1,11 @@
+//! Pluggable disposition of bytes selected by the concrete round-robin Drainer.
+//! Implementations cannot choose rings, move the traversal cursor, or reclaim slots.
+use btel_core::stage::{MarkerBatch, MarkerRange};
+
+pub trait RangeHandler {
+    /// On return the source range has been accepted; its ring may reclaim it.
+    /// A retaining implementation must own its copy before returning.
+    fn accept(&mut self, input: MarkerRange<'_>, emit: impl FnMut(MarkerBatch));
+
+    fn finish(&mut self, _emit: impl FnMut(MarkerBatch)) {}
+}

--- a/baml_language/crates/btel_transport/src/registry.rs
+++ b/baml_language/crates/btel_transport/src/registry.rs
@@ -1,0 +1,228 @@
+//! Copied append-only ring registry, with Btel round-robin traversal.
+//!
+//! The registry is an append-only FIFO list: rings are linked once and never
+//! removed (no pop ⇒ no ABA; no reclamation ⇒ no epochs). FIFO traversal
+//! preserves causal registration order, so a parent ring that creates worker
+//! rings is swept before those descendants. Thread death *orphans* a ring;
+//! the consumer drains it to empty
+//! and *pools* it; a new `(engine, os-thread)` pair *claims* a pooled ring by
+//! CAS before allocating fresh. Registry size is therefore bounded by the
+//! peak number of concurrent `(engine, os-thread)` pairs, not by churn —
+//! tokio blocking-pool threads die after their idle timeout, so the
+//! orphan/pool/claim path is routine, not exotic.
+#![allow(unsafe_code)]
+// On wasm32 there is no background consumer thread, but the cooperative drain
+// uses the same registry sweep path when an adapter opts into profiling.
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
+use std::ptr::null_mut;
+
+use crate::{
+    ring::{OSThreadMarkerRing, OSThreadMarkerRingHandle, RingCtx, RingState},
+    sync::{AtomicPtr, Ordering},
+};
+
+struct RegNode {
+    /// Conceptually `&'static OSThreadMarkerRing`; kept raw so tests can reclaim with full
+    /// provenance. Btel reclaims it after all owning endpoints are gone.
+    ring: *mut OSThreadMarkerRing,
+    next: AtomicPtr<RegNode>,
+}
+
+/// `AtomicPtr` retains pointer provenance and permits moving the sole consumer
+/// endpoint to its worker. Only that endpoint reads/writes this cursor.
+#[derive(Default)]
+pub(crate) struct Cursor {
+    next: AtomicPtr<RegNode>,
+}
+
+pub(crate) struct Visit {
+    pub progress: bool,
+    pub wrapped: bool,
+}
+
+/// Append-only ring registry. One per Btel transport instance.
+pub(crate) struct Registry {
+    head: AtomicPtr<RegNode>,
+    tail: AtomicPtr<RegNode>,
+}
+
+impl Registry {
+    /// Visit one source, retaining our next position across bounded steps.
+    /// Caller must be the registry's unique consumer.
+    pub(crate) unsafe fn visit_next(
+        &self,
+        cursor: &mut Cursor,
+        sink: &mut impl FnMut(&'static OSThreadMarkerRing, &[u8]),
+    ) -> Option<Visit> {
+        let mut node = cursor.next.load(Ordering::Relaxed);
+        if node.is_null() {
+            node = self.head.load(Ordering::Acquire);
+        }
+        if node.is_null() {
+            return None;
+        }
+        let n = unsafe { &*node };
+        let ring = unsafe { &*n.ring };
+        let progress = match ring.state() {
+            RingState::Active => unsafe { ring.drain(&mut |bytes| sink(ring, bytes)) }.progress,
+            RingState::Orphaned => {
+                let outcome = unsafe { ring.drain(&mut |bytes| sink(ring, bytes)) };
+                if outcome.caught_up {
+                    unsafe { ring.mark_pooled() };
+                }
+                outcome.progress
+            }
+            RingState::Pooled => false,
+        };
+        let next = n.next.load(Ordering::Acquire);
+        cursor.next.store(next, Ordering::Relaxed);
+        Some(Visit {
+            progress,
+            wrapped: next.is_null(),
+        })
+    }
+    #[cfg(not(baml_loom))]
+    pub(crate) const fn new() -> Self {
+        Self {
+            head: AtomicPtr::new(null_mut()),
+            tail: AtomicPtr::new(null_mut()),
+        }
+    }
+
+    #[cfg(baml_loom)]
+    pub(crate) fn new() -> Self {
+        Self {
+            head: AtomicPtr::new(null_mut()),
+            tail: AtomicPtr::new(null_mut()),
+        }
+    }
+
+    /// Producer-side acquisition: claim a pooled ring, or allocate and
+    /// register a fresh one. Runs once per `(engine, os-thread)` lifetime —
+    /// the O(rings) scan is irrelevant next to that.
+    ///
+    /// The returned handle is bound to the calling thread (`!Send`), which is
+    /// what upholds the unique-producer contract.
+    pub(crate) fn acquire(
+        &self,
+        ctx: &'static RingCtx,
+        seg_bytes: usize,
+        freelist_cap: usize,
+        engine_id: u64,
+    ) -> Option<OSThreadMarkerRingHandle> {
+        let mut node = self.head.load(Ordering::Acquire);
+        while !node.is_null() {
+            let n = unsafe { &*node };
+            let ring = unsafe { &*n.ring };
+            if ring.try_claim(engine_id) {
+                // SAFETY: the CAS made this thread the unique producer.
+                return Some(unsafe { OSThreadMarkerRingHandle::new(ring) });
+            }
+            node = n.next.load(Ordering::Acquire);
+        }
+        // Keep the raw pointer (not a ref-derived copy) in the node so the
+        // Registry::drop deallocates with original provenance.
+        let ring_ptr = OSThreadMarkerRing::alloc(ctx, seg_bytes, freelist_cap, engine_id)?;
+        self.push(ring_ptr);
+        // SAFETY: a freshly allocated ring is Active and owned by its
+        // creating thread.
+        Some(unsafe { OSThreadMarkerRingHandle::new(&*ring_ptr) })
+    }
+
+    fn push(&self, ring: *mut OSThreadMarkerRing) {
+        let node = Box::into_raw(Box::new(RegNode {
+            ring,
+            next: AtomicPtr::new(null_mut()),
+        }));
+        // The tail exchange is the append linearization point. A concurrent
+        // consumer may miss a node whose predecessor link is not published
+        // yet, but the next sweep observes it; nodes are never removed.
+        let previous = self.tail.swap(node, Ordering::AcqRel);
+        if previous.is_null() {
+            self.head.store(node, Ordering::Release);
+        } else {
+            // SAFETY: `previous` is an append-only registry node that remains
+            // allocated for the registry lifetime, and this appender uniquely
+            // owns its one transition from a null `next` pointer.
+            unsafe { (&*previous).next.store(node, Ordering::Release) };
+        }
+    }
+
+    /// Walks every registered ring (any thread; Acquire loads publish the
+    /// nodes and rings).
+    pub(crate) fn for_each(&self, mut f: impl FnMut(&'static OSThreadMarkerRing)) {
+        let mut node = self.head.load(Ordering::Acquire);
+        while !node.is_null() {
+            let n = unsafe { &*node };
+            f(unsafe { &*n.ring });
+            node = n.next.load(Ordering::Acquire);
+        }
+    }
+
+    /// One consumer sweep (§3.4): drain `Active` rings; drain `Orphaned`
+    /// rings to empty and pool them; skip `Pooled` rings. Returns whether any
+    /// ring yielded bytes.
+    ///
+    /// `sink` may call [`OSThreadMarkerRing::engine_id`] on the ring it is handed: the
+    /// bytes in hand are proof of drain progress, which is that method's
+    /// safety contract.
+    ///
+    /// # Safety
+    /// Caller is the process's single consumer thread.
+    #[cfg(test)]
+    pub(crate) unsafe fn sweep(
+        &self,
+        sink: &mut impl FnMut(&'static OSThreadMarkerRing, &[u8]),
+    ) -> bool {
+        unsafe { self.sweep_outcome(sink) }.progress
+    }
+
+    /// Return both byte progress and whether every visited source caught up.
+    /// Caller is the registry's unique consumer.
+    pub(crate) unsafe fn sweep_outcome(
+        &self,
+        sink: &mut impl FnMut(&'static OSThreadMarkerRing, &[u8]),
+    ) -> crate::ring::DrainOutcome {
+        let mut progress = false;
+        let mut caught_up = true;
+        self.for_each(|ring| match ring.state() {
+            RingState::Active => {
+                let outcome = unsafe { ring.drain(&mut |bytes| sink(ring, bytes)) };
+                progress |= outcome.progress;
+                caught_up &= outcome.caught_up;
+            }
+            RingState::Orphaned => {
+                // The state Acquire (orphan edge) made every pre-death push
+                // visible, and the producer is gone — a caught-up drain has
+                // reached empty. A drain stopped by its segment bound leaves
+                // the ring Orphaned for the next sweep.
+                let outcome = unsafe { ring.drain(&mut |bytes| sink(ring, bytes)) };
+                progress |= outcome.progress;
+                caught_up &= outcome.caught_up;
+                if outcome.caught_up {
+                    unsafe { ring.mark_pooled() };
+                }
+            }
+            RingState::Pooled => {}
+        });
+        crate::ring::DrainOutcome {
+            progress,
+            caught_up,
+        }
+    }
+}
+
+impl Drop for Registry {
+    /// The runtime retains this registry through every endpoint. Once all
+    /// endpoints are gone, it owns and reclaims the nodes and rings. Copied
+    /// tests must likewise quiesce all users before dropping their registry.
+    fn drop(&mut self) {
+        let mut node = self.head.load(Ordering::Relaxed);
+        while !node.is_null() {
+            let boxed = unsafe { Box::from_raw(node) };
+            drop(unsafe { Box::from_raw(boxed.ring) });
+            node = boxed.next.load(Ordering::Relaxed);
+        }
+    }
+}

--- a/baml_language/crates/btel_transport/src/ring.rs
+++ b/baml_language/crates/btel_transport/src/ring.rs
@@ -1,0 +1,741 @@
+//! The segmented SPSC ring (plan §3; design decisions D1–D4, D7).
+//!
+//! One ring per `(engine, os-thread)` pair. Exactly one producer thread (the
+//! claimant — see [`crate::registry`] for the claim protocol) and one
+//! process-wide consumer thread. A full segment links a fresh or recycled
+//! segment while shared General/Transport capacity is available; otherwise
+//! the concrete record is rejected without blocking. Rings are allocated once
+//! and never freed (`&'static`), which makes the orphan/drain/claim lifecycle
+//! race-free without epochs or hazard pointers.
+//!
+//! # Memory-ordering map (the loom checklist, plan §3.7)
+//!
+//! | edge            | Release                         | Acquire                       | publishes |
+//! |-----------------|---------------------------------|-------------------------------|-----------|
+//! | record publish  | `commit_len.store` (producer)   | `commit_len.load` (consumer)  | record bytes ≤ `commit_len` |
+//! | segment link    | `next.store` (producer)         | `next.load` (consumer)        | final `commit_len` of the old segment; D2 resets + first bytes of the new one |
+//! | segment recycle | free-list push CAS (consumer)   | free-list pop (producer)      | consumer is done reading the segment |
+//! | orphan          | `state.store(Orphaned)` (producer thread dtor) | `state.load` (consumer) | every record pushed before thread death |
+//! | pool / claim    | `state.store(Pooled)` (consumer) | claim CAS (new producer)     | consumer is done draining; transitively, the dead producer's position fields |
+//!
+//! # Invariants enforced here (plan §6)
+//!
+//! - The producer never blocks: no mutex, no condvar, no park, no unbounded
+//!   spin anywhere reachable from [`OSThreadMarkerRing::push`]. It runs holding an
+//!   `ActiveHeapPermit`; a blocked producer is an engine-wide GC stall.
+//! - The consumer never touches the GC heap or permits.
+//! - Hitting the live-memory cap rejects the concrete record without blocking
+//!   or aborting BAML execution. The producer reports that loss through the
+//!   boundary's preallocated health path.
+#![allow(unsafe_code)]
+// On wasm32 there is no background consumer thread. The consumer-side helpers
+// are compiled for the cooperative drain path, but not all native-only entry
+// points call them directly.
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
+use std::{marker::PhantomData, ptr::null_mut};
+
+use crossbeam_utils::CachePadded;
+
+#[cfg(not(baml_loom))]
+use crate::memory::{Owner, ProfilerMemoryGovernor, Reservation, ReservationClass};
+use crate::{
+    sync::{AtomicPtr, AtomicU8, AtomicU32, AtomicUsize, Buf, Ordering, UnsafeCell},
+    wake::Wake,
+};
+
+/// `OSThreadMarkerRing` lifecycle states (design D5b).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum RingState {
+    /// Claimed by a live producer thread.
+    Active = 0,
+    /// The producer thread died; the consumer must drain to empty, then pool.
+    Orphaned = 1,
+    /// Drained empty and claimable by a new producer (CAS Pooled→Active).
+    Pooled = 2,
+}
+
+impl RingState {
+    fn from_u8(v: u8) -> RingState {
+        match v {
+            0 => RingState::Active,
+            1 => RingState::Orphaned,
+            2 => RingState::Pooled,
+            _ => unreachable!("invalid RingState discriminant {v}"),
+        }
+    }
+}
+
+/// What one bounded [`OSThreadMarkerRing::drain`] call accomplished.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DrainOutcome {
+    /// Whether any bytes were consumed.
+    pub(crate) progress: bool,
+    /// Whether the drain reached the producer's open segment. `false` means
+    /// the per-call segment bound stopped the chase with published bytes
+    /// still queued — the ring must be drained again before it can be
+    /// considered empty.
+    pub(crate) caught_up: bool,
+}
+
+/// Process-wide context shared by all rings: the live-memory budget and the
+/// consumer wake state.
+pub(crate) struct RingCtx {
+    budget: RingBudget,
+    wake: Wake,
+}
+
+enum RingBudget {
+    #[cfg_attr(not(test), allow(dead_code, reason = "test-only fixed budget"))]
+    Fixed(MemBudget),
+    #[cfg(not(baml_loom))]
+    Governor(ProfilerMemoryGovernor),
+}
+
+impl RingCtx {
+    #[cfg(not(baml_loom))]
+    #[cfg_attr(not(test), allow(dead_code, reason = "test-only fixed budget"))]
+    pub(crate) const fn new(max_overflow_bytes: usize) -> Self {
+        Self {
+            budget: RingBudget::Fixed(MemBudget::new(max_overflow_bytes)),
+            wake: Wake::new(),
+        }
+    }
+
+    #[cfg(baml_loom)]
+    pub(crate) fn new(max_overflow_bytes: usize) -> Self {
+        Self {
+            budget: RingBudget::Fixed(MemBudget::new(max_overflow_bytes)),
+            wake: Wake::new(),
+        }
+    }
+
+    #[cfg(not(baml_loom))]
+    pub(crate) fn with_governor(memory: ProfilerMemoryGovernor) -> Self {
+        Self {
+            budget: RingBudget::Governor(memory),
+            wake: Wake::new(),
+        }
+    }
+
+    pub(crate) fn wake(&self) -> &Wake {
+        &self.wake
+    }
+
+    /// Currently allocated ring-segment bytes (approximate bookkeeping unit:
+    /// buffer + segment header). Test/telemetry surface — production code
+    /// only writes the budget.
+    #[cfg_attr(not(test), allow(dead_code, reason = "test/telemetry accessor"))]
+    pub(crate) fn live_bytes(&self) -> usize {
+        match &self.budget {
+            RingBudget::Fixed(budget) => budget.live(),
+            #[cfg(not(baml_loom))]
+            RingBudget::Governor(memory) => {
+                usize::try_from(memory.used_bytes(ReservationClass::General)).unwrap_or(usize::MAX)
+            }
+        }
+    }
+
+    fn try_charge(&'static self, bytes: usize) -> Option<RingCharge> {
+        match &self.budget {
+            RingBudget::Fixed(budget) => budget.try_charge(bytes).then(|| RingCharge::Fixed {
+                _charge: FixedCharge { budget, bytes },
+            }),
+            #[cfg(not(baml_loom))]
+            RingBudget::Governor(memory) => memory
+                .try_reserve(
+                    ReservationClass::General,
+                    Owner::Transport,
+                    u64::try_from(bytes).unwrap_or(u64::MAX),
+                )
+                .ok()
+                .map(|reservation| RingCharge::Governor {
+                    _reservation: reservation,
+                }),
+        }
+    }
+}
+
+struct FixedCharge {
+    budget: &'static MemBudget,
+    bytes: usize,
+}
+
+impl Drop for FixedCharge {
+    fn drop(&mut self) {
+        self.budget.credit(self.bytes);
+    }
+}
+
+enum RingCharge {
+    Fixed {
+        _charge: FixedCharge,
+    },
+    #[cfg(not(baml_loom))]
+    Governor {
+        _reservation: Reservation,
+    },
+}
+
+/// Live-memory accounting against the sizing policy's transport reserve.
+pub(crate) struct MemBudget {
+    live: AtomicUsize,
+    cap: usize,
+}
+
+impl MemBudget {
+    #[cfg(not(baml_loom))]
+    #[cfg_attr(not(test), allow(dead_code, reason = "test-only fixed budget"))]
+    const fn new(cap: usize) -> Self {
+        Self {
+            live: AtomicUsize::new(0),
+            cap,
+        }
+    }
+
+    #[cfg(baml_loom)]
+    fn new(cap: usize) -> Self {
+        Self {
+            live: AtomicUsize::new(0),
+            cap,
+        }
+    }
+
+    fn try_charge(&self, bytes: usize) -> bool {
+        let mut live = self.live.load(Ordering::Relaxed);
+        loop {
+            let Some(next) = live.checked_add(bytes) else {
+                return false;
+            };
+            if next > self.cap {
+                return false;
+            }
+            match self
+                .live
+                .compare_exchange_weak(live, next, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return true,
+                Err(observed) => live = observed,
+            }
+        }
+    }
+
+    fn credit(&self, bytes: usize) {
+        self.live.fetch_sub(bytes, Ordering::Relaxed);
+    }
+
+    #[cfg_attr(not(test), allow(dead_code, reason = "test/telemetry accessor"))]
+    fn live(&self) -> usize {
+        self.live.load(Ordering::Relaxed)
+    }
+}
+
+struct SegSync {
+    /// Bytes of the segment published so far. Producer `Release`-stores after
+    /// each record's bytes are written; monotonic for the lifetime of one
+    /// fill (reset only by the producer when re-linking a recycled segment).
+    commit_len: AtomicU32,
+    /// Next segment in the chain (`Release` by producer on link), or — while
+    /// the segment sits in the free list — the next free-list node. A
+    /// segment is never in both places, and in-list nodes are immutable
+    /// until popped, so the dual use cannot be observed concurrently.
+    next: AtomicPtr<OSThreadMarkerRingSegment>,
+}
+
+struct OSThreadMarkerRingSegment {
+    /// D3: `{commit_len, next}` get their own cache line so producer commits
+    /// and consumer polls don't false-share with the buffer pointer reads.
+    sync: CachePadded<SegSync>,
+    buf: Buf,
+    _charge: RingCharge,
+}
+
+pub(crate) fn segment_footprint(seg_bytes: usize) -> usize {
+    seg_bytes + size_of::<OSThreadMarkerRingSegment>()
+}
+
+fn alloc_segment(
+    seg_bytes: usize,
+    ctx: &'static RingCtx,
+) -> Option<*mut OSThreadMarkerRingSegment> {
+    let charge = ctx.try_charge(segment_footprint(seg_bytes))?;
+    Some(Box::into_raw(Box::new(OSThreadMarkerRingSegment {
+        sync: CachePadded::new(SegSync {
+            commit_len: AtomicU32::new(0),
+            next: AtomicPtr::new(null_mut()),
+        }),
+        buf: Buf::new(seg_bytes),
+        _charge: charge,
+    })))
+}
+
+/// # Safety
+/// `seg` came from [`alloc_segment`], is reachable from neither the live
+/// chain nor the free list, and no thread will touch it again.
+unsafe fn free_segment(seg: *mut OSThreadMarkerRingSegment) {
+    drop(unsafe { Box::from_raw(seg) });
+}
+
+/// Producer-only position fields (D3 group 1).
+struct RingProducer {
+    head: *mut OSThreadMarkerRingSegment,
+    head_pos: usize,
+}
+
+/// Consumer-only position fields (D3 group 2).
+struct RingConsumer {
+    tail: *mut OSThreadMarkerRingSegment,
+    tail_pos: usize,
+}
+
+/// Shared fields, touched roughly once per segment (D3 group 3).
+struct RingShared {
+    state: AtomicU8,
+    /// Treiber free list of recycled segments. Single pusher (the consumer)
+    /// and single popper (the producer) — see the no-ABA argument on
+    /// [`OSThreadMarkerRing::free_pop`].
+    free_head: AtomicPtr<OSThreadMarkerRingSegment>,
+    /// Approximate free-list length (Relaxed; D7). Transient off-by-one —
+    /// including the brief wrap-below-zero when a pop's decrement lands
+    /// between a push's CAS and its increment — only skews the recycle/free
+    /// choice, which is explicitly tolerant of that.
+    free_len: AtomicUsize,
+    /// Which engine the claimant produces for. Written by the claimant
+    /// *before* its first push, read by the consumer only *after* observing
+    /// a new commit — so the first push's Release/Acquire publishes it.
+    engine_id: UnsafeCell<u64>,
+}
+
+/// The segmented SPSC ring. See the module docs.
+pub(crate) struct OSThreadMarkerRing {
+    p: CachePadded<UnsafeCell<RingProducer>>,
+    c: CachePadded<UnsafeCell<RingConsumer>>,
+    s: CachePadded<RingShared>,
+    /// Immutable after construction.
+    seg_bytes: usize,
+    freelist_cap: usize,
+    ctx: &'static RingCtx,
+}
+
+// SAFETY: all cross-thread access is mediated by the role contracts —
+// `p` is touched only by the unique producer (claim protocol, registry),
+// `c` only by the single consumer thread, `s.engine_id` per the
+// publish-by-first-commit rule — with the Release/Acquire edges in the
+// module-docs table providing the happens-before. The loom suite
+// model-checks exactly these claims.
+unsafe impl Send for OSThreadMarkerRing {}
+unsafe impl Sync for OSThreadMarkerRing {}
+
+impl OSThreadMarkerRing {
+    /// Allocates a ring with one open segment, `Active` and owned by the
+    /// calling thread (the creator is the claimant). The returned pointer is
+    /// conceptually `&'static`: production code never frees rings
+    /// (invariant 7); tests reclaim through this pointer after quiescing.
+    pub(crate) fn alloc(
+        ctx: &'static RingCtx,
+        seg_bytes: usize,
+        freelist_cap: usize,
+        engine_id: u64,
+    ) -> Option<*mut OSThreadMarkerRing> {
+        let seg = alloc_segment(seg_bytes, ctx)?;
+        Some(Box::into_raw(Box::new(OSThreadMarkerRing {
+            p: CachePadded::new(UnsafeCell::new(RingProducer {
+                head: seg,
+                head_pos: 0,
+            })),
+            c: CachePadded::new(UnsafeCell::new(RingConsumer {
+                tail: seg,
+                tail_pos: 0,
+            })),
+            s: CachePadded::new(RingShared {
+                state: AtomicU8::new(RingState::Active as u8),
+                free_head: AtomicPtr::new(null_mut()),
+                free_len: AtomicUsize::new(0),
+                engine_id: UnsafeCell::new(engine_id),
+            }),
+            seg_bytes,
+            freelist_cap,
+            ctx,
+        })))
+    }
+
+    /// The producer hot path (§3.2): bounds check + `memcpy` + one `Release`
+    /// store per record. The slow path (segment link + possible consumer
+    /// wake) runs about once per `seg_bytes / record_len` pushes. No TLS, no
+    /// global loads, no CAS in steady state, no allocation while the free
+    /// list can supply a segment — and never, ever a block.
+    ///
+    /// # Safety
+    /// Caller is the ring's unique producer thread (it claimed the ring and
+    /// the ring is `Active`), and `rec` is a whole encoded record with
+    /// `0 < rec.len() <= seg_bytes`.
+    pub(crate) unsafe fn push(&self, rec: &[u8]) -> bool {
+        debug_assert!(!rec.is_empty());
+        // SAFETY: same producer contract as `push_with`; the closure copies
+        // exactly `rec.len()` bytes into the (uninitialized) slot.
+        unsafe { self.push_with(rec.len(), |slot| slot.copy_from_slice(rec)) }
+    }
+
+    /// Reserve `len` bytes in the ring and let the producer serialize a record
+    /// *directly into them* via `write`, avoiding the encode-to-stack-buffer +
+    /// copy-into-ring double write that [`Self::push`] pays. `write` must
+    /// initialize all `len` bytes (they are committed immediately after it
+    /// returns).
+    ///
+    /// # Safety
+    /// Same contract as [`Self::push`]: this OS thread is the ring's live producer
+    /// (D5a refresh), and exec does not cross an `.await` (plan §6 inv. 4).
+    #[inline]
+    pub(crate) unsafe fn push_with(&self, len: usize, write: impl FnOnce(&mut [u8])) -> bool {
+        debug_assert!(len > 0);
+        self.p.with_mut(|p| {
+            let p = unsafe { &mut *p };
+            if p.head_pos + len > self.seg_bytes {
+                // An oversized record necessarily lands here (head_pos ≥ 0),
+                // so this release-mode check costs one compare per segment
+                // fill — never per push — and is what keeps the write below
+                // in bounds for arbitrary input.
+                assert!(
+                    len <= self.seg_bytes,
+                    "profiling record ({} bytes) exceeds the ring segment size ({} bytes)",
+                    len,
+                    self.seg_bytes
+                );
+                // Slow path: link a recycled or fresh segment.
+                let seg = match unsafe { self.free_pop() } {
+                    Some(seg) => seg,
+                    None => match alloc_segment(self.seg_bytes, self.ctx) {
+                        Some(segment) => segment,
+                        None => return false,
+                    },
+                };
+                unsafe {
+                    // D2: the producer owns the reset, for recycled and fresh
+                    // segments alike. Relaxed is enough: the link store below
+                    // publishes these to the consumer, and the free-list pop
+                    // (Acquire) ordered us after the consumer's last read of
+                    // a recycled segment.
+                    let new_seg = &*seg;
+                    new_seg.sync.commit_len.store(0, Ordering::Relaxed);
+                    new_seg.sync.next.store(null_mut(), Ordering::Relaxed);
+                    // The link: publishes the resets above and — being
+                    // sequenced after every commit to the old head — that
+                    // segment's *final* commit_len (D1).
+                    (&*p.head).sync.next.store(seg, Ordering::Release);
+                }
+                p.head = seg;
+                p.head_pos = 0;
+                // Wake on segment fill, only if the consumer is parked. This
+                // is a one-way notification and cannot block the producer.
+                self.ctx.wake.wake_if_parked();
+            }
+            unsafe {
+                let head = &*p.head;
+                head.buf.with_slice_mut(p.head_pos, len, write);
+                p.head_pos += len;
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "head_pos <= seg_bytes <= 16 MiB, far below u32::MAX"
+                )]
+                head.sync
+                    .commit_len
+                    .store(p.head_pos as u32, Ordering::Release);
+            }
+            true
+        })
+    }
+
+    /// Consumer-side drain (§3.3, with D1 baked in). Hands `sink` each newly
+    /// published byte range — always a whole number of records, because the
+    /// producer commits whole records.
+    ///
+    /// The segment chase is bounded: a producer outpacing this consumer
+    /// keeps linking fresh segments, and an unbounded loop here starves the
+    /// consumer's control messages and session maintenance for as long as
+    /// the flood lasts. A drain that stops at the bound reports
+    /// `caught_up: false`; rollover wakes and the park timeout re-arm the
+    /// next pass.
+    ///
+    /// # Safety
+    /// Caller is the process's single consumer thread.
+    pub(crate) unsafe fn drain(&self, sink: &mut impl FnMut(&[u8])) -> DrainOutcome {
+        const MAX_SEGMENTS_PER_DRAIN: usize = 16;
+        self.c.with_mut(|c| {
+            let c = unsafe { &mut *c };
+            let mut progress = false;
+            let mut retired = 0;
+            loop {
+                let seg = c.tail;
+                let seg_ref = unsafe { &*seg };
+                let committed = seg_ref.sync.commit_len.load(Ordering::Acquire);
+                progress |=
+                    unsafe { consume_range(seg_ref, &mut c.tail_pos, committed as usize, sink) };
+                let next = seg_ref.sync.next.load(Ordering::Acquire);
+                if next.is_null() {
+                    // Still the open segment; caught up for now.
+                    return DrainOutcome {
+                        progress,
+                        caught_up: true,
+                    };
+                }
+                // D1: a non-null `next` means the producer is done with `seg`
+                // forever, and the Acquire above (pairing with the link
+                // Release) made its *final* commit_len visible. Re-load and
+                // drain the remainder before retiring.
+                let committed = seg_ref.sync.commit_len.load(Ordering::Acquire);
+                progress |=
+                    unsafe { consume_range(seg_ref, &mut c.tail_pos, committed as usize, sink) };
+                unsafe { self.retire(seg) };
+                c.tail = next;
+                c.tail_pos = 0;
+                retired += 1;
+                if retired >= MAX_SEGMENTS_PER_DRAIN {
+                    return DrainOutcome {
+                        progress,
+                        caught_up: false,
+                    };
+                }
+            }
+        })
+    }
+
+    /// Producer-side free-list pop.
+    ///
+    /// No ABA despite the bare Treiber loop: this thread is the *only*
+    /// popper (SPSC), and a node's `next` only changes when the single
+    /// pusher writes it *before* pushing — a node already on the list is
+    /// immutable until we pop it. The classic ABA interleaving requires a
+    /// concurrent popper to remove and re-push the observed head; that
+    /// thread does not exist.
+    ///
+    /// # Safety
+    /// Caller is the ring's unique producer thread.
+    unsafe fn free_pop(&self) -> Option<*mut OSThreadMarkerRingSegment> {
+        let mut head = self.s.free_head.load(Ordering::Acquire);
+        loop {
+            if head.is_null() {
+                return None;
+            }
+            // Visible: the Release push that made `head` reachable stored
+            // its `next` first.
+            let next = unsafe { (&*head).sync.next.load(Ordering::Relaxed) };
+            // Acquire on success: pairs with the consumer's Release push —
+            // the consumer's last read of this segment happens-before our
+            // reuse of it (D2's safety chain).
+            match self.s.free_head.compare_exchange(
+                head,
+                next,
+                Ordering::Acquire,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.s.free_len.fetch_sub(1, Ordering::Relaxed);
+                    return Some(head);
+                }
+                Err(observed) => head = observed,
+            }
+        }
+    }
+
+    /// Consumer-side segment retirement (D7): push to the free list, or free
+    /// outright when the list is at cap.
+    ///
+    /// # Safety
+    /// Caller is the consumer thread, has fully drained `seg`, and has
+    /// already advanced `tail` past it (the producer linked past it, so
+    /// neither side can reach it again).
+    unsafe fn retire(&self, seg: *mut OSThreadMarkerRingSegment) {
+        if self.s.free_len.load(Ordering::Relaxed) >= self.freelist_cap {
+            unsafe { free_segment(seg) };
+            return;
+        }
+        let mut head = self.s.free_head.load(Ordering::Relaxed);
+        loop {
+            unsafe { (&*seg).sync.next.store(head, Ordering::Relaxed) };
+            // Release: publishes "the consumer is done reading `seg`" (plus
+            // the next-link above) to the producer's pop.
+            match self
+                .s
+                .free_head
+                .compare_exchange(head, seg, Ordering::Release, Ordering::Relaxed)
+            {
+                Ok(_) => break,
+                Err(observed) => head = observed,
+            }
+        }
+        self.s.free_len.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn state(&self) -> RingState {
+        RingState::from_u8(self.s.state.load(Ordering::Acquire))
+    }
+
+    /// Producer-thread-death hook (D5b), called from the TLS-map destructor.
+    /// The Release pairs with the consumer's `state` Acquire: every record
+    /// pushed before death is visible to the post-orphan drain.
+    pub(crate) fn orphan(&self) {
+        debug_assert_eq!(
+            self.state(),
+            RingState::Active,
+            "only the live claimant's thread death orphans a ring"
+        );
+        self.s
+            .state
+            .store(RingState::Orphaned as u8, Ordering::Release);
+    }
+
+    /// Consumer: mark an orphaned ring claimable after draining it to empty.
+    /// The Release pairs with a claimant's CAS — transitively ordering the
+    /// dead producer's position fields before the new producer's first push.
+    ///
+    /// # Safety
+    /// Caller is the consumer thread and just drained this ring to empty
+    /// after observing it `Orphaned`.
+    pub(crate) unsafe fn mark_pooled(&self) {
+        debug_assert_eq!(
+            self.state(),
+            RingState::Orphaned,
+            "only a drained orphan can be pooled"
+        );
+        self.s
+            .state
+            .store(RingState::Pooled as u8, Ordering::Release);
+    }
+
+    /// New-producer claim: CAS `Pooled → Active`. On success the caller is
+    /// the unique producer and may push from the calling thread only.
+    ///
+    /// Acquire on success: pairs with [`OSThreadMarkerRing::mark_pooled`]'s Release, so the
+    /// consumer's final drain — and, through the orphan edge before it, the
+    /// dead producer's last `head`/`head_pos` writes — happen-before the new
+    /// producer touches them.
+    pub(crate) fn try_claim(&self, engine_id: u64) -> bool {
+        if self
+            .s
+            .state
+            .compare_exchange(
+                RingState::Pooled as u8,
+                RingState::Active as u8,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            // Sound despite no fence here: the consumer reads engine_id only
+            // after observing a commit_len advance, and our first push's
+            // Release is sequenced after this write.
+            self.s.engine_id.with_mut(|p| unsafe { *p = engine_id });
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Which engine the bytes most recently drained from this ring belong to.
+    ///
+    /// # Safety
+    /// Consumer thread only, and only after a [`OSThreadMarkerRing::drain`] on this ring
+    /// reported progress in the current sweep (that drain's Acquire is what
+    /// publishes a new claimant's write).
+    pub(crate) unsafe fn engine_id(&self) -> u64 {
+        self.s.engine_id.with(|p| unsafe { *p })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn free_len(&self) -> usize {
+        self.s.free_len.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for OSThreadMarkerRing {
+    /// Production rings are never dropped (invariant 7: `&'static`, reuse
+    /// don't reclaim). This exists for tests, which reclaim rings after all
+    /// producer/consumer activity has quiesced; then the live chain
+    /// (`tail → … → head`) and the free list are disjoint sets covering
+    /// every segment this ring still owns.
+    fn drop(&mut self) {
+        unsafe {
+            let mut seg = self.c.with_mut(|c| (*c).tail);
+            while !seg.is_null() {
+                let next = (&*seg).sync.next.load(Ordering::Relaxed);
+                free_segment(seg);
+                seg = next;
+            }
+            let mut free = self.s.free_head.load(Ordering::Relaxed);
+            while !free.is_null() {
+                let next = (&*free).sync.next.load(Ordering::Relaxed);
+                free_segment(free);
+                free = next;
+            }
+        }
+    }
+}
+
+/// The producer-side write handle: living proof that the holding thread
+/// claimed the ring. Created only by the claim/acquire paths on the claiming
+/// thread, and `!Send + !Sync` so it cannot leave it — which is what makes
+/// [`OSThreadMarkerRingHandle::push`] safe to expose.
+#[derive(Clone, Copy)]
+pub(crate) struct OSThreadMarkerRingHandle {
+    ring: &'static OSThreadMarkerRing,
+    _not_send_sync: PhantomData<*mut ()>,
+}
+
+impl OSThreadMarkerRingHandle {
+    /// # Safety
+    /// `ring` is `Active` and was claimed by (or created on) the calling
+    /// thread, which makes that thread the unique producer.
+    pub(crate) unsafe fn new(ring: &'static OSThreadMarkerRing) -> Self {
+        Self {
+            ring,
+            _not_send_sync: PhantomData,
+        }
+    }
+
+    /// Push one whole encoded record. Never blocks. Oversized records
+    /// (> segment size) panic on the slow path rather than corrupting the
+    /// ring.
+    ///
+    /// # Safety
+    /// The calling thread must still be the ring's live claimant: not after
+    /// its `ThreadRings` TLS destructor ran (which orphans the ring and lets
+    /// a new thread claim it — a later push would race the new producer).
+    /// `!Send` pins the handle to the claiming thread, but TLS destructor
+    /// ordering is unspecified, so "before TLS teardown" cannot be enforced
+    /// by the type. The engine upholds this via the per-resume refresh
+    /// (D5a): handles are re-fetched from live TLS each exec resume and
+    /// never used from destructors.
+    #[inline]
+    pub(crate) unsafe fn push(self, rec: &[u8]) -> bool {
+        // SAFETY: !Send pins us to the claiming thread; the caller vouches
+        // the claim is still live (contract above).
+        unsafe { self.ring.push(rec) }
+    }
+
+    /// The underlying ring, for D5a snapshots: the engine stores this
+    /// `&'static OSThreadMarkerRing` in the VM and refreshes it once per exec resume.
+    #[must_use]
+    pub(crate) fn ring(self) -> &'static OSThreadMarkerRing {
+        self.ring
+    }
+}
+
+/// Parses nothing: hands `sink` the raw committed range `[tail_pos,
+/// committed)` and advances `tail_pos`. Bytes below `committed` were
+/// published by the Acquire that read it and are immutable until recycle.
+unsafe fn consume_range(
+    seg: &OSThreadMarkerRingSegment,
+    tail_pos: &mut usize,
+    committed: usize,
+    sink: &mut impl FnMut(&[u8]),
+) -> bool {
+    debug_assert!(committed >= *tail_pos, "commit_len went backwards");
+    if committed <= *tail_pos {
+        return false;
+    }
+    let len = committed - *tail_pos;
+    unsafe { seg.buf.with_slice(*tail_pos, len, |bytes| sink(bytes)) };
+    *tail_pos = committed;
+    true
+}

--- a/baml_language/crates/btel_transport/src/runtime.rs
+++ b/baml_language/crates/btel_transport/src/runtime.rs
@@ -1,0 +1,320 @@
+//! Instance-owned ring setup and a single drainer endpoint.
+//!
+//! The copied ring uses stable pointers internally. Every public endpoint
+//! retains the owning Arc; no raw ring reference escapes this module.
+#![allow(unsafe_code)]
+
+use std::{
+    collections::HashSet,
+    fmt,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use btel_core::{
+    marker::Marker,
+    stage::{Aggregator, EventBuilder, MarkerRange, Publisher},
+};
+
+use crate::{
+    Pipeline, RangeHandler,
+    memory::ProfilerMemoryGovernor,
+    registry::{Cursor, Registry},
+    ring::{OSThreadMarkerRingHandle, RingCtx},
+    sizing::{MeasuredLayouts, ProfilerSizingPolicy},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct TransportConfig {
+    pub segment_bytes: usize,
+    pub freelist_segments: usize,
+    pub memory_bytes: u64,
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            segment_bytes: 256 * 1024,
+            freelist_segments: 2,
+            memory_bytes: 256 * 1024 * 1024,
+        }
+    }
+}
+
+impl TransportConfig {
+    /// Preflight for a fixed-source replay that retries full rings. Once all
+    /// backlog is drained, rings may still retain a head plus their freelist.
+    /// Keep one additional segment available so a full head can roll forward.
+    /// This checks configuration once; it does not reserve memory or measure writes.
+    pub fn check_retry_capacity(self, source_count: usize) -> Result<(), TransportError> {
+        if self.segment_bytes == 0 || self.segment_bytes > 16 * 1024 * 1024 {
+            return Err(TransportError::InvalidConfig);
+        }
+        let measured = MeasuredLayouts {
+            transport_segment_bytes: self.segment_bytes as u64,
+            ..MeasuredLayouts::V1
+        };
+        let sizing = ProfilerSizingPolicy::derive(self.memory_bytes, measured)
+            .map_err(|_| TransportError::InvalidConfig)?;
+        let required = self
+            .freelist_segments
+            .checked_add(1)
+            .and_then(|n| n.checked_mul(source_count))
+            .and_then(|n| n.checked_add(1))
+            .and_then(|n| n.checked_mul(crate::ring::segment_footprint(self.segment_bytes)))
+            .and_then(|n| u64::try_from(n).ok())
+            .ok_or(TransportError::InvalidConfig)?;
+        if required > sizing.general_bytes {
+            return Err(TransportError::InsufficientRetryCapacity);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TransportError {
+    InvalidConfig,
+    Closed,
+    DuplicateSource(u64),
+    OutOfMemoryBudget,
+    ActiveProducers,
+    InsufficientRetryCapacity,
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for TransportError {}
+
+#[derive(Default)]
+struct Admission {
+    closed: bool,
+    sources: HashSet<u64>,
+}
+
+struct Inner {
+    // Registry must drop its ring allocations before their budget context.
+    registry: Registry,
+    admission: Mutex<Admission>,
+    active: AtomicUsize,
+    config: TransportConfig,
+    ctx: Box<RingCtx>,
+}
+
+#[derive(Clone)]
+pub struct SourceFactory {
+    inner: Arc<Inner>,
+}
+
+/// Thread-bound writer. Dropping it publishes the source's final write via
+/// orphaning before announcing that the producer has finished.
+pub struct Producer {
+    handle: OSThreadMarkerRingHandle,
+    inner: Arc<Inner>,
+}
+
+/// The sole round-robin drainer for an instance. It owns a persistent cursor.
+/// Scheduling is fixed here; only range handling is supplied by the pipeline.
+/// There is no public per-ring drain or cursor reset API. Movable, not cloned.
+pub struct Drainer {
+    inner: Arc<Inner>,
+    cursor: Cursor,
+}
+
+pub fn transport(config: TransportConfig) -> Result<(SourceFactory, Drainer), TransportError> {
+    if config.segment_bytes == 0 || config.segment_bytes > 16 * 1024 * 1024 {
+        return Err(TransportError::InvalidConfig);
+    }
+    let measured = MeasuredLayouts {
+        transport_segment_bytes: config.segment_bytes as u64,
+        ..MeasuredLayouts::V1
+    };
+    let sizing = ProfilerSizingPolicy::derive(config.memory_bytes, measured)
+        .map_err(|_| TransportError::InvalidConfig)?;
+    let inner = Arc::new(Inner {
+        registry: Registry::new(),
+        admission: Mutex::default(),
+        active: AtomicUsize::new(0),
+        config,
+        ctx: Box::new(RingCtx::with_governor(ProfilerMemoryGovernor::new(
+            sizing, measured,
+        ))),
+    });
+    Ok((
+        SourceFactory {
+            inner: inner.clone(),
+        },
+        Drainer {
+            inner,
+            cursor: Cursor::default(),
+        },
+    ))
+}
+
+impl SourceFactory {
+    /// Call on the OS thread that will write. Registration is outside replay's
+    /// timed path; only this setup operation locks the admission table.
+    pub fn producer(&self, source_id: u64) -> Result<Producer, TransportError> {
+        let mut admission = self
+            .inner
+            .admission
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if admission.closed {
+            return Err(TransportError::Closed);
+        }
+        if admission.sources.contains(&source_id) {
+            return Err(TransportError::DuplicateSource(source_id));
+        }
+        // SAFETY: Box gives a stable address. Producer/Drainer keep Inner
+        // alive; registry drops all rings before ctx, and no static ref escapes.
+        let ctx: &'static RingCtx = unsafe { &*std::ptr::from_ref(&*self.inner.ctx) };
+        let handle = self
+            .inner
+            .registry
+            .acquire(
+                ctx,
+                self.inner.config.segment_bytes,
+                self.inner.config.freelist_segments,
+                source_id,
+            )
+            .ok_or(TransportError::OutOfMemoryBudget)?;
+        admission.sources.insert(source_id);
+        self.inner.active.fetch_add(1, Ordering::Relaxed);
+        Ok(Producer {
+            handle,
+            inner: self.inner.clone(),
+        })
+    }
+
+    pub fn wake_consumer(&self) {
+        self.inner.ctx.wake().force_wake();
+    }
+}
+
+impl Producer {
+    /// Encode directly into the reserved ring slot using the copied marker codec.
+    /// The caller supplies the timestamp, just as the VM producer does.
+    #[inline]
+    pub fn write_marker(&mut self, marker: &Marker<'_>) -> bool {
+        // SAFETY: exclusive thread-bound producer; encode_to initializes the
+        // entire encoded_len slot before the copied ring publishes its commit.
+        unsafe {
+            self.handle.ring().push_with(marker.encoded_len(), |slot| {
+                marker.encode_to(slot);
+            })
+        }
+    }
+
+    /// Write one whole encoded record. False means budget rejection, not retry.
+    #[inline]
+    pub fn write(&mut self, bytes: &[u8]) -> bool {
+        // SAFETY: this private handle cannot outlive its owner or leave the
+        // claiming thread, and only Drop orphans it after the last write.
+        unsafe { self.handle.push(bytes) }
+    }
+}
+
+impl Drop for Producer {
+    fn drop(&mut self) {
+        self.handle.ring().orphan();
+        self.inner.active.fetch_sub(1, Ordering::Release);
+        self.inner.ctx.wake().force_wake();
+    }
+}
+
+impl Drainer {
+    pub fn register_worker(&self) {
+        self.inner.ctx.wake().register_consumer();
+    }
+
+    /// A bounded round-robin service step shared by all drainer presets.
+    pub fn drain<H, B, A, P>(
+        &mut self,
+        pipeline: &mut Pipeline<H, B, A, P>,
+        source_budget: usize,
+    ) -> bool
+    where
+        H: RangeHandler,
+        B: EventBuilder,
+        A: Aggregator<B::Event>,
+        P: Publisher<B::Event, A::Aggregate>,
+    {
+        let mut progress = false;
+        for _ in 0..source_budget.max(1) {
+            // SAFETY: this endpoint is the instance's sole drainer. Every
+            // pipeline call accepts the range before the ring advances.
+            let visit = unsafe {
+                self.inner
+                    .registry
+                    .visit_next(&mut self.cursor, &mut |ring, bytes| {
+                        pipeline.consume(MarkerRange {
+                            source_id: ring.engine_id(),
+                            bytes,
+                        });
+                    })
+            };
+            let Some(visit) = visit else { break };
+            progress |= visit.progress;
+            if visit.wrapped {
+                break;
+            }
+        }
+        progress
+    }
+
+    pub fn idle<H, B, A, P>(
+        &mut self,
+        pipeline: &mut Pipeline<H, B, A, P>,
+        source_budget: usize,
+        timeout: Duration,
+    ) where
+        H: RangeHandler,
+        B: EventBuilder,
+        A: Aggregator<B::Event>,
+        P: Publisher<B::Event, A::Aggregate>,
+    {
+        self.inner.ctx.wake().pre_park();
+        if !self.drain(pipeline, source_budget) {
+            self.inner.ctx.wake().park(timeout);
+        }
+        self.inner.ctx.wake().post_park();
+    }
+
+    /// Seal admission and finish only after producer ownership has ended.
+    /// No decoder/root-completion state participates in this boundary.
+    pub fn finish<H, B, A, P>(self, mut pipeline: Pipeline<H, B, A, P>) -> Result<P, TransportError>
+    where
+        H: RangeHandler,
+        B: EventBuilder,
+        A: Aggregator<B::Event>,
+        P: Publisher<B::Event, A::Aggregate>,
+    {
+        self.inner
+            .admission
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .closed = true;
+        if self.inner.active.load(Ordering::Acquire) != 0 {
+            return Err(TransportError::ActiveProducers);
+        }
+        // After all producer drops, orphan Acquire observes their final
+        // commits. Repeat complete sweeps until every source is drained.
+        while !unsafe {
+            self.inner.registry.sweep_outcome(&mut |ring, bytes| {
+                pipeline.consume(MarkerRange {
+                    source_id: ring.engine_id(),
+                    bytes,
+                });
+            })
+        }
+        .caught_up
+        {}
+        Ok(pipeline.finish())
+    }
+}

--- a/baml_language/crates/btel_transport/src/sizing.rs
+++ b/baml_language/crates/btel_transport/src/sizing.rs
@@ -1,0 +1,203 @@
+/// Frozen accounted layout measurements used by sizing policy v1. Values are
+/// capacity charges, so they include the documented allocator/queue margin
+/// rather than claiming allocator-exact occupied sizes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "preserve the source sizing units and names"
+)]
+pub(crate) struct MeasuredLayouts {
+    pub(crate) execution_slot_bytes: u64,
+    pub(crate) population_item_min_bytes: u64,
+    pub(crate) transport_segment_bytes: u64,
+    pub(crate) active_thread_min_bytes: u64,
+    pub(crate) active_call_min_bytes: u64,
+    pub(crate) unresolved_fact_min_bytes: u64,
+    pub(crate) evidence_item_min_bytes: u64,
+    pub(crate) value_root_min_bytes: u64,
+    pub(crate) writer_batch_min_bytes: u64,
+    /// Accounted charge per pending index-plane record in the stream
+    /// writer's fixed `meta_queue` reservation (`RootEnded` encodes to
+    /// ≈ 286 bytes).
+    pub(crate) meta_record_bytes: u64,
+    pub(crate) fixed_control_bytes: u64,
+}
+
+impl MeasuredLayouts {
+    pub(crate) const V1: Self = Self {
+        execution_slot_bytes: 8 * 1024,
+        population_item_min_bytes: 256,
+        transport_segment_bytes: 256 * 1024,
+        active_thread_min_bytes: 192,
+        active_call_min_bytes: 320,
+        unresolved_fact_min_bytes: 256,
+        evidence_item_min_bytes: 256,
+        value_root_min_bytes: 512,
+        writer_batch_min_bytes: 64 * 1024,
+        meta_record_bytes: 320,
+        fixed_control_bytes: 256 * 1024,
+    };
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DerivedSizing {
+    pub(crate) policy_version: u16,
+    pub(crate) total_bytes: u64,
+    pub(crate) control_reserve_bytes: u64,
+    pub(crate) manual_reserve_bytes: u64,
+    pub(crate) general_bytes: u64,
+    pub(crate) execution_slots: u32,
+    pub(crate) transport_segment_bytes: u64,
+    pub(crate) transport_freelist_segments: u32,
+    pub(crate) producer_queue_slots: u32,
+    pub(crate) cct_epoch_target_bytes: u64,
+    pub(crate) segment_target_bytes: u64,
+    pub(crate) single_value_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct InvalidMemoryBudget {
+    pub(crate) requested_bytes: u64,
+    pub(crate) minimum_bytes: u64,
+}
+
+pub(crate) struct ProfilerSizingPolicy;
+
+impl ProfilerSizingPolicy {
+    pub(crate) const VERSION: u16 = 1;
+    const CONTROL_MIN: u64 = 2 * 1024 * 1024;
+    const CONTROL_MAX: u64 = 16 * 1024 * 1024;
+    const MANUAL_MIN: u64 = 2 * 1024 * 1024;
+    const MANUAL_MAX: u64 = 16 * 1024 * 1024;
+    const GENERAL_MIN: u64 = 4 * 1024 * 1024;
+    const SEGMENT_MIN: u64 = 256 * 1024;
+    const SEGMENT_MAX: u64 = 4 * 1024 * 1024;
+    const EPOCH_MIN: u64 = 1024 * 1024;
+    const EPOCH_MAX: u64 = 64 * 1024 * 1024;
+    const SINGLE_VALUE_MAX: u64 = 16 * 1024 * 1024;
+
+    /// Pure sizing policy. Integer division and clamps are the only adaptive
+    /// operations; there are no hidden counts or environment inputs.
+    pub(crate) fn derive(
+        process_memory_bytes: u64,
+        measured: MeasuredLayouts,
+    ) -> Result<DerivedSizing, InvalidMemoryBudget> {
+        let minimum_bytes = measured
+            .fixed_control_bytes
+            .saturating_add(measured.execution_slot_bytes)
+            .saturating_add(measured.transport_segment_bytes)
+            .saturating_add(Self::CONTROL_MIN)
+            .saturating_add(Self::MANUAL_MIN)
+            .saturating_add(Self::GENERAL_MIN);
+        if process_memory_bytes < minimum_bytes {
+            return Err(InvalidMemoryBudget {
+                requested_bytes: process_memory_bytes,
+                minimum_bytes,
+            });
+        }
+
+        let control_reserve_bytes =
+            (process_memory_bytes / 16).clamp(Self::CONTROL_MIN, Self::CONTROL_MAX);
+        let manual_reserve_bytes =
+            (process_memory_bytes / 16).clamp(Self::MANUAL_MIN, Self::MANUAL_MAX);
+        let general_bytes = process_memory_bytes
+            .checked_sub(control_reserve_bytes)
+            .and_then(|n| n.checked_sub(manual_reserve_bytes))
+            .expect("minimum budget preserves general capacity");
+
+        let slot_bytes = control_reserve_bytes.saturating_sub(measured.fixed_control_bytes)
+            / measured.execution_slot_bytes.max(1);
+        let execution_slots = u32::try_from(slot_bytes.clamp(1, 4096)).unwrap_or(4096);
+        let segment_target_bytes = (general_bytes / 32)
+            .clamp(Self::SEGMENT_MIN, Self::SEGMENT_MAX)
+            .max(measured.writer_batch_min_bytes);
+        let cct_epoch_target_bytes = (general_bytes / 4).clamp(Self::EPOCH_MIN, Self::EPOCH_MAX);
+        let producer_queue_slots =
+            u32::try_from(segment_target_bytes / measured.evidence_item_min_bytes.max(1))
+                .unwrap_or(u32::MAX)
+                .max(1);
+        let value_working_bytes = general_bytes / 4;
+        let single_value_bytes = (value_working_bytes / 4)
+            .min(Self::SINGLE_VALUE_MAX)
+            .max(measured.value_root_min_bytes);
+        Ok(DerivedSizing {
+            policy_version: Self::VERSION,
+            total_bytes: process_memory_bytes,
+            control_reserve_bytes,
+            manual_reserve_bytes,
+            general_bytes,
+            execution_slots,
+            transport_segment_bytes: measured.transport_segment_bytes,
+            transport_freelist_segments: 2,
+            producer_queue_slots,
+            cct_epoch_target_bytes,
+            segment_target_bytes,
+            single_value_bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn representative_256_mib_fixture_is_frozen() {
+        assert_eq!(
+            ProfilerSizingPolicy::derive(256 * 1024 * 1024, MeasuredLayouts::V1),
+            Ok(DerivedSizing {
+                policy_version: 1,
+                total_bytes: 268_435_456,
+                control_reserve_bytes: 16_777_216,
+                manual_reserve_bytes: 16_777_216,
+                general_bytes: 234_881_024,
+                execution_slots: 2016,
+                transport_segment_bytes: 262_144,
+                transport_freelist_segments: 2,
+                producer_queue_slots: 16_384,
+                cct_epoch_target_bytes: 58_720_256,
+                segment_target_bytes: 4_194_304,
+                single_value_bytes: 14_680_064,
+            })
+        );
+    }
+
+    #[test]
+    fn representative_32_mib_fixture_is_frozen() {
+        assert_eq!(
+            ProfilerSizingPolicy::derive(32 * 1024 * 1024, MeasuredLayouts::V1),
+            Ok(DerivedSizing {
+                policy_version: 1,
+                total_bytes: 33_554_432,
+                control_reserve_bytes: 2_097_152,
+                manual_reserve_bytes: 2_097_152,
+                general_bytes: 29_360_128,
+                execution_slots: 224,
+                transport_segment_bytes: 262_144,
+                transport_freelist_segments: 2,
+                producer_queue_slots: 3_584,
+                cct_epoch_target_bytes: 7_340_032,
+                segment_target_bytes: 917_504,
+                single_value_bytes: 1_835_008,
+            })
+        );
+    }
+
+    #[test]
+    fn too_small_budget_is_rejected_without_partial_sizing() {
+        let minimum = MeasuredLayouts::V1.fixed_control_bytes
+            + MeasuredLayouts::V1.execution_slot_bytes
+            + MeasuredLayouts::V1.transport_segment_bytes
+            + ProfilerSizingPolicy::CONTROL_MIN
+            + ProfilerSizingPolicy::MANUAL_MIN
+            + ProfilerSizingPolicy::GENERAL_MIN;
+        assert_eq!(
+            ProfilerSizingPolicy::derive(minimum - 1, MeasuredLayouts::V1),
+            Err(InvalidMemoryBudget {
+                requested_bytes: minimum - 1,
+                minimum_bytes: minimum,
+            })
+        );
+        assert!(ProfilerSizingPolicy::derive(minimum, MeasuredLayouts::V1).is_ok());
+    }
+}

--- a/baml_language/crates/btel_transport/src/sync.rs
+++ b/baml_language/crates/btel_transport/src/sync.rs
@@ -1,0 +1,150 @@
+//! loom/std shims: the ring compiles against these so the exact same code is
+//! model-checked under `RUSTFLAGS="--cfg baml_loom"` and shipped against std.
+#![allow(unsafe_code)]
+// On wasm32 there is no background consumer thread, but shared ring and
+// cooperative-drain code still compile through these std shims.
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
+// `AtomicBool` is re-exported only under loom: the std build's `Wake` uses
+// `std::sync::atomic` directly (its `OnceLock` half has no loom analogue).
+#[cfg(not(baml_loom))]
+pub(crate) use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicU32, AtomicUsize, Ordering};
+#[cfg(all(not(baml_loom), test))]
+pub(crate) use std::thread;
+
+#[cfg(baml_loom)]
+pub(crate) use loom::cell::UnsafeCell;
+#[cfg(baml_loom)]
+pub(crate) use loom::sync::atomic::{
+    AtomicBool, AtomicPtr, AtomicU8, AtomicU32, AtomicUsize, Ordering,
+};
+#[cfg(baml_loom)]
+pub(crate) use loom::thread;
+
+/// std stand-in for [`loom::cell::UnsafeCell`]'s closure-based API.
+#[cfg(not(baml_loom))]
+#[derive(Debug)]
+pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
+
+#[cfg(not(baml_loom))]
+impl<T> UnsafeCell<T> {
+    pub(crate) const fn new(value: T) -> Self {
+        Self(std::cell::UnsafeCell::new(value))
+    }
+
+    /// Immutable access. Caller upholds the no-concurrent-mutation contract
+    /// the loom build model-checks.
+    #[inline]
+    pub(crate) fn with<R>(&self, f: impl FnOnce(*const T) -> R) -> R {
+        f(self.0.get())
+    }
+
+    /// Mutable access. Caller upholds the exclusive-access contract the loom
+    /// build model-checks.
+    #[inline]
+    pub(crate) fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R {
+        f(self.0.get())
+    }
+}
+
+/// A segment's byte buffer.
+///
+/// The producer writes a record's bytes and then publishes them with a
+/// `Release` store of `commit_len`; the consumer only ever reads ranges below
+/// a `commit_len` it `Acquire`-loaded. Producer and consumer therefore touch
+/// disjoint byte ranges at all times. The per-byte cells exist so the loom
+/// build verifies exactly that claim; in the std build they compile away
+/// (`UnsafeCell<u8>` has `u8`'s layout) and writes are a straight `memcpy`.
+pub(crate) struct Buf {
+    #[cfg(not(baml_loom))]
+    bytes: Box<[std::cell::UnsafeCell<u8>]>,
+    #[cfg(baml_loom)]
+    bytes: Box<[loom::cell::UnsafeCell<u8>]>,
+}
+
+impl Buf {
+    pub(crate) fn new(len: usize) -> Self {
+        #[cfg(not(baml_loom))]
+        let bytes = (0..len).map(|_| std::cell::UnsafeCell::new(0u8)).collect();
+        #[cfg(baml_loom)]
+        let bytes = (0..len).map(|_| loom::cell::UnsafeCell::new(0u8)).collect();
+        Self { bytes }
+    }
+
+    /// Calls `f` with a mutable view of `[offset, offset + len)` so the
+    /// producer can serialize a record *directly into the ring*, skipping the
+    /// intermediate stack buffer and the extra copy that encoding into a
+    /// scratch buffer and copying it in would require.
+    ///
+    /// # Safety
+    /// Caller is the ring's unique producer, the range is in bounds, and no
+    /// byte of it has been published (the consumer never reads it
+    /// concurrently). `f` must initialize every byte of the slice before it
+    /// is committed.
+    #[cfg(not(baml_loom))]
+    #[inline]
+    pub(crate) unsafe fn with_slice_mut(
+        &self,
+        offset: usize,
+        len: usize,
+        f: impl FnOnce(&mut [u8]),
+    ) {
+        debug_assert!(offset + len <= self.bytes.len());
+        let base = std::cell::UnsafeCell::raw_get(self.bytes.as_ptr());
+        let slice = unsafe { std::slice::from_raw_parts_mut(base.add(offset), len) };
+        f(slice);
+    }
+
+    /// See the std-build `with_slice_mut`. Fills a temp then stores per byte so
+    /// loom still models the producer's writes (the in-place path is a std-only
+    /// optimization; the byte-level write set is identical).
+    #[cfg(baml_loom)]
+    pub(crate) unsafe fn with_slice_mut(
+        &self,
+        offset: usize,
+        len: usize,
+        f: impl FnOnce(&mut [u8]),
+    ) {
+        let mut tmp = vec![0u8; len];
+        f(&mut tmp);
+        for (i, byte) in tmp.iter().enumerate() {
+            self.bytes[offset + i].with_mut(|p| unsafe { *p = *byte });
+        }
+    }
+
+    /// Calls `f` with the bytes in `[offset, offset + len)`.
+    ///
+    /// # Safety
+    /// Caller is the ring's single consumer and the whole range was published
+    /// by a `commit_len` Release→Acquire pair (committed bytes are never
+    /// rewritten while reachable by the consumer).
+    #[cfg(not(baml_loom))]
+    #[inline]
+    pub(crate) unsafe fn with_slice<R>(
+        &self,
+        offset: usize,
+        len: usize,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> R {
+        debug_assert!(offset + len <= self.bytes.len());
+        let base = std::cell::UnsafeCell::raw_get(self.bytes.as_ptr()).cast_const();
+        let slice = unsafe { std::slice::from_raw_parts(base.add(offset), len) };
+        f(slice)
+    }
+
+    /// See the std-build `with_slice`. Copies out per byte so loom tracks the
+    /// reads.
+    #[cfg(baml_loom)]
+    pub(crate) unsafe fn with_slice<R>(
+        &self,
+        offset: usize,
+        len: usize,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> R {
+        let mut copy = Vec::with_capacity(len);
+        for i in 0..len {
+            copy.push(self.bytes[offset + i].with(|p| unsafe { *p }));
+        }
+        f(&copy)
+    }
+}

--- a/baml_language/crates/btel_transport/src/wake.rs
+++ b/baml_language/crates/btel_transport/src/wake.rs
@@ -1,0 +1,130 @@
+//! Consumer wake/park protocol (design D4).
+//!
+//! The consumer sets a parked flag and sleeps in `park_timeout`; the producer
+//! checks the flag only on segment fill (~1 in `seg_bytes / record_len`
+//! events) and calls [`std::thread::Thread::unpark`] if set. There is no
+//! mutex and no condvar anywhere on the producer side: it runs holding the
+//! engine's heap permit, where blocking would stall GC engine-wide.
+//!
+//! The flag-then-recheck dance *shrinks* but does not *close* the classic
+//! lost-wakeup window. That residual race is deliberately benign: the park
+//! timeout bounds its cost to one interval of buffered ring growth. Bounding
+//! that race is why the timeout exists — do not "fix" the race by adding
+//! producer-side blocking.
+
+// On wasm32 there is no background consumer to wake; cooperative drains call
+// the registry directly. Keep the types compiled so shared ring code stays
+// dual-target without per-call-site cfgs.
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
+pub(crate) use imp::Wake;
+
+#[cfg(not(baml_loom))]
+mod imp {
+    use std::{
+        sync::{
+            OnceLock,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    pub(crate) struct Wake {
+        parked: AtomicBool,
+        consumer: OnceLock<std::thread::Thread>,
+    }
+
+    impl Wake {
+        pub(crate) const fn new() -> Self {
+            Self {
+                parked: AtomicBool::new(false),
+                consumer: OnceLock::new(),
+            }
+        }
+
+        /// The consumer thread registers itself once at startup.
+        pub(crate) fn register_consumer(&self) {
+            let _ = self.consumer.set(std::thread::current());
+        }
+
+        /// Producer slow path. Never blocks: a Relaxed flag load, a lock-free
+        /// `OnceLock::get`, and at most an `unpark` (a wake, not a wait).
+        #[inline]
+        pub(crate) fn wake_if_parked(&self) {
+            if self.parked.load(Ordering::Relaxed) {
+                self.force_wake();
+            }
+        }
+
+        /// Unconditional wake (control-message paths like flush requests,
+        /// which must not depend on the parked flag's timing).
+        pub(crate) fn force_wake(&self) {
+            if let Some(consumer) = self.consumer.get() {
+                consumer.unpark();
+            }
+        }
+
+        /// Consumer: announce intent to park, *before* the final
+        /// no-work recheck. `SeqCst` is cheap here (runs at most ~20×/s).
+        pub(crate) fn pre_park(&self) {
+            self.parked.store(true, Ordering::SeqCst);
+        }
+
+        /// Consumer: sleep until unparked or the timeout elapses. The
+        /// timeout, not the flag, is the loss-of-wakeup backstop.
+        #[expect(clippy::unused_self, reason = "API symmetry with pre/post_park")]
+        pub(crate) fn park(&self, timeout: Duration) {
+            std::thread::park_timeout(timeout);
+        }
+
+        /// Consumer: clear the parked flag after waking.
+        pub(crate) fn post_park(&self) {
+            self.parked.store(false, Ordering::Relaxed);
+        }
+    }
+}
+
+// loom cannot model `park_timeout` (timeouts have no place in exhaustive
+// interleaving search), and the protocol's correctness deliberately does not
+// depend on parking — the timer bounds the benign race. Loom builds get a
+// flag-only stub; the real protocol is exercised by the std-thread stress
+// tests.
+#[cfg(baml_loom)]
+mod imp {
+    use std::time::Duration;
+
+    use crate::sync::{AtomicBool, Ordering};
+
+    pub(crate) struct Wake {
+        parked: AtomicBool,
+    }
+
+    impl Wake {
+        pub(crate) fn new() -> Self {
+            Self {
+                parked: AtomicBool::new(false),
+            }
+        }
+
+        pub(crate) fn register_consumer(&self) {}
+
+        #[inline]
+        pub(crate) fn wake_if_parked(&self) {
+            let _ = self.parked.load(Ordering::Relaxed);
+        }
+
+        pub(crate) fn force_wake(&self) {}
+
+        pub(crate) fn pre_park(&self) {
+            self.parked.store(true, Ordering::SeqCst);
+        }
+
+        pub(crate) fn park(&self, _timeout: Duration) {
+            loom::thread::yield_now();
+        }
+
+        pub(crate) fn post_park(&self) {
+            self.parked.store(false, Ordering::Relaxed);
+        }
+    }
+}

--- a/baml_language/crates/btel_transport/tests/pipeline.rs
+++ b/baml_language/crates/btel_transport/tests/pipeline.rs
@@ -1,0 +1,242 @@
+use std::{cell::RefCell, rc::Rc};
+
+use btel_core::stage::{Aggregator, EventBuilder, MarkerBatch, MarkerRange, Publisher};
+use btel_transport::{Pipeline, RangeHandler, TransportConfig, TransportError, transport};
+
+struct UnusedBuilder;
+impl EventBuilder for UnusedBuilder {
+    type Event = u64;
+    fn build(&mut self, _: MarkerRange<'_>, _: impl FnMut(u64)) {
+        panic!("discard emitted a batch");
+    }
+}
+struct UnusedAggregator;
+impl Aggregator<u64> for UnusedAggregator {
+    type Aggregate = u64;
+    fn observe(&mut self, _: &u64, _: impl FnMut(u64)) {
+        panic!("discard emitted an event");
+    }
+}
+struct UnusedPublisher;
+impl Publisher<u64, u64> for UnusedPublisher {
+    fn event(&mut self, _: u64) {
+        panic!("unexpected publication");
+    }
+    fn aggregate(&mut self, _: u64) {
+        panic!("unexpected aggregation");
+    }
+}
+
+#[derive(Clone)]
+struct Recorder(Rc<RefCell<Vec<(u64, u64)>>>);
+impl RangeHandler for Recorder {
+    fn accept(&mut self, range: MarkerRange<'_>, _: impl FnMut(MarkerBatch)) {
+        for bytes in range.bytes.as_chunks::<8>().0 {
+            self.0
+                .borrow_mut()
+                .push((range.source_id, u64::from_le_bytes(*bytes)));
+        }
+    }
+}
+fn config() -> TransportConfig {
+    TransportConfig {
+        segment_bytes: 64,
+        freelist_segments: 2,
+        memory_bytes: 32 * 1024 * 1024,
+    }
+}
+
+#[test]
+fn finish_drains_more_than_sixteen_segments_exactly_once() {
+    let (factory, drainer) = transport(config()).unwrap();
+    let mut producer = factory.producer(7).unwrap();
+    for n in 0u64..4097 {
+        assert!(producer.write(&n.to_le_bytes()));
+    }
+    drop(producer);
+    let log = Recorder(Rc::default());
+    let observed = log.clone();
+    drainer
+        .finish(Pipeline::new(
+            log,
+            UnusedBuilder,
+            UnusedAggregator,
+            UnusedPublisher,
+        ))
+        .unwrap();
+    assert_eq!(
+        *observed.0.borrow(),
+        (0..4097).map(|n| (7, n)).collect::<Vec<_>>()
+    );
+    assert!(matches!(factory.producer(8), Err(TransportError::Closed)));
+}
+
+#[test]
+fn a_hot_source_does_not_reset_the_round_robin_cursor() {
+    let (factory, mut drainer) = transport(config()).unwrap();
+    let mut hot = factory.producer(1).unwrap();
+    let mut quiet = factory.producer(2).unwrap();
+    for n in 0u64..4097 {
+        assert!(hot.write(&n.to_le_bytes()));
+    }
+    assert!(quiet.write(&99u64.to_le_bytes()));
+    let log = Recorder(Rc::default());
+    let observed = log.clone();
+    let mut pipeline = Pipeline::new(log, UnusedBuilder, UnusedAggregator, UnusedPublisher);
+    assert!(drainer.drain(&mut pipeline, 1));
+    assert!(observed.0.borrow().iter().all(|(source, _)| *source == 1));
+    assert!(drainer.drain(&mut pipeline, 1));
+    assert_eq!(observed.0.borrow().last(), Some(&(2, 99)));
+    drop(hot);
+    drop(quiet);
+    drainer.finish(pipeline).unwrap();
+    assert_eq!(observed.0.borrow().len(), 4098);
+}
+
+#[test]
+fn finishing_with_a_live_writer_is_rejected() {
+    let (factory, drainer) = transport(config()).unwrap();
+    let _producer = factory.producer(1).unwrap();
+    let pipeline = Pipeline::new(
+        Recorder(Rc::default()),
+        UnusedBuilder,
+        UnusedAggregator,
+        UnusedPublisher,
+    );
+    assert!(matches!(
+        drainer.finish(pipeline),
+        Err(TransportError::ActiveProducers)
+    ));
+}
+
+#[test]
+fn stages_flush_in_order_and_events_and_aggregates_take_separate_branches() {
+    type Log = Rc<RefCell<Vec<String>>>;
+    struct H;
+    impl RangeHandler for H {
+        fn accept(&mut self, r: MarkerRange<'_>, mut emit: impl FnMut(MarkerBatch)) {
+            emit(MarkerBatch {
+                source_id: r.source_id,
+                bytes: r.bytes.to_vec(),
+            });
+        }
+        fn finish(&mut self, mut emit: impl FnMut(MarkerBatch)) {
+            emit(MarkerBatch {
+                source_id: 0,
+                bytes: vec![2],
+            });
+        }
+    }
+    struct B;
+    impl EventBuilder for B {
+        type Event = u8;
+        fn build(&mut self, r: MarkerRange<'_>, mut emit: impl FnMut(u8)) {
+            for b in r.bytes {
+                emit(*b);
+            }
+        }
+        fn finish(&mut self, mut emit: impl FnMut(u8)) {
+            emit(3);
+        }
+    }
+    struct A;
+    impl Aggregator<u8> for A {
+        type Aggregate = u64;
+        fn observe(&mut self, e: &u8, mut emit: impl FnMut(u64)) {
+            emit(u64::from(*e) * 10);
+        }
+        fn finish(&mut self, mut emit: impl FnMut(u64)) {
+            emit(99);
+        }
+    }
+    struct P(Log);
+    impl Publisher<u8, u64> for P {
+        fn event(&mut self, e: u8) {
+            self.0.borrow_mut().push(format!("event {e}"));
+        }
+        fn aggregate(&mut self, a: u64) {
+            self.0.borrow_mut().push(format!("aggregate {a}"));
+        }
+        fn finish(&mut self) {
+            self.0.borrow_mut().push("finish".into());
+        }
+    }
+    let log = Log::default();
+    let mut pipeline = Pipeline::new(H, B, A, P(log.clone()));
+    let (factory, mut drainer) = transport(config()).unwrap();
+    let mut producer = factory.producer(1).unwrap();
+    assert!(producer.write(&[1]));
+    assert!(drainer.drain(&mut pipeline, 1));
+    drop(producer);
+    drainer.finish(pipeline).unwrap();
+    assert_eq!(
+        *log.borrow(),
+        [
+            "aggregate 10",
+            "event 1",
+            "aggregate 20",
+            "event 2",
+            "aggregate 30",
+            "event 3",
+            "aggregate 99",
+            "finish"
+        ]
+    );
+}
+
+#[test]
+fn concurrent_endpoints_preserve_every_source_record_after_factory_drop() {
+    let (factory, mut drainer) = transport(config()).unwrap();
+    let writers: Vec<_> = (1..=2)
+        .map(|source| {
+            let factory = factory.clone();
+            std::thread::spawn(move || {
+                let mut producer = factory.producer(source).unwrap();
+                for seq in 0u64..1025 {
+                    assert!(producer.write(&seq.to_le_bytes()));
+                }
+            })
+        })
+        .collect();
+    // The drainer and producers must keep the instance's context alive.
+    drop(factory);
+    let log = Recorder(Rc::default());
+    let observed = log.clone();
+    let mut pipeline = Pipeline::new(log, UnusedBuilder, UnusedAggregator, UnusedPublisher);
+    while writers.iter().any(|writer| !writer.is_finished()) {
+        drainer.drain(&mut pipeline, 1);
+        std::thread::yield_now();
+    }
+    for writer in writers {
+        writer.join().unwrap();
+    }
+    drainer.finish(pipeline).unwrap();
+    let log = observed.0.borrow();
+    assert_eq!(log.len(), 2050);
+    for source in 1..=2 {
+        let actual: Vec<_> = log
+            .iter()
+            .filter(|(id, _)| *id == source)
+            .map(|(_, seq)| *seq)
+            .collect();
+        assert_eq!(actual, (0..1025).collect::<Vec<_>>());
+    }
+}
+
+#[test]
+fn empty_rings_consume_a_turn_without_resetting_the_cursor() {
+    let (factory, mut drainer) = transport(config()).unwrap();
+    let idle = factory.producer(1).unwrap();
+    let mut active = factory.producer(2).unwrap();
+    assert!(active.write(&99u64.to_le_bytes()));
+    let log = Recorder(Rc::default());
+    let observed = log.clone();
+    let mut pipeline = Pipeline::new(log, UnusedBuilder, UnusedAggregator, UnusedPublisher);
+    assert!(!drainer.drain(&mut pipeline, 1));
+    assert!(observed.0.borrow().is_empty());
+    assert!(drainer.drain(&mut pipeline, 1));
+    assert_eq!(*observed.0.borrow(), [(2, 99)]);
+    drop(idle);
+    drop(active);
+    drainer.finish(pipeline).unwrap();
+}

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -143,6 +143,10 @@ name = "forked_google"
 approved_prefixes = ["cloud"]
 name_exceptions = { "google-cloud-auth" = "forked_google_cloud_auth" }
 
+# Experimental Btel telemetry crates.
+[[namespaces]]
+name = "btel"
+
 # bex namespace configuration
 [[namespaces]]
 name = "bex"


### PR DESCRIPTION
Adds a standalone telemetry replay benchmark so we can measure producer/ring/drainer costs before building the asynchronous event pipeline. The production VM and its profiler are unchanged.

The `btel_core` and `btel_transport` crates contain an isolated copy of the existing marker codec, clock, ring and supporting primitives, with copy origins recorded in `source-provenance.json`. A concrete drainer owns persistent round-robin traversal. The benchmark supports live clock reads and direct ring encoding, prepared-byte replay, and a feeder-only baseline; rejected writes retry with bounded spinning and yielding.

`btel_bench` prepares and validates deterministic workloads before timing, then measures completion through full drainage, process CPU and peak RSS. Producer counts, per-source rates, workload sizes, and memory limits are configurable. The Python plot command reproduces the reviewed rate-sweep and total-call charts from saved paired measurements, preserving raw costs, paired differences and observed ranges.

Reading order:
- `btel_bench/src/main.rs` and `replay.rs`: configuration, timing boundaries and worker lifetime.
- `btel_transport/src/runtime.rs`: producer ownership, round-robin draining and completion.
- `btel_bench/src/noop.rs`: the current discard-only path; event building, aggregation and publication are placeholders.
- `btel_bench/plots/plot.py`: reproducible plotting command and result validation.

Validation: 66 targeted native tests passed across the three Btel crates; targeted Clippy passed. The plot generator reproduced all three reference PNGs byte-for-byte with identical JSON summaries and rejected missing/duplicate/invalid measurements. Ten paired repetitions were measured per configuration, including a 420-run paced sweep with 1, 4 and 32 producers. These are synthetic end-to-end costs; baseline subtraction is approximate, and RSS includes preparation.

Stack: follows #4859. The next layer adds reusable batch copying and handoff to a downstream worker.
