### PR TITLE
Add reusable Btel batch copying and downstream handoff

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1802,6 +1802,7 @@ name = "btel_transport"
 version = "0.0.0-beta"
 dependencies = [
  "btel_core",
+ "crossbeam-queue",
  "crossbeam-utils",
  "loom",
 ]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -166,6 +166,7 @@ console_error_panic_hook = "0.1"
 miette = { version = "7.6", default-features = false, features = [ "fancy-no-syscall" ] }
 owo-colors = "4"
 crossbeam-channel = { version = "0.5" }
+crossbeam-queue = "0.3.12"
 # `CachePadded` for the profiling ring's cache-line-aligned field groups
 # (bex_events::prof, plan D3).
 crossbeam-utils = { version = "0.8" }

--- a/baml_language/crates/btel_bench/plots/plot.py
+++ b/baml_language/crates/btel_bench/plots/plot.py
@@ -16,7 +16,7 @@ target_calls_per_second/calls_per_run in identity.json; volume sweeps vary calls
 Output: summary.json, plus PNG and SVG versions of the established charts.
 Without --output, writes to RESULTS/plots. No benchmarks or Rust builds are run.
 Medians/min-max and paired CPU differences are preserved; no outliers are removed.
-Results describe the synthetic drain-only benchmark, not isolated VM overhead.
+Results describe the synthetic transport benchmark, not isolated VM overhead.
 """
 
 import argparse
@@ -43,6 +43,7 @@ def load_results(directory):
     dimension = "requested_calls_per_second" if is_rate else "calls"
     lookup = {}
     transport_settings = set()
+    stages = set()
     for run in runs:
         require(("requested_calls_per_second" in run) == is_rate, "Mixed sweep types")
         require(run["exit_code"] == 0, "Dataset contains a failed measured run")
@@ -63,8 +64,20 @@ def load_results(directory):
         )
         baseline = run["mode"] == "feeder-only"
         require(
-            result["preset"] == ("feeder-only" if baseline else "drain-only"),
-            "This chart's stage labels currently describe the drain-only benchmark",
+            result["preset"]
+            in (
+                {"feeder-only"}
+                if baseline
+                else {"drain-only", "copy-local", "copy-handoff"}
+            ),
+            "Unsupported consumer stage",
+        )
+        if not baseline:
+            stages.add(result["preset"])
+        require(
+            result.get("downstream_threads", 0)
+            == int(not baseline and result["preset"] == "copy-handoff"),
+            "Unexpected downstream worker count",
         )
         require(
             result["consumer_threads"] == (0 if baseline else 1),
@@ -101,12 +114,26 @@ def load_results(directory):
                     result["idle_timeout_micros"],
                     result["idle_rings"],
                     load["batch_markers"],
+                    result.get("batch_payload_bytes"),
+                    result.get("batch_source_ranges"),
+                    result.get("batch_queue_capacity"),
+                    result.get("batch_retained_capacity"),
                 )
             )
         lookup[key] = run
     require(
         len(transport_settings) == 1, "Mixed transport/pacing settings in one sweep"
     )
+    require(
+        len(stages) == 1,
+        "Mixed consumer stages; plot each stage's result directory separately",
+    )
+    identity["consumer_stage"] = stages.pop()
+    identity["stage_description"] = {
+        "drain-only": "discard drainer",
+        "copy-local": "local copy/reuse",
+        "copy-handoff": "copy/handoff + return",
+    }[identity["consumer_stage"]]
     threads = sorted({r["threads"] for r in runs})
     values = sorted({r[dimension] for r in runs})
     if is_rate:

--- a/baml_language/crates/btel_bench/plots/rate.py
+++ b/baml_language/crates/btel_bench/plots/rate.py
@@ -185,7 +185,7 @@ def render(identity, runs, root):
     fig.text(
         0.075,
         0.937,
-        f"{identity['calls_per_run'] / 1e6:g} million calls per run • requested rate split evenly across producers • clock + encoding + rings + discard drainer",
+        f"{identity['calls_per_run'] / 1e6:g} million calls per run • requested rate split evenly across producers • clock + encoding + rings + {identity.get('stage_description', 'discard drainer')}",
         fontsize=10.5,
         color="#475569",
     )

--- a/baml_language/crates/btel_bench/plots/sweep.py
+++ b/baml_language/crates/btel_bench/plots/sweep.py
@@ -1,0 +1,188 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Run the standard rate sweep, then use plot.py on each stage directory.
+
+uv run crates/btel_bench/plots/sweep.py /path/to/btel_bench /path/to/new-results
+
+Runs sequentially, timing through the binary's internal measurement boundaries.
+One feeder baseline is shared by all stages in each (repetition, threads, rate)
+block. Stage order rotates to reduce order bias. The saved identity explicitly
+records this correlation; these are matched blocks, not independent pairs.
+No outliers are removed. Fixture generation and process startup are not timed.
+"""
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--repetitions", type=int, default=10)
+    parser.add_argument("--calls", type=int, default=8_000_000)
+    parser.add_argument("--threads", type=int, nargs="+", default=[1, 4, 32])
+    parser.add_argument(
+        "--rates",
+        type=int,
+        nargs="+",
+        default=[
+            10_000_000,
+            25_000_000,
+            50_000_000,
+            75_000_000,
+            150_000_000,
+            250_000_000,
+            400_000_000,
+        ],
+    )
+    parser.add_argument(
+        "--stages",
+        nargs="+",
+        choices=["discard", "copy-local", "copy-handoff"],
+        default=["discard", "copy-local", "copy-handoff"],
+    )
+    args = parser.parse_args()
+    args.binary = args.binary.resolve()
+    if (
+        args.repetitions <= 0
+        or args.calls <= 0
+        or any(n <= 0 or args.calls % n for n in args.threads)
+        or any(r <= 0 for r in args.rates)
+    ):
+        parser.error(
+            "positive repetitions/rates required; total calls must divide evenly across threads"
+        )
+    if any(
+        len(values) != len(set(values))
+        for values in (args.threads, args.rates, args.stages)
+    ):
+        parser.error("duplicate scenario settings")
+    if args.output.exists() and any(args.output.iterdir()):
+        parser.error("output directory must be new or empty; preserve previous results")
+    args.output.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(args.binary.read_bytes()).hexdigest()
+    identity = {
+        "binary": str(args.binary),
+        "sha256": digest,
+        "platform": platform.platform(),
+        "repetitions": args.repetitions,
+        "calls_per_run": args.calls,
+        "target_calls_per_second": args.rates,
+        "threads": args.threads,
+        "stages": args.stages,
+        "method": "Sequential matched blocks; one shared feeder baseline per block; rotating stage order. Internal elapsed/CPU boundaries exclude setup. RSS includes preparation. No outlier removal. Batch pacing uses 1024 markers; 80 encoded bytes per function call plus thread boundary markers.",
+    }
+    saved = {stage: [] for stage in args.stages}
+    for stage in args.stages:
+        directory = args.output / stage
+        directory.mkdir()
+        (directory / "identity.json").write_text(
+            json.dumps(identity | {"consumer_mode": stage}, indent=2) + "\n"
+        )
+
+    def run(threads, rate, mode, stage, rep, warmup=False):
+        per_source_rate = rate * 80 // threads
+        command = [
+            str(args.binary),
+            "--consumer-mode",
+            stage,
+            "--producer-mode",
+            mode,
+            "--threads",
+            str(threads),
+            "--calls-per-source",
+            str(args.calls // threads),
+            "--source-rates",
+            ",".join([str(per_source_rate)] * threads),
+            "--depth",
+            "8",
+            "--memory-mib",
+            "256",
+        ]
+        proc = subprocess.run(
+            command, capture_output=True, text=True, timeout=120, check=False
+        )
+        if proc.returncode:
+            raise RuntimeError(f"Benchmark failed: {command}\n{proc.stderr}")
+        result = json.loads(proc.stdout)
+        baseline = mode == "feeder-only"
+        expected = {
+            "markers": args.calls * 2 + threads * 2,
+            "input_bytes": args.calls * 80 + threads * 54,
+            "clock_reads": 0 if baseline else args.calls * 2 + threads * 2,
+            "ring_bytes": 0 if baseline else args.calls * 80 + threads * 54,
+            "consumer_threads": 0 if baseline else 1,
+            "downstream_threads": int(not baseline and stage == "copy-handoff"),
+        }
+        if any(result.get(key) != value for key, value in expected.items()):
+            raise ValueError(f"Benchmark workload validation failed: {expected}")
+        if sum(source["calls"] for source in result["sources"]) != args.calls:
+            raise ValueError("Mismatched source call counts")
+        return {
+            "threads": threads,
+            "calls": args.calls,
+            "requested_calls_per_second": rate,
+            "mode": mode,
+            "rep": rep,
+            "warmup": warmup,
+            "command": command,
+            "exit_code": proc.returncode,
+            "result": result,
+        }
+
+    def persist(stage):
+        directory = args.output / stage
+        temporary = directory / "runs.tmp"
+        temporary.write_text(json.dumps(saved[stage], indent=2) + "\n")
+        temporary.replace(directory / "runs.json")
+
+    for threads in args.threads:
+        baseline = run(threads, args.rates[0], "feeder-only", "discard", -1, True)
+        for stage in args.stages:
+            saved[stage].extend(
+                [baseline, run(threads, args.rates[0], "encode-clock", stage, -1, True)]
+            )
+            persist(stage)
+    modes = ["baseline", *args.stages]
+    for rep in range(args.repetitions):
+        for rate_index, rate in enumerate(args.rates):
+            for thread_index, threads in enumerate(args.threads):
+                offset = (rep + rate_index + thread_index) % len(modes)
+                block = {}
+                for stage in modes[offset:] + modes[:offset]:
+                    block[stage] = run(
+                        threads,
+                        rate,
+                        "feeder-only" if stage == "baseline" else "encode-clock",
+                        "discard" if stage == "baseline" else stage,
+                        rep,
+                    )
+                for stage in args.stages:
+                    if (
+                        block["baseline"]["result"]["sources"]
+                        != block[stage]["result"]["sources"]
+                        or block["baseline"]["result"]["loads"]
+                        != block[stage]["result"]["loads"]
+                    ):
+                        raise ValueError("Mismatched workloads in measurement block")
+                    saved[stage].extend([block["baseline"], block[stage]])
+                    persist(stage)
+            print(
+                f"Repetition {rep + 1}/{args.repetitions}: {rate / 1e6:g}M calls/sec complete for all threads/stages",
+                flush=True,
+            )
+    if hashlib.sha256(args.binary.read_bytes()).hexdigest() != digest:
+        raise RuntimeError("Binary changed during the sweep")
+    print(f"Finished. Plot each stage directory under {args.output}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/baml_language/crates/btel_bench/plots/volume.py
+++ b/baml_language/crates/btel_bench/plots/volume.py
@@ -167,14 +167,16 @@ def render(identity, runs, root):
     fig.text(
         0.07,
         0.934,
-        "Full = feeder + clock + encoding + rings + discard drainer. Baseline = feeder with compiler barriers.",
+        f"Full = feeder + clock + encoding + rings + {identity.get('stage_description', 'discard drainer')}. Baseline = feeder with compiler barriers.",
         color="#475569",
         fontsize=10.5,
     )
     fig.text(
         0.07,
         0.101,
-        "1 synthetic call = enter + exit. Baseline emits no bytes and has no drainer; full replay has one round-robin drainer.",
+        "1 synthetic call = enter + exit. Baseline emits no bytes and has no drainer; full replay has one round-robin drainer."
+        if identity.get("consumer_stage") != "copy-handoff"
+        else "1 synthetic call = enter + exit. Full replay has a drainer plus a buffer-return worker; baseline has neither.",
         color="#475569",
         fontsize=10,
     )

--- a/baml_language/crates/btel_bench/src/feeder.rs
+++ b/baml_language/crates/btel_bench/src/feeder.rs
@@ -54,6 +54,68 @@ fn wait_for_capacity(factory: &btel_transport::SourceFactory, mut write: impl Fn
     }
 }
 
+/// Share exactly the same producer loop across consumer configurations.
+/// This single call is outside the per-marker loop; preventing inlining avoids
+/// consumer-type specialization changing producer code/register allocation.
+#[inline(never)]
+pub(crate) fn replay_source<const ENCODE: bool, const FEEDER_ONLY: bool>(
+    producer: &mut btel_transport::Producer,
+    factory: &btel_transport::SourceFactory,
+    fixture: &crate::workload::Fixture,
+    templates: &[Marker<'static>],
+    load: crate::replay::SourceLoad,
+    start: std::time::Instant,
+) -> Result<(), String> {
+    use std::{
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use btel_core::clock;
+    let mut offset = 0usize;
+    let delay = Duration::from_millis(load.start_delay_ms);
+    for (batch_index, batch) in fixture.lengths.chunks(load.batch_markers).enumerate() {
+        let paced_ns = if load.bytes_per_second == 0 {
+            0
+        } else {
+            offset as u128 * 1_000_000_000 / u128::from(load.bytes_per_second)
+        };
+        let pauses = u128::from(load.burst_pause_ms) * batch_index as u128 * 1_000_000;
+        let nanos = u64::try_from(paced_ns + pauses).map_err(|_| "pacing duration overflow")?;
+        let deadline = start
+            .checked_add(delay)
+            .and_then(|t| t.checked_add(Duration::from_nanos(nanos)))
+            .ok_or("pacing deadline overflow")?;
+        // Pacing clocks are per batch; EncodeClock also stamps each marker.
+        if load.bytes_per_second != 0 || load.start_delay_ms != 0 || load.burst_pause_ms != 0 {
+            if let Some(wait) = deadline.checked_duration_since(Instant::now()) {
+                thread::sleep(wait);
+            }
+        }
+        for (within_batch, &len) in batch.iter().enumerate() {
+            let end = offset + usize::from(len);
+            if ENCODE {
+                let mut marker = templates[batch_index * load.batch_markers + within_batch];
+                if FEEDER_ONLY {
+                    // Expose the local copy's contents through a
+                    // reference; passing the value caused an extra
+                    // stack copy. Keep offset work observable too.
+                    // Barriers still make subtraction an estimate.
+                    std::hint::black_box(&marker);
+                    std::hint::black_box(end);
+                } else {
+                    stamp(&mut marker, clock::now_ticks());
+                    write_or_wait(factory, || producer.write_marker(&marker));
+                }
+            } else {
+                write_or_wait(factory, || producer.write(&fixture.bytes[offset..end]));
+            }
+            offset = end;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{cell::RefCell, rc::Rc};

--- a/baml_language/crates/btel_bench/src/main.rs
+++ b/baml_language/crates/btel_bench/src/main.rs
@@ -3,15 +3,26 @@ use std::{io, path::PathBuf, time::Duration};
 
 use btel_bench::{
     feeder::ProducerMode,
-    replay::{self, ReplayConfig, SourceLoad},
+    replay::{self, ConsumerMode, ReplayConfig, SourceLoad},
     workload::Fixture,
 };
-use btel_transport::TransportConfig;
+use btel_transport::{TransportConfig, batch::BatchConfig};
 use clap::Parser;
 
 #[derive(Parser)]
 #[command(about = "Measure Btel ring producers and all-no-op pipeline (drain-only)")]
 struct Args {
+    /// Discard, copy/reuse on the drainer, or copy/handoff to a downstream worker.
+    #[arg(long, value_enum, default_value_t = ConsumerMode::Discard)]
+    consumer_mode: ConsumerMode,
+    #[arg(long, default_value_t = 262_144)]
+    batch_payload_bytes: usize,
+    #[arg(long, default_value_t = 256)]
+    batch_source_ranges: usize,
+    #[arg(long, default_value_t = 64)]
+    batch_queue_capacity: usize,
+    #[arg(long, default_value_t = 8)]
+    batch_retained_capacity: usize,
     /// Live clock/encoding, prepared-byte replay, or a feeder-only baseline.
     #[arg(long, value_enum, default_value_t = ProducerMode::EncodeClock)]
     producer_mode: ProducerMode,
@@ -87,6 +98,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let result = replay::run(
         ReplayConfig {
+            consumer_mode: args.consumer_mode,
+            batch: BatchConfig {
+                payload_bytes: args.batch_payload_bytes,
+                source_ranges: args.batch_source_ranges,
+                queue_batches: args.batch_queue_capacity,
+                retained_batches: args.batch_retained_capacity,
+            },
             producer_mode: args.producer_mode,
             transport: TransportConfig {
                 segment_bytes: args.segment_bytes,

--- a/baml_language/crates/btel_bench/src/noop.rs
+++ b/baml_language/crates/btel_bench/src/noop.rs
@@ -1,6 +1,9 @@
 //! No-op range handling and semantic stages; the concrete Drainer still polls rings.
 use btel_core::stage::{Aggregator, EventBuilder, MarkerBatch, MarkerRange, Publisher};
-use btel_transport::{Pipeline, RangeHandler};
+use btel_transport::{
+    DrainTarget, Pipeline, RangeHandler,
+    batch::{BatchProcessor, SharedMarkerBatch},
+};
 
 #[derive(Default)]
 pub struct DiscardRanges;
@@ -40,6 +43,22 @@ pub fn pipeline() -> NoopPipeline {
     )
 }
 
+impl DrainTarget for DiscardRanges {
+    type Output = ();
+    fn accept(&mut self, _: MarkerRange<'_>) {}
+    fn finish(self) {}
+}
+
+/// Keep copied payload observable without decoding or timing individual records.
+pub struct ReturnBatches;
+impl BatchProcessor for ReturnBatches {
+    type Output = ();
+    fn process(&mut self, batch: &SharedMarkerBatch) {
+        std::hint::black_box(batch);
+    }
+    fn finish(self) {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,7 +69,9 @@ mod tests {
             source_id: 1,
             bytes: &[1, 2, 3],
         };
-        DiscardRanges.accept(range, |_| panic!("discard must not manufacture a batch"));
+        RangeHandler::accept(&mut DiscardRanges, range, |_| {
+            panic!("discard must not manufacture a batch")
+        });
         NoopEventBuilder.build(range, |()| panic!("no-op builder emitted"));
         NoopAggregator.observe(&(), |()| panic!("no-op aggregator emitted"));
         let (factory, mut drainer) =

--- a/baml_language/crates/btel_bench/src/replay.rs
+++ b/baml_language/crates/btel_bench/src/replay.rs
@@ -10,14 +10,26 @@ use std::{
 };
 
 use btel_core::{clock, marker::Marker};
-use btel_transport::{TransportConfig, transport};
+use btel_transport::{
+    DrainTarget, TransportConfig,
+    batch::{BatchConfig, BatchReceiver, CopyHandoff, CopyLocal},
+    transport,
+};
 use serde::Serialize;
 
 use crate::{
-    feeder::{ProducerMode, stamp, write_or_wait},
+    feeder::ProducerMode,
     noop,
     workload::{Fixture, Manifest},
 };
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConsumerMode {
+    Discard,
+    CopyLocal,
+    CopyHandoff,
+}
 
 #[derive(Clone, Copy, Debug, Serialize)]
 pub struct SourceLoad {
@@ -29,6 +41,8 @@ pub struct SourceLoad {
 
 #[derive(Clone, Copy)]
 pub struct ReplayConfig {
+    pub consumer_mode: ConsumerMode,
+    pub batch: BatchConfig,
     pub producer_mode: ProducerMode,
     pub transport: TransportConfig,
     pub source_budget: usize,
@@ -38,6 +52,12 @@ pub struct ReplayConfig {
 
 #[derive(Serialize)]
 pub struct ReplayResult {
+    pub consumer_mode: ConsumerMode,
+    pub downstream_threads: usize,
+    pub batch_payload_bytes: usize,
+    pub batch_source_ranges: usize,
+    pub batch_queue_capacity: usize,
+    pub batch_retained_capacity: usize,
     pub producer_mode: ProducerMode,
     pub clock_kind: Option<String>,
     pub clock_reads: u64,
@@ -105,16 +125,46 @@ pub fn run(
     config: ReplayConfig,
     fixtures: Vec<(Fixture, SourceLoad)>,
 ) -> Result<ReplayResult, String> {
-    match config.producer_mode {
-        ProducerMode::Prepared => run_with::<false, false>(config, fixtures),
-        ProducerMode::EncodeClock => run_with::<true, false>(config, fixtures),
-        ProducerMode::FeederOnly => run_with::<true, true>(config, fixtures),
+    if matches!(config.producer_mode, ProducerMode::FeederOnly) {
+        return run_target(config, fixtures, noop::DiscardRanges, None);
+    }
+    match config.consumer_mode {
+        ConsumerMode::Discard => run_target(config, fixtures, noop::DiscardRanges, None),
+        ConsumerMode::CopyLocal => run_target(
+            config,
+            fixtures,
+            CopyLocal::new(config.batch, noop::ReturnBatches)?,
+            None,
+        ),
+        ConsumerMode::CopyHandoff => {
+            let (target, receiver) = CopyHandoff::new(config.batch)?;
+            run_target(config, fixtures, target, Some(receiver))
+        }
     }
 }
 
-fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
+fn run_target<T: DrainTarget<Output = ()> + Send + 'static>(
     config: ReplayConfig,
     fixtures: Vec<(Fixture, SourceLoad)>,
+    target: T,
+    receiver: Option<BatchReceiver>,
+) -> Result<ReplayResult, String> {
+    match config.producer_mode {
+        ProducerMode::Prepared => run_with::<false, false, T>(config, fixtures, target, receiver),
+        ProducerMode::EncodeClock => run_with::<true, false, T>(config, fixtures, target, receiver),
+        ProducerMode::FeederOnly => run_with::<true, true, T>(config, fixtures, target, receiver),
+    }
+}
+
+fn run_with<
+    const ENCODE: bool,
+    const FEEDER_ONLY: bool,
+    T: DrainTarget<Output = ()> + Send + 'static,
+>(
+    config: ReplayConfig,
+    fixtures: Vec<(Fixture, SourceLoad)>,
+    target: T,
+    batch_receiver: Option<BatchReceiver>,
 ) -> Result<ReplayResult, String> {
     if ENCODE && !FEEDER_ONLY {
         clock::init();
@@ -166,6 +216,17 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
     let gate = Arc::new(Gate::new());
     let stopped = Arc::new(AtomicBool::new(false));
     let (ready_tx, ready_rx) = mpsc::channel();
+    let downstream = batch_receiver.map(|receiver| {
+        let gate = gate.clone();
+        let ready = ready_tx.clone();
+        thread::spawn(move || {
+            ready.send(Ok::<_, String>(())).unwrap();
+            if gate.wait().is_some() {
+                receiver.run(noop::ReturnBatches);
+            }
+            Instant::now()
+        })
+    });
     // A feeder baseline has the same producer setup, but no drainer competing
     // for CPU. Const specialization removes this choice from the marker loop.
     let receiver = if FEEDER_ONLY {
@@ -180,7 +241,7 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
             if gate.wait().is_none() {
                 return Ok(Instant::now());
             }
-            let mut pipeline = noop::pipeline();
+            let mut pipeline = target;
             while !stopped.load(Ordering::Acquire) {
                 if !drainer.drain(&mut pipeline, config.source_budget) {
                     drainer.idle(&mut pipeline, config.source_budget, config.idle_timeout);
@@ -212,51 +273,14 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
             let Some(start) = gate.wait() else {
                 return Err("replay aborted during setup".into());
             };
-            let mut offset = 0usize;
-            let delay = Duration::from_millis(load.start_delay_ms);
-            for (batch_index, batch) in fixture.lengths.chunks(load.batch_markers).enumerate() {
-                let paced_ns = if load.bytes_per_second == 0 {
-                    0
-                } else {
-                    offset as u128 * 1_000_000_000 / u128::from(load.bytes_per_second)
-                };
-                let pauses = u128::from(load.burst_pause_ms) * batch_index as u128 * 1_000_000;
-                let nanos =
-                    u64::try_from(paced_ns + pauses).map_err(|_| "pacing duration overflow")?;
-                let deadline = start
-                    .checked_add(delay)
-                    .and_then(|t| t.checked_add(Duration::from_nanos(nanos)))
-                    .ok_or("pacing deadline overflow")?;
-                // Pacing clocks are per batch; EncodeClock also stamps each marker.
-                if load.bytes_per_second != 0
-                    || load.start_delay_ms != 0
-                    || load.burst_pause_ms != 0
-                {
-                    if let Some(wait) = deadline.checked_duration_since(Instant::now()) {
-                        thread::sleep(wait);
-                    }
-                }
-                for (within_batch, &len) in batch.iter().enumerate() {
-                    let end = offset + usize::from(len);
-                    if ENCODE {
-                        let mut marker = templates[batch_index * load.batch_markers + within_batch];
-                        if FEEDER_ONLY {
-                            // Expose the local copy's contents through a
-                            // reference; passing the value caused an extra
-                            // stack copy. Keep offset work observable too.
-                            // Barriers still make subtraction an estimate.
-                            std::hint::black_box(&marker);
-                            std::hint::black_box(end);
-                        } else {
-                            stamp(&mut marker, clock::now_ticks());
-                            write_or_wait(&factory, || producer.write_marker(&marker));
-                        }
-                    } else {
-                        write_or_wait(&factory, || producer.write(&fixture.bytes[offset..end]));
-                    }
-                    offset = end;
-                }
-            }
+            crate::feeder::replay_source::<ENCODE, FEEDER_ONLY>(
+                &mut producer,
+                &factory,
+                &fixture,
+                &templates,
+                load,
+                start,
+            )?;
             // Keep prepared input alive until the thread exits, after producer
             // drop publishes its last write. No per-marker measurement counter.
             Ok::<_, String>((fixture, templates))
@@ -264,7 +288,8 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
     }
     drop(ready_tx);
     let mut setup_error = None;
-    for _ in 0..writers.len() + usize::from(receiver.is_some()) {
+    for _ in 0..writers.len() + usize::from(receiver.is_some()) + usize::from(downstream.is_some())
+    {
         match ready_rx.recv().map_err(|e| e.to_string())? {
             Ok(()) => {}
             Err(e) => setup_error = Some(e),
@@ -298,6 +323,10 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
         Some(receiver) => receiver.join().map_err(|_| "drainer panicked")??,
         None => producers_done,
     };
+    let finish = match downstream {
+        Some(worker) => finish.max(worker.join().map_err(|_| "batch worker panicked")?),
+        None => finish,
+    };
     let usage_end = usage();
     if let Some(error) = error {
         return Err(error);
@@ -309,13 +338,25 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
     )]
     let bytes_per_second = (!FEEDER_ONLY).then_some(input_bytes as f64 / elapsed);
     Ok(ReplayResult {
+        consumer_mode: config.consumer_mode,
+        downstream_threads: usize::from(
+            !FEEDER_ONLY && matches!(config.consumer_mode, ConsumerMode::CopyHandoff),
+        ),
+        batch_payload_bytes: config.batch.payload_bytes,
+        batch_source_ranges: config.batch.source_ranges,
+        batch_queue_capacity: config.batch.queue_batches,
+        batch_retained_capacity: config.batch.retained_batches,
         producer_mode: config.producer_mode,
         clock_kind: (ENCODE && !FEEDER_ONLY).then(|| format!("{:?}", clock::meta().kind)),
         clock_reads: if ENCODE && !FEEDER_ONLY { markers } else { 0 },
         preset: if FEEDER_ONLY {
             "feeder-only"
         } else {
-            "drain-only"
+            match config.consumer_mode {
+                ConsumerMode::Discard => "drain-only",
+                ConsumerMode::CopyLocal => "copy-local",
+                ConsumerMode::CopyHandoff => "copy-handoff",
+            }
         },
         full_ring_policy: if FEEDER_ONLY {
             "not-applicable"
@@ -325,7 +366,7 @@ fn run_with<const ENCODE: bool, const FEEDER_ONLY: bool>(
         pipeline: if FEEDER_ONLY {
             "none"
         } else {
-            std::any::type_name::<noop::NoopPipeline>()
+            std::any::type_name::<T>()
         },
         source_threads: sources.len(),
         consumer_threads: usize::from(!FEEDER_ONLY),
@@ -384,7 +425,7 @@ mod tests {
 
     #[test]
     fn baseline_preserves_workload_but_reports_no_telemetry_work() {
-        let run_mode = |producer_mode| {
+        let run_mode = |producer_mode, consumer_mode| {
             let fixtures = [(1, 25), (2, 41)]
                 .into_iter()
                 .map(|(source, calls)| {
@@ -401,6 +442,8 @@ mod tests {
                 .collect();
             run(
                 ReplayConfig {
+                    consumer_mode,
+                    batch: BatchConfig::default(),
                     producer_mode,
                     transport: TransportConfig::default(),
                     source_budget: 1,
@@ -411,27 +454,38 @@ mod tests {
             )
             .unwrap()
         };
-        let baseline = run_mode(ProducerMode::FeederOnly);
-        let full = run_mode(ProducerMode::EncodeClock);
-        assert_eq!(baseline.input_bytes, full.input_bytes);
-        assert_eq!(baseline.markers, full.markers);
-        assert_eq!(baseline.source_threads, full.source_threads);
-        assert_eq!(
-            serde_json::to_value(&baseline.sources).unwrap(),
-            serde_json::to_value(&full.sources).unwrap()
-        );
-        assert_eq!(baseline.clock_reads, 0);
-        assert!(baseline.clock_kind.is_none());
-        assert_eq!(baseline.consumer_threads, 0);
-        assert_eq!(baseline.ring_bytes, 0);
-        assert_eq!(baseline.ring_markers, 0);
-        assert!(baseline.bytes_per_second.is_none());
-        assert!(baseline.final_drain_seconds.abs() < f64::EPSILON);
-        assert!(baseline.replay_seconds >= 0.001);
-        assert_eq!(full.clock_reads, full.markers);
-        assert_eq!(full.ring_bytes, full.input_bytes);
-        assert_eq!(full.ring_markers, full.markers);
-        assert_eq!(full.consumer_threads, 1);
-        assert!(full.bytes_per_second.unwrap() > 0.0);
+        for consumer_mode in [
+            ConsumerMode::Discard,
+            ConsumerMode::CopyLocal,
+            ConsumerMode::CopyHandoff,
+        ] {
+            let baseline = run_mode(ProducerMode::FeederOnly, consumer_mode);
+            let full = run_mode(ProducerMode::EncodeClock, consumer_mode);
+            assert_eq!(baseline.input_bytes, full.input_bytes);
+            assert_eq!(baseline.markers, full.markers);
+            assert_eq!(baseline.source_threads, full.source_threads);
+            assert_eq!(
+                serde_json::to_value(&baseline.sources).unwrap(),
+                serde_json::to_value(&full.sources).unwrap()
+            );
+            assert_eq!(baseline.clock_reads, 0);
+            assert!(baseline.clock_kind.is_none());
+            assert_eq!(baseline.consumer_threads, 0);
+            assert_eq!(baseline.ring_bytes, 0);
+            assert_eq!(baseline.ring_markers, 0);
+            assert!(baseline.bytes_per_second.is_none());
+            assert!(baseline.final_drain_seconds.abs() < f64::EPSILON);
+            assert!(baseline.replay_seconds >= 0.001);
+            assert_eq!(full.clock_reads, full.markers);
+            assert_eq!(full.ring_bytes, full.input_bytes);
+            assert_eq!(full.ring_markers, full.markers);
+            assert_eq!(full.consumer_threads, 1);
+            assert!(full.bytes_per_second.unwrap() > 0.0);
+            assert_eq!(baseline.downstream_threads, 0);
+            assert_eq!(
+                full.downstream_threads,
+                usize::from(matches!(consumer_mode, ConsumerMode::CopyHandoff))
+            );
+        }
     }
 }

--- a/baml_language/crates/btel_transport/Cargo.toml
+++ b/baml_language/crates/btel_transport/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 btel_core.workspace = true
+crossbeam-queue.workspace = true
 crossbeam-utils.workspace = true
 
 [target.'cfg(baml_loom)'.dependencies]

--- a/baml_language/crates/btel_transport/src/batch.rs
+++ b/baml_language/crates/btel_transport/src/batch.rs
@@ -1,0 +1,536 @@
+//! Reusable byte batches and ownership transfer after the round-robin drainer.
+//!
+//! Neither path decodes markers. Each committed source range is copied whole,
+//! then the source ring can reuse it. Only this stage may allocate more memory
+//! during a downstream backlog; the VM producer is unchanged.
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, Thread},
+    time::Duration,
+};
+
+use btel_core::stage::MarkerRange;
+use crossbeam_queue::ArrayQueue;
+
+use crate::DrainTarget;
+
+#[derive(Clone, Copy, Debug)]
+pub struct BatchConfig {
+    pub payload_bytes: usize,
+    pub source_ranges: usize,
+    pub queue_batches: usize,
+    pub retained_batches: usize,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self {
+            payload_bytes: 256 * 1024,
+            source_ranges: 256,
+            queue_batches: 64,
+            retained_batches: 8,
+        }
+    }
+}
+
+impl BatchConfig {
+    pub fn validate(self) -> Result<(), &'static str> {
+        if self.payload_bytes == 0
+            || self.source_ranges == 0
+            || self.queue_batches == 0
+            || self.retained_batches == 0
+        {
+            return Err(
+                "batch payload, descriptor, queue and retention capacities must be positive",
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SourceRange {
+    source_id: u64,
+    start: usize,
+    end: usize,
+}
+
+/// The allocation belongs to the transport. Builders borrow ranges until their
+/// processing call returns; they cannot retain a reference to recycled memory.
+#[derive(Debug)]
+pub struct SharedMarkerBatch {
+    bytes: Vec<u8>,
+    sources: Vec<SourceRange>,
+}
+
+impl SharedMarkerBatch {
+    fn new(config: BatchConfig) -> Self {
+        Self {
+            bytes: Vec::with_capacity(config.payload_bytes),
+            sources: Vec::with_capacity(config.source_ranges),
+        }
+    }
+
+    pub fn ranges(&self) -> impl ExactSizeIterator<Item = MarkerRange<'_>> {
+        self.sources.iter().map(|source| MarkerRange {
+            source_id: source.source_id,
+            bytes: &self.bytes[source.start..source.end],
+        })
+    }
+
+    fn needs_flush(&self, range: MarkerRange<'_>) -> bool {
+        !self.sources.is_empty()
+            && (self.sources.len() == self.sources.capacity()
+                || range.bytes.len() > self.bytes.capacity() - self.bytes.len())
+    }
+
+    fn append(&mut self, range: MarkerRange<'_>) {
+        let start = self.bytes.len();
+        // An oversized range can grow an empty batch. It is never split into
+        // partial records and does not cause an endless empty-batch handoff.
+        self.bytes.extend_from_slice(range.bytes);
+        self.sources.push(SourceRange {
+            source_id: range.source_id,
+            start,
+            end: self.bytes.len(),
+        });
+    }
+
+    fn clear(&mut self) {
+        self.bytes.clear();
+        self.sources.clear();
+    }
+}
+
+pub trait BatchProcessor {
+    type Output;
+    fn process(&mut self, batch: &SharedMarkerBatch);
+    fn finish(self) -> Self::Output;
+}
+
+/// Copy into one reusable allocation and process on the drainer thread.
+/// This isolates byte-copy cost before adding cross-thread handoff.
+pub struct CopyLocal<P> {
+    batch: SharedMarkerBatch,
+    processor: P,
+}
+
+impl<P: BatchProcessor> CopyLocal<P> {
+    pub fn new(config: BatchConfig, processor: P) -> Result<Self, &'static str> {
+        config.validate()?;
+        Ok(Self {
+            batch: SharedMarkerBatch::new(config),
+            processor,
+        })
+    }
+
+    fn flush(&mut self) {
+        if !self.batch.sources.is_empty() {
+            self.processor.process(&self.batch);
+            self.batch.clear();
+        }
+    }
+}
+
+impl<P: BatchProcessor> DrainTarget for CopyLocal<P> {
+    type Output = P::Output;
+    fn accept(&mut self, range: MarkerRange<'_>) {
+        if range.bytes.is_empty() {
+            return;
+        }
+        if self.batch.needs_flush(range) {
+            self.flush();
+        }
+        self.batch.append(range);
+    }
+    fn end_step(&mut self) {
+        self.flush();
+    }
+    fn finish(mut self) -> Self::Output {
+        self.flush();
+        self.processor.finish()
+    }
+}
+
+struct Shared {
+    // Fixed-capacity atomic queues, used strictly one sender/one receiver.
+    // Allocation-free push/pop; no new unsafe queue implementation to audit.
+    ready: ArrayQueue<SharedMarkerBatch>,
+    recycled: ArrayQueue<SharedMarkerBatch>,
+    closed: AtomicBool,
+    receiver_alive: AtomicBool,
+    sleeping: AtomicBool,
+    worker: OnceLock<Thread>,
+}
+
+impl Shared {
+    fn notify(&self) {
+        if self.sleeping.load(Ordering::Acquire) {
+            if let Some(worker) = self.worker.get() {
+                worker.unpark();
+            }
+        }
+    }
+}
+
+/// Sole sender, owned by the drainer. Saturated ready queues spill into an
+/// ordered, sender-local backlog rather than blocking OS-ring drainage or
+/// dropping markers. Its memory can grow without a fixed limit in this phase.
+pub struct CopyHandoff {
+    shared: Arc<Shared>,
+    current: SharedMarkerBatch,
+    pending: VecDeque<SharedMarkerBatch>,
+    config: BatchConfig,
+}
+
+pub struct BatchReceiver {
+    shared: Arc<Shared>,
+}
+
+impl CopyHandoff {
+    pub fn new(config: BatchConfig) -> Result<(Self, BatchReceiver), &'static str> {
+        config.validate()?;
+        let shared = Arc::new(Shared {
+            ready: ArrayQueue::new(config.queue_batches),
+            recycled: ArrayQueue::new(config.retained_batches),
+            closed: AtomicBool::new(false),
+            receiver_alive: AtomicBool::new(true),
+            sleeping: AtomicBool::new(false),
+            worker: OnceLock::new(),
+        });
+        for _ in 0..config.retained_batches {
+            shared
+                .recycled
+                .push(SharedMarkerBatch::new(config))
+                .unwrap();
+        }
+        let receiver = BatchReceiver {
+            shared: shared.clone(),
+        };
+        Ok((
+            Self {
+                shared,
+                current: SharedMarkerBatch::new(config),
+                pending: VecDeque::new(),
+                config,
+            },
+            receiver,
+        ))
+    }
+
+    fn check_receiver(&self) {
+        assert!(
+            self.shared.receiver_alive.load(Ordering::Acquire),
+            "batch receiver exited before transport completion"
+        );
+    }
+
+    fn pump(&mut self) {
+        self.check_receiver();
+        // Bound this work even when the worker concurrently empties the queue.
+        for _ in 0..self.config.queue_batches {
+            let Some(batch) = self.pending.pop_front() else {
+                break;
+            };
+            if let Err(batch) = self.shared.ready.push(batch) {
+                self.pending.push_front(batch);
+                break;
+            }
+            self.shared.notify();
+        }
+        if self.pending.is_empty() && self.pending.capacity() > self.config.queue_batches {
+            self.pending.shrink_to(self.config.queue_batches);
+        }
+    }
+
+    fn flush(&mut self) {
+        self.pump();
+        if self.current.sources.is_empty() {
+            return;
+        }
+        let next = self
+            .shared
+            .recycled
+            .pop()
+            .unwrap_or_else(|| SharedMarkerBatch::new(self.config));
+        let batch = std::mem::replace(&mut self.current, next);
+        if self.pending.is_empty() {
+            match self.shared.ready.push(batch) {
+                Ok(()) => self.shared.notify(),
+                Err(batch) => self.pending.push_back(batch),
+            }
+        } else {
+            self.pending.push_back(batch);
+        }
+    }
+}
+
+impl DrainTarget for CopyHandoff {
+    type Output = ();
+    fn accept(&mut self, range: MarkerRange<'_>) {
+        if range.bytes.is_empty() {
+            return;
+        }
+        if self.current.needs_flush(range) {
+            self.flush();
+        }
+        self.current.append(range);
+    }
+    fn end_step(&mut self) {
+        self.flush();
+    }
+    fn finish(mut self) {
+        self.flush();
+        while !self.pending.is_empty() {
+            self.pump();
+            if !self.pending.is_empty() {
+                thread::yield_now();
+            }
+        }
+        // Drop publishes closure only after the final pending batch is queued.
+    }
+}
+
+impl Drop for CopyHandoff {
+    fn drop(&mut self) {
+        self.shared.closed.store(true, Ordering::Release);
+        self.shared.notify();
+    }
+}
+
+impl BatchReceiver {
+    /// Process every queued batch before observing end-of-input. Extra buffers
+    /// from a spike are freed here when the bounded return pool is full.
+    pub fn run<P: BatchProcessor>(self, mut processor: P) -> P::Output {
+        let _ = self.shared.worker.set(thread::current());
+        loop {
+            if let Some(mut batch) = self.shared.ready.pop() {
+                self.shared.sleeping.store(false, Ordering::Release);
+                processor.process(&batch);
+                batch.clear();
+                // A full recycle queue discards only empty storage, never data.
+                drop(self.shared.recycled.push(batch));
+                continue;
+            }
+            if self.shared.closed.load(Ordering::Acquire) {
+                // Recheck after acquiring closure: final enqueue precedes it.
+                if self.shared.ready.is_empty() {
+                    break;
+                }
+                continue;
+            }
+            self.shared.sleeping.store(true, Ordering::Release);
+            // Arm before checking, so a concurrent publish either appears in
+            // the queue or leaves an unpark token. Timeout is a fallback.
+            if self.shared.ready.is_empty() && !self.shared.closed.load(Ordering::Acquire) {
+                thread::park_timeout(Duration::from_micros(200));
+            }
+            self.shared.sleeping.store(false, Ordering::Release);
+        }
+        processor.finish()
+    }
+}
+
+impl Drop for BatchReceiver {
+    fn drop(&mut self) {
+        self.shared.receiver_alive.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct Records(Vec<(u64, Vec<u8>)>);
+    impl BatchProcessor for Records {
+        type Output = Vec<(u64, Vec<u8>)>;
+        fn process(&mut self, batch: &SharedMarkerBatch) {
+            self.0
+                .extend(batch.ranges().map(|r| (r.source_id, r.bytes.to_vec())));
+        }
+        fn finish(self) -> Self::Output {
+            self.0
+        }
+    }
+
+    fn config() -> BatchConfig {
+        BatchConfig {
+            payload_bytes: 16,
+            source_ranges: 2,
+            queue_batches: 2,
+            retained_batches: 2,
+        }
+    }
+
+    #[test]
+    fn local_copy_preserves_sources_whole_ranges_and_oversized_input() {
+        let mut target = CopyLocal::new(config(), Records::default()).unwrap();
+        let expected = [
+            (1, vec![1; 9]),
+            (2, vec![2; 9]),
+            (3, vec![3; 65]),
+            (4, vec![4; 1]),
+        ];
+        for (source_id, bytes) in &expected {
+            target.accept(MarkerRange {
+                source_id: *source_id,
+                bytes,
+            });
+        }
+        assert_eq!(target.finish(), expected);
+    }
+
+    #[test]
+    fn descriptor_exhaustion_flushes_without_reallocating_the_local_buffer() {
+        let mut target = CopyLocal::new(config(), Records::default()).unwrap();
+        let ptr = target.batch.bytes.as_ptr();
+        for source_id in 0..101 {
+            target.accept(MarkerRange {
+                source_id,
+                bytes: &[7],
+            });
+            assert_eq!(target.batch.bytes.as_ptr(), ptr);
+            assert!(target.batch.sources.len() <= 2);
+        }
+        let records = target.finish();
+        assert_eq!(
+            records,
+            (0..101).map(|id| (id, vec![7])).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn saturated_handoff_grows_without_losing_or_reordering_bytes_and_shrinks_afterward() {
+        let (mut sender, receiver) = CopyHandoff::new(config()).unwrap();
+        let shared = sender.shared.clone();
+        // Withhold the downstream worker until far beyond queue/pool capacity.
+        // Acceptance must still return, because draining cannot block on it.
+        for seq in 0u64..1000 {
+            sender.accept(MarkerRange {
+                source_id: seq % 3,
+                bytes: &seq.to_le_bytes(),
+            });
+            sender.end_step();
+        }
+        assert!(sender.pending.len() > config().queue_batches);
+        let worker = thread::spawn(move || receiver.run(Records::default()));
+        // Do not explicitly flush the last partial batch: finish must deliver it.
+        sender.accept(MarkerRange {
+            source_id: 9,
+            bytes: &[42],
+        });
+        sender.finish();
+        let actual = worker.join().unwrap();
+        let mut expected = (0u64..1000)
+            .map(|seq| (seq % 3, seq.to_le_bytes().to_vec()))
+            .collect::<Vec<_>>();
+        expected.push((9, vec![42]));
+        assert_eq!(actual, expected);
+        assert!(shared.ready.is_empty());
+        assert_eq!(shared.recycled.len(), config().retained_batches);
+        assert!(!shared.receiver_alive.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn returned_buffers_reuse_the_preallocated_payload_memory() {
+        struct Ack(std::sync::mpsc::Sender<()>);
+        impl BatchProcessor for Ack {
+            type Output = ();
+            fn process(&mut self, _: &SharedMarkerBatch) {
+                self.0.send(()).unwrap();
+            }
+            fn finish(self) {}
+        }
+        let (mut sender, receiver) = CopyHandoff::new(config()).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut pointers = std::collections::HashSet::new();
+        pointers.insert(sender.current.bytes.as_ptr() as usize);
+        // All initial allocations can be inspected here without timing counters.
+        let first = sender.shared.recycled.pop().unwrap();
+        let second = sender.shared.recycled.pop().unwrap();
+        pointers.insert(first.bytes.as_ptr() as usize);
+        pointers.insert(second.bytes.as_ptr() as usize);
+        sender.shared.recycled.push(first).unwrap();
+        sender.shared.recycled.push(second).unwrap();
+        let worker = thread::spawn(move || receiver.run(Ack(tx)));
+        for _ in 0..100 {
+            sender.accept(MarkerRange {
+                source_id: 1,
+                bytes: &[1, 2, 3],
+            });
+            sender.end_step();
+            rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            assert!(pointers.contains(&(sender.current.bytes.as_ptr() as usize)));
+        }
+        sender.finish();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn receiver_failure_is_reported_instead_of_spinning_forever() {
+        let (mut sender, receiver) = CopyHandoff::new(config()).unwrap();
+        drop(receiver);
+        sender.accept(MarkerRange {
+            source_id: 1,
+            bytes: &[1],
+        });
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sender.finish())).is_err()
+        );
+    }
+
+    #[test]
+    fn real_rings_finish_every_source_through_the_downstream_worker() {
+        let (factory, mut drainer) = crate::transport(crate::TransportConfig {
+            segment_bytes: 64,
+            memory_bytes: 32 * 1024 * 1024,
+            freelist_segments: 2,
+        })
+        .unwrap();
+        let (mut target, receiver) = CopyHandoff::new(BatchConfig {
+            payload_bytes: 128,
+            ..config()
+        })
+        .unwrap();
+        let worker = thread::spawn(move || receiver.run(Records::default()));
+        let writers: Vec<_> = (1..=3)
+            .map(|source_id| {
+                let factory = factory.clone();
+                thread::spawn(move || {
+                    let mut producer = factory.producer(source_id).unwrap();
+                    for seq in 0u64..4097 {
+                        assert!(producer.write(&seq.to_le_bytes()));
+                    }
+                })
+            })
+            .collect();
+        while writers.iter().any(|w| !w.is_finished()) {
+            drainer.drain(&mut target, 1);
+            thread::yield_now();
+        }
+        for writer in writers {
+            writer.join().unwrap();
+        }
+        drainer.finish(target).unwrap();
+        let records = worker.join().unwrap();
+        for source in 1..=3 {
+            let actual: Vec<_> = records
+                .iter()
+                .filter(|(id, _)| *id == source)
+                .flat_map(|(_, bytes)| {
+                    bytes
+                        .as_chunks::<8>()
+                        .0
+                        .iter()
+                        .map(|bytes| u64::from_le_bytes(*bytes))
+                })
+                .collect();
+            assert_eq!(actual, (0..4097).collect::<Vec<_>>());
+        }
+    }
+}

--- a/baml_language/crates/btel_transport/src/drain_target.rs
+++ b/baml_language/crates/btel_transport/src/drain_target.rs
@@ -1,0 +1,18 @@
+//! Byte disposition is independent of both ring traversal and semantic stages.
+use btel_core::stage::MarkerRange;
+
+pub trait DrainTarget {
+    type Output;
+
+    /// Returning accepts the whole range. The source ring may then reuse it;
+    /// a retaining target must finish its copy before returning.
+    fn accept(&mut self, range: MarkerRange<'_>);
+
+    /// End of one bounded round-robin step. Publish partial batches here so
+    /// sparse sources do not wait for a payload buffer to fill.
+    fn end_step(&mut self) {}
+
+    /// All producers are gone and their rings have been drained. Deliver any
+    /// remaining bytes before closing the downstream input.
+    fn finish(self) -> Self::Output;
+}

--- a/baml_language/crates/btel_transport/src/lib.rs
+++ b/baml_language/crates/btel_transport/src/lib.rs
@@ -1,5 +1,12 @@
-//! Experimental fork of the producer ring plus a new no-op pipeline runtime.
-//! Start reading `pipeline.rs`, then `range_handler.rs` and `runtime.rs`.
+//! Experimental producer rings and reusable batch transport.
+//! Start with `runtime.rs` and `drain_target.rs`, then `batch.rs`.
+//! `pipeline.rs` retains the synchronous semantic-stage adapter.
+#[cfg(not(baml_loom))]
+pub mod batch;
+#[cfg(not(baml_loom))]
+mod drain_target;
+#[cfg(not(baml_loom))]
+pub use drain_target::DrainTarget;
 #[allow(
     dead_code,
     reason = "preserve copied governor behavior for later experiments"

--- a/baml_language/crates/btel_transport/src/pipeline.rs
+++ b/baml_language/crates/btel_transport/src/pipeline.rs
@@ -1,7 +1,25 @@
 //! The stage assembly. No runtime mode enum or trait objects enter this path.
 use btel_core::stage::{Aggregator, EventBuilder, MarkerBatch, MarkerRange, Publisher};
 
-use crate::RangeHandler;
+use crate::{DrainTarget, RangeHandler};
+
+impl<H, B, A, P> DrainTarget for Pipeline<H, B, A, P>
+where
+    H: RangeHandler,
+    B: EventBuilder,
+    A: Aggregator<B::Event>,
+    P: Publisher<B::Event, A::Aggregate>,
+{
+    type Output = P;
+
+    fn accept(&mut self, input: MarkerRange<'_>) {
+        self.consume(input);
+    }
+
+    fn finish(self) -> P {
+        Self::finish(self)
+    }
+}
 
 pub struct Pipeline<H, B, A, P> {
     range_handler: H,

--- a/baml_language/crates/btel_transport/src/runtime.rs
+++ b/baml_language/crates/btel_transport/src/runtime.rs
@@ -14,13 +14,10 @@ use std::{
     time::Duration,
 };
 
-use btel_core::{
-    marker::Marker,
-    stage::{Aggregator, EventBuilder, MarkerRange, Publisher},
-};
+use btel_core::{marker::Marker, stage::MarkerRange};
 
 use crate::{
-    Pipeline, RangeHandler,
+    DrainTarget,
     memory::ProfilerMemoryGovernor,
     registry::{Cursor, Registry},
     ring::{OSThreadMarkerRingHandle, RingCtx},
@@ -234,17 +231,7 @@ impl Drainer {
     }
 
     /// A bounded round-robin service step shared by all drainer presets.
-    pub fn drain<H, B, A, P>(
-        &mut self,
-        pipeline: &mut Pipeline<H, B, A, P>,
-        source_budget: usize,
-    ) -> bool
-    where
-        H: RangeHandler,
-        B: EventBuilder,
-        A: Aggregator<B::Event>,
-        P: Publisher<B::Event, A::Aggregate>,
-    {
+    pub fn drain<T: DrainTarget>(&mut self, pipeline: &mut T, source_budget: usize) -> bool {
         let mut progress = false;
         for _ in 0..source_budget.max(1) {
             // SAFETY: this endpoint is the instance's sole drainer. Every
@@ -253,7 +240,7 @@ impl Drainer {
                 self.inner
                     .registry
                     .visit_next(&mut self.cursor, &mut |ring, bytes| {
-                        pipeline.consume(MarkerRange {
+                        pipeline.accept(MarkerRange {
                             source_id: ring.engine_id(),
                             bytes,
                         });
@@ -265,20 +252,16 @@ impl Drainer {
                 break;
             }
         }
+        pipeline.end_step();
         progress
     }
 
-    pub fn idle<H, B, A, P>(
+    pub fn idle<T: DrainTarget>(
         &mut self,
-        pipeline: &mut Pipeline<H, B, A, P>,
+        pipeline: &mut T,
         source_budget: usize,
         timeout: Duration,
-    ) where
-        H: RangeHandler,
-        B: EventBuilder,
-        A: Aggregator<B::Event>,
-        P: Publisher<B::Event, A::Aggregate>,
-    {
+    ) {
         self.inner.ctx.wake().pre_park();
         if !self.drain(pipeline, source_budget) {
             self.inner.ctx.wake().park(timeout);
@@ -288,13 +271,7 @@ impl Drainer {
 
     /// Seal admission and finish only after producer ownership has ended.
     /// No decoder/root-completion state participates in this boundary.
-    pub fn finish<H, B, A, P>(self, mut pipeline: Pipeline<H, B, A, P>) -> Result<P, TransportError>
-    where
-        H: RangeHandler,
-        B: EventBuilder,
-        A: Aggregator<B::Event>,
-        P: Publisher<B::Event, A::Aggregate>,
-    {
+    pub fn finish<T: DrainTarget>(self, mut pipeline: T) -> Result<T::Output, TransportError> {
         self.inner
             .admission
             .lock()
@@ -307,14 +284,16 @@ impl Drainer {
         // commits. Repeat complete sweeps until every source is drained.
         while !unsafe {
             self.inner.registry.sweep_outcome(&mut |ring, bytes| {
-                pipeline.consume(MarkerRange {
+                pipeline.accept(MarkerRange {
                     source_id: ring.engine_id(),
                     bytes,
                 });
             })
         }
         .caught_up
-        {}
+        {
+            pipeline.end_step();
+        }
         Ok(pipeline.finish())
     }
 }


### PR DESCRIPTION
Adds the transport stage between the OS-thread rings and a future event builder. With `--consumer-mode copy-handoff`, the round-robin drainer copies committed byte ranges into reusable batches and hands ownership to a second worker, which currently returns the buffers without decoding markers. `copy-local` isolates copying/reuse on the drainer, and `discard` remains the reference.

A batch contains contiguous payload bytes and per-source range descriptors. Payload or descriptor exhaustion publishes it; the end of a bounded drain step publishes partial batches. Oversized ranges grow an empty batch and are kept whole. The handoff and return paths use preallocated atomic ArrayQueues with one sender/receiver each. A full handoff queue spills into an ordered drainer-local backlog that can grow; the drainer does not drop data or wait for the downstream worker. Returned empty buffers above the retained pool capacity are freed.

The drainer now depends on `DrainTarget`, removing its coupling to semantic pipeline types. The existing synchronous pipeline remains available through an adapter. Completion drains every source, flushes the final batch and backlog, closes downstream input, and waits for downstream completion in the benchmark. Producer/ring algorithms and the production VM are unchanged.

Reading order:
- `btel_transport/src/drain_target.rs`: borrowed-range acceptance and completion contract.
- `btel_transport/src/batch.rs`: batch ownership, local reuse, queued handoff and recycling; tests at the bottom.
- `btel_transport/src/runtime.rs`: persistent round-robin traversal and end-of-step flush.
- `btel_bench/src/replay.rs`: worker setup and timing through downstream completion.
- `btel_bench/plots/sweep.py`: repeatable rate sweep with a shared feeder baseline per measurement block.

The producer loop is shared across consumer configurations, avoiding consumer-type specialization changing producer code generation. No per-marker measurement counters or timing probes were added. Plot generation preserves the existing layouts and labels the selected stage.

Validation: targeted native tests and Clippy pass. New tests cover descriptor/payload exhaustion, oversized whole ranges, preallocated memory reuse, a blocked downstream worker with backlog far beyond queue capacity, final partial-batch delivery, exact per-source ordering through real rings, and receiver failure. The benchmark baseline/completion test covers all three consumer modes.

Scope: the downstream processor is still a no-op; span matching, aggregation and publication are subsequent work. Backlog memory is intentionally unbounded under sustained overload. RSS includes prepared benchmark inputs, and subtracting the feeder baseline estimates rather than exactly attributes CPU cost.

Stack: follows #4860.


Measured comparison (8 million calls/run, 400 million requested calls/sec, medians of 10 repetitions on this machine):

| Producers | Discard achieved Mcalls/s | Local copy/reuse | Copy/handoff |
| --- | ---: | ---: | ---: |
| 1 | 66.9 | 62.2 | 58.7 |
| 4 | 184.1 | 96.5 | 143.5 |
| 32 | 223.6 | 192.8 | 145.5 |

The complete sweep executed 840 measured processes across seven requested rates and three producer counts. Each measurement block shares one feeder baseline across all three stages; raw costs are primary, and subtraction is approximate. The result exposes a measurable handoff cost rather than assuming it is negligible. The optimized binary contains one shared clocked producer loop for every consumer mode. Stage-specific plots use the same established layout.
