### PR TITLE
Build Btel spans incrementally after buffer handoff

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1780,12 +1780,20 @@ dependencies = [
 name = "btel_bench"
 version = "0.0.0-beta"
 dependencies = [
+ "btel_builder",
  "btel_core",
  "btel_transport",
  "clap",
  "libc",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "btel_builder"
+version = "0.0.0-beta"
+dependencies = [
+ "btel_core",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -66,6 +66,7 @@ license = "Apache-2.0"
 version = "0.0.0-beta"
 
 [workspace.dependencies]
+btel_builder = { path = "crates/btel_builder" }
 btel_core = { path = "crates/btel_core" }
 btel_transport = { path = "crates/btel_transport" }
 #  Internal dependencies (baml_*)

--- a/baml_language/crates/btel_bench/Cargo.toml
+++ b/baml_language/crates/btel_bench/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+btel_builder.workspace = true
 btel_core.workspace = true
 btel_transport.workspace = true
 clap = { workspace = true, features = [ "derive" ] }

--- a/baml_language/crates/btel_bench/plots/plot.py
+++ b/baml_language/crates/btel_bench/plots/plot.py
@@ -68,7 +68,7 @@ def load_results(directory):
             in (
                 {"feeder-only"}
                 if baseline
-                else {"drain-only", "copy-local", "copy-handoff"}
+                else {"drain-only", "copy-local", "copy-handoff", "build-spans"}
             ),
             "Unsupported consumer stage",
         )
@@ -76,13 +76,25 @@ def load_results(directory):
             stages.add(result["preset"])
         require(
             result.get("downstream_threads", 0)
-            == int(not baseline and result["preset"] == "copy-handoff"),
+            == int(
+                not baseline and result["preset"] in ("copy-handoff", "build-spans")
+            ),
             "Unexpected downstream worker count",
         )
         require(
             result["consumer_threads"] == (0 if baseline else 1),
             "Unexpected drainer count",
         )
+        if not baseline and result["preset"] == "build-spans":
+            require(
+                result.get("builder")
+                == {
+                    "closed_spans": run["calls"],
+                    "standalone_events": run["threads"] * 2,
+                    "unmatched_halves": 0,
+                },
+                "Builder output validation failed",
+            )
         require(len(result["loads"]) == run["threads"], "Source load count mismatch")
         for metric in (
             "replay_seconds",
@@ -133,6 +145,7 @@ def load_results(directory):
         "drain-only": "discard drainer",
         "copy-local": "local copy/reuse",
         "copy-handoff": "copy/handoff + return",
+        "build-spans": "copy/handoff + span builder + counting sink",
     }[identity["consumer_stage"]]
     threads = sorted({r["threads"] for r in runs})
     values = sorted({r[dimension] for r in runs})

--- a/baml_language/crates/btel_bench/plots/rate.py
+++ b/baml_language/crates/btel_bench/plots/rate.py
@@ -192,7 +192,12 @@ def render(identity, runs, root):
     fig.text(
         0.075,
         0.118,
-        "1 call = enter + exit. Achieved rate = total calls / elapsed time through complete drain; this is not span-builder throughput.",
+        "1 call = enter + exit. Achieved rate = total calls / elapsed time through complete drain; "
+        + (
+            "includes span building and output counting."
+            if identity["consumer_stage"] == "build-spans"
+            else "this is not span-builder throughput."
+        ),
         fontsize=10,
         color="#475569",
     )

--- a/baml_language/crates/btel_bench/plots/sweep.py
+++ b/baml_language/crates/btel_bench/plots/sweep.py
@@ -46,7 +46,7 @@ def main():
     parser.add_argument(
         "--stages",
         nargs="+",
-        choices=["discard", "copy-local", "copy-handoff"],
+        choices=["discard", "copy-local", "copy-handoff", "build-spans"],
         default=["discard", "copy-local", "copy-handoff"],
     )
     args = parser.parse_args()
@@ -120,10 +120,23 @@ def main():
             "clock_reads": 0 if baseline else args.calls * 2 + threads * 2,
             "ring_bytes": 0 if baseline else args.calls * 80 + threads * 54,
             "consumer_threads": 0 if baseline else 1,
-            "downstream_threads": int(not baseline and stage == "copy-handoff"),
+            "downstream_threads": int(
+                not baseline and stage in ("copy-handoff", "build-spans")
+            ),
         }
         if any(result.get(key) != value for key, value in expected.items()):
             raise ValueError(f"Benchmark workload validation failed: {expected}")
+        if (
+            not baseline
+            and stage == "build-spans"
+            and result.get("builder")
+            != {
+                "closed_spans": args.calls,
+                "standalone_events": threads * 2,
+                "unmatched_halves": 0,
+            }
+        ):
+            raise ValueError("Builder output validation failed")
         if sum(source["calls"] for source in result["sources"]) != args.calls:
             raise ValueError("Mismatched source call counts")
         return {

--- a/baml_language/crates/btel_bench/src/builder.rs
+++ b/baml_language/crates/btel_bench/src/builder.rs
@@ -1,0 +1,135 @@
+//! Benchmark sink: observe completed output without aggregation or storage.
+use btel_builder::{TelemetryEvent, TelemetryEventBuilder};
+use btel_transport::batch::{BatchProcessor, SharedMarkerBatch};
+use serde::Serialize;
+
+#[derive(Default, Debug, Serialize)]
+pub struct BuilderReport {
+    pub closed_spans: u64,
+    pub standalone_events: u64,
+    pub unmatched_halves: usize,
+}
+
+#[derive(Default)]
+pub struct BuildSpans {
+    builder: TelemetryEventBuilder,
+    report: BuilderReport,
+    error: Option<String>,
+}
+
+impl BatchProcessor for BuildSpans {
+    type Output = Result<BuilderReport, String>;
+
+    fn process(&mut self, batch: &SharedMarkerBatch) {
+        // Still return all batches after failure so producers/drainer can
+        // finish. This run will fail validation rather than hang or report success.
+        if self.error.is_some() {
+            return;
+        }
+        for range in batch.ranges() {
+            let result = self.builder.try_build(range, |event| {
+                match &event {
+                    TelemetryEvent::ClosedSpan(_) => self.report.closed_spans += 1,
+                    _ => self.report.standalone_events += 1,
+                }
+                std::hint::black_box(event);
+            });
+            if let Err(error) = result {
+                self.error = Some(format!("span builder failed: {error:?}"));
+                return;
+            }
+        }
+    }
+
+    fn finish(mut self) -> Self::Output {
+        if let Some(error) = self.error {
+            return Err(error);
+        }
+        self.report.unmatched_halves = self.builder.open_spans().len();
+        Ok(self.report)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{thread, time::Duration};
+
+    use btel_core::stage::MarkerRange;
+    use btel_transport::{
+        DrainTarget, TransportConfig,
+        batch::{BatchConfig, CopyHandoff},
+    };
+
+    use super::*;
+    use crate::{
+        feeder::ProducerMode,
+        replay::{self, ConsumerMode, ReplayConfig, SourceLoad},
+        workload::Fixture,
+    };
+
+    #[test]
+    fn malformed_batches_report_failure_after_recycling_and_shutdown() {
+        let (mut sender, receiver) = CopyHandoff::new(BatchConfig {
+            payload_bytes: 4,
+            source_ranges: 1,
+            queue_batches: 1,
+            retained_batches: 1,
+        })
+        .unwrap();
+        let worker = thread::spawn(move || receiver.run(BuildSpans::default()));
+        for _ in 0..1000 {
+            sender.accept(MarkerRange {
+                source_id: 1,
+                bytes: &[255],
+            });
+            sender.end_step();
+        }
+        sender.finish();
+        assert!(worker.join().unwrap().unwrap_err().contains("UnknownTag"));
+    }
+
+    #[test]
+    fn tiny_recycled_batches_build_every_nested_call_in_both_producer_modes() {
+        for producer_mode in [ProducerMode::Prepared, ProducerMode::EncodeClock] {
+            let fixtures = (1..=3)
+                .map(|source| {
+                    (
+                        Fixture::prepare(source, 4097, 64, None).unwrap(),
+                        SourceLoad {
+                            bytes_per_second: 0,
+                            start_delay_ms: 0,
+                            batch_markers: 1024,
+                            burst_pause_ms: 0,
+                        },
+                    )
+                })
+                .collect();
+            let result = replay::run(
+                ReplayConfig {
+                    consumer_mode: ConsumerMode::BuildSpans,
+                    batch: BatchConfig {
+                        payload_bytes: 64,
+                        source_ranges: 1,
+                        queue_batches: 2,
+                        retained_batches: 2,
+                    },
+                    producer_mode,
+                    transport: TransportConfig {
+                        segment_bytes: 64,
+                        freelist_segments: 1,
+                        memory_bytes: 32 * 1024 * 1024,
+                    },
+                    source_budget: 1,
+                    idle_rings: 2,
+                    idle_timeout: Duration::from_micros(20),
+                },
+                fixtures,
+            )
+            .unwrap();
+            let report = result.builder.unwrap();
+            assert_eq!(report.closed_spans, 3 * 4097);
+            assert_eq!(report.standalone_events, 6);
+            assert_eq!(report.unmatched_halves, 0);
+        }
+    }
+}

--- a/baml_language/crates/btel_bench/src/lib.rs
+++ b/baml_language/crates/btel_bench/src/lib.rs
@@ -4,3 +4,5 @@ pub mod replay;
 pub mod workload;
 
 pub mod feeder;
+
+pub mod builder;

--- a/baml_language/crates/btel_bench/src/main.rs
+++ b/baml_language/crates/btel_bench/src/main.rs
@@ -1,4 +1,4 @@
-//! One binary, one preset for Phase A. Start with `--help`.
+//! One binary, selectable downstream stages. Start with `--help`.
 use std::{io, path::PathBuf, time::Duration};
 
 use btel_bench::{
@@ -10,9 +10,9 @@ use btel_transport::{TransportConfig, batch::BatchConfig};
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(about = "Measure Btel ring producers and all-no-op pipeline (drain-only)")]
+#[command(about = "Measure Btel producers, transport, and incremental span building")]
 struct Args {
-    /// Discard, copy/reuse on the drainer, or copy/handoff to a downstream worker.
+    /// Discard, copy locally, hand off buffers, or build spans on the worker.
     #[arg(long, value_enum, default_value_t = ConsumerMode::Discard)]
     consumer_mode: ConsumerMode,
     #[arg(long, default_value_t = 262_144)]

--- a/baml_language/crates/btel_bench/src/replay.rs
+++ b/baml_language/crates/btel_bench/src/replay.rs
@@ -29,6 +29,7 @@ pub enum ConsumerMode {
     Discard,
     CopyLocal,
     CopyHandoff,
+    BuildSpans,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -52,6 +53,7 @@ pub struct ReplayConfig {
 
 #[derive(Serialize)]
 pub struct ReplayResult {
+    pub builder: Option<crate::builder::BuilderReport>,
     pub consumer_mode: ConsumerMode,
     pub downstream_threads: usize,
     pub batch_payload_bytes: usize,
@@ -136,7 +138,7 @@ pub fn run(
             CopyLocal::new(config.batch, noop::ReturnBatches)?,
             None,
         ),
-        ConsumerMode::CopyHandoff => {
+        ConsumerMode::CopyHandoff | ConsumerMode::BuildSpans => {
             let (target, receiver) = CopyHandoff::new(config.batch)?;
             run_target(config, fixtures, target, Some(receiver))
         }
@@ -220,11 +222,19 @@ fn run_with<
         let gate = gate.clone();
         let ready = ready_tx.clone();
         thread::spawn(move || {
+            let builder = crate::builder::BuildSpans::default();
             ready.send(Ok::<_, String>(())).unwrap();
-            if gate.wait().is_some() {
-                receiver.run(noop::ReturnBatches);
-            }
-            Instant::now()
+            let result = if gate.wait().is_some() {
+                if matches!(config.consumer_mode, ConsumerMode::BuildSpans) {
+                    receiver.run(builder).map(Some)
+                } else {
+                    receiver.run(noop::ReturnBatches);
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
+            };
+            (Instant::now(), result)
         })
     });
     // A feeder baseline has the same producer setup, but no drainer competing
@@ -323,13 +333,25 @@ fn run_with<
         Some(receiver) => receiver.join().map_err(|_| "drainer panicked")??,
         None => producers_done,
     };
-    let finish = match downstream {
-        Some(worker) => finish.max(worker.join().map_err(|_| "batch worker panicked")?),
-        None => finish,
+    let (finish, builder) = match downstream {
+        Some(worker) => {
+            let (at, report) = worker.join().map_err(|_| "batch worker panicked")?;
+            (finish.max(at), report?)
+        }
+        None => (finish, None),
     };
     let usage_end = usage();
     if let Some(error) = error {
         return Err(error);
+    }
+    if let Some(report) = &builder {
+        let expected_calls: u64 = sources.iter().map(|source| source.calls).sum();
+        if report.closed_spans != expected_calls
+            || report.standalone_events != sources.len() as u64 * 2
+            || report.unmatched_halves != 0
+        {
+            return Err(format!("builder output mismatch: {report:?}"));
+        }
     }
     let elapsed = finish.duration_since(start).as_secs_f64();
     #[expect(
@@ -338,9 +360,14 @@ fn run_with<
     )]
     let bytes_per_second = (!FEEDER_ONLY).then_some(input_bytes as f64 / elapsed);
     Ok(ReplayResult {
+        builder,
         consumer_mode: config.consumer_mode,
         downstream_threads: usize::from(
-            !FEEDER_ONLY && matches!(config.consumer_mode, ConsumerMode::CopyHandoff),
+            !FEEDER_ONLY
+                && matches!(
+                    config.consumer_mode,
+                    ConsumerMode::CopyHandoff | ConsumerMode::BuildSpans
+                ),
         ),
         batch_payload_bytes: config.batch.payload_bytes,
         batch_source_ranges: config.batch.source_ranges,
@@ -356,6 +383,7 @@ fn run_with<
                 ConsumerMode::Discard => "drain-only",
                 ConsumerMode::CopyLocal => "copy-local",
                 ConsumerMode::CopyHandoff => "copy-handoff",
+                ConsumerMode::BuildSpans => "build-spans",
             }
         },
         full_ring_policy: if FEEDER_ONLY {
@@ -458,6 +486,7 @@ mod tests {
             ConsumerMode::Discard,
             ConsumerMode::CopyLocal,
             ConsumerMode::CopyHandoff,
+            ConsumerMode::BuildSpans,
         ] {
             let baseline = run_mode(ProducerMode::FeederOnly, consumer_mode);
             let full = run_mode(ProducerMode::EncodeClock, consumer_mode);
@@ -484,7 +513,10 @@ mod tests {
             assert_eq!(baseline.downstream_threads, 0);
             assert_eq!(
                 full.downstream_threads,
-                usize::from(matches!(consumer_mode, ConsumerMode::CopyHandoff))
+                usize::from(matches!(
+                    consumer_mode,
+                    ConsumerMode::CopyHandoff | ConsumerMode::BuildSpans
+                ))
             );
         }
     }

--- a/baml_language/crates/btel_builder/Cargo.toml
+++ b/baml_language/crates/btel_builder/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "btel_builder"
+description = "Incremental Btel marker matching and owned telemetry events"
+version.workspace = true
+publish = false
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+btel_core.workspace = true

--- a/baml_language/crates/btel_builder/src/event.rs
+++ b/baml_language/crates/btel_builder/src/event.rs
@@ -1,0 +1,90 @@
+//! Owned output: no references into transport buffers survive a builder call.
+use btel_core::{
+    ids::{BexCallId, BexThreadId, FunctionId},
+    marker::{CallSiteSourceSpan, FunctionEndStatus, ThreadEndStatus},
+};
+
+/// Identity within one engine. A builder must never mix engines/processes.
+/// OS source IDs are provenance, not identity: logical calls can migrate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CallKey {
+    pub thread_id: BexThreadId,
+    pub call_id: BexCallId,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SpanStart {
+    pub source_id: u64,
+    pub flags: u8,
+    pub parent_call_id: BexCallId,
+    pub function_id: FunctionId,
+    pub call_site: Option<CallSiteSourceSpan>,
+    pub ticks: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SpanEnd {
+    pub source_id: u64,
+    pub status: FunctionEndStatus,
+    pub ticks: u64,
+    pub await_ns: u64,
+    pub await_count: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ClosedSpan {
+    pub key: CallKey,
+    pub start: SpanStart,
+    pub end: SpanEnd,
+}
+
+impl ClosedSpan {
+    /// Preserve raw ticks. Inverted clocks are unknown duration, never wrapped
+    /// or silently clamped. Tick-to-time conversion belongs downstream.
+    pub fn duration_ticks(&self) -> Option<u64> {
+        self.end.ticks.checked_sub(self.start.ticks)
+    }
+}
+
+/// An unmatched half, retained until its counterpart arrives (no eviction yet).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpenSpan {
+    Start(SpanStart),
+    End(SpanEnd),
+}
+
+/// Current non-call markers are standalone facts, not closure barriers.
+/// Late ID updates remain separate events; already-emitted spans aren't held
+/// waiting for metadata. Logs can follow this same immediate-output path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TelemetryEvent {
+    ClosedSpan(ClosedSpan),
+    /// Returned at input shutdown by the generic stage adapter; not a closed span.
+    UnmatchedSpan {
+        key: CallKey,
+        half: OpenSpan,
+    },
+    ThreadStarted {
+        source_id: u64,
+        flags: u8,
+        thread_id: BexThreadId,
+        parent_thread_id: BexThreadId,
+        parent_call_id: BexCallId,
+        ticks: u64,
+        /// None for the root encoding; Some(None) for a spawn with no site.
+        spawn_site: Option<Option<CallSiteSourceSpan>>,
+        name: Vec<u8>,
+    },
+    ThreadEnded {
+        source_id: u64,
+        thread_id: BexThreadId,
+        ticks: u64,
+        status: ThreadEndStatus,
+    },
+    BoundaryLocalId {
+        source_id: u64,
+        key: CallKey,
+        ticks: u64,
+        id: [u8; 16],
+    },
+}

--- a/baml_language/crates/btel_builder/src/lib.rs
+++ b/baml_language/crates/btel_builder/src/lib.rs
@@ -1,0 +1,219 @@
+//! Incremental, single-owner event building for one engine's marker stream.
+//! Input ranges contain whole records. Arrival may interleave OS sources and
+//! batches arbitrarily. No execution-ready signal or stack nesting is required.
+//! Closed spans are emitted immediately; only unmatched halves are retained.
+pub mod event;
+pub mod open_span_store;
+
+use btel_core::{
+    marker::{self, DecodeError, Marker},
+    stage::{EventBuilder, MarkerRange},
+};
+pub use event::{CallKey, ClosedSpan, OpenSpan, SpanEnd, SpanStart, TelemetryEvent};
+pub use open_span_store::OpenSpanStore;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BuildErrorKind {
+    Decode(DecodeError),
+    DuplicateHalf(CallKey),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BuildError {
+    pub source_id: u64,
+    pub byte_offset: usize,
+    pub kind: BuildErrorKind,
+}
+
+#[derive(Default)]
+pub struct TelemetryEventBuilder {
+    open: OpenSpanStore,
+}
+
+impl TelemetryEventBuilder {
+    pub fn open_spans(&self) -> &OpenSpanStore {
+        &self.open
+    }
+
+    /// End of an input session preserves unresolved facts; it never invents
+    /// closing timestamps or waits for absent markers.
+    pub fn into_open_spans(self) -> OpenSpanStore {
+        self.open
+    }
+
+    /// Decode and emit incrementally. On error, the valid prefix has already
+    /// been processed. The caller must report failure, not retry the whole range.
+    pub fn try_build(
+        &mut self,
+        input: MarkerRange<'_>,
+        mut emit: impl FnMut(TelemetryEvent),
+    ) -> Result<(), BuildError> {
+        let mut offset = 0;
+        while offset < input.bytes.len() {
+            let (marker, consumed) =
+                marker::decode(&input.bytes[offset..]).map_err(|error| BuildError {
+                    source_id: input.source_id,
+                    byte_offset: offset,
+                    kind: BuildErrorKind::Decode(error),
+                })?;
+            self.accept(input.source_id, marker, &mut emit)
+                .map_err(|key| BuildError {
+                    source_id: input.source_id,
+                    byte_offset: offset,
+                    kind: BuildErrorKind::DuplicateHalf(key),
+                })?;
+            offset += consumed;
+        }
+        Ok(())
+    }
+
+    fn accept(
+        &mut self,
+        source_id: u64,
+        marker: Marker<'_>,
+        mut emit: impl FnMut(TelemetryEvent),
+    ) -> Result<(), CallKey> {
+        let (key, half) = match marker {
+            Marker::FunctionEnter {
+                flags,
+                thread_id,
+                call_id,
+                parent_call_id,
+                function_id,
+                call_site,
+                ts_ticks,
+            } => (
+                CallKey { thread_id, call_id },
+                OpenSpan::Start(SpanStart {
+                    source_id,
+                    flags,
+                    parent_call_id,
+                    function_id,
+                    call_site,
+                    ticks: ts_ticks,
+                }),
+            ),
+            Marker::FunctionExit {
+                status,
+                thread_id,
+                call_id,
+                ts_ticks,
+            } => (
+                CallKey { thread_id, call_id },
+                OpenSpan::End(SpanEnd {
+                    source_id,
+                    status,
+                    ticks: ts_ticks,
+                    await_ns: 0,
+                    await_count: 0,
+                }),
+            ),
+            Marker::FunctionExitAwaited {
+                status,
+                thread_id,
+                call_id,
+                ts_ticks,
+                await_ns,
+                await_count,
+            } => (
+                CallKey { thread_id, call_id },
+                OpenSpan::End(SpanEnd {
+                    source_id,
+                    status,
+                    ticks: ts_ticks,
+                    await_ns,
+                    await_count,
+                }),
+            ),
+            Marker::BexThreadStart {
+                flags,
+                thread_id,
+                parent_thread_id,
+                parent_call_id,
+                ts_ticks,
+                name,
+            } => {
+                emit(TelemetryEvent::ThreadStarted {
+                    source_id,
+                    flags,
+                    thread_id,
+                    parent_thread_id,
+                    parent_call_id,
+                    ticks: ts_ticks,
+                    spawn_site: None,
+                    name: name.to_vec(),
+                });
+                return Ok(());
+            }
+            Marker::BexThreadStartSpawned {
+                flags,
+                thread_id,
+                parent_thread_id,
+                parent_call_id,
+                ts_ticks,
+                spawn_site,
+                name,
+            } => {
+                emit(TelemetryEvent::ThreadStarted {
+                    source_id,
+                    flags,
+                    thread_id,
+                    parent_thread_id,
+                    parent_call_id,
+                    ticks: ts_ticks,
+                    spawn_site: Some(spawn_site),
+                    name: name.to_vec(),
+                });
+                return Ok(());
+            }
+            Marker::BexThreadEnd {
+                status,
+                thread_id,
+                ts_ticks,
+            } => {
+                emit(TelemetryEvent::ThreadEnded {
+                    source_id,
+                    thread_id,
+                    ticks: ts_ticks,
+                    status,
+                });
+                return Ok(());
+            }
+            Marker::SetBoundaryLocalId {
+                thread_id,
+                call_id,
+                id,
+                ts_ticks,
+            } => {
+                emit(TelemetryEvent::BoundaryLocalId {
+                    source_id,
+                    key: CallKey { thread_id, call_id },
+                    ticks: ts_ticks,
+                    id,
+                });
+                return Ok(());
+            }
+        };
+        if let Some(span) = self.open.insert(key, half)? {
+            emit(TelemetryEvent::ClosedSpan(span));
+        }
+        Ok(())
+    }
+}
+
+impl EventBuilder for TelemetryEventBuilder {
+    type Event = TelemetryEvent;
+
+    fn finish(&mut self, mut emit: impl FnMut(Self::Event)) {
+        for (key, half) in self.open.drain() {
+            emit(TelemetryEvent::UnmatchedSpan { key, half });
+        }
+    }
+
+    /// Adapter for the infallible stage contract: corrupt committed input is
+    /// fatal. Drivers that report errors without panicking use `try_build`.
+    fn build(&mut self, input: MarkerRange<'_>, emit: impl FnMut(Self::Event)) {
+        self.try_build(input, emit)
+            .expect("invalid committed markers");
+    }
+}

--- a/baml_language/crates/btel_builder/src/open_span_store.rs
+++ b/baml_language/crates/btel_builder/src/open_span_store.rs
@@ -1,0 +1,52 @@
+use std::collections::{HashMap, hash_map::Entry};
+
+use crate::event::{CallKey, ClosedSpan, OpenSpan};
+
+/// Only unmatched halves live here. Capacity grows with concurrent unmatched
+/// calls, not total completed calls. No timeout, thread-end flush, or tombstones.
+#[derive(Default)]
+pub struct OpenSpanStore {
+    spans: HashMap<CallKey, OpenSpan>,
+}
+
+impl OpenSpanStore {
+    pub fn len(&self) -> usize {
+        self.spans.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&CallKey, &OpenSpan)> {
+        self.spans.iter()
+    }
+
+    pub(crate) fn drain(&mut self) -> impl Iterator<Item = (CallKey, OpenSpan)> + '_ {
+        self.spans.drain()
+    }
+
+    /// Same-side duplicates fail without overwriting the retained fact.
+    /// Completed IDs aren't retained: replay deduplication is not this store's job.
+    pub(crate) fn insert(
+        &mut self,
+        key: CallKey,
+        half: OpenSpan,
+    ) -> Result<Option<ClosedSpan>, CallKey> {
+        match self.spans.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(half);
+                Ok(None)
+            }
+            Entry::Occupied(entry) => {
+                let ((OpenSpan::Start(start), OpenSpan::End(end))
+                | (OpenSpan::End(end), OpenSpan::Start(start))) = (*entry.get(), half)
+                else {
+                    return Err(key);
+                };
+                entry.remove();
+                Ok(Some(ClosedSpan { key, start, end }))
+            }
+        }
+    }
+}

--- a/baml_language/crates/btel_builder/tests/build.rs
+++ b/baml_language/crates/btel_builder/tests/build.rs
@@ -1,0 +1,317 @@
+use btel_builder::{BuildErrorKind, OpenSpan, TelemetryEvent, TelemetryEventBuilder};
+use btel_core::{
+    ids::{BexCallId, BexThreadId, FunctionId},
+    marker::{
+        CallSiteSourceSpan, DecodeError, FunctionEndStatus, MAX_RECORD_LEN, Marker, ThreadEndStatus,
+    },
+    stage::MarkerRange,
+};
+
+fn enter(thread: u64, call: u64) -> Marker<'static> {
+    Marker::FunctionEnter {
+        flags: 7,
+        thread_id: BexThreadId(thread),
+        call_id: BexCallId(call),
+        parent_call_id: BexCallId(call.saturating_sub(1)),
+        function_id: FunctionId(42),
+        call_site: Some(CallSiteSourceSpan {
+            file_id: 2,
+            start_offset: 3,
+            end_offset: 9,
+            line: 1,
+        }),
+        ts_ticks: 10,
+    }
+}
+fn exit(thread: u64, call: u64) -> Marker<'static> {
+    Marker::FunctionExit {
+        thread_id: BexThreadId(thread),
+        call_id: BexCallId(call),
+        status: FunctionEndStatus::Errored,
+        ts_ticks: 30,
+    }
+}
+fn bytes(markers: &[Marker<'_>]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for marker in markers {
+        let mut buffer = [0; MAX_RECORD_LEN];
+        let len = marker.encode(&mut buffer);
+        bytes.extend_from_slice(&buffer[..len]);
+    }
+    bytes
+}
+fn push(
+    builder: &mut TelemetryEventBuilder,
+    source: u64,
+    markers: &[Marker<'_>],
+) -> Vec<TelemetryEvent> {
+    let bytes = bytes(markers);
+    let mut out = Vec::new();
+    builder
+        .try_build(
+            MarkerRange {
+                source_id: source,
+                bytes: &bytes,
+            },
+            |event| out.push(event),
+        )
+        .unwrap();
+    // Outputs must outlive the transport's bytes.
+    out
+}
+
+#[test]
+fn matches_across_sources_in_both_arrival_orders_with_owned_fields() {
+    for reverse in [false, true] {
+        let mut builder = TelemetryEventBuilder::default();
+        let (first, second) = if reverse {
+            (exit(9, 2), enter(9, 2))
+        } else {
+            (enter(9, 2), exit(9, 2))
+        };
+        assert!(push(&mut builder, 10, &[first]).is_empty());
+        assert_eq!(builder.open_spans().len(), 1);
+        let out = push(&mut builder, 20, &[second]);
+        let [TelemetryEvent::ClosedSpan(span)] = out.as_slice() else {
+            panic!("expected span");
+        };
+        assert_eq!(span.key.thread_id, BexThreadId(9));
+        assert_eq!(span.key.call_id, BexCallId(2));
+        assert_eq!(span.start.parent_call_id, BexCallId(1));
+        assert_eq!(span.start.function_id, FunctionId(42));
+        assert_eq!(span.start.flags, 7);
+        assert_eq!(span.start.call_site.unwrap().end_offset, 9);
+        assert_eq!(span.start.source_id, if reverse { 20 } else { 10 });
+        assert_eq!(span.end.source_id, if reverse { 10 } else { 20 });
+        assert_eq!(span.end.status, FunctionEndStatus::Errored);
+        assert_eq!(span.duration_ticks(), Some(20));
+        assert!(builder.open_spans().is_empty());
+    }
+}
+
+#[test]
+fn logical_identity_separates_reused_call_ids_without_requiring_a_stack() {
+    let mut builder = TelemetryEventBuilder::default();
+    let out = push(
+        &mut builder,
+        1,
+        &[
+            enter(1, 1),
+            enter(1, 2),
+            enter(2, 1),
+            exit(1, 1),
+            exit(2, 1),
+            exit(1, 2),
+        ],
+    );
+    let keys: Vec<_> = out
+        .iter()
+        .map(|event| {
+            let TelemetryEvent::ClosedSpan(span) = event else {
+                panic!("expected span");
+            };
+            (span.key.thread_id.0, span.key.call_id.0)
+        })
+        .collect();
+    assert_eq!(keys, [(1, 1), (2, 1), (1, 2)]);
+    assert!(builder.open_spans().is_empty());
+}
+
+#[test]
+fn awaited_exit_preserves_status_and_clock_inversion() {
+    let mut builder = TelemetryEventBuilder::default();
+    let out = push(
+        &mut builder,
+        1,
+        &[
+            Marker::FunctionExitAwaited {
+                status: FunctionEndStatus::Cancelled,
+                thread_id: BexThreadId(3),
+                call_id: BexCallId(7),
+                ts_ticks: 5,
+                await_ns: 300,
+                await_count: 2,
+            },
+            enter(3, 7),
+        ],
+    );
+    let [TelemetryEvent::ClosedSpan(span)] = out.as_slice() else {
+        panic!("expected span");
+    };
+    assert_eq!(span.end.await_ns, 300);
+    assert_eq!(span.end.await_count, 2);
+    assert_eq!(span.end.status, FunctionEndStatus::Cancelled);
+    assert_eq!(span.duration_ticks(), None);
+}
+
+#[test]
+fn thread_end_does_not_close_or_delete_unmatched_calls() {
+    let mut builder = TelemetryEventBuilder::default();
+    let out = push(
+        &mut builder,
+        1,
+        &[
+            enter(1, 1),
+            exit(1, 2),
+            Marker::BexThreadEnd {
+                status: ThreadEndStatus::Completed,
+                thread_id: BexThreadId(1),
+                ts_ticks: 40,
+            },
+        ],
+    );
+    assert!(matches!(
+        out.as_slice(),
+        [TelemetryEvent::ThreadEnded { .. }]
+    ));
+    assert_eq!(builder.open_spans().len(), 2);
+    assert_eq!(push(&mut builder, 2, &[exit(1, 1)]).len(), 1);
+    let store = builder.into_open_spans();
+    assert_eq!(store.len(), 1);
+    let (key, half) = store.iter().next().unwrap();
+    assert_eq!(key.call_id, BexCallId(2));
+    assert!(matches!(half, OpenSpan::End(_)));
+}
+
+#[test]
+fn metadata_is_owned_and_late_ids_are_immediate_events() {
+    let mut builder = TelemetryEventBuilder::default();
+    let out = push(
+        &mut builder,
+        4,
+        &[
+            Marker::BexThreadStart {
+                flags: 1,
+                thread_id: BexThreadId(1),
+                parent_thread_id: BexThreadId(0),
+                parent_call_id: BexCallId(0),
+                ts_ticks: 2,
+                name: b"root",
+            },
+            Marker::BexThreadStartSpawned {
+                flags: 2,
+                thread_id: BexThreadId(2),
+                parent_thread_id: BexThreadId(1),
+                parent_call_id: BexCallId(3),
+                ts_ticks: 5,
+                spawn_site: None,
+                name: b"child",
+            },
+            enter(2, 1),
+            exit(2, 1),
+            Marker::SetBoundaryLocalId {
+                thread_id: BexThreadId(2),
+                call_id: BexCallId(1),
+                id: [9; 16],
+                ts_ticks: 40,
+            },
+        ],
+    );
+    assert!(
+        matches!(&out[0], TelemetryEvent::ThreadStarted { name, spawn_site: None, .. } if name == b"root")
+    );
+    assert!(
+        matches!(&out[1], TelemetryEvent::ThreadStarted { name, spawn_site: Some(None), .. } if name == b"child")
+    );
+    assert!(matches!(&out[2], TelemetryEvent::ClosedSpan(_)));
+    assert!(matches!(&out[3], TelemetryEvent::BoundaryLocalId { id, .. } if *id == [9; 16]));
+    assert!(builder.open_spans().is_empty());
+}
+
+#[test]
+fn corruption_and_duplicate_halves_report_offsets_without_overwriting() {
+    for marker in [enter(1, 1), exit(1, 1)] {
+        let mut builder = TelemetryEventBuilder::default();
+        let buffer = bytes(&[marker, marker]);
+        let error = builder
+            .try_build(
+                MarkerRange {
+                    source_id: 12,
+                    bytes: &buffer,
+                },
+                |_| panic!("unexpected output"),
+            )
+            .unwrap_err();
+        assert_eq!(error.source_id, 12);
+        assert_eq!(error.byte_offset, marker.encoded_len());
+        assert!(matches!(error.kind, BuildErrorKind::DuplicateHalf(_)));
+        assert_eq!(builder.open_spans().len(), 1);
+    }
+    let mut builder = TelemetryEventBuilder::default();
+    let mut buffer = bytes(&[enter(1, 1)]);
+    buffer.push(255);
+    let error = builder
+        .try_build(
+            MarkerRange {
+                source_id: 8,
+                bytes: &buffer,
+            },
+            |_| {},
+        )
+        .unwrap_err();
+    assert_eq!(error.byte_offset, enter(1, 1).encoded_len());
+    assert_eq!(
+        error.kind,
+        BuildErrorKind::Decode(DecodeError::UnknownTag(255))
+    );
+    let error = builder
+        .try_build(
+            MarkerRange {
+                source_id: 8,
+                bytes: &[1],
+            },
+            |_| {},
+        )
+        .unwrap_err();
+    assert_eq!(error.kind, BuildErrorKind::Decode(DecodeError::Truncated));
+    assert_eq!(builder.open_spans().len(), 1);
+}
+
+#[test]
+fn shuffled_halves_across_many_ranges_leave_only_truly_missing_facts() {
+    let mut records = Vec::new();
+    for thread in 1..=8 {
+        for call in 1..=100 {
+            records.push(enter(thread, call));
+            records.push(exit(thread, call));
+        }
+    }
+    // Deterministic shuffle, no additional RNG dependency.
+    let mut state = 42u64;
+    for i in (1..records.len()).rev() {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        let j = usize::try_from(state % (i as u64 + 1)).unwrap();
+        records.swap(i, j);
+    }
+    let mut builder = TelemetryEventBuilder::default();
+    let mut keys = std::collections::HashSet::new();
+    for (i, chunk) in records.chunks(7).enumerate() {
+        for event in push(&mut builder, i as u64 % 3, chunk) {
+            let TelemetryEvent::ClosedSpan(span) = event else {
+                panic!("expected span");
+            };
+            assert!(keys.insert(span.key));
+        }
+    }
+    assert_eq!(keys.len(), 800);
+    assert!(builder.into_open_spans().is_empty());
+}
+
+#[test]
+fn generic_stage_shutdown_emits_unmatched_facts_without_fabricating_spans() {
+    use btel_core::stage::EventBuilder;
+    let mut builder = TelemetryEventBuilder::default();
+    push(&mut builder, 1, &[enter(1, 1), exit(2, 1)]);
+    let mut events = Vec::new();
+    builder.finish(|event| events.push(event));
+    assert_eq!(events.len(), 2);
+    assert!(
+        events
+            .iter()
+            .all(|event| matches!(event, TelemetryEvent::UnmatchedSpan { .. }))
+    );
+    assert!(builder.open_spans().is_empty());
+    builder.finish(|_| panic!("must not emit twice"));
+}


### PR DESCRIPTION
Btel replay can now measure real span construction after buffer handoff. Enter and exit markers form a closed span as soon as both arrive, including when the exit arrives first or the logical call moves between OS rings. No execution-ready signal is required.

Adds `btel_builder` with owned event types and an unmatched-half store scoped to one engine. It preserves source provenance, call-site fields, awaited-exit data, thread metadata, and late ID updates. Unmatched halves grow without eviction; shutdown returns unresolved facts instead of inventing closed spans. There is no production VM wiring, aggregation, publication, or replay deduplication in this layer.

`--consumer-mode build-spans` uses the existing downstream worker and batch recycling. Producer code and round-robin ring draining are unchanged. The benchmark observes emitted values, counts completed output, and rejects runs with missing spans or leftover halves. The standard plot generator supports the new stage and retains the existing layout.

Validation: focused builder/replay tests cover both arrival orders, OS-source migration, logical identity, shuffled records, awaited exits, metadata ownership, duplicate/corrupt input, unresolved shutdown, and real ring recycling with tiny batches. Native tests, targeted Clippy, and repository commit hooks passed. The 630 measured benchmark processes completed successfully (ten repetitions per rate/thread/stage block, with a shared feeder baseline). Every builder run produced all eight million expected spans with zero unmatched halves. The previous handoff PNG also regenerates byte-for-byte unchanged.

Stacked above #4863.

Benchmark medians at 400M requested calls/sec, eight million calls per run:

| Stage | Producers | Achieved Mcalls/sec | Full CPU ns/call | Peak RSS GiB |
| --- | ---: | ---: | ---: | ---: |
| copy-handoff | 1 | 59.0 | 28.4 | 2.05 |
| copy-handoff | 4 | 156.1 | 31.5 | 1.90 |
| copy-handoff | 32 | 145.5 | 56.2 | 2.00 |
| build-spans | 1 | 12.7 | 168.0 | 2.82 |
| build-spans | 4 | 12.9 | 176.8 | 2.54 |
| build-spans | 32 | 11.9 | 230.3 | 2.47 |

At four producers, the builder configuration finished production in 55ms and completed all processing in 622ms, versus 51ms total for handoff-only. These are end-to-end synthetic replay rates, including clock reads, encoding, rings, copying, and the output-counting sink. CPU includes all participating threads and backlog handling; RSS includes prepared fixtures. This sweep covers nested calls; shuffled/migrating/unmatched records are correctness-tested but are not separate performance workloads yet.

Reproduce with the optimized benchmark binary:

```sh
cargo build -p btel_bench --profile btel
uv run crates/btel_bench/plots/sweep.py /path/to/btel_bench /path/to/new-results --stages copy-handoff build-spans
uv run crates/btel_bench/plots/plot.py /path/to/new-results/build-spans
uv run crates/btel_bench/plots/plot.py /path/to/new-results/copy-handoff
```
